### PR TITLE
feat: add reset method for resetting userId and deviceId

### DIFF
--- a/packages/analytics-browser/scripts/templates/browser-snippet.template.js
+++ b/packages/analytics-browser/scripts/templates/browser-snippet.template.js
@@ -67,7 +67,6 @@ const snippet = (integrity, version) => `
     var funcs = [
       'getDeviceId',
       'setDeviceId',
-      'regenerateDeviceId',
       'getSessionId',
       'setSessionId',
       'getUserId',

--- a/packages/analytics-browser/scripts/templates/browser-snippet.template.js
+++ b/packages/analytics-browser/scripts/templates/browser-snippet.template.js
@@ -74,6 +74,7 @@ const snippet = (integrity, version) => `
       'setUserId',
       'setOptOut',
       'setTransport',
+      'reset',
     ];
     var funcsWithPromise = [
       'init',

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -97,6 +97,11 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     this.setDeviceId(deviceId);
   }
 
+  reset() {
+    this.setUserId(undefined);
+    this.regenerateDeviceId();
+  }
+
   getSessionId() {
     return this.config.sessionId;
   }
@@ -299,13 +304,25 @@ export const setDeviceId = client.setDeviceId.bind(client);
 /**
  * Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you
  * are doing. This can be used in conjunction with `setUserId(undefined)` to anonymize users after they log out.
- * With an `unefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
+ * With an `undefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
  *
  * ```typescript
  * regenerateDeviceId();
  * ```
  */
 export const regenerateDeviceId = client.regenerateDeviceId.bind(client);
+
+/**
+ * reset is a shortcut to anonymize users after they log out, by:
+ *   - setting userId to `undefined`
+ *   - regenerating a new random deviceId
+ * With an `unefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
+ *
+ * ```typescript
+ * reset();
+ * ```
+ */
+export const reset = client.reset.bind(client);
 
 /**
  * Returns current session ID.

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -9,6 +9,7 @@ export {
   init,
   logEvent,
   remove,
+  reset,
   revenue,
   setDeviceId,
   setGroup,

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -183,6 +183,20 @@ describe('browser-client', () => {
     });
   });
 
+  describe('reset', () => {
+    test('should reset user id and generate new device id config', async () => {
+      const client = new AmplitudeBrowser();
+      await client.init(API_KEY);
+      client.setUserId(USER_ID);
+      client.setDeviceId(DEVICE_ID);
+      expect(client.getUserId()).toBe(USER_ID);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
+      client.reset();
+      expect(client.getUserId()).toBe(undefined);
+      expect(client.getDeviceId()).not.toBe(DEVICE_ID);
+    });
+  });
+
   describe('getSessionId', () => {
     test('should get session id', async () => {
       const client = new AmplitudeBrowser();

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -10,6 +10,7 @@ import {
   init,
   logEvent,
   remove,
+  reset,
   Revenue,
   revenue,
   runQueuedFunctions,
@@ -37,6 +38,7 @@ describe('index', () => {
     expect(typeof remove).toBe('function');
     expect(typeof Revenue).toBe('function');
     expect(typeof revenue).toBe('function');
+    expect(typeof reset).toBe('function');
     expect(typeof runQueuedFunctions).toBe('function');
     expect(typeof setDeviceId).toBe('function');
     expect(typeof setGroup).toBe('function');

--- a/packages/analytics-react-native/src/index.ts
+++ b/packages/analytics-react-native/src/index.ts
@@ -9,6 +9,7 @@ export {
   init,
   logEvent,
   remove,
+  reset,
   revenue,
   setDeviceId,
   setGroup,

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -119,6 +119,11 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     this.setDeviceId(deviceId);
   }
 
+  reset() {
+    this.setUserId(undefined);
+    this.regenerateDeviceId();
+  }
+
   getSessionId() {
     return this.config.sessionId;
   }
@@ -285,13 +290,25 @@ export const setDeviceId = client.setDeviceId.bind(client);
 /**
  * Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you
  * are doing. This can be used in conjunction with `setUserId(undefined)` to anonymize users after they log out.
- * With an `unefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
+ * With an `undefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
  *
  * ```typescript
  * regenerateDeviceId();
  * ```
  */
 export const regenerateDeviceId = client.regenerateDeviceId.bind(client);
+
+/**
+ * reset is a shortcut to anonymize users after they log out, by:
+ *   - setting userId to `undefined`
+ *   - regenerating a new random deviceId
+ * With an `unefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
+ *
+ * ```typescript
+ * reset();
+ * ```
+ */
+export const reset = client.reset.bind(client);
 
 /**
  * Returns current session ID.

--- a/packages/analytics-react-native/test/index.test.ts
+++ b/packages/analytics-react-native/test/index.test.ts
@@ -10,6 +10,7 @@ import {
   init,
   logEvent,
   remove,
+  reset,
   Revenue,
   revenue,
   setDeviceId,
@@ -33,6 +34,7 @@ describe('index', () => {
     expect(typeof init).toBe('function');
     expect(typeof logEvent).toBe('function');
     expect(typeof remove).toBe('function');
+    expect(typeof reset).toBe('function');
     expect(typeof Revenue).toBe('function');
     expect(typeof revenue).toBe('function');
     expect(typeof setDeviceId).toBe('function');

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -194,6 +194,20 @@ describe('react-native-client', () => {
     });
   });
 
+  describe('reset', () => {
+    test('should reset user id and generate new device id config', async () => {
+      const client = new AmplitudeReactNative();
+      await client.init(API_KEY);
+      client.setUserId(USER_ID);
+      client.setDeviceId(DEVICE_ID);
+      expect(client.getUserId()).toBe(USER_ID);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
+      client.reset();
+      expect(client.getUserId()).toBe(undefined);
+      expect(client.getDeviceId()).not.toBe(DEVICE_ID);
+    });
+  });
+
   describe('getSessionId', () => {
     test('should get session id', async () => {
       const client = new AmplitudeReactNative();


### PR DESCRIPTION
### Summary
This PR adds and exposes the `#reset` method for user to reset `userId` and `deviceId`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
