### PR TITLE
build: limit snippet regeneration when ready to release

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -33,7 +33,7 @@
     "publish": "node scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "GENERATE_SNIPPET=true && yarn build",
+    "version": "GENERATE_SNIPPET=true yarn build",
     "vesion-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {

--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -33,7 +33,7 @@
     "publish": "node scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn build",
+    "version": "GENERATE_SNIPPET=true && yarn build",
     "vesion-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {

--- a/packages/analytics-browser/rollup.config.js
+++ b/packages/analytics-browser/rollup.config.js
@@ -12,7 +12,7 @@ const amplitudeSnippet = () => {
     options: (opt) => {
       return new Promise((resolve) => {
         opt.input = 'generated/amplitude-snippet.js';
-        if (process.env.GITHUB_WORKFLOW !== 'Continuous Deployment') return resolve(opt);
+        if (process.env.GENERATE_SNIPPET !== 'true') return resolve(opt);
         exec('node scripts/version/create-snippet.js', (err) => {
           if (err) {
             throw err;


### PR DESCRIPTION
### Summary

`yarn build` runs twice in deployment, which is fine. the first one is for validation of its current state, the second one is to include the new version (as the upcoming release would be assigned a new version). however, the first occurrence generates a snippet, and we don't want that because lerna will find uncommitted changes. we only want it to run on the second occurrence since we need to include the new version in the final bundle

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
