### PR TITLE
fix: use uuid for default device id

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -13,6 +13,7 @@ import { LocalStorage } from './storage/local-storage';
 import { MemoryStorage } from './storage/memory';
 import { getCookieName } from './session-manager';
 import { getQueryParams } from './utils/query-params';
+import { UUID } from './utils/uuid';
 
 export const defaultConfig = {
   cookieExpiration: 365,
@@ -117,7 +118,7 @@ export const createEventsStorage = (overrides?: BrowserOptions) => {
 };
 
 export const createDeviceId = (idFromCookies?: string, idFromOptions?: string, idFromQueryParams?: string) => {
-  return idFromOptions || idFromQueryParams || idFromCookies || Date.now().toString();
+  return idFromOptions || idFromQueryParams || idFromCookies || UUID();
 };
 
 export const createSessionId = (idFromCookies = 0, idFromOptions = 0, lastEventTime = 0, sessionTimeout: number) => {

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -212,6 +212,11 @@ describe('config', () => {
       const deviceId = Config.createDeviceId('cookieDeviceId', undefined, undefined);
       expect(deviceId).toBe('cookieDeviceId');
     });
+
+    test('should return uuid', () => {
+      const deviceId = Config.createDeviceId(undefined, undefined, undefined);
+      expect(deviceId.substring(14, 15)).toEqual('4');
+    });
   });
 
   describe('createSessionId', () => {


### PR DESCRIPTION
# Description

Use uuid() to provide default device id if cookies, options, and query params are not provided

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)