### PR TITLE
fix: fixes auto gen of snippet instructions

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -34,7 +34,7 @@
     "publish": "node scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "GENERATE_SNIPPET=true yarn version-file && yarn build",
+    "version": "yarn version-file && GENERATE_SNIPPET=true yarn build",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {


### PR DESCRIPTION
### Summary

Fixes auto gen of snippet instructions. Prior to the fix the snippet instructions are not being generated for a new release.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
