### PR TITLE
feat: adds support for multiple instance creation

### DIFF
--- a/packages/analytics-browser/scripts/templates/browser-snippet.template.js
+++ b/packages/analytics-browser/scripts/templates/browser-snippet.template.js
@@ -1,6 +1,6 @@
 const snippet = (integrity, version) => `
 !(function (window, document) {
-  var amplitude = window.amplitude || { _q: [] };
+  var amplitude = window.amplitude || { _q: [], _iq: [] };
   if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');
   else {
     amplitude.invoked = true;
@@ -96,7 +96,7 @@ const snippet = (integrity, version) => `
                 resolve: resolve,
               });
             }),
-          }
+          };
           if (isPromise) return result;
         };
       }
@@ -108,6 +108,14 @@ const snippet = (integrity, version) => `
       }
     }
     setUpProxy(amplitude);
+    amplitude.createInstance = function (instance) {
+      if (typeof instance !== 'string' || instance.length === 0)) return undefined;
+      if (!Object.prototype.hasOwnProperty.call(amplitude._iq, instance)) {
+        amplitude._iq[instance] = { _q: [] };
+        setUpProxy(amplitude._iq[instance]);
+      }
+      return amplitude._iq[instance];
+    };
     window.amplitude = amplitude;
   }
 })(window, document);

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -2,6 +2,7 @@ import { AmplitudeCore, Destination, Identify, Revenue, returnWrapper } from '@a
 import {
   BrowserConfig,
   BrowserOptions,
+  CreateBrowserInstance,
   EventOptions,
   Identify as IIdentify,
   Result,
@@ -124,200 +125,38 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
   }
 }
 
-const client = new AmplitudeBrowser();
-
 /**
- * Initializes the Amplitude SDK with your apiKey, userId and optional configurations.
- * This method must be called before any other operations.
+ * > EXPERIMENTAL
+ *
+ * Creates additional Amplitude instance. This can be used to instantiate
+ * a new tracker with a different `API_KEY` and configuration.
  *
  * ```typescript
- * await init(API_KEY, USER_ID, options).promise;
+ * const amp2 = createInstance('amp-2');
+ * await amp2.init(API_KEY_2, '', options).promise;
  * ```
  */
-export const init = returnWrapper(client.init.bind(client));
+export const createInstance: CreateBrowserInstance = (instanceName: string) => {
+  const instance = new AmplitudeBrowser(instanceName);
+  return {
+    init: returnWrapper(instance.init.bind(instance)),
+    add: returnWrapper(instance.add.bind(instance)),
+    remove: returnWrapper(instance.remove.bind(instance)),
+    track: returnWrapper(instance.track.bind(instance)),
+    logEvent: returnWrapper(instance.logEvent.bind(instance)),
+    identify: returnWrapper(instance.identify.bind(instance)),
+    groupIdentify: returnWrapper(instance.groupIdentify.bind(instance)),
+    setGroup: returnWrapper(instance.setGroup.bind(instance)),
+    revenue: returnWrapper(instance.revenue.bind(instance)),
+    getUserId: instance.getUserId.bind(instance),
+    setUserId: instance.setUserId.bind(instance),
+    getDeviceId: instance.getDeviceId.bind(instance),
+    setDeviceId: instance.setDeviceId.bind(instance),
+    getSessionId: instance.getSessionId.bind(instance),
+    setSessionId: instance.setSessionId.bind(instance),
+    setOptOut: instance.setOptOut.bind(instance),
+    setTransport: instance.setTransport.bind(instance),
+  };
+};
 
-/**
- * Adds a new plugin.
- *
- * ```typescript
- * const plugin = {...};
- * amplitude.add(plugin);
- * ```
- */
-export const add = returnWrapper(client.add.bind(client));
-
-/**
- * Removes a plugin.
- *
- * ```typescript
- * amplitude.remove('myPlugin');
- * ```
- */
-export const remove = returnWrapper(client.remove.bind(client));
-
-/**
- * Tracks user-defined event, with specified type, optional event properties and optional overwrites.
- *
- * ```typescript
- * // event tracking with event type only
- * track('Page Load');
- *
- * // event tracking with event type and additional event properties
- * track('Page Load', { loadTime: 1000 });
- *
- * // event tracking with event type, additional event properties, and overwritten event options
- * track('Page Load', { loadTime: 1000 }, { sessionId: -1 });
- *
- * // alternatively, this tracking method is awaitable
- * const result = await track('Page Load').promise;
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const track = returnWrapper(client.track.bind(client));
-
-/**
- * Alias for track()
- */
-export const logEvent = returnWrapper(client.logEvent.bind(client));
-
-/**
- * Sends an identify event containing user property operations
- *
- * ```typescript
- * const id = new Identify();
- * id.set('colors', ['rose', 'gold']);
- * identify(id);
- *
- * // alternatively, this tracking method is awaitable
- * const result = await identify(id).promise;
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const identify = returnWrapper(client.identify.bind(client));
-
-/**
- * Sends a group identify event containing group property operations.
- *
- * ```typescript
- * const id = new Identify();
- * id.set('skills', ['js', 'ts']);
- * const groupType = 'org';
- * const groupName = 'engineering';
- * groupIdentify(groupType, groupName, id);
- *
- * // alternatively, this tracking method is awaitable
- * const result = await groupIdentify(groupType, groupName, id).promise;
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const groupIdentify = returnWrapper(client.groupIdentify.bind(client));
-export const setGroup = returnWrapper(client.setGroup.bind(client));
-
-/**
- * Sends a revenue event containing revenue property operations.
- *
- * ```typescript
- * const rev = new Revenue();
- * rev.setRevenue(100);
- * revenue(rev);
- *
- * // alternatively, this tracking method is awaitable
- * const result = await revenue(rev).promise;
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const revenue = returnWrapper(client.revenue.bind(client));
-
-/**
- * Returns current user ID.
- *
- * ```typescript
- * const userId = getUserId();
- * ```
- */
-export const getUserId = client.getUserId.bind(client);
-
-/**
- * Sets a new user ID.
- *
- * ```typescript
- * setUserId('userId');
- * ```
- */
-export const setUserId = client.setUserId.bind(client);
-
-/**
- * Returns current device ID.
- *
- * ```typescript
- * const deviceId = getDeviceId();
- * ```
- */
-export const getDeviceId = client.getDeviceId.bind(client);
-
-/**
- * Sets a new device ID.
- * When setting a custom device ID, make sure the value is sufficiently unique.
- * A uuid is recommended.
- *
- * ```typescript
- * setDeviceId('deviceId');
- * ```
- */
-export const setDeviceId = client.setDeviceId.bind(client);
-
-/**
- * Returns current session ID.
- *
- * ```typescript
- * const sessionId = getSessionId();
- * ```
- */
-export const getSessionId = client.getSessionId.bind(client);
-
-/**
- * Sets a new session ID.
- * When settign a custom session ID, make sure the value is in milliseconds since epoch (Unix Timestamp).
- *
- * ```typescript
- * setSessionId(Date.now());
- * ```
- */
-export const setSessionId = client.setSessionId.bind(client);
-
-/**
- * Sets a new optOut config value. This toggles event tracking on/off.
- *
- *```typescript
- * // Stops tracking
- * setOptOut(true);
- *
- * // Starts/resumes tracking
- * setOptOut(false);
- * ```
- */
-export const setOptOut = client.setOptOut.bind(client);
-
-/**
- *  Sets the network transport type for events.
- *
- * ```typescript
- * // Use Fetch API
- * setTransport('fetch');
- *
- * // Use XMLHttpRequest API
- * setTransport('xhr');
- *
- * // Use navigator.sendBeacon API
- * setTransport('beacon');
- * ```
- */
-export const setTransport = client.setTransport.bind(client);
+export default createInstance('$default');

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -1,4 +1,5 @@
-export {
+import client from './browser-client';
+export const {
   add,
   getDeviceId,
   getSessionId,
@@ -16,7 +17,8 @@ export {
   setTransport,
   setUserId,
   track,
-} from './browser-client';
+} = client;
+export { createInstance } from './browser-client';
 export { runQueuedFunctions } from './utils/snippet-helper';
 export { Revenue, Identify } from '@amplitude/analytics-core';
 export * as Types from '@amplitude/analytics-types';

--- a/packages/analytics-browser/src/snippet-index.ts
+++ b/packages/analytics-browser/src/snippet-index.ts
@@ -7,4 +7,11 @@ if (globalThis.amplitude.invoked) {
   const queue = globalThis.amplitude._q;
   globalThis.amplitude._q = [];
   runQueuedFunctions(amplitude, queue);
+
+  for (const name in globalThis.amplitude._iq) {
+    const instance = Object.assign(globalThis.amplitude._iq[name], amplitude.createInstance(name));
+    const queue = instance._q;
+    instance._q = [];
+    runQueuedFunctions(instance, queue);
+  }
 }

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1,4 +1,4 @@
-import { AmplitudeBrowser } from '../src/browser-client';
+import { AmplitudeBrowser, createInstance } from '../src/browser-client';
 import * as core from '@amplitude/analytics-core';
 import * as Config from '../src/config';
 import * as SessionManager from '../src/session-manager';
@@ -301,6 +301,29 @@ describe('browser-client', () => {
       expect(result.code).toEqual(200);
       expect(send).toHaveBeenCalledTimes(1);
       expect(convertProxyObjectToRealObject).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createInstance', () => {
+    test('should return new instance', () => {
+      const instance = createInstance('amp');
+      expect(typeof instance.init).toBe('function');
+      expect(typeof instance.add).toBe('function');
+      expect(typeof instance.remove).toBe('function');
+      expect(typeof instance.track).toBe('function');
+      expect(typeof instance.logEvent).toBe('function');
+      expect(typeof instance.identify).toBe('function');
+      expect(typeof instance.groupIdentify).toBe('function');
+      expect(typeof instance.setGroup).toBe('function');
+      expect(typeof instance.revenue).toBe('function');
+      expect(typeof instance.getUserId).toBe('function');
+      expect(typeof instance.setUserId).toBe('function');
+      expect(typeof instance.getDeviceId).toBe('function');
+      expect(typeof instance.setDeviceId).toBe('function');
+      expect(typeof instance.getSessionId).toBe('function');
+      expect(typeof instance.setSessionId).toBe('function');
+      expect(typeof instance.setOptOut).toBe('function');
+      expect(typeof instance.setTransport).toBe('function');
     });
   });
 });

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -1,5 +1,6 @@
 import {
   add,
+  createInstance,
   getDeviceId,
   getSessionId,
   getUserId,
@@ -24,6 +25,7 @@ import {
 describe('index', () => {
   test('should expose apis', () => {
     expect(typeof add).toBe('function');
+    expect(typeof createInstance).toBe('function');
     expect(typeof groupIdentify).toBe('function');
     expect(typeof getDeviceId).toBe('function');
     expect(typeof getSessionId).toBe('function');

--- a/packages/analytics-node/src/index.ts
+++ b/packages/analytics-node/src/index.ts
@@ -1,15 +1,5 @@
-export {
-  add,
-  groupIdentify,
-  identify,
-  init,
-  logEvent,
-  remove,
-  revenue,
-  setGroup,
-  setOptOut,
-  track,
-  flush,
-} from './node-client';
+import client from './node-client';
+export const { add, groupIdentify, identify, init, logEvent, remove, revenue, setGroup, setOptOut, track, flush } =
+  client;
 export { Revenue, Identify } from '@amplitude/analytics-core';
 export * as Types from '@amplitude/analytics-types';

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -1,5 +1,5 @@
-import { AmplitudeCore, Destination } from '@amplitude/analytics-core';
-import { NodeConfig, NodeOptions } from '@amplitude/analytics-types';
+import { AmplitudeCore, Destination, returnWrapper } from '@amplitude/analytics-core';
+import { CreateNodeInstance, NodeConfig, NodeOptions } from '@amplitude/analytics-types';
 import { Context } from './plugins/context';
 import { useNodeConfig } from './config';
 
@@ -8,145 +8,27 @@ export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
     const nodeOptions = useNodeConfig(apiKey, {
       ...options,
     });
-
     await super.init(undefined, undefined, nodeOptions);
-
     await this.add(new Context());
     await this.add(new Destination());
   }
 }
 
-const client = new AmplitudeNode();
+export const createInstance: CreateNodeInstance = (instanceName: string) => {
+  const client = new AmplitudeNode(instanceName);
+  return {
+    init: returnWrapper(client.init.bind(client)),
+    add: returnWrapper(client.add.bind(client)),
+    remove: returnWrapper(client.remove.bind(client)),
+    track: returnWrapper(client.track.bind(client)),
+    logEvent: returnWrapper(client.logEvent.bind(client)),
+    identify: returnWrapper(client.identify.bind(client)),
+    groupIdentify: returnWrapper(client.groupIdentify.bind(client)),
+    setGroup: returnWrapper(client.setGroup.bind(client)),
+    revenue: returnWrapper(client.revenue.bind(client)),
+    setOptOut: client.setOptOut.bind(client),
+    flush: returnWrapper(client.flush.bind(client)),
+  };
+};
 
-/**
- * Initializes the Amplitude SDK with your apiKey, userId and optional configurations.
- * This method must be called before any other operations.
- *
- * ```typescript
- * await init(API_KEY, USER_ID, options);
- * ```
- */
-export const init = client.init.bind(client);
-
-/**
- * Adds a new plugin.
- *
- * ```typescript
- * const plugin = {...};
- * await add(plugin);
- * ```
- */
-export const add = client.add.bind(client);
-
-/**
- * Removes a plugin.
- *
- * ```typescript
- * await remove('myPlugin');
- * ```
- */
-export const remove = client.remove.bind(client);
-
-/**
- * Tracks user-defined event, with specified type, optional event properties and optional overwrites.
- *
- * ```typescript
- * // event tracking with event type only
- * track('Page Load');
- *
- * // event tracking with event type and additional event properties
- * track('Page Load', { loadTime: 1000 });
- *
- * // event tracking with event type, additional event properties, and overwritten event options
- * track('Page Load', { loadTime: 1000 }, { sessionId: -1 });
- *
- * // alternatively, this tracking method is awaitable
- * const result = await track('Page Load');
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const track = client.track.bind(client);
-
-/**
- * Alias for track()
- */
-export const logEvent = client.logEvent.bind(client);
-
-/**
- * Sends an identify event containing user property operations
- *
- * ```typescript
- * const id = new Identify();
- * id.set('colors', ['rose', 'gold']);
- * identify(id);
- *
- * // alternatively, this tracking method is awaitable
- * const result = await identify(id);
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const identify = client.identify.bind(client);
-
-/**
- * Sends a group identify event containing group property operations.
- *
- * ```typescript
- * const id = new Identify();
- * id.set('skills', ['js', 'ts']);
- * const groupType = 'org';
- * const groupName = 'engineering';
- * groupIdentify(groupType, groupName, id);
- *
- * // alternatively, this tracking method is awaitable
- * const result = await groupIdentify(groupType, groupName, id);
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const groupIdentify = client.groupIdentify.bind(client);
-export const setGroup = client.setGroup.bind(client);
-
-/**
- * Sends a revenue event containing revenue property operations.
- *
- * ```typescript
- * const rev = new Revenue();
- * rev.setRevenue(100);
- * revenue(rev);
- *
- * // alternatively, this tracking method is awaitable
- * const result = await revenue(rev);
- * console.log(result.event); // {...}
- * console.log(result.code); // 200
- * console.log(result.message); // "Event tracked successfully"
- * ```
- */
-export const revenue = client.revenue.bind(client);
-
-/**
- * Sets a new optOut config value. This toggles event tracking on/off.
- *
- *```typescript
- * // Stops tracking
- * setOptOut(true);
- *
- * // Starts/resumes tracking
- * setOptOut(false);
- * ```
- */
-export const setOptOut = client.setOptOut.bind(client);
-
-/**
- * Flush and send all the events which haven't been sent.
- *
- *```typescript
- * // Send all the unsent events
- * flush();
- * ```
- */
-export const flush = client.flush.bind(client);
+export default createInstance('$default');

--- a/packages/analytics-node/test/node-client.test.ts
+++ b/packages/analytics-node/test/node-client.test.ts
@@ -1,4 +1,4 @@
-import { AmplitudeNode } from '../src/node-client';
+import { AmplitudeNode, createInstance } from '../src/node-client';
 import * as core from '@amplitude/analytics-core';
 import { Status } from '@amplitude/analytics-types';
 
@@ -92,6 +92,23 @@ describe('node-client', () => {
       const result = await client.revenue(revenueObject);
       expect(result.code).toEqual(200);
       expect(send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createInstance', () => {
+    test('should return new instance', () => {
+      const instance = createInstance('amp');
+      expect(typeof instance.init).toBe('function');
+      expect(typeof instance.add).toBe('function');
+      expect(typeof instance.remove).toBe('function');
+      expect(typeof instance.track).toBe('function');
+      expect(typeof instance.logEvent).toBe('function');
+      expect(typeof instance.identify).toBe('function');
+      expect(typeof instance.groupIdentify).toBe('function');
+      expect(typeof instance.setGroup).toBe('function');
+      expect(typeof instance.revenue).toBe('function');
+      expect(typeof instance.setOptOut).toBe('function');
+      expect(typeof instance.flush).toBe('function');
     });
   });
 });

--- a/packages/analytics-types/src/client.ts
+++ b/packages/analytics-types/src/client.ts
@@ -1,0 +1,268 @@
+import { AmplitudeReturn } from './amplitude-promise';
+import { BaseEvent, EventOptions } from './base-event';
+import { BrowserConfig, Config, NodeConfig } from './config';
+import { Identify, Revenue } from './event';
+import { Plugin } from './plugin';
+import { Result } from './result';
+import { TransportType } from './transport';
+
+/**
+ * Initializes the Amplitude SDK with your apiKey, userId and optional configurations.
+ * This method must be called before any other operations.
+ *
+ * ```typescript
+ * await init(API_KEY, USER_ID, options).promise;
+ * ```
+ */
+type Init<T extends Config> = (apiKey: string, userId?: string, options?: T) => AmplitudeReturn<void>;
+
+/**
+ * Adds a new plugin.
+ *
+ * ```typescript
+ * const plugin = {
+ *   name: 'myPlugin',
+ *   type: PluginType.ENRICHMENT,
+ *   setup(config: Config) {
+ *     return;
+ *   },
+ *   execute(context: Event) {
+ *     return context;
+ *   },
+ * };
+ * amplitude.add(plugin);
+ * ```
+ */
+type Add = (plugin: Plugin) => AmplitudeReturn<void>;
+
+/**
+ * Removes a plugin.
+ *
+ * ```typescript
+ * amplitude.remove('myPlugin');
+ * ```
+ */
+type Remove = (pluginName: string) => AmplitudeReturn<void>;
+
+/**
+ * Tracks user-defined event, with specified type, optional event properties and optional overwrites.
+ *
+ * ```typescript
+ * // event tracking with event type only
+ * track('Page Load');
+ *
+ * // event tracking with event type and additional event properties
+ * track('Page Load', { loadTime: 1000 });
+ *
+ * // event tracking with event type, additional event properties, and overwritten event options
+ * track('Page Load', { loadTime: 1000 }, { sessionId: -1 });
+ *
+ * // alternatively, this tracking method is awaitable
+ * const result = await track('Page Load').promise;
+ * console.log(result.event); // {...}
+ * console.log(result.code); // 200
+ * console.log(result.message); // "Event tracked successfully"
+ * ```
+ */
+type Track = (
+  eventInput: BaseEvent | string,
+  eventProperties?: Record<string, any>,
+  eventOptions?: EventOptions,
+) => AmplitudeReturn<Result>;
+
+/**
+ * Alias for track()
+ */
+type LogEvent = Track;
+
+/**
+ * Sends an identify event containing user property operations
+ *
+ * ```typescript
+ * const id = new Identify();
+ * id.set('colors', ['rose', 'gold']);
+ * identify(id);
+ *
+ * // alternatively, this tracking method is awaitable
+ * const result = await identify(id).promise;
+ * console.log(result.event); // {...}
+ * console.log(result.code); // 200
+ * console.log(result.message); // "Event tracked successfully"
+ * ```
+ */
+type TrackIdentify = (
+  identify: Identify,
+  eventOptions?: EventOptions,
+  userId?: string,
+  deviceId?: string,
+) => AmplitudeReturn<Result>;
+
+/**
+ * Sends a group identify event containing group property operations.
+ *
+ * ```typescript
+ * const id = new Identify();
+ * id.set('skills', ['js', 'ts']);
+ * const groupType = 'org';
+ * const groupName = 'engineering';
+ * groupIdentify(groupType, groupName, id);
+ *
+ * // alternatively, this tracking method is awaitable
+ * const result = await groupIdentify(groupType, groupName, id).promise;
+ * console.log(result.event); // {...}
+ * console.log(result.code); // 200
+ * console.log(result.message); // "Event tracked successfully"
+ * ```
+ */
+type TrackGroupIdentify = (
+  groupType: string,
+  groupName: string | string[],
+  identify: Identify,
+  eventOptions?: EventOptions,
+  userId?: string,
+  deviceId?: string,
+) => AmplitudeReturn<Result>;
+
+type TrackSetGroup = (groupType: string, groupName: string | string[]) => AmplitudeReturn<Result>;
+
+/**
+ * Sends a revenue event containing revenue property operations.
+ *
+ * ```typescript
+ * const rev = new Revenue();
+ * rev.setRevenue(100);
+ * revenue(rev);
+ *
+ * // alternatively, this tracking method is awaitable
+ * const result = await revenue(rev).promise;
+ * console.log(result.event); // {...}
+ * console.log(result.code); // 200
+ * console.log(result.message); // "Event tracked successfully"
+ * ```
+ */
+type TrackRevenue = (revenue: Revenue, eventOptions?: EventOptions) => AmplitudeReturn<Result>;
+
+/**
+ * Sets a new optOut config value. This toggles event tracking on/off.
+ *
+ *```typescript
+ * // Stops tracking
+ * setOptOut(true);
+ *
+ * // Starts/resumes tracking
+ * setOptOut(false);
+ * ```
+ */
+type SetOptOut = (optOut: boolean) => void;
+
+export interface CoreClient<T extends Config = Config> {
+  init: Init<T>;
+  add: Add;
+  remove: Remove;
+  track: Track;
+  logEvent: LogEvent;
+  identify: TrackIdentify;
+  groupIdentify: TrackGroupIdentify;
+  setGroup: TrackSetGroup;
+  revenue: TrackRevenue;
+  setOptOut: SetOptOut;
+}
+
+/**
+ * Flush all unsent events.
+ *
+ *```typescript
+ * flush();
+ * ```
+ */
+type Flush = () => AmplitudeReturn<void>;
+export interface NodeClient extends CoreClient<NodeConfig> {
+  flush: Flush;
+}
+
+/**
+ * Returns current user ID.
+ *
+ * ```typescript
+ * const userId = getUserId();
+ * ```
+ */
+type GetUserId = () => string | undefined;
+
+/**
+ * Sets a new user ID.
+ *
+ * ```typescript
+ * setUserId('userId');
+ * ```
+ */
+type SetUserId = (userId: string) => void;
+
+/**
+ * Returns current device ID.
+ *
+ * ```typescript
+ * const deviceId = getDeviceId();
+ * ```
+ */
+type GetDeviceId = () => string | undefined;
+
+/**
+ * Sets a new device ID.
+ * When setting a custom device ID, make sure the value is sufficiently unique.
+ * A uuid is recommended.
+ *
+ * ```typescript
+ * setDeviceId('deviceId');
+ * ```
+ */
+type SetDeviceId = (deviceId: string) => void;
+
+/**
+ * Returns current session ID.
+ *
+ * ```typescript
+ * const sessionId = getSessionId();
+ * ```
+ */
+type GetSessionId = () => number | undefined;
+
+/**
+ * Sets a new session ID.
+ * When settign a custom session ID, make sure the value is in milliseconds since epoch (Unix Timestamp).
+ *
+ * ```typescript
+ * setSessionId(Date.now());
+ * ```
+ */
+type SetSessionId = (sessionId: number) => void;
+
+/**
+ *  Sets the network transport type for events.
+ *
+ * ```typescript
+ * // Use Fetch API
+ * setTransport('fetch');
+ *
+ * // Use XMLHttpRequest API
+ * setTransport('xhr');
+ *
+ * // Use navigator.sendBeacon API
+ * setTransport('beacon');
+ * ```
+ */
+type SetTransport = (transport: TransportType) => void;
+
+export interface BrowserClient extends CoreClient<BrowserConfig> {
+  getUserId: GetUserId;
+  setUserId: SetUserId;
+  getDeviceId: GetDeviceId;
+  setDeviceId: SetDeviceId;
+  getSessionId: GetSessionId;
+  setSessionId: SetSessionId;
+  setTransport: SetTransport;
+}
+
+type CreateInstance<T extends CoreClient<U>, U extends Config> = (instanceName: string) => T;
+export type CreateBrowserInstance = CreateInstance<BrowserClient, BrowserConfig>;
+export type CreateNodeInstance = CreateInstance<NodeClient, NodeConfig>;

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -1,5 +1,6 @@
 export { AmplitudeReturn } from './amplitude-promise';
 export { BaseEvent, EventOptions } from './base-event';
+export { BrowserClient, CoreClient, CreateBrowserInstance, CreateNodeInstance, NodeClient } from './client';
 export {
   BrowserConfig,
   BrowserOptions,

--- a/packages/analytics-types/src/proxy.ts
+++ b/packages/analytics-types/src/proxy.ts
@@ -10,4 +10,5 @@ export type QueueProxy = Array<ProxyItem>;
 
 export interface InstanceProxy {
   _q: QueueProxy;
+  _iq: Record<string, InstanceProxy>;
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -6,5 +6,6 @@
   "logLevel": "Error",
   "name": "Amplitude SDK",
   "out": "docs",
-  "readme": "./README.md"
+  "readme": "./README.md",
+  "disableSources": true
 }


### PR DESCRIPTION
### Summary

Adds support for multiple instance creation. Each instance has its own API_KEY, plugins, configurations.

```typescript
// this is the default instance
amplitude.init('asdf');
amplitude.track('event-1');

// this is the second instance
const amp2 = amplitude.createInstance();
amp2.init('qwerty', undefined, {
  serverUrl: 'https://domain.com',
});
amp2.track('event-2');
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
