### PR TITLE
fix: add event options to setGroup

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -61,8 +61,8 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
     return this.dispatch(event);
   }
 
-  setGroup(groupType: string, groupName: string | string[]) {
-    const event = createGroupEvent(groupType, groupName);
+  setGroup(groupType: string, groupName: string | string[], eventOptions?: EventOptions) {
+    const event = createGroupEvent(groupType, groupName, eventOptions);
     return this.dispatch(event);
   }
 

--- a/packages/analytics-core/src/utils/event-builder.ts
+++ b/packages/analytics-core/src/utils/event-builder.ts
@@ -52,11 +52,12 @@ export const createGroupIdentifyEvent = (
   return groupIdentify;
 };
 
-export const createGroupEvent = (groupType: string, groupName: string | string[]) => {
+export const createGroupEvent = (groupType: string, groupName: string | string[], eventOptions?: EventOptions) => {
   const identify = new Identify();
   identify.set(groupType, groupName);
 
   const groupEvent: IdentifyEvent = {
+    ...eventOptions,
     event_type: SpecialEventType.IDENTIFY,
     user_properties: identify.getUserProperties(),
     groups: {

--- a/packages/analytics-core/test/utils/event-builder.test.ts
+++ b/packages/analytics-core/test/utils/event-builder.test.ts
@@ -71,6 +71,24 @@ describe('event-builder', () => {
 
   describe('createGroupEvent', () => {
     test('should create group event', () => {
+      const eventOptions = { user_id: 'userId', device_id: 'deviceId' };
+      const event = createGroupEvent('a', 'b', eventOptions);
+      expect(event).toEqual({
+        event_type: SpecialEventType.IDENTIFY,
+        user_properties: {
+          $set: {
+            a: 'b',
+          },
+        },
+        groups: {
+          a: 'b',
+        },
+        user_id: 'userId',
+        device_id: 'deviceId',
+      });
+    });
+
+    test('should handle missing event options', () => {
       const event = createGroupEvent('a', 'b');
       expect(event).toEqual({
         event_type: SpecialEventType.IDENTIFY,


### PR DESCRIPTION
### Summary

Adds `eventOptions` to `setGroup`

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
