### PR TITLE
fix: update plan type to include version id

### DIFF
--- a/packages/analytics-types/src/plan.ts
+++ b/packages/analytics-types/src/plan.ts
@@ -8,4 +8,6 @@ export interface Plan {
   source?: string;
   /** The tracking plan version e.g. "1", "15" */
   version?: string;
+  /** The tracking plan version Id e.g. "9ec23ba0-275f-468f-80d1-66b88bff9529" */
+  versionId?: string;
 }


### PR DESCRIPTION
### Summary

Adds `versionId` to plan field in event options

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
