### PR TITLE
feat: add amplitude built-in plugins

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -1,12 +1,16 @@
-import { init as _init, track as _track } from '@amplitude/analytics-core';
+import { add, Destination, init as _init, track as _track } from '@amplitude/analytics-core';
 import { BrowserConfig, BrowserOptions } from '@amplitude/analytics-types';
 import { createConfig, getConfig } from './config';
+import { Context } from './plugins/context';
 import { updateCookies } from './session-manager';
 
 export const init = (apiKey: string, userId?: string, options?: BrowserOptions) => {
   const browserOptions = createConfig(apiKey, userId, options);
   const config = _init(browserOptions) as BrowserConfig;
   updateCookies(config);
+
+  void add(new Context());
+  void add(new Destination());
 };
 
 export const setUserId = (userId: string) => {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -44,15 +44,13 @@ export const revenue = (revenue: Revenue) => {
   return dispatch(event, config);
 };
 
-export const add = async (plugins: Plugin[]) => {
+export const add = async (plugin: Plugin) => {
   const config = getConfig();
-  const registrations = plugins.map((plugin) => register(plugin, config));
-  await Promise.all(registrations);
+  return register(plugin, config);
 };
 
-export const remove = async (pluginNames: string[]) => {
-  const deregistrations = pluginNames.map((name) => deregister(name));
-  await Promise.all(deregistrations);
+export const remove = async (pluginName: string) => {
+  return deregister(pluginName);
 };
 
 export const dispatch = async (event: Event, config: Config) => {

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -84,11 +84,11 @@ describe('core-client', () => {
       };
 
       // add
-      await client.add([plugin]);
+      await client.add(plugin);
       expect(register).toBeCalledTimes(1);
 
       // remove
-      await client.remove([plugin.name]);
+      await client.remove(plugin.name);
       expect(deregister).toBeCalledTimes(1);
     });
   });


### PR DESCRIPTION
# Description

* Add built-in plugin on browse init
* Update add/remove plugin interface only accept one plugin at a time

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)