### PR TITLE
build: fix s3 object key

### DIFF
--- a/packages/analytics-browser/deploy/publish-to-s3.js
+++ b/packages/analytics-browser/deploy/publish-to-s3.js
@@ -12,7 +12,7 @@ let deployedCount = 0;
 console.log('[Publish to AWS S3] START');
 const promises = files.map((file) => {
   const body = fs.readFileSync(path.join(location, file));
-  const key = `libs/${file.replace('amplitude', `amplitude-next-${pkg.version}`)}`;
+  const key = `libs/${file.replace('amplitude', `analytics-browser-${pkg.version}`)}`;
   const client = new S3Client();
 
   const headObject = new HeadObjectCommand({


### PR DESCRIPTION
# Description

Fix s3 object key. This also affects the script src url used in snippet installation.

Before: 
`cdn.amplitude.com/libs/amplitude-x-y-z`

After:
`cdn.amplitude.com/libs/analytics-browser-x.y.z`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
