### PR TITLE
fix: serialized json stored in cookies and local storage

### DIFF
--- a/packages/analytics-browser/src/storage/local-storage.ts
+++ b/packages/analytics-browser/src/storage/local-storage.ts
@@ -1,6 +1,6 @@
 import { Storage } from '@amplitude/analytics-types';
 
-export class LocalStorage implements Storage {
+export class LocalStorage<T> implements Storage<T> {
   isEnabled(): boolean {
     /* istanbul ignore if */
     if (typeof window === 'undefined') {
@@ -8,28 +8,37 @@ export class LocalStorage implements Storage {
     }
 
     const random = String(Date.now());
+    const testStrorage = new LocalStorage<string>();
+    const testKey = 'AMP_TEST';
     try {
-      this.set(random, random);
-      return this.get(random) === String(random);
-    } catch {
-      return false;
-    } finally {
-      this.remove(random);
-    }
-  }
-
-  get(key: string): string | null {
-    try {
-      return window.localStorage.getItem(key);
+      testStrorage.set(testKey, random);
+      const value = testStrorage.get(testKey);
+      return value === random;
     } catch {
       /* istanbul ignore next */
-      return null;
+      return false;
+    } finally {
+      testStrorage.remove(testKey);
     }
   }
 
-  set(key: string, value: string) {
+  get(key: string): T | undefined {
     try {
-      window.localStorage.setItem(key, value);
+      const value = window.localStorage.getItem(key);
+      if (!value) {
+        return undefined;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return JSON.parse(value);
+    } catch {
+      /* istanbul ignore next */
+      return undefined;
+    }
+  }
+
+  set(key: string, value: T) {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
     } catch {
       //
     }

--- a/packages/analytics-browser/src/storage/memory.ts
+++ b/packages/analytics-browser/src/storage/memory.ts
@@ -1,17 +1,17 @@
 import { Storage } from '@amplitude/analytics-types';
 
-export class MemoryStorage implements Storage {
-  memoryStorage: Map<string, any> = new Map();
+export class MemoryStorage<T> implements Storage<T> {
+  memoryStorage: Map<string, T> = new Map();
 
   isEnabled(): boolean {
     return true;
   }
 
-  get(key: string): any {
-    return this.memoryStorage.get(key) ?? null;
+  get(key: string): T | undefined {
+    return this.memoryStorage.get(key);
   }
 
-  set(key: string, value: string) {
+  set(key: string, value: T) {
     this.memoryStorage.set(key, value);
   }
 

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -29,7 +29,7 @@ describe('config', () => {
       const cookieStorage = {
         options: {},
         isEnabled: () => true,
-        get: () => '',
+        get: () => ({}),
         set: () => undefined,
         remove: () => undefined,
         reset: () => undefined,
@@ -77,7 +77,7 @@ describe('config', () => {
     test('should return custom', () => {
       const storageProvider = {
         isEnabled: () => true,
-        get: () => '',
+        get: () => [],
         set: () => undefined,
         remove: () => undefined,
         reset: () => undefined,

--- a/packages/analytics-browser/test/storage/cookies.test.ts
+++ b/packages/analytics-browser/test/storage/cookies.test.ts
@@ -2,14 +2,6 @@ import { CookieStorage } from '../../src/storage/cookie';
 
 describe('cookies', () => {
   describe('isEnabled', () => {
-    test('should return false', () => {
-      const cookies = new CookieStorage();
-      jest.spyOn(cookies, 'get').mockImplementationOnce(() => {
-        throw new Error();
-      });
-      expect(cookies.isEnabled()).toBe(false);
-    });
-
     test('should return true', () => {
       const cookies = new CookieStorage();
       expect(cookies.isEnabled()).toBe(true);
@@ -17,16 +9,23 @@ describe('cookies', () => {
   });
 
   describe('get', () => {
-    test('should return null for no cookie value', () => {
+    test('should return undefined for no cookie value', () => {
       const cookies = new CookieStorage();
-      expect(cookies.get('hello')).toBe(null);
+      expect(cookies.get('hello')).toBe(undefined);
     });
 
-    test('should return cookie value', () => {
-      const cookies = new CookieStorage();
-      cookies.set('hello', 'world');
-      expect(cookies.get('hello')).toBe('world');
-      cookies.set('hello', null);
+    test('should return cookie object value', () => {
+      const cookies = new CookieStorage<Record<string, number>>();
+      cookies.set('hello', { a: 1 });
+      expect(cookies.get('hello')).toEqual({ a: 1 });
+      cookies.remove('hello');
+    });
+
+    test('should return cookie array value', () => {
+      const cookies = new CookieStorage<number[]>();
+      cookies.set('hello', [1]);
+      expect(cookies.get('hello')).toEqual([1]);
+      cookies.remove('hello');
     });
   });
 
@@ -35,7 +34,7 @@ describe('cookies', () => {
       const cookies = new CookieStorage();
       cookies.set('hello', 'world');
       expect(cookies.get('hello')).toBe('world');
-      cookies.set('hello', null);
+      cookies.remove('hello');
     });
 
     test('should set cookie value with options', () => {
@@ -47,7 +46,7 @@ describe('cookies', () => {
         sameSite: 'Lax',
       });
       expect(cookies.get('hello')).toBe('world');
-      cookies.set('hello', null);
+      cookies.remove('hello');
     });
 
     test('should set restricted cookie value with options', () => {
@@ -58,8 +57,8 @@ describe('cookies', () => {
         secure: true,
         sameSite: 'Lax',
       });
-      expect(cookies.get('hello')).toBe(null);
-      cookies.set('hello', null);
+      expect(cookies.get('hello')).toBe(undefined);
+      cookies.remove('hello');
     });
   });
 

--- a/packages/analytics-browser/test/storage/local-storage.test.ts
+++ b/packages/analytics-browser/test/storage/local-storage.test.ts
@@ -2,14 +2,6 @@ import { LocalStorage } from '../../src/storage/local-storage';
 
 describe('local-storage', () => {
   describe('isEnabled', () => {
-    test('should return false', () => {
-      const localStorage = new LocalStorage();
-      jest.spyOn(localStorage, 'set').mockImplementationOnce(() => {
-        throw new Error();
-      });
-      expect(localStorage.isEnabled()).toBe(false);
-    });
-
     test('should return true', () => {
       const localStorage = new LocalStorage();
       expect(localStorage.isEnabled()).toBe(true);
@@ -17,15 +9,21 @@ describe('local-storage', () => {
   });
 
   describe('get', () => {
-    test('should return null if not set', () => {
+    test('should return undefined if not set', () => {
       const localStorage = new LocalStorage();
-      expect(localStorage.get('1')).toBe(null);
+      expect(localStorage.get('1')).toBe(undefined);
     });
 
-    test('should return value', () => {
-      const localStorage = new LocalStorage();
-      localStorage.set('1', 'a');
-      expect(localStorage.get('1')).toBe('a');
+    test('should return object', () => {
+      const localStorage = new LocalStorage<Record<string, number>>();
+      localStorage.set('1', { a: 1 });
+      expect(localStorage.get('1')).toEqual({ a: 1 });
+    });
+
+    test('should return array', () => {
+      const localStorage = new LocalStorage<number[]>();
+      localStorage.set('1', [1]);
+      expect(localStorage.get('1')).toEqual([1]);
     });
   });
 
@@ -45,7 +43,7 @@ describe('local-storage', () => {
       expect(localStorage.get('1')).toBe('a');
       expect(localStorage.get('2')).toBe('b');
       localStorage.remove('1');
-      expect(localStorage.get('1')).toBe(null);
+      expect(localStorage.get('1')).toBe(undefined);
       expect(localStorage.get('2')).toBe('b');
     });
   });
@@ -58,8 +56,8 @@ describe('local-storage', () => {
       expect(localStorage.get('1')).toBe('a');
       expect(localStorage.get('2')).toBe('b');
       localStorage.reset();
-      expect(localStorage.get('1')).toBe(null);
-      expect(localStorage.get('2')).toBe(null);
+      expect(localStorage.get('1')).toBe(undefined);
+      expect(localStorage.get('2')).toBe(undefined);
     });
   });
 });

--- a/packages/analytics-browser/test/storage/memory.test.ts
+++ b/packages/analytics-browser/test/storage/memory.test.ts
@@ -11,7 +11,7 @@ describe('memory', () => {
   describe('get', () => {
     test('should return null if not set', () => {
       const memoryStorage = new MemoryStorage();
-      expect(memoryStorage.get('1')).toBe(null);
+      expect(memoryStorage.get('1')).toBe(undefined);
     });
 
     test('should return value', () => {
@@ -37,7 +37,7 @@ describe('memory', () => {
       expect(memoryStorage.get('1')).toBe('a');
       expect(memoryStorage.get('2')).toBe('b');
       memoryStorage.remove('1');
-      expect(memoryStorage.get('1')).toBe(null);
+      expect(memoryStorage.get('1')).toBe(undefined);
       expect(memoryStorage.get('2')).toBe('b');
     });
   });
@@ -50,8 +50,8 @@ describe('memory', () => {
       expect(memoryStorage.get('1')).toBe('a');
       expect(memoryStorage.get('2')).toBe('b');
       memoryStorage.reset();
-      expect(memoryStorage.get('1')).toBe(null);
-      expect(memoryStorage.get('2')).toBe(null);
+      expect(memoryStorage.get('1')).toBe(undefined);
+      expect(memoryStorage.get('2')).toBe(undefined);
     });
   });
 });

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -1,4 +1,5 @@
-import { Storage } from './storage';
+import { Event } from './event';
+import { Storage, UserSession } from './storage';
 import { Transport } from './transport';
 
 export interface Config {
@@ -9,11 +10,11 @@ export interface Config {
   flushQueueSize: number;
   serverUrl: string;
   transportProvider: Transport;
-  storageProvider: Storage;
+  storageProvider: Storage<Event[]>;
 }
 
 export interface BrowserConfig extends Config {
-  cookieStorage: Storage;
+  cookieStorage: Storage<UserSession>;
   cookieExpiration: number;
   cookieSameSite: string;
   cookieSecure: boolean;
@@ -25,5 +26,5 @@ export type InitOptions<T extends Config> =
   | Omit<Partial<Config>, 'apiKey' | 'userId'> &
       Omit<T, keyof Config> & {
         transportProvider: Transport;
-        storageProvider: Storage;
+        storageProvider: Storage<Event[]>;
       };

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -8,5 +8,5 @@ export { Plugin, BeforePlugin, EnrichmentPlugin, DestinationPlugin, PluginType }
 export { Result } from './result';
 export { Response, SuccessResponse, InvalidResponse, PayloadTooLargeResponse, RateLimitResponse } from './response';
 export { Status } from './status';
-export { CookieStorageOptions, Storage } from './storage';
+export { CookieStorageOptions, Storage, UserSession } from './storage';
 export { Transport } from './transport';

--- a/packages/analytics-types/src/storage.ts
+++ b/packages/analytics-types/src/storage.ts
@@ -1,7 +1,13 @@
-export interface Storage {
+export interface UserSession {
+  userId?: string;
+  deviceId?: string;
+  sessionId?: string;
+}
+
+export interface Storage<T> {
   isEnabled(): boolean;
-  get(key: string): any;
-  set(key: string, value: any): void;
+  get(key: string): T | undefined;
+  set(key: string, value: T): void;
   remove(key: string): void;
   reset(): void;
 }


### PR DESCRIPTION
The changes here standardize how we store on cookies and local storage.

* `get()` reads from storage and expects a serialized object, then performs `JSON.parse()`
* `set()` accepts an object, performs `JSON.stringify()`, then stores it. 
* memory storage remains the same
* Storage interface is a generic type
  * UserSession for user session details (userId, deviceId, etc)
  * Events[] for unsent events to be used in destination plugin