### PR TITLE
fix: js script export name for marketing analytics plugins

### DIFF
--- a/packages/marketing-analytics-browser/src/typings/browser-client.ts
+++ b/packages/marketing-analytics-browser/src/typings/browser-client.ts
@@ -3,7 +3,7 @@ import {
   BrowserClient as AnalyticsBrowserClient,
   BrowserOptions as AnalyticsBrowserOptions,
 } from '@amplitude/analytics-types';
-import { Types as PageViewTrackingPluginTypes } from '@amplitude/plugin-page-view-tracking-browser';
+import { Types as PageViewTrackingTypes } from '@amplitude/plugin-page-view-tracking-browser';
 import { Types as WebAttributionPluginTypes } from '@amplitude/plugin-web-attribution-browser';
 
 export interface BrowserClient extends AnalyticsBrowserClient {
@@ -13,5 +13,5 @@ export interface BrowserClient extends AnalyticsBrowserClient {
 export type BrowserOptions = AnalyticsBrowserOptions & {
   attribution?: WebAttributionPluginTypes.Options;
 } & {
-  trackPageViews?: PageViewTrackingPluginTypes.Options | boolean;
+  trackPageViews?: PageViewTrackingTypes.Options | boolean;
 };

--- a/packages/plugin-page-view-tracking-browser/rollup.config.js
+++ b/packages/plugin-page-view-tracking-browser/rollup.config.js
@@ -1,5 +1,6 @@
 import { umd, iife } from '../../scripts/build/rollup.config';
 
 iife.input = umd.input;
+iife.output.name = 'pageViewTracking';
 
 export default [umd, iife];

--- a/packages/plugin-page-view-tracking-browser/src/index.ts
+++ b/packages/plugin-page-view-tracking-browser/src/index.ts
@@ -1,2 +1,3 @@
 export { pageViewTrackingPlugin } from './page-view-tracking';
+export { pageViewTrackingPlugin as plugin } from './page-view-tracking';
 export * as Types from './typings/page-view-tracking';

--- a/packages/plugin-web-attribution-browser/rollup.config.js
+++ b/packages/plugin-web-attribution-browser/rollup.config.js
@@ -1,5 +1,6 @@
 import { umd, iife } from '../../scripts/build/rollup.config';
 
 iife.input = umd.input;
+iife.output.name = 'webAttribution';
 
 export default [umd, iife];

--- a/packages/plugin-web-attribution-browser/src/index.ts
+++ b/packages/plugin-web-attribution-browser/src/index.ts
@@ -1,2 +1,3 @@
 export { webAttributionPlugin } from './web-attribution';
+export { webAttributionPlugin as plugin } from './web-attribution';
 export * as Types from './typings/web-attribution';

--- a/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
+++ b/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
@@ -2,7 +2,7 @@ import { createInstance } from '@amplitude/analytics-browser';
 import { webAttributionPlugin } from '../src/web-attribution';
 import { PluginCampaignTracker } from '../src/plugin-campaign-tracker';
 
-describe('WebAttributionPlugin', () => {
+describe('webAttributionPlugin', () => {
   const API_KEY = 'API_KEY';
   const USER_ID = 'USER_ID';
 

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -45,7 +45,11 @@ export const umd = {
       browser: true,
     }),
     commonjs(),
-    terser(),
+    terser({
+      output: {
+        comments: false,
+      },
+    }),
     gzip(),
   ],
 };
@@ -68,7 +72,11 @@ export const iife = {
       browser: true,
     }),
     commonjs(),
-    terser(),
+    terser({
+      output: {
+        comments: false,
+      },
+    }),
     gzip(),
   ],
 };


### PR DESCRIPTION
### Summary

Exports plugins using a plugin's name instead of `amplitude` to prevent naming conflict on window.

For npm installation

```ts
import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser'; // preferred for npm installation
// or `import { plugin } from '@amplitude/plugin-page-view-tracking-browser';`
```

For script installation

```html
<script src="https://cdn.amplitude.com/libs/plugin-page-view-tracking-browser-0.3.2-beta.1-min.js.gz"></script>
<script>
  pageViewTracking.plugin(); // preferred for script installation
  // or `pageViewTrackingPlugin.pageViewTrackingPlugin();`
</script>
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
