### PR TITLE
fix: allow setting undefined user id via setUserId()

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -281,8 +281,8 @@ export const setDeviceId = client.setDeviceId.bind(client);
 
 /**
  * Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you
- * are doing. This can be used in conjunction with `setUserId(null)` to anonymize users after they log out.
- * With a null userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
+ * are doing. This can be used in conjunction with `setUserId(undefined)` to anonymize users after they log out.
+ * With an `unefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
  *
  * ```typescript
  * regenerateDeviceId();

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -44,7 +44,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     return this.config.userId;
   }
 
-  setUserId(userId: string) {
+  setUserId(userId: string | undefined) {
     this.config.userId = userId;
     updateCookies(this.config);
   }


### PR DESCRIPTION
### Summary

* Update `client.setUserId()` signature to allow unsetting user id by passing `undefined` value

```ts
// ✅ allowed
client.setUserId('user@amplitude.com');
client.setUserId(undefined);

// ❌ not allowed
client.setUserId();
```

Fixes: https://github.com/amplitude/Amplitude-TypeScript/issues/115

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
