### PR TITLE
fix: added flush to snippet template

### DIFF
--- a/packages/analytics-browser/scripts/templates/browser-snippet.template.js
+++ b/packages/analytics-browser/scripts/templates/browser-snippet.template.js
@@ -85,6 +85,7 @@ const snippet = (integrity, version) => `
       'groupIdentify',
       'setGroup',
       'revenue',
+      'flush',
     ];
     function setUpProxy(instance) {
       function proxyMain(fn, isPromise) {


### PR DESCRIPTION
### Summary

Added flush api to snippet template. This allows flush api to be called before sdk is loaded, which is very unlikely. Not an urgent fix.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
