### PR TITLE
fix: change auto page tracking to be opt in

### DIFF
--- a/packages/analytics-browser/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-browser/src/attribution/campaign-tracker.ts
@@ -34,7 +34,7 @@ export class CampaignTracker implements ICampaignTracker {
 
     this.disabled = Boolean(options.disabled);
     this.trackNewCampaigns = Boolean(options.trackNewCampaigns);
-    this.trackPageViews = options.trackPageViews === undefined || Boolean(options.trackPageViews);
+    this.trackPageViews = Boolean(options.trackPageViews);
     this.excludeReferrers = options.excludeReferrers ?? [];
     if (typeof location !== 'undefined') {
       this.excludeReferrers.unshift(location.hostname);

--- a/packages/analytics-browser/test/attribution/campaign-tracker.test.ts
+++ b/packages/analytics-browser/test/attribution/campaign-tracker.test.ts
@@ -101,6 +101,7 @@ describe('CampaignTracker', () => {
         storage: new MemoryStorage<Campaign>(),
         track: jest.fn(),
         onNewCampaign: jest.fn(),
+        trackPageViews: true,
       };
       const campaignTracker = new CampaignTracker(API_KEY, config);
       const campaignEvent = campaignTracker.createCampaignEvent({
@@ -150,7 +151,6 @@ describe('CampaignTracker', () => {
         track: jest.fn(),
         onNewCampaign: jest.fn(),
         initialEmptyValue: '(none)',
-        trackPageViews: false,
       };
       const campaignTracker = new CampaignTracker(API_KEY, config);
       const campaignEvent = campaignTracker.createCampaignEvent({


### PR DESCRIPTION
### Summary

auto page tracking to be off by default. turning this on by default increases the number of events sent.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
