### PR TITLE
refactor: clean up attribution config

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -1,7 +1,7 @@
 import { AmplitudeCore, Destination, Identify, Revenue, UUID, returnWrapper } from '@amplitude/analytics-core';
 import { CampaignTracker, getAnalyticsConnector, IdentityEventSender } from '@amplitude/analytics-client-common';
 import {
-  AttributionBrowserOptions,
+  AttributionOptions,
   BrowserClient,
   BrowserConfig,
   BrowserOptions,
@@ -82,7 +82,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     await this.runAttributionStrategy(browserOptions.attribution, isNewSession);
   }
 
-  async runAttributionStrategy(attributionConfig?: AttributionBrowserOptions, isNewSession = false) {
+  async runAttributionStrategy(attributionConfig?: AttributionOptions, isNewSession = false) {
     const track = this.track.bind(this);
     const onNewCampaign = this.setSessionId.bind(this, Date.now());
 

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -1,5 +1,5 @@
 import {
-  AttributionBrowserOptions,
+  AttributionOptions,
   Event,
   BrowserOptions,
   BrowserConfig as IBrowserConfig,
@@ -50,7 +50,7 @@ export const getDefaultConfig = () => {
 
 export class BrowserConfig extends Config implements IBrowserConfig {
   appVersion?: string;
-  attribution?: AttributionBrowserOptions;
+  attribution?: AttributionOptions;
   cookieExpiration: number;
   cookieSameSite: string;
   cookieSecure: boolean;

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -4,8 +4,7 @@ import {
   ReactNativeConfig,
   Campaign,
   ReactNativeOptions,
-  AdditionalReactNativeOptions,
-  AttributionReactNativeOptions,
+  AttributionOptions,
   ReactNativeClient,
 } from '@amplitude/analytics-types';
 import { Context } from './plugins/context';
@@ -14,7 +13,7 @@ import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
 
 export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
-  async init(apiKey: string, userId?: string, options?: ReactNativeOptions & AdditionalReactNativeOptions) {
+  async init(apiKey: string, userId?: string, options?: ReactNativeOptions) {
     // Step 0: Block concurrent initialization
     if (this.initializing) {
       return;
@@ -78,7 +77,7 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     await this.runAttributionStrategy(options?.attribution, isNewSession);
   }
 
-  async runAttributionStrategy(attributionConfig?: AttributionReactNativeOptions, isNewSession = false) {
+  async runAttributionStrategy(attributionConfig?: AttributionOptions, isNewSession = false) {
     if (isNative()) {
       return;
     }

--- a/packages/analytics-types/src/campaign.ts
+++ b/packages/analytics-types/src/campaign.ts
@@ -1,5 +1,5 @@
 import { BaseEvent } from './base-event';
-import { AttributionBrowserOptions } from './config';
+import { AttributionOptions } from './config';
 import { Storage } from './storage';
 
 export interface UTMParameters extends Record<string, string | undefined> {
@@ -26,7 +26,7 @@ export interface CampaignParser {
   parse(): Promise<Campaign>;
 }
 
-export interface CampaignTrackerOptions extends AttributionBrowserOptions {
+export interface CampaignTrackerOptions extends AttributionOptions {
   storage: Storage<Campaign>;
   track: CampaignTrackFunction;
   onNewCampaign: (campaign: Campaign) => unknown;

--- a/packages/analytics-types/src/client/web-client.ts
+++ b/packages/analytics-types/src/client/web-client.ts
@@ -1,5 +1,5 @@
 import { AmplitudeReturn } from '../amplitude-promise';
-import { AdditionalReactNativeOptions, BrowserOptions, ReactNativeOptions } from '../config';
+import { BrowserOptions, ReactNativeOptions } from '../config';
 import { TransportType } from '../transport';
 import { BaseClient } from './base-client';
 
@@ -115,9 +115,5 @@ export interface ReactNativeClient extends Client {
    * await init(API_KEY, options).promise;
    * ```
    */
-  init(
-    apiKey: string,
-    userId?: string,
-    options?: ReactNativeOptions & AdditionalReactNativeOptions,
-  ): AmplitudeReturn<void>;
+  init(apiKey: string, userId?: string, options?: ReactNativeOptions): AmplitudeReturn<void>;
 }

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -32,8 +32,7 @@ export interface Config {
 
 export interface BrowserConfig extends Config {
   appVersion?: string;
-  /** @deprecated Use the web attribution plugin configuration instead. */
-  attribution?: AttributionBrowserOptions;
+  attribution?: AttributionOptions;
   deviceId?: string;
   cookieExpiration: number;
   cookieSameSite: string;
@@ -79,7 +78,7 @@ export interface ReactNativeTrackingOptions extends TrackingOptions {
   carrier?: boolean;
 }
 
-export interface AttributionBrowserOptions {
+export interface AttributionOptions {
   disabled?: boolean;
   excludeReferrers?: string[];
   initialEmptyValue?: string;
@@ -95,12 +94,6 @@ export type BrowserOptions = Omit<
   >,
   'apiKey'
 >;
-
-export interface AdditionalReactNativeOptions {
-  attribution?: AttributionReactNativeOptions;
-}
-
-export type AttributionReactNativeOptions = AttributionBrowserOptions;
 
 export type ReactNativeOptions = Omit<
   Partial<

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -12,9 +12,7 @@ export {
 } from './campaign';
 export { BrowserClient, ReactNativeClient, NodeClient } from './client';
 export {
-  AdditionalReactNativeOptions,
-  AttributionBrowserOptions,
-  AttributionReactNativeOptions,
+  AttributionOptions,
   BrowserConfig,
   BrowserOptions,
   Config,

--- a/packages/plugin-web-attribution-browser/src/plugin-campaign-tracker.ts
+++ b/packages/plugin-web-attribution-browser/src/plugin-campaign-tracker.ts
@@ -1,11 +1,11 @@
-import { AttributionBrowserOptions, Campaign } from '@amplitude/analytics-types';
+import { AttributionOptions, Campaign } from '@amplitude/analytics-types';
 import { CampaignTracker } from '@amplitude/analytics-client-common';
 import { Storage } from '@amplitude/analytics-types';
 
 export class PluginCampaignTracker {
   campaignTracker: CampaignTracker;
 
-  constructor(apiKey: string, storage: Storage<Campaign>, options: AttributionBrowserOptions) {
+  constructor(apiKey: string, storage: Storage<Campaign>, options: AttributionOptions) {
     this.campaignTracker = new CampaignTracker(apiKey, {
       ...options,
       trackPageViews: false,


### PR DESCRIPTION
### Summary

Temporarily remove deprecation message for `config.attribution` while plugins are not published yet. Consolidate to single attribution type for browser and react-native.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
