### PR TITLE
fix: remove Awaited type to support older versions of typescript

### DIFF
--- a/packages/analytics-browser/src/utils/snippet-helper.ts
+++ b/packages/analytics-browser/src/utils/snippet-helper.ts
@@ -17,7 +17,7 @@ export const convertProxyObjectToRealObject = <T>(instance: T, queue: QueueProxy
     const { name, args, resolve } = queue[i];
     const fn = instance && instance[name as keyof T];
     if (typeof fn === 'function') {
-      const result = fn.apply(instance, args) as AmplitudeReturn<Result>;
+      const result = fn.apply(instance, args) as AmplitudeReturn<Promise<Result>>;
       if (typeof resolve === 'function') {
         resolve(result?.promise);
       }

--- a/packages/analytics-core/src/utils/return-wrapper.ts
+++ b/packages/analytics-core/src/utils/return-wrapper.ts
@@ -1,7 +1,7 @@
 import { AmplitudeReturn } from '@amplitude/analytics-types';
 
-export const returnWrapper = <T extends (...args: any) => any>(fn: T) => {
-  return (...args: Parameters<T>): AmplitudeReturn<ReturnType<T>> => ({
+export const returnWrapper =
+  <T extends (...args: any) => any>(fn: T) =>
+  (...args: Parameters<T>): AmplitudeReturn<ReturnType<T>> => ({
     promise: fn(...args) as ReturnType<T>,
   });
-};

--- a/packages/analytics-core/src/utils/return-wrapper.ts
+++ b/packages/analytics-core/src/utils/return-wrapper.ts
@@ -1,7 +1,7 @@
 import { AmplitudeReturn } from '@amplitude/analytics-types';
 
-export const returnWrapper =
-  <T extends (...args: any) => any>(fn: T) =>
-  (...args: Parameters<T>): AmplitudeReturn<Awaited<ReturnType<T>>> => ({
+export const returnWrapper = <T extends (...args: any) => any>(fn: T) => {
+  return (...args: Parameters<T>): AmplitudeReturn<ReturnType<T>> => ({
     promise: fn(...args) as ReturnType<T>,
   });
+};

--- a/packages/analytics-types/src/amplitude-promise.ts
+++ b/packages/analytics-types/src/amplitude-promise.ts
@@ -1,3 +1,3 @@
 export interface AmplitudeReturn<T> {
-  promise: Promise<T>;
+  promise: T;
 }


### PR DESCRIPTION
### Summary

Fixes https://github.com/amplitude/Amplitude-TypeScript/issues/120

`Awaited` is only available starting TypeScript v4.5. This PR removes the use of `Awaited` type and replaces it with something effectively similar to support older versions of TypeScript.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
