### PR TITLE
build: set no side effect to optimize bundle size

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -12,6 +12,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/analytics-client-common/package.json
+++ b/packages/analytics-client-common/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/analytics-node/package.json
+++ b/packages/analytics-node/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/analytics-types/package.json
+++ b/packages/analytics-types/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/marketing-analytics-browser/package.json
+++ b/packages/marketing-analytics-browser/package.json
@@ -12,6 +12,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-page-view-tracking-browser/package.json
+++ b/packages/plugin-page-view-tracking-browser/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
@@ -33,10 +34,19 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^1.5.0",
     "@amplitude/analytics-client-common": "^0.2.1",
     "@amplitude/analytics-types": "^0.10.2",
     "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@amplitude/analytics-browser": "^1.5.0",
+    "@rollup/plugin-commonjs": "^21.0.2",
+    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-typescript": "^8.3.1",
+    "rollup": "^2.69.0",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.0.0",
+    "rollup-plugin-terser": "^7.0.2"
   },
   "files": [
     "lib"

--- a/packages/plugin-web-attribution-browser/package.json
+++ b/packages/plugin-web-attribution-browser/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
@@ -33,10 +34,19 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^1.5.0",
     "@amplitude/analytics-client-common": "^0.2.1",
     "@amplitude/analytics-types": "^0.10.2",
     "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@amplitude/analytics-browser": "^1.5.0",
+    "@rollup/plugin-commonjs": "^21.0.2",
+    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-typescript": "^8.3.1",
+    "rollup": "^2.69.0",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.0.0",
+    "rollup-plugin-terser": "^7.0.2"
   },
   "files": [
     "lib"


### PR DESCRIPTION
### Summary

Optimize bundle size by declaring that packages do not have side effects, effectively tree shaking more unused code. 

Info about side effects: https://sgom.es/posts/2020-06-15-everything-you-never-wanted-to-know-about-side-effects/

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
