### PR TITLE
fix: encode cookies and set top level domain

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -137,7 +137,8 @@ export const useBrowserConfig = async (
   options?: BrowserOptions,
 ): Promise<IBrowserConfig> => {
   const defaultConfig = getDefaultConfig();
-  const cookieStorage = await createCookieStorage(options);
+  const domain = options?.domain ?? (await getTopLevelDomain());
+  const cookieStorage = await createCookieStorage({ ...options, domain });
   const cookieName = getCookieName(apiKey);
   const cookies = await cookieStorage.get(cookieName);
   const queryParams = getQueryParams();
@@ -148,6 +149,7 @@ export const useBrowserConfig = async (
     cookieStorage,
     sessionManager,
     deviceId: createDeviceId(cookies?.deviceId, options?.deviceId, queryParams.deviceId),
+    domain,
     optOut: options?.optOut ?? Boolean(cookies?.optOut),
     sessionId: (await cookieStorage.get(cookieName))?.sessionId ?? options?.sessionId,
     storageProvider: await createEventsStorage(options),
@@ -207,4 +209,32 @@ export const createTransport = (transport?: TransportType) => {
     return new SendBeaconTransport();
   }
   return getDefaultConfig().transportProvider;
+};
+
+export const getTopLevelDomain = async (url?: string) => {
+  if (!(await new CookieStorage<string>().isEnabled()) || (!url && typeof location === 'undefined')) {
+    return '';
+  }
+
+  const host = url ?? location.hostname;
+  const parts = host.split('.');
+  const levels = [];
+  const storageKey = 'AMP_TLDTEST';
+
+  for (let i = parts.length - 2; i >= 0; --i) {
+    levels.push(parts.slice(i).join('.'));
+  }
+  for (let i = 0; i < levels.length; i++) {
+    const domain = levels[i];
+    const options = { domain: '.' + domain };
+    const storage = new CookieStorage<number>(options);
+    await storage.set(storageKey, 1);
+    const value = await storage.get(storageKey);
+    if (value) {
+      await storage.remove(storageKey);
+      return '.' + domain;
+    }
+  }
+
+  return '';
 };

--- a/packages/analytics-browser/src/storage/cookie.ts
+++ b/packages/analytics-browser/src/storage/cookie.ts
@@ -29,11 +29,16 @@ export class CookieStorage<T> implements Storage<T> {
   }
 
   async get(key: string): Promise<T | undefined> {
-    const value = await this.getRaw(key);
+    let value = await this.getRaw(key);
     if (!value) {
       return undefined;
     }
     try {
+      try {
+        value = decodeURIComponent(atob(value));
+      } catch {
+        // value not encoded
+      }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return JSON.parse(value);
     } catch {
@@ -61,7 +66,7 @@ export class CookieStorage<T> implements Storage<T> {
         date.setTime(date.getTime() + expires * 24 * 60 * 60 * 1000);
         expireDate = date;
       }
-      let str = `${key}=${JSON.stringify(value)}`;
+      let str = `${key}=${btoa(encodeURIComponent(JSON.stringify(value)))}`;
       if (expireDate) {
         str += `; expires=${expireDate.toUTCString()}`;
       }

--- a/packages/analytics-browser/test/storage/cookies.test.ts
+++ b/packages/analytics-browser/test/storage/cookies.test.ts
@@ -14,6 +14,13 @@ describe('cookies', () => {
       expect(await cookies.get('hello')).toBe(undefined);
     });
 
+    test('should return non-encoded value', async () => {
+      const cookies = new CookieStorage();
+      document.cookie = 'hello=world';
+      expect(await cookies.get('hello')).toBe(undefined);
+      await cookies.remove('world');
+    });
+
     test('should return cookie object value', async () => {
       const cookies = new CookieStorage<Record<string, number>>();
       await cookies.set('hello', { a: 1 });


### PR DESCRIPTION
### Summary

#### 1. Sets cookie domain to top level domain by default
* This allows cookie to be shared across subdomains

#### 2. Encodes cookie value when set.
* When reading, SDK tries to decode first, otherwise skips decoding and proceeds
* Skipping decoding allows SDK to be backwards compatible

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: Yes. Cookie domain are set to top level domain by default
