### PR TITLE
fix: missing tracked events before init issue

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -50,10 +50,13 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     await this.add(new Context());
     await this.add(new Destination());
 
-    // Step 5: Track attributions
+    // Step 5: Set timeline ready for processing events
+    this.timeline.isReady = true;
+
+    // Step 6: Track attributions
     await this.runAttributionStrategy(options?.attribution, isNewSession);
 
-    // Step 6: Flush existing events, which might be collected by track before init
+    // Step 7: Flush existing events, which might be collected by track before init
     // This flush needs to run after plugin installation to gain the correct attributes
     await this.timeline.flush();
   }

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -52,6 +52,10 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
 
     // Step 5: Track attributions
     await this.runAttributionStrategy(options?.attribution, isNewSession);
+
+    // Step 6: Flush existing events, which might be collected by track before init
+    // This flush needs to run after plugin installation to gain the correct attributes
+    await this.timeline.flush();
   }
 
   async runAttributionStrategy(attributionConfig?: AttributionBrowserOptions, isNewSession = false) {

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -51,14 +51,14 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     await this.add(new Destination());
 
     // Step 5: Set timeline ready for processing events
+    // Send existing events, which might be collected by track before init
     this.timeline.isReady = true;
+    if (!this.config.optOut) {
+      this.timeline.scheduleApply(0);
+    }
 
     // Step 6: Track attributions
     await this.runAttributionStrategy(options?.attribution, isNewSession);
-
-    // Step 7: Flush existing events, which might be collected by track before init
-    // This flush needs to run after plugin installation to gain the correct attributes
-    await this.timeline.flush();
   }
 
   async runAttributionStrategy(attributionConfig?: AttributionBrowserOptions, isNewSession = false) {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -82,10 +82,6 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
       if (this.config?.optOut) {
         return buildResult(event, 0, OPT_OUT_MESSAGE);
       }
-      // if not init yet, only #push the events, #apply will be skipped in timeline
-      if (!this.config) {
-        return this.timeline.push(event);
-      }
       const result = await this.timeline.push(event);
       if (result.code === 200) {
         this.config.loggerProvider.log(result.message);

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -27,13 +27,14 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
   timeline: Timeline;
 
   constructor(name = '$default') {
+    this.timeline = new Timeline();
     this.name = name;
   }
 
   // NOTE: Do not use `_apiKey` and `_userId` here
   init(_apiKey: string | undefined, _userId: string | undefined, config: T) {
     this.config = config;
-    this.timeline = new Timeline();
+    this.timeline.reset();
     return Promise.resolve();
   }
 
@@ -75,6 +76,10 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
 
   async dispatch(event: Event) {
     try {
+      // if not init yet, only #push the events, #apply will be skipped in timeline
+      if (!this.config) {
+        return this.timeline.push(event, this.config);
+      }
       const result = await this.timeline.push(event, this.config);
       if (result.code === 200) {
         this.config.loggerProvider.log(result.message);

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -84,9 +84,9 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
       }
       // if not init yet, only #push the events, #apply will be skipped in timeline
       if (!this.config) {
-        return this.timeline.push(event, null);
+        return this.timeline.push(event);
       }
-      const result = await this.timeline.push(event, this.config);
+      const result = await this.timeline.push(event);
       if (result.code === 200) {
         this.config.loggerProvider.log(result.message);
       } else {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -17,6 +17,8 @@ import {
 } from './utils/event-builder';
 import { Timeline } from './timeline';
 import { buildResult } from './utils/result-builder';
+import { OPT_OUT_MESSAGE } from './messages';
+
 export class AmplitudeCore<T extends Config> implements CoreClient<T> {
   name: string;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -76,9 +78,13 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
 
   async dispatch(event: Event) {
     try {
+      // skip event processing if opt out
+      if (this.config?.optOut) {
+        return buildResult(event, 0, OPT_OUT_MESSAGE);
+      }
       // if not init yet, only #push the events, #apply will be skipped in timeline
       if (!this.config) {
-        return this.timeline.push(event, this.config);
+        return this.timeline.push(event, null);
       }
       const result = await this.timeline.push(event, this.config);
       if (result.code === 200) {

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -31,13 +31,20 @@ export class Timeline {
     return Promise.resolve();
   }
 
+  reset() {
+    this.plugins = [];
+  }
+
   push(event: Event, config: Config) {
     return new Promise<Result>((resolve) => {
-      if (config.optOut) {
+      if (config?.optOut) {
         resolve(buildResult(event, 0, OPT_OUT_MESSAGE));
         return;
       }
       this.queue.push([event, resolve]);
+      if (!config) {
+        return;
+      }
       this.scheduleApply(0);
     });
   }

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -39,12 +39,9 @@ export class Timeline {
     this.plugins = [];
   }
 
-  push(event: Event, config: Config | null) {
+  push(event: Event) {
     return new Promise<Result>((resolve) => {
       this.queue.push([event, resolve]);
-      if (config === null) {
-        return;
-      }
       this.scheduleApply(0);
     });
   }
@@ -113,7 +110,7 @@ export class Timeline {
     );
 
     const executeDestinations = destination.map((plugin) => {
-      return plugin.flush && plugin.flush(true);
+      return plugin.flush && plugin.flush();
     });
 
     await Promise.all(executeDestinations);

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -145,17 +145,17 @@ describe('core-client', () => {
       expect(push).toBeCalledTimes(0);
     });
 
-    test('should handle config is null', async () => {
-      const configWithoutInit = new AmplitudeCore();
-      const push = jest.spyOn(configWithoutInit.timeline, 'push').mockReturnValueOnce(new Promise(() => undefined));
+    test('should handle timeline is not ready', async () => {
+      const clientWithoutInit = new AmplitudeCore();
+      const push = jest.spyOn(clientWithoutInit.timeline, 'push').mockReturnValueOnce(new Promise(() => undefined));
       const event: Event = {
         event_type: 'event_type',
       };
 
-      const result = configWithoutInit.dispatch(event);
+      const result = clientWithoutInit.dispatch(event);
       expect(await promiseState(result)).toEqual('pending');
       expect(push).toBeCalledTimes(1);
-      expect(push).toBeCalledWith(event, null);
+      expect(push).toBeCalledWith(event);
     });
   });
 

--- a/packages/analytics-core/test/helpers/default.ts
+++ b/packages/analytics-core/test/helpers/default.ts
@@ -20,3 +20,25 @@ export const useDefaultConfig = (): Config => ({
 export const API_KEY = 'apiKey';
 export const USER_ID = 'userId';
 export const DEVICE_ID = 'deviceId';
+
+/*
+There is no way to figure out the state of a promise with normal API.
+This helper expose the state of a promise via race.
+https://stackoverflow.com/a/35820220
+
+Example:
+const a = Promise.resolve();
+const b = Promise.reject();
+const c = new Promise(() => {});
+
+promiseState(a).then(state => console.log(state)); // fulfilled
+promiseState(b).then(state => console.log(state)); // rejected
+promiseState(c).then(state => console.log(state)); // pending
+*/
+export function promiseState(p: Promise<any>) {
+  const t = {};
+  return Promise.race([p, t]).then(
+    (v) => (v === t ? 'pending' : 'fulfilled'),
+    () => 'rejected',
+  );
+}

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -74,18 +74,14 @@ describe('timeline', () => {
       event_type: `${id}:event_type`,
     });
     await Promise.all([
-      timeline.push(event(1), config).then(() => timeline.push(event(1.1), config)),
+      timeline.push(event(1)).then(() => timeline.push(event(1.1))),
+      timeline.push(event(2)).then(() => Promise.all([timeline.push(event(2.1)), timeline.push(event(2.2))])),
       timeline
-        .push(event(2), config)
-        .then(() => Promise.all([timeline.push(event(2.1), config), timeline.push(event(2.2), config)])),
-      timeline
-        .push(event(3), config)
+        .push(event(3))
         .then(() =>
           Promise.all([
-            timeline
-              .push(event(3.1), config)
-              .then(() => Promise.all([timeline.push(event(3.11), config), timeline.push(event(3.12), config)])),
-            timeline.push(event(3.2), config),
+            timeline.push(event(3.1)).then(() => Promise.all([timeline.push(event(3.11)), timeline.push(event(3.12))])),
+            timeline.push(event(3.2)),
           ]),
         ),
     ]);
@@ -105,8 +101,7 @@ describe('timeline', () => {
       const event = {
         event_type: 'hello',
       };
-      const config = null;
-      const result = timeline.push(event, config);
+      const result = timeline.push(event);
       expect(await promiseState(result)).toEqual('pending');
       expect(timeline.queue.length).toBe(1);
     });
@@ -149,10 +144,10 @@ describe('timeline', () => {
       };
       const config = useDefaultConfig();
       await timeline.register(plugin, config);
-      void timeline.push(createTrackEvent('a'), config);
-      void timeline.push(createTrackEvent('b'), config);
-      void timeline.push(createTrackEvent('c'), config);
-      void timeline.push(createTrackEvent('d'), config);
+      void timeline.push(createTrackEvent('a'));
+      void timeline.push(createTrackEvent('b'));
+      void timeline.push(createTrackEvent('c'));
+      void timeline.push(createTrackEvent('d'));
       expect(timeline.queue.length).toBe(4);
       await timeline.flush();
       expect(timeline.queue.length).toBe(0);

--- a/packages/analytics-node-test/test/index.test.ts
+++ b/packages/analytics-node-test/test/index.test.ts
@@ -55,6 +55,30 @@ describe('integration', () => {
       scope.done();
     });
 
+    test('should track event when init is called after', async () => {
+      const scope = nock(url).post(path).reply(200, success);
+
+      const pendingResponse = amplitude.track('test event', undefined, {
+        user_id: 'sdk.dev@amplitude.com',
+        device_id: 'deviceId',
+      }).promise;
+      await amplitude.init('API_KEY').promise;
+      const response = await pendingResponse;
+      expect(response.event).toEqual({
+        user_id: 'sdk.dev@amplitude.com',
+        device_id: 'deviceId',
+        time: number,
+        insert_id: uuid,
+        partner_id: undefined,
+        event_type: 'test event',
+        event_id: 0,
+        library: library,
+      });
+      expect(response.code).toBe(200);
+      expect(response.message).toBe(SUCCESS_MESSAGE);
+      scope.done();
+    });
+
     test('should track event with base event', async () => {
       const scope = nock(url).post(path).reply(200, success);
 

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -15,11 +15,11 @@ export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
     await this.add(new Destination());
 
     // Set timeline ready for processing events
+    // Send existing events, which might be collected by track before init
     this.timeline.isReady = true;
-
-    // Flush existing events, which might be collected by track before init
-    // This flush needs to run after plugin installation to gain the correct attributes
-    await this.timeline.flush();
+    if (!this.config.optOut) {
+      this.timeline.scheduleApply(0);
+    }
   }
 }
 

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -14,6 +14,9 @@ export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
     await this.add(new Context());
     await this.add(new Destination());
 
+    // Set timeline ready for processing events
+    this.timeline.isReady = true;
+
     // Flush existing events, which might be collected by track before init
     // This flush needs to run after plugin installation to gain the correct attributes
     await this.timeline.flush();

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -13,6 +13,10 @@ export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
 
     await this.add(new Context());
     await this.add(new Destination());
+
+    // Flush existing events, which might be collected by track before init
+    // This flush needs to run after plugin installation to gain the correct attributes
+    await this.timeline.flush();
   }
 }
 

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -59,6 +59,10 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
 
     // Step 5: Track attributions
     await this.runAttributionStrategy(options?.attribution, isNewSession);
+
+    // Step 6: Flush existing events, which might be collected by track before init
+    // This flush needs to run after plugin installation to gain the correct attributes
+    await this.timeline.flush();
   }
 
   async runAttributionStrategy(attributionConfig?: AttributionReactNativeOptions, isNewSession = false) {

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -57,10 +57,13 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     await this.add(new IdentityEventSender());
     await this.add(new Destination());
 
-    // Step 5: Track attributions
+    // Step 5: Set timeline ready for processing events
+    this.timeline.isReady = true;
+
+    // Step 6: Track attributions
     await this.runAttributionStrategy(options?.attribution, isNewSession);
 
-    // Step 6: Flush existing events, which might be collected by track before init
+    // Step 7: Flush existing events, which might be collected by track before init
     // This flush needs to run after plugin installation to gain the correct attributes
     await this.timeline.flush();
   }

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -58,14 +58,14 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     await this.add(new Destination());
 
     // Step 5: Set timeline ready for processing events
+    // Send existing events, which might be collected by track before init
     this.timeline.isReady = true;
+    if (!this.config.optOut) {
+      this.timeline.scheduleApply(0);
+    }
 
     // Step 6: Track attributions
     await this.runAttributionStrategy(options?.attribution, isNewSession);
-
-    // Step 7: Flush existing events, which might be collected by track before init
-    // This flush needs to run after plugin installation to gain the correct attributes
-    await this.timeline.flush();
   }
 
   async runAttributionStrategy(attributionConfig?: AttributionReactNativeOptions, isNewSession = false) {

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -27,7 +27,7 @@ export interface DestinationPlugin {
   type: PluginType.DESTINATION;
   setup(config: Config): Promise<undefined>;
   execute(context: Event): Promise<Result>;
-  flush?(useRetry?: boolean): Promise<void>;
+  flush?(): Promise<void>;
 }
 
 export type Plugin = BeforePlugin | EnrichmentPlugin | DestinationPlugin;

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -27,7 +27,7 @@ export interface DestinationPlugin {
   type: PluginType.DESTINATION;
   setup(config: Config): Promise<undefined>;
   execute(context: Event): Promise<Result>;
-  flush?(): Promise<void>;
+  flush?(useRetry?: boolean): Promise<void>;
 }
 
 export type Plugin = BeforePlugin | EnrichmentPlugin | DestinationPlugin;


### PR DESCRIPTION
### Summary
This PR addresses https://github.com/amplitude/Amplitude-TypeScript/issues/132, by:
- Elevate `timeline` initialization in the `AmplitudeCore` constructor
- When events are `track`ed before `init`, `push` the events to `timeline` without `apply`
- When `init` happens:
  - `reset` plugins in `timeline`
  - install plugins, this will make sure `init` also resets the plugins like the behavior before
  - `flush` all pushed events

### Test
To test this rare case, I use the following code to reproduce the issue and test the fix:
```
function App() {
  const buttonClickHandler = async () => {
    await track(`Button Click ${new Date().toISOString()}`, { name: 'App' })
    await init('api-key', 'marvin@amplitude.com')
  }

  const reinitButtonClickHandler = async () => {
    await init('api-key', 'marvin@amplitude.com')
    await track(`Reinit ${new Date().toISOString()}`, { name: 'App' })
  }

  return (
    <div className="App">
      <header className="App-header">
        <img src={logo} className="App-logo" alt="logo" />
        <h2>Amplitude Analytics Browser Example with React</h2>

        <button onClick={buttonClickHandler}>
          Track
        </button>

        <button onClick={reinitButtonClickHandler}>
          Re-init
        </button>
      </header>
    </div>
  );
}
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
No