### PR TITLE
fix: remove userId and deviceId from createIdentifyEvent and createGroupIdentifyEvent

### DIFF
--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -171,7 +171,7 @@ describe('browser-client', () => {
         },
       });
       const identifyObject = new core.Identify();
-      const result = await client.identify(identifyObject);
+      const result = await client.identify(identifyObject, { user_id: '123' });
       expect(result.code).toEqual(200);
       expect(send).toHaveBeenCalledTimes(1);
     });

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -40,20 +40,13 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
 
   logEvent = this.track.bind(this);
 
-  identify(identify: Identify, eventOptions?: EventOptions, userId?: string, deviceId?: string) {
-    const event = createIdentifyEvent(userId, deviceId, identify, eventOptions);
+  identify(identify: Identify, eventOptions?: EventOptions) {
+    const event = createIdentifyEvent(identify, eventOptions);
     return this.dispatch(event);
   }
 
-  groupIdentify(
-    groupType: string,
-    groupName: string | string[],
-    identify: Identify,
-    eventOptions?: EventOptions,
-    userId?: string,
-    deviceId?: string,
-  ) {
-    const event = createGroupIdentifyEvent(userId, deviceId, groupType, groupName, identify, eventOptions);
+  groupIdentify(groupType: string, groupName: string | string[], identify: Identify, eventOptions?: EventOptions) {
+    const event = createGroupIdentifyEvent(groupType, groupName, identify, eventOptions);
     return this.dispatch(event);
   }
 

--- a/packages/analytics-core/src/utils/event-builder.ts
+++ b/packages/analytics-core/src/utils/event-builder.ts
@@ -24,29 +24,17 @@ export const createTrackEvent = (
   };
 };
 
-export const createIdentifyEvent = (
-  userId: string | undefined,
-  deviceId: string | undefined,
-  identify: IIdentify,
-  eventOptions?: EventOptions,
-): IdentifyEvent => {
+export const createIdentifyEvent = (identify: IIdentify, eventOptions?: EventOptions): IdentifyEvent => {
   const identifyEvent: IdentifyEvent = {
     ...eventOptions,
     event_type: SpecialEventType.IDENTIFY,
     user_properties: identify.getUserProperties(),
-    user_id: userId,
   };
-
-  if (deviceId !== undefined && deviceId.length > 0) {
-    identifyEvent.device_id = deviceId;
-  }
 
   return identifyEvent;
 };
 
 export const createGroupIdentifyEvent = (
-  userId: string | undefined,
-  deviceId: string | undefined,
   groupType: string,
   groupName: string | string[],
   identify: IIdentify,
@@ -59,12 +47,7 @@ export const createGroupIdentifyEvent = (
     groups: {
       [groupType]: groupName,
     },
-    user_id: userId,
   };
-
-  if (deviceId !== undefined && deviceId.length > 0) {
-    groupIdentify.device_id = deviceId;
-  }
 
   return groupIdentify;
 };

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -1,7 +1,7 @@
 import { Event, Plugin, PluginType, Status } from '@amplitude/analytics-types';
 import { AmplitudeCore, Identify, Revenue } from '../src/index';
 import * as timeline from '../src/timeline';
-import { USER_ID, DEVICE_ID, useDefaultConfig } from './helpers/default';
+import { useDefaultConfig } from './helpers/default';
 
 describe('core-client', () => {
   const success = { event: { event_type: 'sample' }, code: 200, message: Status.Success };
@@ -31,7 +31,7 @@ describe('core-client', () => {
     test('should call identify', async () => {
       const dispatch = jest.spyOn(client, 'dispatch').mockReturnValueOnce(Promise.resolve(success));
       const identify: Identify = new Identify();
-      const response = await client.identify(identify, undefined, USER_ID, DEVICE_ID);
+      const response = await client.identify(identify, undefined);
       expect(response).toEqual(success);
       expect(dispatch).toHaveBeenCalledTimes(1);
     });
@@ -41,7 +41,7 @@ describe('core-client', () => {
     test('should call groupIdentify', async () => {
       const dispatch = jest.spyOn(client, 'dispatch').mockReturnValueOnce(Promise.resolve(success));
       const identify = new Identify();
-      const response = await client.groupIdentify('groupType', 'groupName', identify, undefined, USER_ID, DEVICE_ID);
+      const response = await client.groupIdentify('groupType', 'groupName', identify, undefined);
       expect(response).toEqual(success);
       expect(dispatch).toHaveBeenCalledTimes(1);
     });

--- a/packages/analytics-core/test/utils/event-builder.test.ts
+++ b/packages/analytics-core/test/utils/event-builder.test.ts
@@ -48,11 +48,9 @@ describe('event-builder', () => {
 
   describe('createIdentifyEvent', () => {
     test('should create event', () => {
-      const userId = 'userId';
-      const deviceId = 'deviceId';
       const identify = new Identify();
-      const eventOptions = { user_id: 'eventUserId' };
-      const event = createIdentifyEvent(userId, deviceId, identify, eventOptions);
+      const eventOptions = { user_id: 'userId', device_id: 'deviceId' };
+      const event = createIdentifyEvent(identify, eventOptions);
       expect(event).toEqual({
         event_type: SpecialEventType.IDENTIFY,
         user_properties: {},
@@ -62,14 +60,11 @@ describe('event-builder', () => {
     });
 
     test('should handle missing deviceId', () => {
-      const userId = undefined;
-      const deviceId = undefined;
       const identify = new Identify();
-      const event = createIdentifyEvent(userId, deviceId, identify);
+      const event = createIdentifyEvent(identify);
       expect(event).toEqual({
         event_type: SpecialEventType.IDENTIFY,
         user_properties: {},
-        user_id: undefined,
       });
     });
   });
@@ -93,13 +88,11 @@ describe('event-builder', () => {
 
   describe('createGroupIdentifyEvent', () => {
     test('should create event', () => {
-      const userId = 'userId';
-      const deviceId = 'deviceId';
       const groupType = 'groupType';
       const groupName = 'groupName';
       const identify = new Identify();
-      const eventOptions = { user_id: 'eventUserId' };
-      const event = createGroupIdentifyEvent(userId, deviceId, groupType, groupName, identify, eventOptions);
+      const eventOptions = { user_id: 'userId', device_id: 'deviceId' };
+      const event = createGroupIdentifyEvent(groupType, groupName, identify, eventOptions);
       expect(event).toEqual({
         event_type: SpecialEventType.GROUP_IDENTIFY,
         group_properties: {},
@@ -112,19 +105,16 @@ describe('event-builder', () => {
     });
 
     test('should handle missing deviceId', () => {
-      const userId = undefined;
-      const deviceId = undefined;
       const groupType = 'groupType';
       const groupName = 'groupName';
       const identify = new Identify();
-      const event = createGroupIdentifyEvent(userId, deviceId, groupType, groupName, identify);
+      const event = createGroupIdentifyEvent(groupType, groupName, identify);
       expect(event).toEqual({
         event_type: SpecialEventType.GROUP_IDENTIFY,
         group_properties: {},
         groups: {
           groupType: 'groupName',
         },
-        user_id: undefined,
       });
     });
   });


### PR DESCRIPTION
…oupIdentifyEvent

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This PR is to remove `userId` and `deviceId` from createIdentifyEvent and createGroupIdentifyEvent. `deviceId` and `userId` can be set through `eventOptions`.


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
