### PR TITLE
fix: allow min_id_length option in http payload

### DIFF
--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -43,6 +43,7 @@ export class Config implements IConfig {
   flushQueueSize: number;
   loggerProvider: ILogger;
   logLevel: LogLevel;
+  minIdLength?: number;
   partnerId?: string;
   plugins: Plugin[];
   optOut: boolean;
@@ -65,6 +66,7 @@ export class Config implements IConfig {
     this.flushQueueSize = options.flushQueueSize || defaultConfig.flushQueueSize;
     this.loggerProvider = options.loggerProvider || defaultConfig.loggerProvider;
     this.logLevel = options.logLevel ?? defaultConfig.logLevel;
+    this.minIdLength = options.minIdLength;
     this.partnerId = options.partnerId;
     this.plugins = defaultConfig.plugins;
     this.optOut = options.optOut ?? defaultConfig.optOut;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -112,6 +112,9 @@ export class Destination implements DestinationPlugin {
     const payload = {
       api_key: this.config.apiKey,
       events: list.map((context) => context.event),
+      options: {
+        min_id_length: this.config.minIdLength,
+      },
     };
 
     try {

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -19,6 +19,7 @@ export interface Config {
   flushQueueSize: number;
   logLevel: LogLevel;
   loggerProvider: Logger;
+  minIdLength?: number;
   optOut: boolean;
   partnerId?: string;
   plugins: Plugin[];


### PR DESCRIPTION
### Summary

The changes in this PR allow `minIdLength` to be configurable. This can be done by passing `minIdLength` as part of config object on init call.

```ts
amplitude.init(API_KEY, '', {
  minIdLength: 1,
});
```

Fixes: https://github.com/amplitude/Amplitude-TypeScript/issues/98

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
