### PR TITLE
fix: correct platform and add adid

### DIFF
--- a/examples/react-native/app/README.md
+++ b/examples/react-native/app/README.md
@@ -5,7 +5,7 @@
 ## Setup
 ```
 # cd into Amplitude-TypeScript/examples/react-native/app directory
-npm install
+yarn install
 cd ios
 pod install
 ```
@@ -18,13 +18,13 @@ pod install
 ### Android
 ```
 # cd into Amplitude-TypeScript/examples/react-native/app directory
-npm run android
+yarn run android
 ```
 
 ### iOS
 ```
 # cd into Amplitude-TypeScript/examples/react-native/app directory
-npm run ios
+yarn run ios
 ```
 
 ### Issues

--- a/examples/react-native/expo-app/README.md
+++ b/examples/react-native/expo-app/README.md
@@ -5,7 +5,7 @@
 ## Setup
 ```
 # cd into Amplitude-TypeScript/examples/react-native/expo-app directory
-npm install
+yarn install
 ```
 
 ## Run
@@ -17,17 +17,17 @@ npm install
 ### Android
 ```
 # cd into Amplitude-TypeScript/examples/react-native/expo-app directory
-npm run android
+yarn run android
 ```
 
 ### iOS
 ```
 # cd into Amplitude-TypeScript/examples/react-native/expo-app directory
-npm run ios
+yarn run ios
 ```
 
 ### Web
 ```
 # cd into Amplitude-TypeScript/examples/react-native/expo-app directory
-npm run web
+yarn run web
 ```

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeModule.kt
@@ -23,7 +23,7 @@ class AmplitudeReactNativeModule(private val reactContext: ReactApplicationConte
     private fun getApplicationContext(promise: Promise) {
         promise.resolve(WritableNativeMap().apply {
             putString("version", androidContextProvider.versionName)
-            putString("platform", androidContextProvider.osName)
+            putString("platform", androidContextProvider.platform)
             putString("language", androidContextProvider.language)
             putString("osName", androidContextProvider.osName)
             putString("osVersion", androidContextProvider.osVersion)
@@ -31,6 +31,7 @@ class AmplitudeReactNativeModule(private val reactContext: ReactApplicationConte
             putString("deviceManufacturer", androidContextProvider.manufacturer)
             putString("deviceModel", androidContextProvider.model)
             putString("carrier", androidContextProvider.carrier)
+            putString("adid", androidContextProvider.advertisingId)
         })
     }
 }

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AndroidContextProvider.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AndroidContextProvider.kt
@@ -38,6 +38,7 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
     val country: String?
     val versionName: String?
     val osName: String
+    val platform: String
     val osVersion: String
     val brand: String
     val manufacturer: String
@@ -52,6 +53,7 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
       advertisingId = fetchAdvertisingId()
       versionName = fetchVersionName()
       osName = OS_NAME
+      platform = PLATFORM
       osVersion = fetchOsVersion()
       brand = fetchBrand()
       manufacturer = fetchManufacturer()
@@ -322,6 +324,8 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
     get() = cachedInfo!!.versionName
   val osName: String
     get() = cachedInfo!!.osName
+  val platform: String
+    get() = cachedInfo!!.platform
   val osVersion: String
     get() = cachedInfo!!.osVersion
   val brand: String
@@ -402,6 +406,7 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
 
   companion object {
     const val OS_NAME = "android"
+    const val PLATFORM = "Android"
     const val SETTING_LIMIT_AD_TRACKING = "limit_ad_tracking"
     const val SETTING_ADVERTISING_ID = "advertising_id"
     fun generateUUID(): String {

--- a/packages/analytics-react-native/src/plugins/context.ts
+++ b/packages/analytics-react-native/src/plugins/context.ts
@@ -18,6 +18,7 @@ type NativeContext = {
   deviceManufacturer: string;
   deviceModel: string;
   carrier: string;
+  adid: string;
 };
 
 export interface AmplitudeReactNative {
@@ -73,6 +74,7 @@ export class Context implements BeforePlugin {
     const deviceModel = nativeContext?.deviceModel || this.uaResult.device.model || this.uaResult.os.name;
     const language = nativeContext?.language || getLanguage();
     const carrier = nativeContext?.carrier;
+    const adid = nativeContext?.adid;
 
     const event: Event = {
       user_id: this.config.userId,
@@ -88,6 +90,7 @@ export class Context implements BeforePlugin {
       ...(this.config.trackingOptions.language && { language: language }),
       ...(this.config.trackingOptions.carrier && { carrier: carrier }),
       ...(this.config.trackingOptions.ipAddress && { ip: IP_ADDRESS }),
+      ...(this.config.trackingOptions.adid && { adid: adid }),
       insert_id: UUID(),
       partner_id: this.config.partnerId,
       plan: this.config.plan,

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -46,7 +46,9 @@ export interface BrowserConfig extends Config {
   userId?: string;
 }
 
-export type ReactNativeConfig = BrowserConfig;
+export type ReactNativeConfig = Omit<BrowserConfig, 'trackingOptions'> & {
+  trackingOptions: ReactNativeTrackingOptions;
+};
 
 export type NodeConfig = Config;
 
@@ -71,6 +73,10 @@ export interface TrackingOptions {
   platform?: boolean;
   region?: boolean;
   versionName?: boolean;
+}
+
+export interface ReactNativeTrackingOptions extends TrackingOptions {
+  adid?: boolean;
 }
 
 export interface AdditionalBrowserOptions {


### PR DESCRIPTION
### Summary
- Update react-native readme to use `yarn` instead of `npm`
- Correct `platform` value
- Add `adid` option, see example:
```
trackingOptions: {
  adid: false
}
```

This PR addresses:
- https://github.com/amplitude/Amplitude-TypeScript/issues/177
- https://github.com/amplitude/Amplitude-TypeScript/issues/176
(@BrodaNoel)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
