### PR TITLE
fix: move types to analytics-types

### DIFF
--- a/packages/analytics-browser/src/typings/browser-snippet.d.ts
+++ b/packages/analytics-browser/src/typings/browser-snippet.d.ts
@@ -1,16 +1,4 @@
-import { Result } from '@amplitude/analytics-types';
-
-interface ProxyItem {
-  name: string;
-  args: any[];
-  resolve?: (promise: Promise<Result>) => void;
-}
-
-export type QueueProxy = Array<ProxyItem>;
-
-export interface InstanceProxy {
-  _q: QueueProxy;
-}
+import { InstanceProxy } from '@amplitude/analytics-types';
 
 declare global {
   // globalThis only includes `var` declarations

--- a/packages/analytics-browser/src/utils/snippet-helper.ts
+++ b/packages/analytics-browser/src/utils/snippet-helper.ts
@@ -1,5 +1,4 @@
-import { QueueProxy, InstanceProxy } from '../typings/browser-snippet';
-import { AmplitudeReturn, Result } from '@amplitude/analytics-types';
+import { AmplitudeReturn, InstanceProxy, QueueProxy, Result } from '@amplitude/analytics-types';
 
 /**
  * Applies the proxied functions on the proxied amplitude snippet to an instance of the real object.

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1,4 +1,3 @@
-import type { QueueProxy } from '../src/typings/browser-snippet';
 import {
   init,
   groupIdentify,
@@ -22,7 +21,7 @@ import * as Config from '../src/config';
 import * as SessionManager from '../src/session-manager';
 import * as attribution from '../src/attribution';
 import { runQueuedFunctions } from '../src/utils/snippet-helper';
-import { PluginType, TransportType } from '@amplitude/analytics-types';
+import { PluginType, QueueProxy, TransportType } from '@amplitude/analytics-types';
 import { XHRTransport } from '../src/transports/xhr';
 
 describe('browser-client', () => {

--- a/packages/analytics-browser/test/utils/snippet-helper.test.ts
+++ b/packages/analytics-browser/test/utils/snippet-helper.test.ts
@@ -1,4 +1,4 @@
-import type { QueueProxy } from '../../src/typings/browser-snippet';
+import { QueueProxy } from '@amplitude/analytics-types';
 import { convertProxyObjectToRealObject, isInstanceProxy } from '../../src/utils/snippet-helper';
 
 describe('snippet-helper', () => {

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -23,6 +23,7 @@ export { Payload } from './payload';
 export { Plugin, BeforePlugin, EnrichmentPlugin, DestinationPlugin, PluginType } from './plugin';
 export { Result } from './result';
 export { Response, SuccessResponse, InvalidResponse, PayloadTooLargeResponse, RateLimitResponse } from './response';
+export { QueueProxy, InstanceProxy } from './proxy';
 export { Status } from './status';
 export { CookieStorageOptions, Storage, UserSession } from './storage';
 export { Transport, TransportType } from './transport';

--- a/packages/analytics-types/src/proxy.ts
+++ b/packages/analytics-types/src/proxy.ts
@@ -1,0 +1,13 @@
+import { Result } from './result';
+
+interface ProxyItem {
+  name: string;
+  args: any[];
+  resolve?: (promise: Promise<Result>) => void;
+}
+
+export type QueueProxy = Array<ProxyItem>;
+
+export interface InstanceProxy {
+  _q: QueueProxy;
+}


### PR DESCRIPTION
# Description

The types declared in `typings/` directory is not getting included in the esm bundle. `typings/` is only use for dev purposes. This is used in generated `d.ts` files for esm build. Th poposed change is to move these type definitions to analytics-types package to guarantee inclusion.

Fixes https://github.com/amplitude/Amplitude-TypeScript/issues/69

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
