### PR TITLE
fix: removes deprecated uuid from event options

### DIFF
--- a/packages/analytics-types/src/base-event.ts
+++ b/packages/analytics-types/src/base-event.ts
@@ -34,7 +34,6 @@ export interface EventOptions {
   android_id?: string;
   language?: string;
   ip?: string;
-  uuid?: string;
   price?: number;
   quantity?: number;
   revenue?: number;


### PR DESCRIPTION
### Summary

Removes uuid event options

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No 😉 
