### PR TITLE
fix: resolve web attribution is not tracking the first direct/organic traffic

### DIFF
--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -43,15 +43,16 @@ export class CampaignTracker implements ICampaignTracker {
   }
 
   isNewCampaign(current: Campaign, previous: Campaign | undefined) {
-    if (!previous) {
-      return true;
-    }
     const { referrer: _referrer, ...currentCampaign } = current;
-    const { referrer: _previous_referrer, ...previousCampaign } = previous;
+    const { referrer: _previous_referrer, ...previousCampaign } = previous || {};
 
     const isReferrerExcluded = Boolean(
       currentCampaign.referring_domain && this.excludeReferrers.includes(currentCampaign.referring_domain),
     );
+
+    if (!previous) {
+      return !isReferrerExcluded;
+    }
     const hasNewCampaign = JSON.stringify(currentCampaign) !== JSON.stringify(previousCampaign);
 
     return !isReferrerExcluded && hasNewCampaign;

--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -43,7 +43,7 @@ export class CampaignTracker implements ICampaignTracker {
   }
 
   isNewCampaign(current: Campaign, previous: Campaign | undefined) {
-    if (typeof previous === 'undefined') {
+    if (!previous) {
       return true;
     }
     const { referrer: _referrer, ...currentCampaign } = current;

--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -42,7 +42,10 @@ export class CampaignTracker implements ICampaignTracker {
     this.initialEmptyValue = options.initialEmptyValue ?? EMPTY_VALUE;
   }
 
-  isNewCampaign(current: Campaign, previous: Campaign) {
+  isNewCampaign(current: Campaign, previous: Campaign | undefined) {
+    if (typeof previous === 'undefined') {
+      return true;
+    }
     const { referrer: _referrer, ...currentCampaign } = current;
     const { referrer: _previous_referrer, ...previousCampaign } = previous;
 
@@ -58,8 +61,8 @@ export class CampaignTracker implements ICampaignTracker {
     await this.storage.set(this.storageKey, campaign);
   }
 
-  async getCampaignFromStorage(): Promise<Campaign> {
-    return (await this.storage.get(this.storageKey)) || { ...BASE_CAMPAIGN };
+  async getCampaignFromStorage(): Promise<Campaign | undefined> {
+    return await this.storage.get(this.storageKey);
   }
 
   createCampaignEvent(campaign: Campaign) {

--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -50,9 +50,6 @@ export class CampaignTracker implements ICampaignTracker {
       currentCampaign.referring_domain && this.excludeReferrers.includes(currentCampaign.referring_domain),
     );
 
-    if (!previous) {
-      return !isReferrerExcluded;
-    }
     const hasNewCampaign = JSON.stringify(currentCampaign) !== JSON.stringify(previousCampaign);
 
     return !isReferrerExcluded && hasNewCampaign;

--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -52,7 +52,7 @@ export class CampaignTracker implements ICampaignTracker {
 
     const hasNewCampaign = JSON.stringify(currentCampaign) !== JSON.stringify(previousCampaign);
 
-    return !isReferrerExcluded && hasNewCampaign;
+    return !isReferrerExcluded && (!previous || hasNewCampaign);
   }
 
   async saveCampaignToStorage(campaign: Campaign): Promise<void> {

--- a/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
+++ b/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
@@ -60,6 +60,21 @@ describe('CampaignTracker', () => {
       };
       expect(campaignTracker.isNewCampaign(currentCampaign, previousCampaign)).toBe(false);
     });
+
+    test('should return true for undefined previous campaign', () => {
+      const config = {
+        storage: new MemoryStorage<Campaign>(),
+        track: jest.fn(),
+        onNewCampaign: jest.fn(),
+        excludeReferrers: ['a'],
+      };
+      const campaignTracker = new CampaignTracker(API_KEY, config);
+      const previousCampaign = undefined;
+      const currentCampaign = {
+        ...BASE_CAMPAIGN,
+      };
+      expect(campaignTracker.isNewCampaign(currentCampaign, previousCampaign)).toBe(true);
+    });
   });
 
   describe('saveCampaignToStorage', () => {
@@ -88,9 +103,7 @@ describe('CampaignTracker', () => {
       };
       const campaignTracker = new CampaignTracker(API_KEY, config);
       const get = jest.spyOn(campaignTracker.storage, 'get');
-      expect(await campaignTracker.getCampaignFromStorage()).toEqual({
-        ...BASE_CAMPAIGN,
-      });
+      expect(await campaignTracker.getCampaignFromStorage()).toEqual(undefined);
       expect(get).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
+++ b/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
@@ -75,6 +75,22 @@ describe('CampaignTracker', () => {
       };
       expect(campaignTracker.isNewCampaign(currentCampaign, previousCampaign)).toBe(true);
     });
+
+    test('should return false for undefined previous campaign and excluded referrer', () => {
+      const config = {
+        storage: new MemoryStorage<Campaign>(),
+        track: jest.fn(),
+        onNewCampaign: jest.fn(),
+        excludeReferrers: ['a'],
+      };
+      const campaignTracker = new CampaignTracker(API_KEY, config);
+      const previousCampaign = undefined;
+      const currentCampaign = {
+        ...BASE_CAMPAIGN,
+        referring_domain: 'a',
+      };
+      expect(campaignTracker.isNewCampaign(currentCampaign, previousCampaign)).toBe(false);
+    });
   });
 
   describe('saveCampaignToStorage', () => {

--- a/packages/plugin-web-attribution-browser/test/plugin-campaign-tracker.test.ts
+++ b/packages/plugin-web-attribution-browser/test/plugin-campaign-tracker.test.ts
@@ -13,7 +13,7 @@ describe('PluginCampaignTracker', () => {
       const storage = new MemoryStorage<Campaign>();
       const tracker = new PluginCampaignTracker(API_KEY, storage, config);
       await tracker.onPageChange(async ({ isNewCampaign }) => {
-        expect(isNewCampaign).toBe(false);
+        expect(isNewCampaign).toBe(true);
       });
     });
   });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This PR is to fix not tracking the first direct/organic traffic for web attribution. 
- `getCampaignFromStorage` returns false if no campaign is found
- `isNewCampaign` returns true if previous campaign is undefined

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
