### PR TITLE
fix: allow implicit undefined return for Plugin.setup interface

### DIFF
--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -11,21 +11,21 @@ export enum PluginType {
 export interface BeforePlugin {
   name: string;
   type: PluginType.BEFORE;
-  setup(config: Config): Promise<undefined>;
+  setup(config: Config): Promise<void>;
   execute(context: Event): Promise<Event>;
 }
 
 export interface EnrichmentPlugin {
   name: string;
   type: PluginType.ENRICHMENT;
-  setup(config: Config): Promise<undefined>;
+  setup(config: Config): Promise<void>;
   execute(context: Event): Promise<Event>;
 }
 
 export interface DestinationPlugin {
   name: string;
   type: PluginType.DESTINATION;
-  setup(config: Config): Promise<undefined>;
+  setup(config: Config): Promise<void>;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Updates plugin interface for setup method to allow implicit return

With this fix, the code example below will be allowed by TS compiler:

```ts
const plugin = (): amplitude.Types.Plugin => {
  return {
    name: '',
    type: amplitude.Types.PluginType.ENRICHMENT,
    setup: async (c) => {},
    execute: async (e) => {
      return e;
    },
  };
};
```

Previously, setup needed to `return undefined`.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
