### PR TITLE
fix: fix groupIdentify code example snippets

### DIFF
--- a/packages/analytics-browser/README.md
+++ b/packages/analytics-browser/README.md
@@ -125,10 +125,10 @@ import { Identify, groupIdentify } from '@amplitude/analytics-browser';
 
 const groupType = 'plan';
 const groupName = 'enterprise';
-const event = new Identify()
-event.set('key1', 'value1');
+const identity = new Identify()
+identity.set('key1', 'value1');
 
-groupIdentify(groupType, groupName, identify);
+groupIdentify(groupType, groupName, identity);
 ```
 
 ### Track Revenue

--- a/packages/analytics-node/README.md
+++ b/packages/analytics-node/README.md
@@ -111,10 +111,10 @@ import { Identify, groupIdentify } from '@amplitude/analytics-node';
 
 const groupType = 'plan';
 const groupName = 'enterprise';
-const event = new Identify()
-event.set('key1', 'value1');
+const identity = new Identify()
+identity.set('key1', 'value1');
 
-groupIdentify(groupType, groupName, identify);
+groupIdentify(groupType, groupName, identity);
 ```
 
 ### Track Revenue

--- a/packages/analytics-react-native/README.md
+++ b/packages/analytics-react-native/README.md
@@ -109,10 +109,10 @@ import { Identify, groupIdentify } from '@amplitude/analytics-react-native';
 
 const groupType = 'plan';
 const groupName = 'enterprise';
-const event = new Identify()
-event.set('key1', 'value1');
+const identity = new Identify()
+identity.set('key1', 'value1');
 
-groupIdentify(groupType, groupName, identify);
+groupIdentify(groupType, groupName, identity);
 ```
 
 ### Track Revenue


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR is fixing a mistake in all subpackage Readmes in `groupIdentify` section. The original snippet defined an `event` but used `identify` const in the `groupIdentify` call. This PR unifies the const to be the same. I also took the liberty to change the common naming from `identify` to `identity` as I believe the semantics matter and variables and consts should not be named by what they do (e.g. `identify`), but what they are (e.g. `identity`).


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
