### PR TITLE
fix: cookie expires prematurely due to incorrectly used option

### DIFF
--- a/packages/analytics-browser/src/storage/cookie.ts
+++ b/packages/analytics-browser/src/storage/cookie.ts
@@ -51,9 +51,10 @@ export class CookieStorage<T> implements Storage<T> {
     return match.substring(key.length + 1);
   }
 
-  set(key: string, value: T | null, options?: CookieStorageOptions) {
+  set(key: string, value: T | null) {
     try {
-      const expires = value !== null ? options?.expirationDays : -1;
+      const expirationDays = this.options.expirationDays ?? 0;
+      const expires = value !== null ? expirationDays : -1;
       let expireDate: Date | undefined = undefined;
       if (expires) {
         const date = new Date();
@@ -65,14 +66,14 @@ export class CookieStorage<T> implements Storage<T> {
         str += `; expires=${expireDate.toUTCString()}`;
       }
       str += '; path=/';
-      if (options?.domain) {
-        str += `; domain=${options.domain}`;
+      if (this.options.domain) {
+        str += `; domain=${this.options.domain}`;
       }
-      if (options?.secure) {
+      if (this.options.secure) {
         str += '; Secure';
       }
-      if (options?.sameSite) {
-        str += `; SameSite=${options.sameSite}`;
+      if (this.options.sameSite) {
+        str += `; SameSite=${this.options.sameSite}`;
       }
       window.document.cookie = str;
     } catch {

--- a/packages/analytics-browser/test/storage/cookies.test.ts
+++ b/packages/analytics-browser/test/storage/cookies.test.ts
@@ -38,25 +38,25 @@ describe('cookies', () => {
     });
 
     test('should set cookie value with options', () => {
-      const cookies = new CookieStorage();
-      cookies.set('hello', 'world', {
+      const cookies = new CookieStorage({
         expirationDays: 365,
         domain: '',
         secure: false,
         sameSite: 'Lax',
       });
+      cookies.set('hello', 'world');
       expect(cookies.get('hello')).toBe('world');
       cookies.remove('hello');
     });
 
     test('should set restricted cookie value with options', () => {
-      const cookies = new CookieStorage();
-      cookies.set('hello', 'world', {
+      const cookies = new CookieStorage({
         expirationDays: 365,
         domain: '.amplitude.com',
         secure: true,
         sameSite: 'Lax',
       });
+      cookies.set('hello', 'world');
       expect(cookies.get('hello')).toBe(undefined);
       cookies.remove('hello');
     });


### PR DESCRIPTION
### Summary

Previously uses options in params, which is not passed. Options in constructor is passed already and better to use.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
