### PR TITLE
feat: add support for auto page view tracking

### DIFF
--- a/packages/analytics-browser/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-browser/src/attribution/campaign-tracker.ts
@@ -32,7 +32,7 @@ export class CampaignTracker implements ICampaignTracker {
     this.disabled = Boolean(options.disabled);
     this.excludeReferrers = options.excludeReferrers ?? [];
     this.initialEmptyValue = options.initialEmptyValue ?? EMPTY_VALUE;
-    this.resetSessionOnNewCampaign = options.resetSessionOnNewCampaign ?? options.trackNewCampaigns === true;
+    this.resetSessionOnNewCampaign = options.resetSessionOnNewCampaign ?? options.trackNewCampaigns;
 
     if (typeof location !== 'undefined') {
       this.excludeReferrers.unshift(location.hostname);

--- a/packages/analytics-browser/src/plugins/attribution.ts
+++ b/packages/analytics-browser/src/plugins/attribution.ts
@@ -1,0 +1,51 @@
+import {
+  BeforePlugin,
+  BrowserConfig,
+  Event,
+  PluginType,
+  AdditionalBrowserOptions,
+  PluginSetupOptions,
+  Campaign,
+} from '@amplitude/analytics-types';
+import { CampaignTracker } from '../attribution/campaign-tracker';
+import { AmplitudeBrowser } from '../browser-client';
+import { createFlexibleStorage } from '../config';
+
+export class Attribution implements BeforePlugin {
+  name = 'attribution';
+  type = PluginType.BEFORE as const;
+
+  constructor(private readonly options: AdditionalBrowserOptions = {}) {}
+
+  async setup(config: BrowserConfig, options: PluginSetupOptions): Promise<undefined> {
+    const attributionConfig = this.options.attribution ?? {};
+
+    if (attributionConfig.disabled) {
+      return Promise.resolve(undefined);
+    }
+
+    const instance = options.instance as AmplitudeBrowser;
+    const storage = await createFlexibleStorage<Campaign>(config);
+
+    const campaignTracker = new CampaignTracker(config.apiKey, {
+      ...attributionConfig,
+      storage,
+    });
+
+    void instance.timeline.ready.then(() =>
+      campaignTracker.onStateChange(async () => {
+        void campaignTracker.trackOn('onAttribution', (currentCampaign) => {
+          if (campaignTracker.resetSessionOnNewCampaign) {
+            instance.setSessionId(Date.now());
+          }
+          return instance.track(campaignTracker.createCampaignEvent(currentCampaign));
+        });
+      }),
+    );
+    return Promise.resolve(undefined);
+  }
+
+  async execute(context: Event): Promise<Event> {
+    return context;
+  }
+}

--- a/packages/analytics-browser/src/plugins/pageTracking.ts
+++ b/packages/analytics-browser/src/plugins/pageTracking.ts
@@ -1,0 +1,66 @@
+import {
+  BeforePlugin,
+  BrowserConfig,
+  Event,
+  PluginType,
+  AdditionalBrowserOptions,
+  PluginSetupOptions,
+  Campaign,
+  BaseEvent,
+} from '@amplitude/analytics-types';
+import { CampaignTracker } from '../attribution/campaign-tracker';
+import { AmplitudeBrowser } from '../browser-client';
+import { createFlexibleStorage } from '../config';
+
+export class PageTracking implements BeforePlugin {
+  name = 'pageTracking';
+  type = PluginType.BEFORE as const;
+
+  constructor(private readonly options: AdditionalBrowserOptions = {}) {}
+
+  async setup(config: BrowserConfig, options: PluginSetupOptions): Promise<undefined> {
+    const attributionConfig = this.options.attribution ?? {};
+    const pageTrackingConfig = this.options.trackPageViews ?? false;
+
+    if (!pageTrackingConfig) {
+      return Promise.resolve(undefined);
+    }
+
+    const instance = options.instance as AmplitudeBrowser;
+    const storage = await createFlexibleStorage<Campaign>(config);
+
+    let { filter = undefined } = typeof pageTrackingConfig === 'object' ? pageTrackingConfig : {};
+
+    if (typeof filter === 'undefined' && attributionConfig.trackPageViews === true) {
+      filter = 'onAttribution';
+    }
+
+    const campaignTracker = new CampaignTracker(config.apiKey, {
+      ...attributionConfig,
+      storage,
+    });
+
+    void instance.timeline.ready.then(() =>
+      campaignTracker.onStateChange(async () => {
+        void campaignTracker.trackOn(filter, () => instance.track(this.createPageViewEvent()));
+      }),
+    );
+    return Promise.resolve(undefined);
+  }
+
+  async execute(context: Event): Promise<Event> {
+    return context;
+  }
+
+  private createPageViewEvent(): Event {
+    const pageViewEvent: BaseEvent = {
+      event_type: 'Page View',
+      event_properties: {
+        page_title: /* istanbul ignore next */ (typeof document !== 'undefined' && document.title) || '',
+        page_location: /* istanbul ignore next */ (typeof location !== 'undefined' && location.href) || '',
+        page_path: /* istanbul ignore next */ (typeof location !== 'undefined' && location.pathname) || '',
+      },
+    };
+    return pageViewEvent;
+  }
+}

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -96,37 +96,6 @@ describe('browser-client', () => {
       expect(useBrowserConfig).toHaveBeenCalledTimes(1);
     });
 
-    test('should track attributions', async () => {
-      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
-        optOut: false,
-      });
-      const client = new AmplitudeBrowser();
-      const runAttributionStrategy = jest
-        .spyOn(client, 'runAttributionStrategy')
-        .mockReturnValueOnce(Promise.resolve(undefined));
-      await client.init(API_KEY, USER_ID);
-      expect(parseOldCookies).toHaveBeenCalledTimes(1);
-      expect(runAttributionStrategy).toHaveBeenCalledTimes(1);
-    });
-
-    test('should track attributions with config', async () => {
-      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
-        optOut: false,
-      });
-      const client = new AmplitudeBrowser();
-      const runAttributionStrategy = jest
-        .spyOn(client, 'runAttributionStrategy')
-        .mockReturnValueOnce(Promise.resolve(undefined));
-      await client.init(API_KEY, USER_ID, {
-        attribution: {
-          excludeReferrers: [],
-          initialEmptyValue: '',
-        },
-      });
-      expect(parseOldCookies).toHaveBeenCalledTimes(1);
-      expect(runAttributionStrategy).toHaveBeenCalledTimes(1);
-    });
-
     test('should set user id and device id in analytics connector', async () => {
       const cookieStorage = new core.MemoryStorage<UserSession>();
       jest.spyOn(cookieStorage, 'get').mockResolvedValue({
@@ -168,29 +137,6 @@ describe('browser-client', () => {
           k: 'v',
         },
       });
-      expect(track).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('trackCampaign', () => {
-    test('should track campaign', async () => {
-      const client = new AmplitudeBrowser();
-      const track = jest.spyOn(client, 'track').mockReturnValueOnce(
-        Promise.resolve({
-          code: 200,
-          message: '',
-          event: {
-            event_type: 'event_type',
-          },
-        }),
-      );
-      await client.init(API_KEY, USER_ID, {
-        attribution: {
-          disabled: false,
-        },
-      });
-      const result = await client.runAttributionStrategy();
-      expect(result).toBe(undefined);
       expect(track).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/analytics-browser/test/plugins/attribution.test.ts
+++ b/packages/analytics-browser/test/plugins/attribution.test.ts
@@ -1,0 +1,240 @@
+import { CampaignTracker } from '../../src/attribution/campaign-tracker';
+import { AmplitudeBrowser } from '../../src/browser-client';
+import { Attribution } from '../../src/plugins/attribution';
+import { useDefaultConfig } from '../helpers/default';
+
+describe('attribution', () => {
+  const API_KEY = 'API_KEY';
+  const USER_ID = 'USER_ID';
+
+  describe('setup', () => {
+    describe('should send an identify event', () => {
+      test('when a campaign changes', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution();
+        const config = useDefaultConfig();
+        const sessionId = instance.getSessionId();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_type: '$identify',
+          user_properties: {
+            $set: {
+              utm_source: 'amp-test',
+            },
+            $setOnce: {
+              initial_fbclid: 'EMPTY',
+              initial_gclid: 'EMPTY',
+              initial_referrer: 'EMPTY',
+              initial_referring_domain: 'EMPTY',
+              initial_utm_campaign: 'EMPTY',
+              initial_utm_content: 'EMPTY',
+              initial_utm_medium: 'EMPTY',
+              initial_utm_source: 'amp-test',
+              initial_utm_term: 'EMPTY',
+            },
+            $unset: {
+              fbclid: '-',
+              gclid: '-',
+              referrer: '-',
+              referring_domain: '-',
+              utm_campaign: '-',
+              utm_content: '-',
+              utm_medium: '-',
+              utm_term: '-',
+            },
+          },
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(sessionId).toBe(sessionId);
+      });
+
+      test('when a campaign changes and attribution.trackNewCampaigns is true', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution({
+          attribution: {
+            trackNewCampaigns: true,
+          },
+        });
+        const config = useDefaultConfig();
+        const sessionId = instance.getSessionId();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_type: '$identify',
+          user_properties: {
+            $set: {
+              utm_source: 'amp-test',
+            },
+            $setOnce: {
+              initial_fbclid: 'EMPTY',
+              initial_gclid: 'EMPTY',
+              initial_referrer: 'EMPTY',
+              initial_referring_domain: 'EMPTY',
+              initial_utm_campaign: 'EMPTY',
+              initial_utm_content: 'EMPTY',
+              initial_utm_medium: 'EMPTY',
+              initial_utm_source: 'amp-test',
+              initial_utm_term: 'EMPTY',
+            },
+            $unset: {
+              fbclid: '-',
+              gclid: '-',
+              referrer: '-',
+              referring_domain: '-',
+              utm_campaign: '-',
+              utm_content: '-',
+              utm_medium: '-',
+              utm_term: '-',
+            },
+          },
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(instance.getSessionId()).not.toBe(sessionId);
+      });
+
+      test('when a campaign changes but keep the same session id', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution({
+          attribution: {
+            resetSessionOnNewCampaign: true,
+          },
+        });
+        const config = useDefaultConfig();
+        const sessionId = instance.getSessionId();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_type: '$identify',
+          user_properties: {
+            $set: {
+              utm_source: 'amp-test',
+            },
+            $setOnce: {
+              initial_fbclid: 'EMPTY',
+              initial_gclid: 'EMPTY',
+              initial_referrer: 'EMPTY',
+              initial_referring_domain: 'EMPTY',
+              initial_utm_campaign: 'EMPTY',
+              initial_utm_content: 'EMPTY',
+              initial_utm_medium: 'EMPTY',
+              initial_utm_source: 'amp-test',
+              initial_utm_term: 'EMPTY',
+            },
+            $unset: {
+              fbclid: '-',
+              gclid: '-',
+              referrer: '-',
+              referring_domain: '-',
+              utm_campaign: '-',
+              utm_content: '-',
+              utm_medium: '-',
+              utm_term: '-',
+            },
+          },
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(instance.getSessionId()).not.toBe(sessionId);
+      });
+    });
+
+    describe('should not send an identify event', () => {
+      test('when it is disabled', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution({
+          attribution: {
+            disabled: true,
+          },
+        });
+        const config = useDefaultConfig();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/packages/analytics-browser/test/plugins/pageTracking.test.ts
+++ b/packages/analytics-browser/test/plugins/pageTracking.test.ts
@@ -1,0 +1,338 @@
+import { PageTracking } from '../../src/plugins/pageTracking';
+import { CampaignTracker } from '../../src/attribution/campaign-tracker';
+import { AmplitudeBrowser } from '../../src/browser-client';
+import { useDefaultConfig } from '../helpers/default';
+
+describe('pageTracking', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '',
+        href: '',
+        pathname: '',
+        search: '',
+        writable: true,
+      },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '',
+        href: '',
+        pathname: '',
+        search: '',
+        writable: false,
+      },
+    });
+  });
+
+  const API_KEY = 'API_KEY';
+  const USER_ID = 'USER_ID';
+
+  describe('setup', () => {
+    describe('should send a page view event', () => {
+      test('when a campaign changes and filter is "onAttribution"', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: 'onAttribution',
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when a campaign changes, filter is undefined and attribution.trackPageViews is true', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          attribution: {
+            trackPageViews: true,
+          },
+          trackPageViews: true,
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when filter is a function and it returns true', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: () => true,
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when filter is undefined', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: false,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {},
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when trackPageViews is true', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: true,
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('should not send a page view event', () => {
+      test('when a campaign does not change and filter is "onAttribution"', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: false,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: 'onAttribution',
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+
+      test('when filter is a function and it returns false', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: () => false,
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+
+      test('when trackPageViews is false', async () => {
+        const instance = new AmplitudeBrowser();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: false,
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -72,15 +72,15 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
     return this.dispatch(event);
   }
 
-  async add(plugin: Plugin) {
+  async add(plugin: Plugin): Promise<void> {
     if (!this.config) {
       this.q.push(this.add.bind(this, plugin));
       return;
     }
-    return this.timeline.register(plugin, this.config);
+    return this.timeline.register(plugin, this.config, this);
   }
 
-  async remove(pluginName: string) {
+  async remove(pluginName: string): Promise<void> {
     if (!this.config) {
       this.q.push(this.remove.bind(this, pluginName));
       return;

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -2,9 +2,11 @@ import { Timeline } from '../src/timeline';
 import { Event, Plugin, PluginType } from '@amplitude/analytics-types';
 import { useDefaultConfig, promiseState } from './helpers/default';
 import { createTrackEvent } from '../src/utils/event-builder';
+import { AmplitudeCore } from '../src/core-client';
 
 describe('timeline', () => {
   let timeline = new Timeline();
+  const instance = new AmplitudeCore();
 
   beforeEach(() => {
     timeline = new Timeline();
@@ -61,9 +63,9 @@ describe('timeline', () => {
     };
     const config = useDefaultConfig();
     // register
-    await timeline.register(before, config);
-    await timeline.register(enrichment, config);
-    await timeline.register(destination, config);
+    await timeline.register(before, config, instance);
+    await timeline.register(enrichment, config, instance);
+    await timeline.register(destination, config, instance);
     timeline.isReady = true;
 
     expect(beforeSetup).toHaveBeenCalledTimes(1);
@@ -123,7 +125,7 @@ describe('timeline', () => {
         execute: beforeExecute,
       };
       const config = useDefaultConfig();
-      await timeline.register(before, config);
+      await timeline.register(before, config, instance);
       await timeline.apply(undefined);
       await timeline.deregister(before.name);
       expect(beforeExecute).toHaveBeenCalledTimes(0);
@@ -164,9 +166,9 @@ describe('timeline', () => {
       };
 
       const config = useDefaultConfig();
-      await timeline.register(before, config);
-      await timeline.register(enrichment, config);
-      await timeline.register(destination, config);
+      await timeline.register(before, config, instance);
+      await timeline.register(enrichment, config, instance);
+      await timeline.register(destination, config, instance);
 
       const event = {
         event_type: 'some-event',
@@ -199,7 +201,7 @@ describe('timeline', () => {
         flush,
       };
       const config = useDefaultConfig();
-      await timeline.register(plugin, config);
+      await timeline.register(plugin, config, instance);
       void timeline.push(createTrackEvent('a'));
       void timeline.push(createTrackEvent('b'));
       void timeline.push(createTrackEvent('c'));

--- a/packages/analytics-react-native/src/plugins/attribution.ts
+++ b/packages/analytics-react-native/src/plugins/attribution.ts
@@ -1,0 +1,51 @@
+import {
+  BeforePlugin,
+  ReactNativeConfig,
+  Event,
+  PluginType,
+  AdditionalReactNativeOptions,
+  PluginSetupOptions,
+  Campaign,
+} from '@amplitude/analytics-types';
+import { CampaignTracker } from '../attribution/campaign-tracker';
+import { AmplitudeReactNative } from '../react-native-client';
+import { createFlexibleStorage } from '../config';
+
+export class Attribution implements BeforePlugin {
+  name = 'attribution';
+  type = PluginType.BEFORE as const;
+
+  constructor(private readonly options: AdditionalReactNativeOptions = {}) {}
+
+  async setup(config: ReactNativeConfig, options: PluginSetupOptions): Promise<undefined> {
+    const attributionConfig = this.options.attribution ?? {};
+
+    if (attributionConfig.disabled) {
+      return Promise.resolve(undefined);
+    }
+
+    const instance = options.instance as AmplitudeReactNative;
+    const storage = await createFlexibleStorage<Campaign>(config);
+
+    const campaignTracker = new CampaignTracker(config.apiKey, {
+      ...attributionConfig,
+      storage,
+    });
+
+    void instance.timeline.ready.then(() =>
+      campaignTracker.onStateChange(async () => {
+        void campaignTracker.trackOn('onAttribution', (currentCampaign) => {
+          if (campaignTracker.resetSessionOnNewCampaign) {
+            instance.setSessionId(Date.now());
+          }
+          return instance.track(campaignTracker.createCampaignEvent(currentCampaign));
+        });
+      }),
+    );
+    return Promise.resolve(undefined);
+  }
+
+  async execute(context: Event): Promise<Event> {
+    return context;
+  }
+}

--- a/packages/analytics-react-native/src/plugins/pageTracking.ts
+++ b/packages/analytics-react-native/src/plugins/pageTracking.ts
@@ -1,0 +1,66 @@
+import {
+  BeforePlugin,
+  ReactNativeConfig,
+  Event,
+  PluginType,
+  AdditionalReactNativeOptions,
+  PluginSetupOptions,
+  Campaign,
+  BaseEvent,
+} from '@amplitude/analytics-types';
+import { CampaignTracker } from '../attribution/campaign-tracker';
+import { AmplitudeReactNative } from '../react-native-client';
+import { createFlexibleStorage } from '../config';
+
+export class PageTracking implements BeforePlugin {
+  name = 'pageTracking';
+  type = PluginType.BEFORE as const;
+
+  constructor(private readonly options: AdditionalReactNativeOptions = {}) {}
+
+  async setup(config: ReactNativeConfig, options: PluginSetupOptions): Promise<undefined> {
+    const attributionConfig = this.options.attribution ?? {};
+    const pageTrackingConfig = this.options.trackPageViews ?? false;
+
+    if (!pageTrackingConfig) {
+      return Promise.resolve(undefined);
+    }
+
+    const instance = options.instance as AmplitudeReactNative;
+    const storage = await createFlexibleStorage<Campaign>(config);
+
+    let { filter = undefined } = typeof pageTrackingConfig === 'object' ? pageTrackingConfig : {};
+
+    if (typeof filter === 'undefined' && attributionConfig.trackPageViews === true) {
+      filter = 'onAttribution';
+    }
+
+    const campaignTracker = new CampaignTracker(config.apiKey, {
+      ...attributionConfig,
+      storage,
+    });
+
+    void instance.timeline.ready.then(() =>
+      campaignTracker.onStateChange(async () => {
+        void campaignTracker.trackOn(filter, () => instance.track(this.createPageViewEvent()));
+      }),
+    );
+    return Promise.resolve(undefined);
+  }
+
+  async execute(context: Event): Promise<Event> {
+    return context;
+  }
+
+  private createPageViewEvent(): Event {
+    const pageViewEvent: BaseEvent = {
+      event_type: 'Page View',
+      event_properties: {
+        page_title: /* istanbul ignore next */ (typeof document !== 'undefined' && document.title) || '',
+        page_location: /* istanbul ignore next */ (typeof location !== 'undefined' && location.href) || '',
+        page_path: /* istanbul ignore next */ (typeof location !== 'undefined' && location.pathname) || '',
+      },
+    };
+    return pageViewEvent;
+  }
+}

--- a/packages/analytics-react-native/test/plugins/attribution.test.ts
+++ b/packages/analytics-react-native/test/plugins/attribution.test.ts
@@ -1,0 +1,240 @@
+import { CampaignTracker } from '../../src/attribution/campaign-tracker';
+import { AmplitudeReactNative } from '../../src/react-native-client';
+import { Attribution } from '../../src/plugins/attribution';
+import { useDefaultConfig } from '../helpers/default';
+
+describe('attribution', () => {
+  const API_KEY = 'API_KEY';
+  const USER_ID = 'USER_ID';
+
+  describe('setup', () => {
+    describe('should send an identify event', () => {
+      test('when a campaign changes', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution();
+        const config = useDefaultConfig();
+        const sessionId = instance.getSessionId();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_type: '$identify',
+          user_properties: {
+            $set: {
+              utm_source: 'amp-test',
+            },
+            $setOnce: {
+              initial_fbclid: 'EMPTY',
+              initial_gclid: 'EMPTY',
+              initial_referrer: 'EMPTY',
+              initial_referring_domain: 'EMPTY',
+              initial_utm_campaign: 'EMPTY',
+              initial_utm_content: 'EMPTY',
+              initial_utm_medium: 'EMPTY',
+              initial_utm_source: 'amp-test',
+              initial_utm_term: 'EMPTY',
+            },
+            $unset: {
+              fbclid: '-',
+              gclid: '-',
+              referrer: '-',
+              referring_domain: '-',
+              utm_campaign: '-',
+              utm_content: '-',
+              utm_medium: '-',
+              utm_term: '-',
+            },
+          },
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(sessionId).toBe(sessionId);
+      });
+
+      test('when a campaign changes and attribution.trackNewCampaigns is true', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution({
+          attribution: {
+            trackNewCampaigns: true,
+          },
+        });
+        const config = useDefaultConfig();
+        const sessionId = instance.getSessionId();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_type: '$identify',
+          user_properties: {
+            $set: {
+              utm_source: 'amp-test',
+            },
+            $setOnce: {
+              initial_fbclid: 'EMPTY',
+              initial_gclid: 'EMPTY',
+              initial_referrer: 'EMPTY',
+              initial_referring_domain: 'EMPTY',
+              initial_utm_campaign: 'EMPTY',
+              initial_utm_content: 'EMPTY',
+              initial_utm_medium: 'EMPTY',
+              initial_utm_source: 'amp-test',
+              initial_utm_term: 'EMPTY',
+            },
+            $unset: {
+              fbclid: '-',
+              gclid: '-',
+              referrer: '-',
+              referring_domain: '-',
+              utm_campaign: '-',
+              utm_content: '-',
+              utm_medium: '-',
+              utm_term: '-',
+            },
+          },
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(instance.getSessionId()).not.toBe(sessionId);
+      });
+
+      test('when a campaign changes but keep the same session id', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution({
+          attribution: {
+            resetSessionOnNewCampaign: true,
+          },
+        });
+        const config = useDefaultConfig();
+        const sessionId = instance.getSessionId();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_type: '$identify',
+          user_properties: {
+            $set: {
+              utm_source: 'amp-test',
+            },
+            $setOnce: {
+              initial_fbclid: 'EMPTY',
+              initial_gclid: 'EMPTY',
+              initial_referrer: 'EMPTY',
+              initial_referring_domain: 'EMPTY',
+              initial_utm_campaign: 'EMPTY',
+              initial_utm_content: 'EMPTY',
+              initial_utm_medium: 'EMPTY',
+              initial_utm_source: 'amp-test',
+              initial_utm_term: 'EMPTY',
+            },
+            $unset: {
+              fbclid: '-',
+              gclid: '-',
+              referrer: '-',
+              referring_domain: '-',
+              utm_campaign: '-',
+              utm_content: '-',
+              utm_medium: '-',
+              utm_term: '-',
+            },
+          },
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(instance.getSessionId()).not.toBe(sessionId);
+      });
+    });
+
+    describe('should not send an identify event', () => {
+      test('when it is disabled', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const attribution = new Attribution({
+          attribution: {
+            disabled: true,
+          },
+        });
+        const config = useDefaultConfig();
+        await attribution.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/packages/analytics-react-native/test/plugins/pageTracking.test.ts
+++ b/packages/analytics-react-native/test/plugins/pageTracking.test.ts
@@ -1,0 +1,338 @@
+import { PageTracking } from '../../src/plugins/pageTracking';
+import { CampaignTracker } from '../../src/attribution/campaign-tracker';
+import { AmplitudeReactNative } from '../../src/react-native-client';
+import { useDefaultConfig } from '../helpers/default';
+
+describe('pageTracking', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '',
+        href: '',
+        pathname: '',
+        search: '',
+        writable: true,
+      },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '',
+        href: '',
+        pathname: '',
+        search: '',
+        writable: false,
+      },
+    });
+  });
+
+  const API_KEY = 'API_KEY';
+  const USER_ID = 'USER_ID';
+
+  describe('setup', () => {
+    describe('should send a page view event', () => {
+      test('when a campaign changes and filter is "onAttribution"', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: 'onAttribution',
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when a campaign changes, filter is undefined and attribution.trackPageViews is true', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          attribution: {
+            trackPageViews: true,
+          },
+          trackPageViews: true,
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when filter is a function and it returns true', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: () => true,
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when filter is undefined', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: false,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {},
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledWith({
+          event_properties: {
+            page_location: '',
+            page_path: '',
+            page_title: '',
+          },
+          event_type: 'Page View',
+        });
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('when trackPageViews is true', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: true,
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('should not send a page view event', () => {
+      test('when a campaign does not change and filter is "onAttribution"', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: false,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: 'onAttribution',
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+
+      test('when filter is a function and it returns false', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: {
+            filter: () => false,
+          },
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+
+      test('when trackPageViews is false', async () => {
+        const instance = new AmplitudeReactNative();
+        const track = jest.spyOn(instance, 'track').mockReturnValueOnce(
+          Promise.resolve({
+            code: 200,
+            message: '',
+            event: {
+              event_type: 'event_type',
+            },
+          }),
+        );
+
+        jest.spyOn(CampaignTracker.prototype as any, 'getCurrentState').mockReturnValue({
+          isNewCampaign: true,
+          currentCampaign: { utm_source: 'amp-test' },
+        });
+
+        await instance.init(API_KEY, USER_ID, {
+          attribution: {
+            disabled: true,
+          },
+        });
+
+        const pageTracking = new PageTracking({
+          trackPageViews: false,
+        });
+        const config = useDefaultConfig();
+        await pageTracking.setup(config, { instance });
+
+        expect(track).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -106,37 +106,6 @@ describe('react-native-client', () => {
       expect(parseOldCookies).toHaveBeenCalledTimes(1);
     });
 
-    test('should track attributions', async () => {
-      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
-        optOut: false,
-      });
-      const client = new AmplitudeReactNative();
-      const runAttributionStrategy = jest
-        .spyOn(client, 'runAttributionStrategy')
-        .mockReturnValueOnce(Promise.resolve(undefined));
-      await client.init(API_KEY, USER_ID);
-      expect(parseOldCookies).toHaveBeenCalledTimes(1);
-      expect(runAttributionStrategy).toHaveBeenCalledTimes(1);
-    });
-
-    test('should track attributions with config', async () => {
-      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
-        optOut: false,
-      });
-      const client = new AmplitudeReactNative();
-      const runAttributionStrategy = jest
-        .spyOn(client, 'runAttributionStrategy')
-        .mockReturnValueOnce(Promise.resolve(undefined));
-      await client.init(API_KEY, USER_ID, {
-        attribution: {
-          excludeReferrers: [],
-          initialEmptyValue: '',
-        },
-      });
-      expect(parseOldCookies).toHaveBeenCalledTimes(1);
-      expect(runAttributionStrategy).toHaveBeenCalledTimes(1);
-    });
-
     test('should set user id and device id in analytics connector', async () => {
       const cookieStorage = new core.MemoryStorage<UserSession>();
       jest.spyOn(cookieStorage, 'get').mockResolvedValue({
@@ -181,31 +150,6 @@ describe('react-native-client', () => {
       expect(track).toHaveBeenCalledTimes(1);
     });
   });
-
-  if (isWeb()) {
-    describe('trackCampaign', () => {
-      test('should track campaign', async () => {
-        const client = new AmplitudeReactNative();
-        const track = jest.spyOn(client, 'track').mockReturnValueOnce(
-          Promise.resolve({
-            code: 200,
-            message: '',
-            event: {
-              event_type: 'event_type',
-            },
-          }),
-        );
-        await client.init(API_KEY, USER_ID, {
-          attribution: {
-            disabled: false,
-          },
-        });
-        const result = await client.runAttributionStrategy();
-        expect(result).toBe(undefined);
-        expect(track).toHaveBeenCalledTimes(1);
-      });
-    });
-  }
 
   describe('getUserId', () => {
     test('should get user id', async () => {

--- a/packages/analytics-types/src/campaign.ts
+++ b/packages/analytics-types/src/campaign.ts
@@ -1,5 +1,6 @@
 import { BaseEvent } from './base-event';
-import { AttributionBrowserOptions } from './config';
+import { AttributionBrowserOptions, PageTrackingFilter } from './config';
+import { IdentifyEvent } from './event';
 import { Storage } from './storage';
 
 export interface UTMParameters extends Record<string, string | undefined> {
@@ -28,12 +29,14 @@ export interface CampaignParser {
 
 export interface CampaignTrackerOptions extends AttributionBrowserOptions {
   storage: Storage<Campaign>;
-  track: CampaignTrackFunction;
-  onNewCampaign: (campaign: Campaign) => unknown;
 }
 
-export interface CampaignTracker extends CampaignTrackerOptions {
-  send(force: boolean): Promise<void>;
+export interface CampaignTracker {
+  isNewCampaign(currentCampaign: Campaign, previousCampaign: Campaign): boolean;
+  saveCampaignToStorage(campaign: Campaign): Promise<void>;
+  getCampaignFromStorage(): Promise<Campaign>;
+  createCampaignEvent(campaign: Campaign): IdentifyEvent;
+  trackOn(filter: PageTrackingFilter, callback: (currentCampaign: Campaign) => unknown): unknown;
 }
 
 export type CampaignTrackFunction = (event: BaseEvent) => Promise<unknown>;

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -85,7 +85,9 @@ export interface AttributionBrowserOptions {
   excludeReferrers?: string[];
   initialEmptyValue?: string;
   resetSessionOnNewCampaign?: boolean;
+  /** @deprecated New campaigns are now always tracked by default. Setting this to true also sets resetSessionOnNewCampaign to true. */
   trackNewCampaigns?: boolean;
+  /** @deprecated Use the new top level trackPageViews configuration instead. */
   trackPageViews?: boolean;
 }
 

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -77,15 +77,23 @@ export interface ReactNativeTrackingOptions extends TrackingOptions {
 
 export interface AdditionalBrowserOptions {
   attribution?: AttributionBrowserOptions;
+  trackPageViews?: boolean | PageTrackingBrowserOptions;
 }
 
 export interface AttributionBrowserOptions {
   disabled?: boolean;
   excludeReferrers?: string[];
   initialEmptyValue?: string;
+  resetSessionOnNewCampaign?: boolean;
   trackNewCampaigns?: boolean;
   trackPageViews?: boolean;
 }
+
+export interface PageTrackingBrowserOptions {
+  filter?: PageTrackingFilter;
+}
+
+export type PageTrackingFilter = 'onAttribution' | (() => boolean) | undefined;
 
 export type BrowserOptions = Omit<
   Partial<
@@ -98,9 +106,12 @@ export type BrowserOptions = Omit<
 
 export interface AdditionalReactNativeOptions {
   attribution?: AttributionReactNativeOptions;
+  trackPageViews?: boolean | PageTrackingReactNativeOptions;
 }
 
 export type AttributionReactNativeOptions = AttributionBrowserOptions;
+
+export type PageTrackingReactNativeOptions = PageTrackingBrowserOptions;
 
 export type ReactNativeOptions = Omit<
   Partial<

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -22,6 +22,9 @@ export {
   InitOptions,
   NodeConfig,
   NodeOptions,
+  PageTrackingBrowserOptions,
+  PageTrackingReactNativeOptions,
+  PageTrackingFilter,
   ReactNativeConfig,
   ReactNativeOptions,
   ReactNativeTrackingOptions,
@@ -50,7 +53,7 @@ export { EventBridge, EventBridgeChannel, EventBridgeContainer, EventBridgeRecei
 export { Logger, LogLevel } from './logger';
 export { Payload } from './payload';
 export { Plan } from './plan';
-export { Plugin, BeforePlugin, EnrichmentPlugin, DestinationPlugin, PluginType } from './plugin';
+export { Plugin, BeforePlugin, EnrichmentPlugin, DestinationPlugin, PluginType, PluginSetupOptions } from './plugin';
 export { Result } from './result';
 export { Response, SuccessResponse, InvalidResponse, PayloadTooLargeResponse, RateLimitResponse } from './response';
 export { QueueProxy, InstanceProxy } from './proxy';

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -1,6 +1,7 @@
 import { Event } from './event';
 import { Config } from './config';
 import { Result } from './result';
+import { CoreClient } from './core-client';
 
 export enum PluginType {
   BEFORE = 'before',
@@ -8,24 +9,28 @@ export enum PluginType {
   DESTINATION = 'destination',
 }
 
+export interface PluginSetupOptions {
+  instance: CoreClient<Config>;
+}
+
 export interface BeforePlugin {
   name: string;
   type: PluginType.BEFORE;
-  setup(config: Config): Promise<undefined>;
+  setup(config: Config, options: PluginSetupOptions): Promise<undefined>;
   execute(context: Event): Promise<Event>;
 }
 
 export interface EnrichmentPlugin {
   name: string;
   type: PluginType.ENRICHMENT;
-  setup(config: Config): Promise<undefined>;
+  setup(config: Config, options: PluginSetupOptions): Promise<undefined>;
   execute(context: Event): Promise<Event>;
 }
 
 export interface DestinationPlugin {
   name: string;
   type: PluginType.DESTINATION;
-  setup(config: Config): Promise<undefined>;
+  setup(config: Config, options: PluginSetupOptions): Promise<undefined>;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This PR is to add support for auto page view tracking:
- Migrate web attribution into a plugin
- Add page tracking plugin
- Update CampaignTracker
- Remove `runAttributionStrategy` function

#### Note to reviewers
The code base and test cases for both browser and react native are similar. Please review browser one primarily. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
