### PR TITLE
docs: fix tsconfig again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           yarn build
 
+      - name: Build docs
+        run: |
+          yarn docs:check
+
       - name: Test all packages
         run: |
           yarn test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,5 @@
 name: Generate Docs
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -12,7 +9,7 @@ jobs:
 
       - name: Setup
         run: |
-          yarn install
+          yarn
           yarn build
           yarn docs
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "lerna run build --stream",
     "docs": "typedoc",
+    "docs:check": "typedoc --emit none",
     "fix": "lerna run fix --stream",
     "lint": "lerna run lint --stream",
     "lint:staged": "lint-staged",

--- a/packages/analytics-browser/test/utils/language.test.ts
+++ b/packages/analytics-browser/test/utils/language.test.ts
@@ -1,16 +1,18 @@
 import { getLanguage } from '../../src/utils/language';
-
-declare global {
-  interface Navigator {
-    language: string | undefined;
-    languages: string[] | undefined;
-    userLanguage: string | undefined;
-  }
+interface Navigator {
+  language: string | undefined;
+  languages: string[] | undefined;
+  userLanguage: string | undefined;
 }
 
 describe('language', () => {
+  // Simulates other browser version
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const nav: Navigator = navigator;
+
   beforeAll(() => {
-    Object.defineProperty(navigator, 'userLanguage', {
+    Object.defineProperty(nav, 'userLanguage', {
       get: () => '',
       configurable: true,
       enumerable: true,
@@ -18,8 +20,8 @@ describe('language', () => {
   });
 
   afterAll(() => {
-    if (navigator?.userLanguage) {
-      delete navigator.userLanguage;
+    if (nav.userLanguage) {
+      delete nav.userLanguage;
     }
   });
 
@@ -52,16 +54,16 @@ describe('language', () => {
     jest.spyOn(window as any, 'navigator', 'get').mockReturnValue(undefined);
     expect(getLanguage()).toBe('');
   });
-});
 
-function enableNavigatorLanguageProperties(properties: Array<'languages' | 'language' | 'userLanguage'>) {
-  jest
-    .spyOn(navigator, 'languages', 'get')
-    .mockReturnValue(properties.includes('languages') ? ['some-locale', 'some-other-locale'] : undefined);
-  jest
-    .spyOn(navigator, 'language', 'get')
-    .mockReturnValue(properties.includes('language') ? 'some-second-locale' : undefined);
-  jest
-    .spyOn(navigator, 'userLanguage', 'get')
-    .mockReturnValue(properties.includes('userLanguage') ? 'some-third-locale' : undefined);
-}
+  function enableNavigatorLanguageProperties(properties: Array<'languages' | 'language' | 'userLanguage'>) {
+    jest
+      .spyOn(nav, 'languages', 'get')
+      .mockReturnValue(properties.includes('languages') ? ['some-locale', 'some-other-locale'] : undefined);
+    jest
+      .spyOn(nav, 'language', 'get')
+      .mockReturnValue(properties.includes('language') ? 'some-second-locale' : undefined);
+    jest
+      .spyOn(nav, 'userLanguage', 'get')
+      .mockReturnValue(properties.includes('userLanguage') ? 'some-third-locale' : undefined);
+  }
+});

--- a/packages/analytics-browser/tsconfig.json
+++ b/packages/analytics-browser/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "test/**/*"],
-  "exclude": [],
   "compilerOptions": {
     "baseUrl": ".",
     "esModuleInterop": true,

--- a/packages/analytics-core/tsconfig.json
+++ b/packages/analytics-core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "test/**/*"],
-  "exclude": [],
   "compilerOptions": {
     "baseUrl": ".",
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "exclude": ["**/test/*"],
   "compilerOptions": {
     "alwaysStrict": false,
     "declaration": true,


### PR DESCRIPTION
# Description

* Fix test to remove TS violation with multiple types declaration for `global.Navigator`
```
Error: node_modules/typescript/lib/lib.dom.d.ts:95[43](https://github.com/amplitude/Amplitude-TypeScript/runs/5666623402?check_suite_focus=true#step:3:43):11 - error TS2430: Interface 'Navigator' incorrectly extends interface 'NavigatorLanguage'.
  Types of property 'language' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

9543 interface Navigator extends NavigatorAutomationInformation, NavigatorConcurrentHardware, NavigatorContentUtils, NavigatorCookies, NavigatorID, NavigatorLanguage, NavigatorNetworkInformation, NavigatorOnLine, NavigatorPlugins, NavigatorStorage {
```
* Fix `tsconfig.json` in all projects to include all files

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)
