### PR TITLE
fix: define correct dependencies for @amplitude/analytics-connector

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@amplitude/analytics-client-common": "^0.2.2-beta.0",
-    "@amplitude/analytics-connector": "^1.4.5",
     "@amplitude/analytics-core": "^0.9.4-beta.0",
     "@amplitude/analytics-types": "^0.10.3-beta.0",
     "@amplitude/ua-parser-js": "^0.7.31",

--- a/packages/analytics-client-common/package.json
+++ b/packages/analytics-client-common/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
+    "@amplitude/analytics-connector": "^1.4.5",
     "@amplitude/analytics-core": "^0.9.4-beta.0",
     "@amplitude/analytics-types": "^0.10.3-beta.0",
     "tslib": "^2.3.1"

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@amplitude/analytics-client-common": "^0.2.2-beta.0",
-    "@amplitude/analytics-connector": "1.4.5",
     "@amplitude/analytics-core": "^0.9.4-beta.0",
     "@amplitude/analytics-types": "^0.10.3-beta.0",
     "@amplitude/ua-parser-js": "^0.7.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@amplitude/analytics-connector@1.4.5", "@amplitude/analytics-connector@^1.4.5":
+"@amplitude/analytics-connector@^1.4.5":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.5.tgz#07e9375101332bd8b6f15e39e70f31f287e87ad0"
   integrity sha512-ELAP6ivg+13uSk+TOirGZE/92M+tTbeiQ/i7eXgDO4Hiy00Abf/UxO/rp9WovtxCyeFYTILrujEYxPv5cRQmFw==


### PR DESCRIPTION
### Summary

Fix `@amplitude/analytics-connector` being installed in secondary dependency, not as direct

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
