### PR TITLE
fix: prevent concurrent init calls

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -21,6 +21,12 @@ import { IdentityEventSender } from './plugins/identity';
 
 export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
   async init(apiKey: string, userId?: string, options?: BrowserOptions & AdditionalBrowserOptions) {
+    // Step 0: Block concurrent initialization
+    if (this.initializing) {
+      return;
+    }
+    this.initializing = true;
+
     // Step 1: Read cookies stored by old SDK
     const oldCookies = await parseOldCookies(apiKey, options);
 
@@ -64,6 +70,8 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     await this.add(new Context());
     await this.add(new IdentityEventSender());
     await this.add(new Destination());
+
+    this.initializing = false;
 
     // Step 5: Set timeline ready for processing events
     // Send existing events, which might be collected by track before init

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -74,6 +74,28 @@ describe('browser-client', () => {
       expect(parseOldCookies).toHaveBeenCalledTimes(1);
     });
 
+    test('should call prevent concurrent init executions', async () => {
+      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
+        optOut: false,
+      });
+      const useBrowserConfig = jest.spyOn(Config, 'useBrowserConfig');
+      const client = new AmplitudeBrowser();
+      await Promise.all([
+        client.init(API_KEY, USER_ID, {
+          ...attributionConfig,
+        }),
+        client.init(API_KEY, USER_ID, {
+          ...attributionConfig,
+        }),
+        client.init(API_KEY, USER_ID, {
+          ...attributionConfig,
+        }),
+      ]);
+      // NOTE: `parseOldCookies` and `useBrowserConfig` are only called once despite multiple init calls
+      expect(parseOldCookies).toHaveBeenCalledTimes(1);
+      expect(useBrowserConfig).toHaveBeenCalledTimes(1);
+    });
+
     test('should track attributions', async () => {
       const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
         optOut: false,

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -20,6 +20,7 @@ import { buildResult } from './utils/result-builder';
 import { OPT_OUT_MESSAGE } from './messages';
 
 export class AmplitudeCore<T extends Config> implements CoreClient<T> {
+  initializing = false;
   name: string;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -5,6 +5,12 @@ import { useNodeConfig } from './config';
 
 export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
   async init(apiKey: string, options?: NodeOptions) {
+    // Step 0: Block concurrent initialization
+    if (this.initializing) {
+      return;
+    }
+    this.initializing = true;
+
     const nodeOptions = useNodeConfig(apiKey, {
       ...options,
     });
@@ -13,6 +19,8 @@ export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
 
     await this.add(new Context());
     await this.add(new Destination());
+
+    this.initializing = false;
 
     // Set timeline ready for processing events
     // Send existing events, which might be collected by track before init

--- a/packages/analytics-node/test/node-client.test.ts
+++ b/packages/analytics-node/test/node-client.test.ts
@@ -1,6 +1,7 @@
 import { AmplitudeNode } from '../src/node-client';
 import * as core from '@amplitude/analytics-core';
 import { Status } from '@amplitude/analytics-types';
+import * as Config from '../src/config';
 
 describe('node-client', () => {
   const API_KEY = 'API_KEY';
@@ -12,6 +13,14 @@ describe('node-client', () => {
         flushIntervalMillis: 1000,
       });
       expect(client.config).toBeDefined();
+    });
+
+    test('should call prevent concurrent init executions', async () => {
+      const client = new AmplitudeNode();
+      const useNodeConfig = jest.spyOn(Config, 'useNodeConfig');
+      await Promise.all([client.init(API_KEY), client.init(API_KEY), client.init(API_KEY)]);
+      // NOTE: `useNodeConfig` is only called once despite multiple init calls
+      expect(useNodeConfig).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -16,6 +16,12 @@ import { getAnalyticsConnector } from './utils/analytics-connector';
 
 export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
   async init(apiKey: string, userId?: string, options?: ReactNativeOptions & AdditionalReactNativeOptions) {
+    // Step 0: Block concurrent initialization
+    if (this.initializing) {
+      return;
+    }
+    this.initializing = true;
+
     // Step 1: Read cookies stored by old SDK
     const oldCookies = await parseOldCookies(apiKey, options);
 
@@ -59,6 +65,8 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     await this.add(new Context());
     await this.add(new IdentityEventSender());
     await this.add(new Destination());
+
+    this.initializing = false;
 
     // Step 5: Set timeline ready for processing events
     // Send existing events, which might be collected by track before init


### PR DESCRIPTION
### Summary

Prevents concurrent init calls for the same amplitude instance

Previously, the following code performs initialization multiple times. This leads to race conditions on 1) reading from storage; 2) resetting timeline state; and 3) installing plugins

```ts
amplitude.init(API_KEY); // performs full init
amplitude.init(API_KEY); // performs full init
amplitude.init(API_KEY); // performs full init
```

With this fix, succeeding `init` calls while one execution is pending exits early.

```ts
amplitude.init(API_KEY); // performs full init
amplitude.init(API_KEY); // returns early
amplitude.init(API_KEY); // returns early
```

However, serial `init` calls retains status quo behavior.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
