### PR TITLE
fix: adds error handling for invalid api

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -435,7 +435,7 @@ describe('integration', () => {
         library: library,
       });
       expect(response.code).toBe(500);
-      expect(response.message).toBe('unknown');
+      expect(response.message).toBe('Invalid API key');
       scope.done();
     }, 10000);
 

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -435,7 +435,7 @@ describe('integration', () => {
         library: library,
       });
       expect(response.code).toBe(500);
-      expect(response.message).toBe('Invalid API key');
+      expect(response.message).toBe('Event rejected due to exceeded retry count');
       scope.done();
     }, 10000);
 

--- a/packages/analytics-core/src/messages.ts
+++ b/packages/analytics-core/src/messages.ts
@@ -3,3 +3,4 @@ export const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred';
 export const MAX_RETRIES_EXCEEDED_MESSAGE = 'Event rejected due to exceeded retry count';
 export const OPT_OUT_MESSAGE = 'Event skipped due to optOut config';
 export const MISSING_API_KEY_MESSAGE = 'Event rejected due to missing API key';
+export const INVALID_API_KEY = 'Invalid API key';

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -171,12 +171,7 @@ export class Destination implements DestinationPlugin {
   }
 
   handleInvalidResponse(res: InvalidResponse, list: Context[]) {
-    if (res.body.missingField) {
-      this.fulfillRequest(list, res.statusCode, res.body.error);
-      return;
-    }
-
-    if (res.body.error.startsWith(INVALID_API_KEY)) {
+    if (res.body.missingField || res.body.error.startsWith(INVALID_API_KEY)) {
       this.fulfillRequest(list, res.statusCode, res.body.error);
       return;
     }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -12,7 +12,13 @@ import {
   Status,
   SuccessResponse,
 } from '@amplitude/analytics-types';
-import { MISSING_API_KEY_MESSAGE, SUCCESS_MESSAGE, UNEXPECTED_ERROR_MESSAGE } from '../messages';
+import {
+  INVALID_API_KEY,
+  MAX_RETRIES_EXCEEDED_MESSAGE,
+  MISSING_API_KEY_MESSAGE,
+  SUCCESS_MESSAGE,
+  UNEXPECTED_ERROR_MESSAGE,
+} from '../messages';
 import { STORAGE_PREFIX } from '../constants';
 import { chunk } from '../utils/chunk';
 import { buildResult } from '../utils/result-builder';
@@ -63,7 +69,7 @@ export class Destination implements DestinationPlugin {
         context.attempts += 1;
         return true;
       }
-      void this.fulfillRequest([context], 500, Status.Unknown);
+      void this.fulfillRequest([context], 500, MAX_RETRIES_EXCEEDED_MESSAGE);
       return false;
     });
 
@@ -166,6 +172,11 @@ export class Destination implements DestinationPlugin {
 
   handleInvalidResponse(res: InvalidResponse, list: Context[]) {
     if (res.body.missingField) {
+      this.fulfillRequest(list, res.statusCode, res.body.error);
+      return;
+    }
+
+    if (res.body.error.startsWith(INVALID_API_KEY)) {
       this.fulfillRequest(list, res.statusCode, res.body.error);
       return;
     }

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -1,8 +1,12 @@
 import { Destination } from '../../src/plugins/destination';
 import { DestinationContext, Payload, Status } from '@amplitude/analytics-types';
 import { API_KEY, useDefaultConfig } from '../helpers/default';
-import { MISSING_API_KEY_MESSAGE, SUCCESS_MESSAGE, UNEXPECTED_ERROR_MESSAGE } from '../../src/messages';
-import { INVALID_API_KEY } from '../../src/messages';
+import {
+  INVALID_API_KEY,
+  MISSING_API_KEY_MESSAGE,
+  SUCCESS_MESSAGE,
+  UNEXPECTED_ERROR_MESSAGE,
+} from '../../src/messages';
 
 describe('destination', () => {
   describe('setup', () => {

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -2,6 +2,7 @@ import { Destination } from '../../src/plugins/destination';
 import { DestinationContext, Payload, Status } from '@amplitude/analytics-types';
 import { API_KEY, useDefaultConfig } from '../helpers/default';
 import { MISSING_API_KEY_MESSAGE, SUCCESS_MESSAGE, UNEXPECTED_ERROR_MESSAGE } from '../../src/messages';
+import { INVALID_API_KEY } from '../../src/messages';
 
 describe('destination', () => {
   describe('setup', () => {
@@ -396,6 +397,40 @@ describe('destination', () => {
       });
       expect(result.code).toBe(0);
       expect(result.message).toBe(UNEXPECTED_ERROR_MESSAGE);
+      expect(transportProvider.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not retry with invalid api key', async () => {
+      class Http {
+        send = jest.fn().mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: Status.Invalid,
+            statusCode: 400,
+            body: {
+              error: INVALID_API_KEY,
+            },
+          });
+        });
+      }
+      const transportProvider = new Http();
+      const destination = new Destination();
+      destination.retryTimeout = 10;
+      const config = {
+        ...useDefaultConfig(),
+        flushQueueSize: 2,
+        flushIntervalMillis: 500,
+        transportProvider,
+      };
+      await destination.setup(config);
+      const results = await Promise.all([
+        destination.execute({
+          event_type: 'event_type',
+        }),
+        destination.execute({
+          event_type: 'event_type',
+        }),
+      ]);
+      expect(results[0].code).toBe(400);
       expect(transportProvider.send).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/analytics-node-test/test/index.test.ts
+++ b/packages/analytics-node-test/test/index.test.ts
@@ -310,7 +310,7 @@ describe('integration', () => {
         library: library,
       });
       expect(response.code).toBe(500);
-      expect(response.message).toBe('Invalid API key');
+      expect(response.message).toBe('Event rejected due to exceeded retry count');
       scope.done();
     }, 10000);
 

--- a/packages/analytics-node-test/test/index.test.ts
+++ b/packages/analytics-node-test/test/index.test.ts
@@ -310,7 +310,7 @@ describe('integration', () => {
         library: library,
       });
       expect(response.code).toBe(500);
-      expect(response.message).toBe('unknown');
+      expect(response.message).toBe('Invalid API key');
       scope.done();
     }, 10000);
 


### PR DESCRIPTION
### Summary

* Adds error handling for invalid api. The determination is made by the Amplitude http/batch apis. Previously, this is not caught and is retried multiple times (until max retry) which is unnecessary.
* Adds better error messages for requests that failed due to max retry limits.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
