### PR TITLE
fix: allow option.serverUrl to be used in destination plugin

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -645,4 +645,39 @@ describe('integration', () => {
       scope.done();
     });
   });
+
+  describe('custom config', () => {
+    describe('serverUrl', () => {
+      test('should track event to custom serverUrl', async () => {
+        const serverUrl = 'https://domain.com';
+        const scope = nock(serverUrl).post(path).reply(200, success);
+
+        amplitude.init('API_KEY', undefined, {
+          ...opts,
+          serverUrl: serverUrl + path,
+        });
+        const response = await amplitude.track('test event').promise;
+        expect(response.event).toEqual({
+          user_id: undefined,
+          device_id: uuid,
+          session_id: number,
+          time: number,
+          platform: 'Web',
+          os_name: 'WebKit',
+          os_version: '537.36',
+          device_manufacturer: undefined,
+          language: 'en-US',
+          ip: '$remote',
+          insert_id: uuid,
+          partner_id: undefined,
+          event_type: 'test event',
+          event_id: 0,
+          library: library,
+        });
+        expect(response.code).toBe(200);
+        expect(response.message).toBe(SUCCESS_MESSAGE);
+        scope.done();
+      });
+    });
+  });
 });

--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -49,7 +49,7 @@ export class Config implements IConfig {
   optOut: boolean;
   saveEvents: boolean;
   serverUrl: string | undefined;
-  serverZone: ServerZone;
+  serverZone?: ServerZone;
   transportProvider: Transport;
   storageProvider: Storage<Event[]>;
   useBatch: boolean;
@@ -78,7 +78,7 @@ export class Config implements IConfig {
     this.useBatch = options.useBatch ?? defaultConfig.useBatch;
     this.loggerProvider.enable(this.logLevel);
 
-    const serverConfig = createServerConfig(options.serverZone, options.useBatch);
+    const serverConfig = createServerConfig(options.serverUrl, options.serverZone, options.useBatch);
     this.serverZone = serverConfig.serverZone;
     this.serverUrl = serverConfig.serverUrl;
   }
@@ -92,9 +92,13 @@ export const getServerUrl = (serverZone: ServerZone, useBatch: boolean) => {
 };
 
 export const createServerConfig = (
+  serverUrl = '',
   serverZone: ServerZone = getDefaultConfig().serverZone,
   useBatch: boolean = getDefaultConfig().useBatch,
 ) => {
+  if (serverUrl) {
+    return { serverUrl, serverZone: undefined };
+  }
   const _serverZone = [ServerZone.US, ServerZone.EU].includes(serverZone) ? serverZone : getDefaultConfig().serverZone;
   return {
     serverZone: _serverZone,

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -118,7 +118,7 @@ export class Destination implements DestinationPlugin {
     };
 
     try {
-      const { serverUrl } = createServerConfig(this.config.serverZone, this.config.useBatch);
+      const { serverUrl } = createServerConfig(this.config.serverUrl, this.config.serverZone, this.config.useBatch);
       const res = await this.config.transportProvider.send(serverUrl, payload);
       if (res === null) {
         this.fulfillRequest(list, 0, UNEXPECTED_ERROR_MESSAGE);

--- a/packages/analytics-core/test/config.test.ts
+++ b/packages/analytics-core/test/config.test.ts
@@ -90,10 +90,17 @@ describe('config', () => {
   });
 
   describe('createServerConfig', () => {
+    test('should return custom server url', () => {
+      expect(createServerConfig('https://domain.com')).toEqual({
+        serverZone: undefined,
+        serverUrl: 'https://domain.com',
+      });
+    });
+
     test('should return default', () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore to test invalid values
-      expect(createServerConfig('', undefined)).toEqual({
+      expect(createServerConfig('', '', undefined)).toEqual({
         serverZone: ServerZone.US,
         serverUrl: AMPLITUDE_SERVER_URL,
       });

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -25,7 +25,7 @@ export interface Config {
   plugins: Plugin[];
   saveEvents: boolean;
   serverUrl: string | undefined;
-  serverZone: ServerZone;
+  serverZone?: ServerZone;
   sessionId?: number;
   storageProvider: Storage<Event[]>;
   transportProvider: Transport;


### PR DESCRIPTION
### Summary

SDK does not use `options.serverUrl`. The changes uses `options.serverUrl` to set `config.serverUrl` and be used in destination plugin. Fixes https://github.com/amplitude/Amplitude-TypeScript/issues/103

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
