### PR TITLE
fix: handle error gracefully when identify is set with null

### DIFF
--- a/packages/analytics-core/src/utils/valid-properties.ts
+++ b/packages/analytics-core/src/utils/valid-properties.ts
@@ -28,6 +28,8 @@ export const isValidProperties = (property: string, value: any): boolean => {
         return false;
       }
     }
+  } else if (value === null || value === undefined) {
+    return false;
   } else if (typeof value === 'object') {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return isValidObject(value);

--- a/packages/analytics-core/test/identify.test.ts
+++ b/packages/analytics-core/test/identify.test.ts
@@ -166,4 +166,24 @@ describe('Identify class', () => {
 
     expect(identify.getUserProperties()).toStrictEqual(expectedProperties);
   });
+
+  test('should not allow to set a key to null', () => {
+    const identify = new Identify();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore bypassing ts rules to test unexpected input
+    identify.set('PROPERTY_NAME', null);
+    const expectedProperties = {};
+
+    expect(identify.getUserProperties()).toStrictEqual(expectedProperties);
+  });
+
+  test('should not allow to set a key to undefined', () => {
+    const identify = new Identify();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore bypassing ts rules to test unexpected input
+    identify.set('PROPERTY_NAME', undefined);
+    const expectedProperties = {};
+
+    expect(identify.getUserProperties()).toStrictEqual(expectedProperties);
+  });
 });

--- a/packages/analytics-core/test/utils/valid-properties.test.ts
+++ b/packages/analytics-core/test/utils/valid-properties.test.ts
@@ -1,6 +1,6 @@
 import { isValidProperties } from '../../src/utils/valid-properties';
 
-describe('validProperties', () => {
+describe('isValidProperties', () => {
   test('should pass on valid properties', () => {
     const validProperties = {
       keyForString: 'stringValue',
@@ -63,5 +63,13 @@ describe('validProperties', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     expect(isValidProperties(1 as any, validProperties)).toBe(false);
+  });
+
+  test('should return false for null value', () => {
+    expect(isValidProperties('key', null)).toBe(false);
+  });
+
+  test('should return false for undefined value', () => {
+    expect(isValidProperties('key', undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
### Summary

When identify is assigned a `null` value, make it no-op. `null` values of identify is ignored by the API.

Fixes #136

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
