### PR TITLE
fix: fix early return if array element is a valid object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib/
 *.tsbuildinfo
 coverage/
 docs/
+.idea/

--- a/packages/analytics-core/src/utils/valid-properties.ts
+++ b/packages/analytics-core/src/utils/valid-properties.ts
@@ -20,7 +20,7 @@ export const isValidProperties = (property: string, value: any): boolean => {
       if (Array.isArray(valueElement)) {
         return false;
       } else if (typeof valueElement === 'object') {
-        isValid = isValid && isValidObject(value);
+        isValid = isValid && isValidObject(valueElement as object);
       } else if (!['number', 'string'].includes(typeof valueElement)) {
         return false;
       }

--- a/packages/analytics-core/src/utils/valid-properties.ts
+++ b/packages/analytics-core/src/utils/valid-properties.ts
@@ -15,12 +15,16 @@ export const isValidObject = (properties: { [key: string]: any }): boolean => {
 export const isValidProperties = (property: string, value: any): boolean => {
   if (typeof property !== 'string') return false;
   if (Array.isArray(value)) {
+    let isValid = true;
     for (const valueElement of value) {
       if (Array.isArray(valueElement)) {
         return false;
       } else if (typeof valueElement === 'object') {
-        return isValidObject(value);
+        isValid = isValid && isValidObject(value);
       } else if (!['number', 'string'].includes(typeof valueElement)) {
+        return false;
+      }
+      if (!isValid) {
         return false;
       }
     }

--- a/packages/analytics-core/test/utils/valid-properties.test.ts
+++ b/packages/analytics-core/test/utils/valid-properties.test.ts
@@ -46,7 +46,7 @@ describe('validProperties', () => {
   });
 
   test('should fail on invalid property with invalid object in array', () => {
-    const inValidProperties = [{keyForString: 'stringValue'}, {keyForString: [['stringValue']]}, 15];
+    const inValidProperties = [{ keyForString: 'stringValue' }, { keyForString: [['stringValue']] }, 15];
     expect(isValidProperties('property', inValidProperties)).toBe(false);
   });
 

--- a/packages/analytics-core/test/utils/valid-properties.test.ts
+++ b/packages/analytics-core/test/utils/valid-properties.test.ts
@@ -45,6 +45,11 @@ describe('validProperties', () => {
     expect(isValidProperties('property', inValidProperties)).toBe(false);
   });
 
+  test('should fail on invalid property with invalid object in array', () => {
+    const inValidProperties = [{keyForString: 'stringValue'}, {keyForString: [['stringValue']]}, 15];
+    expect(isValidProperties('property', inValidProperties)).toBe(false);
+  });
+
   test('should fail when any key is not string', () => {
     const validProperties = {
       keyForString: 'stringValue',


### PR DESCRIPTION
### Summary

fix early return if array element is a valid object

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no