### PR TITLE
fix: allow undefined storage provider

### DIFF
--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -44,7 +44,7 @@ export class Config implements IConfig {
   serverUrl: string | undefined;
   serverZone?: ServerZone;
   transportProvider: Transport;
-  storageProvider: Storage<Event[]>;
+  storageProvider?: Storage<Event[]>;
   useBatch: boolean;
 
   private _optOut = false;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -36,7 +36,7 @@ export class Destination implements DestinationPlugin {
     this.config = config;
 
     this.storageKey = `${STORAGE_PREFIX}_${this.config.apiKey.substring(0, 10)}`;
-    const unsent = await this.config.storageProvider.get(this.storageKey);
+    const unsent = await this.config.storageProvider?.get(this.storageKey);
     this.saveEvents(); // sets storage to '[]'
     if (unsent && unsent.length > 0) {
       void Promise.all(unsent.map((event) => this.execute(event))).catch();
@@ -248,6 +248,6 @@ export class Destination implements DestinationPlugin {
       return;
     }
     const events = Array.from(this.queue.map((context) => context.event));
-    void this.config.storageProvider.set(this.storageKey, events);
+    void this.config.storageProvider?.set(this.storageKey, events);
   }
 }

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -26,6 +26,14 @@ describe('destination', () => {
       const event = {
         event_type: 'hello',
       };
+      config.storageProvider = {
+        isEnabled: async () => true,
+        get: async () => undefined,
+        set: async () => undefined,
+        remove: async () => undefined,
+        reset: async () => undefined,
+        getRaw: async () => undefined,
+      };
       const get = jest.spyOn(config.storageProvider, 'get').mockResolvedValueOnce([event]);
       const execute = jest.spyOn(destination, 'execute').mockReturnValueOnce(
         Promise.resolve({
@@ -37,6 +45,15 @@ describe('destination', () => {
       await destination.setup(config);
       expect(get).toHaveBeenCalledTimes(1);
       expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    test('should be ok with undefined storage', async () => {
+      const destination = new Destination();
+      const config = useDefaultConfig();
+      config.storageProvider = undefined;
+      const execute = jest.spyOn(destination, 'execute');
+      await destination.setup(config);
+      expect(execute).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -328,6 +345,14 @@ describe('destination', () => {
       const destination = new Destination();
       destination.config = useDefaultConfig();
       destination.config.saveEvents = true;
+      destination.config.storageProvider = {
+        isEnabled: async () => true,
+        get: async () => undefined,
+        set: async () => undefined,
+        remove: async () => undefined,
+        reset: async () => undefined,
+        getRaw: async () => undefined,
+      };
       const set = jest.spyOn(destination.config.storageProvider, 'set').mockResolvedValueOnce(undefined);
       destination.saveEvents();
       expect(set).toHaveBeenCalledTimes(1);
@@ -337,9 +362,25 @@ describe('destination', () => {
       const destination = new Destination();
       destination.config = useDefaultConfig();
       destination.config.saveEvents = false;
+      destination.config.storageProvider = {
+        isEnabled: async () => true,
+        get: async () => undefined,
+        set: async () => undefined,
+        remove: async () => undefined,
+        reset: async () => undefined,
+        getRaw: async () => undefined,
+      };
       const set = jest.spyOn(destination.config.storageProvider, 'set').mockResolvedValueOnce(undefined);
       destination.saveEvents();
       expect(set).toHaveBeenCalledTimes(0);
+    });
+
+    test('should be ok with no storage provider', () => {
+      const destination = new Destination();
+      destination.config = useDefaultConfig();
+      destination.config.saveEvents = false;
+      destination.config.storageProvider = undefined;
+      expect(destination.saveEvents()).toBe(undefined);
     });
   });
 

--- a/packages/analytics-node/src/config.ts
+++ b/packages/analytics-node/src/config.ts
@@ -1,10 +1,10 @@
-import { NodeOptions, NodeConfig as INodeConfig, Event } from '@amplitude/analytics-types';
-import { Config, MemoryStorage } from '@amplitude/analytics-core';
+import { NodeOptions, NodeConfig as INodeConfig } from '@amplitude/analytics-types';
+import { Config } from '@amplitude/analytics-core';
 import { Http } from './transports/http';
 
 export class NodeConfig extends Config implements INodeConfig {
   constructor(apiKey: string, options?: NodeOptions) {
-    const storageProvider = options?.storageProvider ?? new MemoryStorage<Event[]>();
+    const storageProvider = options?.storageProvider;
     const transportProvider = options?.transportProvider ?? new Http();
 
     super({

--- a/packages/analytics-node/test/config.test.ts
+++ b/packages/analytics-node/test/config.test.ts
@@ -23,7 +23,7 @@ describe('config', () => {
         saveEvents: true,
         serverUrl: 'https://api2.amplitude.com/2/httpapi',
         serverZone: 'US',
-        storageProvider: new core.MemoryStorage(),
+        storageProvider: undefined,
         transportProvider: new Http(),
         useBatch: false,
       });
@@ -50,7 +50,7 @@ describe('config', () => {
         serverUrl: 'https://api2.amplitude.com/2/httpapi',
         serverZone: 'US',
         sessionId: undefined,
-        storageProvider: new core.MemoryStorage(),
+        storageProvider: undefined,
         transportProvider: new Http(),
         userId: undefined,
         useBatch: false,

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -24,7 +24,7 @@ export interface Config {
   saveEvents: boolean;
   serverUrl: string | undefined;
   serverZone?: ServerZone;
-  storageProvider: Storage<Event[]>;
+  storageProvider?: Storage<Event[]>;
   transportProvider: Transport;
   useBatch: boolean;
 }
@@ -56,7 +56,6 @@ export type InitOptions<T extends Config> =
       Omit<T, keyof Config> & {
         apiKey: string;
         transportProvider: Transport;
-        storageProvider: Storage<Event[]>;
       };
 
 export interface TrackingOptions {


### PR DESCRIPTION
### Summary

Sets storage provider in core config as optional. Allows SDK to be configured with no storage provider, effectively turning off persisting unsent events. 

Before the fix, the default config for Node SDK uses in memory storage with `saveEvents` is set to `true`. In memory storage for Node doesn't provide any value to Node but only hurts it by taking memory resources.

This fix allows Node SDK to set storage provider to `undefined`, turning of saving unsent events and fixing the issue on memory usage. SDK can still be configured to have a custom storage provider.

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
