### PR TITLE
fix: handle parsing malformed query parameters for web attribution

### DIFF
--- a/packages/analytics-browser/src/utils/query-params.ts
+++ b/packages/analytics-browser/src/utils/query-params.ts
@@ -5,12 +5,22 @@ export const getQueryParams = (): Record<string, string | undefined> => {
   }
   const pairs = window.location.search.substring(1).split('&').filter(Boolean);
   const params = pairs.reduce<Record<string, string | undefined>>((acc, curr) => {
-    const [key, value = ''] = curr.split('=', 2);
+    const query = curr.split('=', 2);
+    const key = tryDecodeURIComponent(query[0]);
+    const value = tryDecodeURIComponent(query[1]);
     if (!value) {
       return acc;
     }
-    acc[decodeURIComponent(key)] = decodeURIComponent(value);
+    acc[key] = value;
     return acc;
   }, {});
   return params;
+};
+
+export const tryDecodeURIComponent = (value = '') => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return '';
+  }
 };

--- a/packages/analytics-browser/test/utils/query-params.test.ts
+++ b/packages/analytics-browser/test/utils/query-params.test.ts
@@ -2,27 +2,38 @@ import { getQueryParams } from '../../src/utils/query-params';
 
 describe('query-params', () => {
   describe('getQueryParams', () => {
-    beforeEach(() => {
+    beforeAll(() => {
       Object.defineProperty(window, 'location', {
         value: {
-          search: '?a=1&b=2%20test&&c%24=hello&d',
+          search: '',
+          writable: true,
         },
       });
     });
 
-    beforeEach(() => {
+    afterAll(() => {
       Object.defineProperty(window, 'location', {
-        value: undefined,
+        value: {
+          search: '',
+          writable: false,
+        },
       });
     });
 
     test('should parse query params', () => {
+      window.location.search = '?a=1&b=2%20test&&c%24=hello&d';
       const params = getQueryParams();
       expect(params).toEqual({
         a: '1',
         b: '2 test',
         c$: 'hello',
       });
+    });
+
+    test('should parse malformed uri', () => {
+      window.location.search = '?fb=X+%EF%BF%BD%93+C';
+      const params = getQueryParams();
+      expect(params).toEqual({});
     });
   });
 });

--- a/packages/analytics-react-native/src/utils/query-params.ts
+++ b/packages/analytics-react-native/src/utils/query-params.ts
@@ -1,18 +1,26 @@
-import { isNative } from './platform';
-
 export const getQueryParams = (): Record<string, string | undefined> => {
   /* istanbul ignore if */
-  if (isNative() || typeof window === 'undefined') {
+  if (typeof window === 'undefined') {
     return {};
   }
   const pairs = window.location.search.substring(1).split('&').filter(Boolean);
   const params = pairs.reduce<Record<string, string | undefined>>((acc, curr) => {
-    const [key, value = ''] = curr.split('=', 2);
+    const query = curr.split('=', 2);
+    const key = tryDecodeURIComponent(query[0]);
+    const value = tryDecodeURIComponent(query[1]);
     if (!value) {
       return acc;
     }
-    acc[decodeURIComponent(key)] = decodeURIComponent(value);
+    acc[key] = value;
     return acc;
   }, {});
   return params;
+};
+
+export const tryDecodeURIComponent = (value = '') => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return '';
+  }
 };

--- a/packages/analytics-react-native/test/utils/query-params.test.ts
+++ b/packages/analytics-react-native/test/utils/query-params.test.ts
@@ -3,17 +3,21 @@ import { isWeb } from '../../src/utils/platform';
 
 describe('query-params', () => {
   describe('getQueryParams', () => {
-    beforeEach(() => {
+    beforeAll(() => {
       Object.defineProperty(window, 'location', {
         value: {
-          search: '?a=1&b=2%20test&&c%24=hello&d',
+          search: '',
+          writable: true,
         },
       });
     });
 
-    beforeEach(() => {
+    afterAll(() => {
       Object.defineProperty(window, 'location', {
-        value: undefined,
+        value: {
+          search: '',
+          writable: false,
+        },
       });
     });
 
@@ -22,12 +26,19 @@ describe('query-params', () => {
      */
     if (isWeb()) {
       test('should parse query params', () => {
+        window.location.search = '?a=1&b=2%20test&&c%24=hello&d';
         const params = getQueryParams();
         expect(params).toEqual({
           a: '1',
           b: '2 test',
           c$: 'hello',
         });
+      });
+
+      test('should parse malformed uri', () => {
+        window.location.search = '?fb=X+%EF%BF%BD%93+C';
+        const params = getQueryParams();
+        expect(params).toEqual({});
       });
     } else {
       test('empty test case so jest doesnt fail', () => {


### PR DESCRIPTION
### Summary

Amplitude SDK throws an error when parsing malformed query parameters. The fix is to add try/catch around the parsing logic and returning an empty string if query parameters are malformed

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No