### PR TITLE
fix: cover the case when apiKey is missing in the runtime

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -26,6 +26,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     this.initializing = true;
 
     // Step 1: Read cookies stored by old SDK
+    apiKey = apiKey ?? '';
     const oldCookies = await parseOldCookies(apiKey, options);
 
     // Step 2: Create browser config

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -18,7 +18,7 @@ import { useBrowserConfig, createTransport, createFlexibleStorage } from './conf
 import { parseOldCookies } from './cookie-migration';
 
 export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
-  async init(apiKey: string, userId?: string, options?: BrowserOptions) {
+  async init(apiKey = '', userId?: string, options?: BrowserOptions) {
     // Step 0: Block concurrent initialization
     if (this.initializing) {
       return;
@@ -26,7 +26,6 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
     this.initializing = true;
 
     // Step 1: Read cookies stored by old SDK
-    apiKey = apiKey ?? '';
     const oldCookies = await parseOldCookies(apiKey, options);
 
     // Step 2: Create browser config

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -33,6 +33,18 @@ describe('browser-client', () => {
       expect(parseOldCookies).toHaveBeenCalledTimes(1);
     });
 
+    test('should initialize without error when apiKey is undefined', async () => {
+      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
+        optOut: false,
+      });
+      const client = new AmplitudeBrowser();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      await client.init(undefined as any, USER_ID, {
+        ...attributionConfig,
+      });
+      expect(parseOldCookies).toHaveBeenCalledTimes(1);
+    });
+
     test('should read from old cookies config', async () => {
       const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
         optOut: false,

--- a/packages/analytics-client-common/test/cookie-name.test.ts
+++ b/packages/analytics-client-common/test/cookie-name.test.ts
@@ -3,14 +3,22 @@ import { API_KEY } from './helpers/constants';
 
 describe('cookie-name', () => {
   describe('getCookieName', () => {
-    test('should reutrn cookie name', () => {
+    test('should return cookie name', () => {
       expect(getCookieName(API_KEY)).toBe('AMP_apiKey');
+    });
+
+    test('should handle apiKey is empty string', () => {
+      expect(getCookieName('')).toBe('AMP');
     });
   });
 
   describe('getOldCookieName', () => {
-    test('should reutrn cookie name', () => {
+    test('should return cookie name', () => {
       expect(getOldCookieName(API_KEY)).toBe('amp_apiKey');
+    });
+
+    test('should handle apiKey is empty string', () => {
+      expect(getOldCookieName('')).toBe('amp_');
     });
   });
 });

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -4,14 +4,13 @@ import { Context } from './plugins/context';
 import { useNodeConfig } from './config';
 
 export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
-  async init(apiKey: string, options?: NodeOptions) {
+  async init(apiKey = '', options?: NodeOptions) {
     // Step 0: Block concurrent initialization
     if (this.initializing) {
       return;
     }
     this.initializing = true;
 
-    apiKey = apiKey ?? '';
     const nodeOptions = useNodeConfig(apiKey, {
       ...options,
     });

--- a/packages/analytics-node/src/node-client.ts
+++ b/packages/analytics-node/src/node-client.ts
@@ -11,6 +11,7 @@ export class AmplitudeNode extends AmplitudeCore<NodeConfig> {
     }
     this.initializing = true;
 
+    apiKey = apiKey ?? '';
     const nodeOptions = useNodeConfig(apiKey, {
       ...options,
     });

--- a/packages/analytics-node/test/node-client.test.ts
+++ b/packages/analytics-node/test/node-client.test.ts
@@ -15,6 +15,15 @@ describe('node-client', () => {
       expect(client.config).toBeDefined();
     });
 
+    test('should initialize without error when apiKey is undefined', async () => {
+      const client = new AmplitudeNode();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      await client.init(undefined as any, {
+        flushIntervalMillis: 1000,
+      });
+      expect(client.config).toBeDefined();
+    });
+
     test('should call prevent concurrent init executions', async () => {
       const client = new AmplitudeNode();
       const useNodeConfig = jest.spyOn(Config, 'useNodeConfig');

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -13,7 +13,7 @@ import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
 
 export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
-  async init(apiKey: string, userId?: string, options?: ReactNativeOptions) {
+  async init(apiKey = '', userId?: string, options?: ReactNativeOptions) {
     // Step 0: Block concurrent initialization
     if (this.initializing) {
       return;
@@ -21,7 +21,6 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     this.initializing = true;
 
     // Step 1: Read cookies stored by old SDK
-    apiKey = apiKey ?? '';
     const oldCookies = await parseOldCookies(apiKey, options);
 
     // Step 2: Create react native config

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -21,6 +21,7 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
     this.initializing = true;
 
     // Step 1: Read cookies stored by old SDK
+    apiKey = apiKey ?? '';
     const oldCookies = await parseOldCookies(apiKey, options);
 
     // Step 2: Create react native config

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -38,6 +38,18 @@ describe('react-native-client', () => {
       expect(parseOldCookies).toHaveBeenCalledTimes(1);
     });
 
+    test('should initialize without error when apiKey is undefined', async () => {
+      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
+        optOut: false,
+      });
+      const client = new AmplitudeReactNative();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      await client.init(undefined as any, USER_ID, {
+        ...attributionConfig,
+      });
+      expect(parseOldCookies).toHaveBeenCalledTimes(1);
+    });
+
     test('should read from old cookies config', async () => {
       const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
         optOut: false,


### PR DESCRIPTION
### Summary
Fix the edge case that `apiKey` might be null or undefined in the runtime.

Refer to issue: https://github.com/amplitude/Amplitude-TypeScript/issues/238

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
