### PR TITLE
fix: add callable queue when init is pending

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -22,7 +22,7 @@ describe('integration', () => {
   });
 
   // WARNING: This test has to run first
-  // It assumes tests under the assumption that amplitude has not be initiated at all
+  // This test is under the assumption that amplitude has not be initiated at all
   // To achieve this condition, it must run before any other tests
   describe('FIRST TEST: defer initialization', () => {
     test('should allow init to be called after other APIs', () => {

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -3,6 +3,7 @@ import { default as nock } from 'nock';
 import { success } from './responses';
 import 'isomorphic-fetch';
 import { path, SUCCESS_MESSAGE, url, uuidPattern } from './constants';
+import { PluginType } from '@amplitude/analytics-types';
 
 describe('integration', () => {
   const uuid: string = expect.stringMatching(uuidPattern) as string;
@@ -18,6 +19,66 @@ describe('integration', () => {
   afterEach(() => {
     // clean up cookies
     document.cookie = 'AMP_API_KEY=null; expires=-1';
+  });
+
+  // WARNING: This test has to run first
+  // It assumes tests under the assumption that amplitude has not be initiated at all
+  // To achieve this condition, it must run before any other tests
+  describe('FIRST TEST: defer initialization', () => {
+    test('should allow init to be called after other APIs', () => {
+      return new Promise((resolve) => {
+        const scope = nock(url).post(path).reply(200, success);
+
+        // NOTE: Values to assert on
+        const sessionId = Date.now() - 1000;
+        const userId = 'user@amplitude.com';
+        const deviceId = 'device-12345';
+        const platform = 'Jest';
+
+        amplitude.setUserId(userId);
+        amplitude.setDeviceId(deviceId);
+        amplitude.setSessionId(sessionId);
+        amplitude.add({
+          type: PluginType.ENRICHMENT,
+          name: 'custom',
+          setup: async () => {
+            return undefined;
+          },
+          execute: async (event) => {
+            event.platform = platform;
+            return event;
+          },
+        });
+        void amplitude.track('Event Before Init').promise.then((response) => {
+          expect(response.event).toEqual({
+            device_id: deviceId, // NOTE: Device ID was set before init
+            device_manufacturer: undefined,
+            event_id: 0,
+            event_type: 'Event Before Init',
+            insert_id: uuid,
+            ip: '$remote',
+            language: 'en-US',
+            library: library,
+            os_name: 'WebKit',
+            os_version: '537.36',
+            partner_id: undefined,
+            plan: undefined,
+            platform: platform, // NOTE: Session ID was set using a plugin added before init
+            session_id: sessionId, // NOTE: Session ID was set before init
+            time: number,
+            user_id: userId, // NOTE: User ID was set before init
+          });
+          expect(response.code).toBe(200);
+          expect(response.message).toBe(SUCCESS_MESSAGE);
+          scope.done();
+          resolve(undefined);
+        });
+        amplitude.init('API_KEY', undefined, {
+          ...opts,
+          serverUrl: url + path,
+        });
+      });
+    });
   });
 
   describe('track', () => {

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -1,4 +1,4 @@
-import { AmplitudeCore, Destination, Identify, Revenue, returnWrapper } from '@amplitude/analytics-core';
+import { AmplitudeCore, Destination, Identify, Revenue, returnWrapper, UUID } from '@amplitude/analytics-core';
 import {
   AdditionalBrowserOptions,
   AttributionBrowserOptions,
@@ -13,7 +13,7 @@ import {
 } from '@amplitude/analytics-types';
 import { convertProxyObjectToRealObject, isInstanceProxy } from './utils/snippet-helper';
 import { Context } from './plugins/context';
-import { useBrowserConfig, createTransport, createDeviceId, createFlexibleStorage } from './config';
+import { useBrowserConfig, createTransport, createFlexibleStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { CampaignTracker } from './attribution/campaign-tracker';
 import { getAnalyticsConnector } from './utils/analytics-connector';
@@ -92,44 +92,51 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
   }
 
   getUserId() {
-    return this.config.userId;
+    return this.config?.userId;
   }
 
   setUserId(userId: string | undefined) {
+    if (!this.config) {
+      this.q.push(this.setUserId.bind(this, userId));
+      return;
+    }
     this.config.userId = userId;
   }
 
   getDeviceId() {
-    return this.config.deviceId;
+    return this.config?.deviceId;
   }
 
   setDeviceId(deviceId: string) {
+    if (!this.config) {
+      this.q.push(this.setDeviceId.bind(this, deviceId));
+      return;
+    }
     this.config.deviceId = deviceId;
-  }
-
-  regenerateDeviceId() {
-    const deviceId = createDeviceId();
-    this.setDeviceId(deviceId);
   }
 
   reset() {
     this.setUserId(undefined);
-    this.regenerateDeviceId();
+    this.setDeviceId(UUID());
   }
 
   getSessionId() {
-    return this.config.sessionId;
+    return this.config?.sessionId;
   }
 
   setSessionId(sessionId: number) {
+    if (!this.config) {
+      this.q.push(this.setSessionId.bind(this, sessionId));
+      return;
+    }
     this.config.sessionId = sessionId;
   }
 
-  setOptOut(optOut: boolean) {
-    this.config.optOut = optOut;
-  }
-
   setTransport(transport: TransportType) {
+    if (!this.config) {
+      this.q.push(this.setTransport.bind(this, transport));
+      return;
+    }
     this.config.transportProvider = createTransport(transport);
   }
 
@@ -315,17 +322,6 @@ export const getDeviceId = client.getDeviceId.bind(client);
  * ```
  */
 export const setDeviceId = client.setDeviceId.bind(client);
-
-/**
- * Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you
- * are doing. This can be used in conjunction with `setUserId(undefined)` to anonymize users after they log out.
- * With an `undefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
- *
- * ```typescript
- * regenerateDeviceId();
- * ```
- */
-export const regenerateDeviceId = client.regenerateDeviceId.bind(client);
 
 /**
  * reset is a shortcut to anonymize users after they log out, by:

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -35,7 +35,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     await super._init(browserOptions);
 
     // Step 3: Manage session
-    let isNewSession = false;
+    let isNewSession = !this.config.lastEventTime;
     if (
       !this.config.sessionId ||
       (this.config.lastEventTime && Date.now() - this.config.lastEventTime > this.config.sessionTimeout)
@@ -43,7 +43,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
       // Either
       // 1) No previous session; or
       // 2) Previous session expired
-      this.config.sessionId = Date.now();
+      this.setSessionId(Date.now());
       isNewSession = true;
     }
 

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -130,6 +130,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
       return;
     }
     this.config.sessionId = sessionId;
+    this.config.lastEventTime = undefined;
   }
 
   setTransport(transport: TransportType) {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -181,6 +181,11 @@ describe('browser-client', () => {
       });
       expect(client.getUserId()).toBe(USER_ID);
     });
+
+    test('should handle undefined config', async () => {
+      const client = new AmplitudeBrowser();
+      expect(client.getUserId()).toBe(undefined);
+    });
   });
 
   describe('setUserId', () => {
@@ -193,6 +198,21 @@ describe('browser-client', () => {
       client.setUserId(USER_ID);
       expect(client.getUserId()).toBe(USER_ID);
     });
+
+    test('should defer set user id', () => {
+      return new Promise<void>((resolve) => {
+        const client = new AmplitudeBrowser();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(client.getUserId()).toBe('user@amplitude.com');
+            resolve();
+          });
+        client.setUserId('user@amplitude.com');
+      });
+    });
   });
 
   describe('getDeviceId', () => {
@@ -203,6 +223,11 @@ describe('browser-client', () => {
         ...attributionConfig,
       });
       expect(client.getDeviceId()).toBe(DEVICE_ID);
+    });
+
+    test('should handle undefined config', async () => {
+      const client = new AmplitudeBrowser();
+      expect(client.getDeviceId()).toBe(undefined);
     });
   });
 
@@ -215,16 +240,20 @@ describe('browser-client', () => {
       client.setDeviceId(DEVICE_ID);
       expect(client.getDeviceId()).toBe(DEVICE_ID);
     });
-  });
 
-  describe('regenerateDeviceId', () => {
-    test('should generate new device id config', async () => {
-      const client = new AmplitudeBrowser();
-      await client.init(API_KEY);
-      client.setDeviceId(DEVICE_ID);
-      expect(client.getDeviceId()).toBe(DEVICE_ID);
-      client.regenerateDeviceId();
-      expect(client.getDeviceId()).not.toBe(DEVICE_ID);
+    test('should defer set device id', () => {
+      return new Promise<void>((resolve) => {
+        const client = new AmplitudeBrowser();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(client.getDeviceId()).toBe('asdfg');
+            resolve();
+          });
+        client.setDeviceId('asdfg');
+      });
     });
   });
 
@@ -251,6 +280,11 @@ describe('browser-client', () => {
       });
       expect(client.getSessionId()).toBe(1);
     });
+
+    test('should handle undefined config', async () => {
+      const client = new AmplitudeBrowser();
+      expect(client.getSessionId()).toBe(undefined);
+    });
   });
 
   describe('setSessionId', () => {
@@ -262,16 +296,20 @@ describe('browser-client', () => {
       client.setSessionId(1);
       expect(client.getSessionId()).toBe(1);
     });
-  });
 
-  describe('setOptOut', () => {
-    test('should set opt out', async () => {
-      const client = new AmplitudeBrowser();
-      await client.init(API_KEY, undefined, {
-        ...attributionConfig,
+    test('should defer set session id', () => {
+      return new Promise<void>((resolve) => {
+        const client = new AmplitudeBrowser();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(client.getSessionId()).toBe(1);
+            resolve();
+          });
+        client.setSessionId(1);
       });
-      client.setOptOut(true);
-      expect(client.config.optOut).toBe(true);
     });
   });
 
@@ -285,6 +323,23 @@ describe('browser-client', () => {
       });
       client.setTransport(TransportType.Fetch);
       expect(createTransport).toHaveBeenCalledTimes(2);
+    });
+
+    test('should defer set transport', () => {
+      return new Promise<void>((resolve) => {
+        const fetch = new FetchTransport();
+        const createTransport = jest.spyOn(Config, 'createTransport').mockReturnValueOnce(fetch);
+        const client = new AmplitudeBrowser();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(createTransport).toHaveBeenCalledTimes(2);
+            resolve();
+          });
+        client.setTransport(TransportType.Fetch);
+      });
     });
   });
 

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -42,7 +42,6 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
     for (const queuedFunction of queuedFunctions) {
       await queuedFunction();
     }
-    return undefined;
   }
 
   track(eventInput: BaseEvent | string, eventProperties?: Record<string, any>, eventOptions?: EventOptions) {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -34,15 +34,15 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
     this.name = name;
   }
 
-  _init(config: T) {
+  async _init(config: T) {
     this.config = config;
     this.timeline.reset();
     const queuedFunctions = this.q;
     this.q = [];
-    queuedFunctions.map(async (queuedFunction) => {
+    for (const queuedFunction of queuedFunctions) {
       await queuedFunction();
-    });
-    return Promise.resolve();
+    }
+    return undefined;
   }
 
   track(eventInput: BaseEvent | string, eventProperties?: Record<string, any>, eventOptions?: EventOptions) {

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -47,7 +47,7 @@ export class Timeline {
   }
 
   scheduleApply(timeout: number) {
-    if (this.applying && this.isReady) return;
+    if (!this.isReady || this.applying) return;
     this.applying = true;
     setTimeout(() => {
       void this.apply(this.queue.shift()).then(() => {

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -87,6 +87,22 @@ describe('core-client', () => {
       await client.remove(plugin.name);
       expect(deregister).toBeCalledTimes(1);
     });
+
+    test('should queue add/remove', async () => {
+      const client = new AmplitudeCore();
+      const register = jest.spyOn(client.timeline, 'register');
+      const deregister = jest.spyOn(client.timeline, 'deregister');
+      await client.add({
+        name: 'example',
+        type: PluginType.BEFORE,
+        setup: jest.fn(),
+        execute: jest.fn(),
+      });
+      await client.remove('example');
+      await client._init(useDefaultConfig());
+      expect(register).toHaveBeenCalledTimes(1);
+      expect(deregister).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('dispatch', () => {
@@ -162,6 +178,13 @@ describe('core-client', () => {
   describe('setOptOut', () => {
     test('should update opt out value', () => {
       client.setOptOut(true);
+      expect(client.config.optOut).toBe(true);
+    });
+
+    test('should defer update opt out value', async () => {
+      const client = new AmplitudeCore();
+      client.setOptOut(true);
+      await client._init(useDefaultConfig());
       expect(client.config.optOut).toBe(true);
     });
   });

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -1,4 +1,4 @@
-import { AmplitudeCore, Destination, returnWrapper } from '@amplitude/analytics-core';
+import { AmplitudeCore, Destination, returnWrapper, UUID } from '@amplitude/analytics-core';
 import {
   ReactNativeConfig,
   Campaign,
@@ -7,7 +7,7 @@ import {
   AttributionReactNativeOptions,
 } from '@amplitude/analytics-types';
 import { Context } from './plugins/context';
-import { useReactNativeConfig, createDeviceId, createFlexibleStorage } from './config';
+import { useReactNativeConfig, createFlexibleStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { CampaignTracker } from './attribution/campaign-tracker';
 import { isNative } from './utils/platform';
@@ -90,10 +90,14 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
   }
 
   getUserId() {
-    return this.config.userId;
+    return this.config?.userId;
   }
 
   setUserId(userId: string | undefined) {
+    if (!this.config) {
+      this.q.push(this.setUserId.bind(this, userId));
+      return;
+    }
     this.config.userId = userId;
     getAnalyticsConnector()
       .identityStore.editIdentity()
@@ -104,10 +108,14 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
   }
 
   getDeviceId() {
-    return this.config.deviceId;
+    return this.config?.deviceId;
   }
 
   setDeviceId(deviceId: string) {
+    if (!this.config) {
+      this.q.push(this.setDeviceId.bind(this, deviceId));
+      return;
+    }
     this.config.deviceId = deviceId;
     getAnalyticsConnector()
       .identityStore.editIdentity()
@@ -117,26 +125,21 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
       .commit();
   }
 
-  regenerateDeviceId() {
-    const deviceId = createDeviceId();
-    this.setDeviceId(deviceId);
-  }
-
   reset() {
     this.setUserId(undefined);
-    this.regenerateDeviceId();
+    this.setDeviceId(UUID());
   }
 
   getSessionId() {
-    return this.config.sessionId;
+    return this.config?.sessionId;
   }
 
   setSessionId(sessionId: number) {
+    if (!this.config) {
+      this.q.push(this.setSessionId.bind(this, sessionId));
+      return;
+    }
     this.config.sessionId = sessionId;
-  }
-
-  setOptOut(optOut: boolean) {
-    this.config.optOut = optOut;
   }
 }
 
@@ -289,17 +292,6 @@ export const getDeviceId = client.getDeviceId.bind(client);
  * ```
  */
 export const setDeviceId = client.setDeviceId.bind(client);
-
-/**
- * Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you
- * are doing. This can be used in conjunction with `setUserId(undefined)` to anonymize users after they log out.
- * With an `undefined` userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.
- *
- * ```typescript
- * regenerateDeviceId();
- * ```
- */
-export const regenerateDeviceId = client.regenerateDeviceId.bind(client);
 
 /**
  * reset is a shortcut to anonymize users after they log out, by:

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -30,7 +30,7 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     await super._init(reactNativeOptions);
 
     // Step 3: Manage session
-    let isNewSession = false;
+    let isNewSession = !this.config.lastEventTime;
     if (
       !this.config.sessionId ||
       (this.config.lastEventTime && Date.now() - this.config.lastEventTime > this.config.sessionTimeout)
@@ -38,7 +38,7 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
       // Either
       // 1) No previous session; or
       // 2) Previous session expired
-      this.config.sessionId = Date.now();
+      this.setSessionId(Date.now());
       isNewSession = true;
     }
 

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -4,7 +4,6 @@ import * as CookieMigration from '../src/cookie-migration';
 import { Status, UserSession } from '@amplitude/analytics-types';
 import { isWeb } from '../src/utils/platform';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { AmplitudeBrowser } from '@amplitude/analytics-browser/src/browser-client';
 import { getAnalyticsConnector } from '@amplitude/analytics-browser/src/utils/analytics-connector';
 
 describe('react-native-client', () => {
@@ -122,7 +121,7 @@ describe('react-native-client', () => {
         deviceId: DEVICE_ID,
         optOut: false,
       });
-      const client = new AmplitudeBrowser();
+      const client = new AmplitudeReactNative();
       await client.init(API_KEY, USER_ID, {
         optOut: true,
         cookieStorage,
@@ -136,7 +135,7 @@ describe('react-native-client', () => {
     });
 
     test('should set up event bridge and track events', async () => {
-      const client = new AmplitudeBrowser();
+      const client = new AmplitudeReactNative();
       await client.init(API_KEY, USER_ID, {
         optOut: false,
         ...attributionConfig,
@@ -193,6 +192,11 @@ describe('react-native-client', () => {
       });
       expect(client.getUserId()).toBe(USER_ID);
     });
+
+    test('should handle undefined config', async () => {
+      const client = new AmplitudeReactNative();
+      expect(client.getUserId()).toBe(undefined);
+    });
   });
 
   describe('setUserId', () => {
@@ -205,6 +209,21 @@ describe('react-native-client', () => {
       client.setUserId(USER_ID);
       expect(client.getUserId()).toBe(USER_ID);
     });
+
+    test('should defer set user id', () => {
+      return new Promise<void>((resolve) => {
+        const client = new AmplitudeReactNative();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(client.getUserId()).toBe('user@amplitude.com');
+            resolve();
+          });
+        client.setUserId('user@amplitude.com');
+      });
+    });
   });
 
   describe('getDeviceId', () => {
@@ -215,6 +234,11 @@ describe('react-native-client', () => {
         ...attributionConfig,
       });
       expect(client.getDeviceId()).toBe(DEVICE_ID);
+    });
+
+    test('should handle undefined config', async () => {
+      const client = new AmplitudeReactNative();
+      expect(client.getDeviceId()).toBe(undefined);
     });
   });
 
@@ -227,16 +251,20 @@ describe('react-native-client', () => {
       client.setDeviceId(DEVICE_ID);
       expect(client.getDeviceId()).toBe(DEVICE_ID);
     });
-  });
 
-  describe('regenerateDeviceId', () => {
-    test('should generate new device id config', async () => {
-      const client = new AmplitudeReactNative();
-      await client.init(API_KEY);
-      client.setDeviceId(DEVICE_ID);
-      expect(client.getDeviceId()).toBe(DEVICE_ID);
-      client.regenerateDeviceId();
-      expect(client.getDeviceId()).not.toBe(DEVICE_ID);
+    test('should defer set device id', () => {
+      return new Promise<void>((resolve) => {
+        const client = new AmplitudeReactNative();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(client.getDeviceId()).toBe('asdfg');
+            resolve();
+          });
+        client.setDeviceId('asdfg');
+      });
     });
   });
 
@@ -263,6 +291,11 @@ describe('react-native-client', () => {
       });
       expect(client.getSessionId()).toBe(1);
     });
+
+    test('should handle undefined config', async () => {
+      const client = new AmplitudeReactNative();
+      expect(client.getSessionId()).toBe(undefined);
+    });
   });
 
   describe('setSessionId', () => {
@@ -273,6 +306,21 @@ describe('react-native-client', () => {
       });
       client.setSessionId(1);
       expect(client.getSessionId()).toBe(1);
+    });
+
+    test('should defer set session id', () => {
+      return new Promise<void>((resolve) => {
+        const client = new AmplitudeReactNative();
+        void client
+          .init(API_KEY, undefined, {
+            ...attributionConfig,
+          })
+          .then(() => {
+            expect(client.getSessionId()).toBe(1);
+            resolve();
+          });
+        client.setSessionId(1);
+      });
     });
   });
 


### PR DESCRIPTION
### Summary

Adds a queue to push callable functions that require `this.config` to be called. Once `this.config` is ready, invoke all functions in the queue.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
