### PR TITLE
fix: remove unintended options passed to browser SDK

### DIFF
--- a/packages/marketing-analytics-browser/README.md
+++ b/packages/marketing-analytics-browser/README.md
@@ -56,7 +56,7 @@ amplitude.init(API_KEY, USER_ID, {
   },
 
   // Enable auto page view tracking
-  trackPageViews: {
+  pageViewTracking: {
     trackOn: 'attribution',
   }
 });

--- a/packages/marketing-analytics-browser/src/browser-client.ts
+++ b/packages/marketing-analytics-browser/src/browser-client.ts
@@ -1,23 +1,35 @@
-import { createInstance as createBrowserInstance } from '@amplitude/analytics-browser';
+import { createInstance as createBaseInstance } from '@amplitude/analytics-browser';
 import { returnWrapper } from '@amplitude/analytics-core';
 import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
 import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
-import { Context } from './plugins/context';
-import { BrowserClient, BrowserOptions } from './typings/browser-client';
+import { context } from './plugins/context';
+import { Client, Options } from './typings/browser-client';
+import { BrowserOptions } from '@amplitude/analytics-types';
 
-export const createInstance = (): BrowserClient => {
-  const client = createBrowserInstance();
+export const createInstance = (): Client => {
+  const client = createBaseInstance();
 
-  const init = async (apiKey: string, userId?: string, options?: BrowserOptions) => {
-    if (!options?.attribution?.disabled) {
-      await client.add(webAttributionPlugin(client, options?.attribution)).promise;
+  const init = async (apiKey: string, userId?: string, options: Options = {}) => {
+    const { attribution, pageViewTracking, ...restOfOptions } = options;
+    const browserOptions: BrowserOptions = restOfOptions;
+
+    if (!attribution?.disabled) {
+      await client.add(webAttributionPlugin(client, attribution)).promise;
     }
-    if (options?.trackPageViews) {
-      const pageViewTrackingPluginOptions = typeof options.trackPageViews === 'boolean' ? {} : options.trackPageViews;
-      await client.add(pageViewTrackingPlugin(client, pageViewTrackingPluginOptions)).promise;
+
+    if (pageViewTracking) {
+      const pageViewTrackingOptions = typeof pageViewTracking === 'boolean' ? {} : pageViewTracking;
+      await client.add(pageViewTrackingPlugin(client, pageViewTrackingOptions)).promise;
     }
-    await client.add(new Context()).promise;
-    await client.init(apiKey, userId, options).promise;
+
+    await client.add(context()).promise;
+
+    // NOTE: Explicitly disable core web attribution logic in favor of web attribution plugin
+    browserOptions.attribution = {
+      disabled: true,
+    };
+
+    await client.init(apiKey, userId, browserOptions).promise;
   };
 
   return {

--- a/packages/marketing-analytics-browser/src/plugins/context.ts
+++ b/packages/marketing-analytics-browser/src/plugins/context.ts
@@ -1,21 +1,15 @@
 import { Event, PluginType, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { VERSION } from '../version';
 
-export class Context implements EnrichmentPlugin {
-  name = 'context';
-  type = PluginType.ENRICHMENT as const;
-
-  library = `amplitude-ma-ts/${VERSION}`;
-
-  setup(): Promise<undefined> {
-    return Promise.resolve(undefined);
-  }
-
-  async execute(context: Event): Promise<Event> {
-    const event: Event = {
+export const context = (): EnrichmentPlugin => {
+  const library = `amplitude-ma-ts/${VERSION}`;
+  return {
+    name: 'context',
+    type: PluginType.ENRICHMENT,
+    setup: async () => undefined,
+    execute: async (context: Event) => ({
       ...context,
-      library: this.library,
-    };
-    return event;
-  }
-}
+      library,
+    }),
+  };
+};

--- a/packages/marketing-analytics-browser/src/typings/browser-client.ts
+++ b/packages/marketing-analytics-browser/src/typings/browser-client.ts
@@ -6,12 +6,16 @@ import {
 import { Types as PageViewTrackingTypes } from '@amplitude/plugin-page-view-tracking-browser';
 import { Types as WebAttributionPluginTypes } from '@amplitude/plugin-web-attribution-browser';
 
-export interface BrowserClient extends AnalyticsBrowserClient {
-  init(apiKey: string, userId?: string, options?: BrowserOptions): AmplitudeReturn<void>;
+export interface Client extends AnalyticsBrowserClient {
+  init(apiKey: string, userId?: string, options?: Options): AmplitudeReturn<void>;
 }
 
-export type BrowserOptions = AnalyticsBrowserOptions & {
+export type Options = AnalyticsBrowserOptions & AttributionOptions & PageViewTracking;
+
+export type AttributionOptions = {
   attribution?: WebAttributionPluginTypes.Options;
-} & {
-  trackPageViews?: PageViewTrackingTypes.Options | boolean;
+};
+
+export type PageViewTracking = {
+  pageViewTracking?: PageViewTrackingTypes.Options | boolean;
 };

--- a/packages/marketing-analytics-browser/test/browser-client.test.ts
+++ b/packages/marketing-analytics-browser/test/browser-client.test.ts
@@ -83,7 +83,7 @@ describe('browser-client', () => {
       expect(init).toHaveBeenCalledTimes(1);
     });
 
-    test('should add page view tracking plugin when trackPageViews is true', async () => {
+    test('should add page view tracking plugin when pageViewTracking is true', async () => {
       const init = jest.fn().mockImplementation(() => ({
         promise: Promise.resolve(),
       }));
@@ -105,14 +105,14 @@ describe('browser-client', () => {
         attribution: {
           disabled: true,
         },
-        trackPageViews: true,
+        pageViewTracking: true,
       }).promise;
 
       expect(add).toHaveBeenCalledTimes(2);
       expect(init).toHaveBeenCalledTimes(1);
     });
 
-    test('should add page view tracking plugin when trackPageViews is set', async () => {
+    test('should add page view tracking plugin when pageViewTracking is set', async () => {
       const init = jest.fn().mockImplementation(() => ({
         promise: Promise.resolve(),
       }));
@@ -134,7 +134,7 @@ describe('browser-client', () => {
         attribution: {
           disabled: true,
         },
-        trackPageViews: {
+        pageViewTracking: {
           trackOn: 'attribution',
         },
       }).promise;
@@ -143,7 +143,7 @@ describe('browser-client', () => {
       expect(init).toHaveBeenCalledTimes(1);
     });
 
-    test('should not add page view tracking plugin when trackPageViews is false', async () => {
+    test('should not add page view tracking plugin when pageViewTracking is false', async () => {
       const init = jest.fn().mockImplementation(() => ({
         promise: Promise.resolve(),
       }));
@@ -165,7 +165,7 @@ describe('browser-client', () => {
         attribution: {
           disabled: true,
         },
-        trackPageViews: false,
+        pageViewTracking: false,
       }).promise;
 
       expect(add).toHaveBeenCalledTimes(1);

--- a/packages/marketing-analytics-browser/test/integration.test.ts
+++ b/packages/marketing-analytics-browser/test/integration.test.ts
@@ -127,7 +127,7 @@ describe('e2e', () => {
     const client = createInstance();
     client.init('API_KEY', undefined, {
       ...opts,
-      trackPageViews: {
+      pageViewTracking: {
         trackOn: 'attribution',
       },
     });
@@ -220,7 +220,7 @@ describe('e2e', () => {
       attribution: {
         disabled: true,
       },
-      trackPageViews: true,
+      pageViewTracking: true,
     });
 
     return new Promise<void>((resolve) => {
@@ -274,7 +274,7 @@ describe('e2e', () => {
     const client = createInstance();
     client.init('API_KEY', undefined, {
       ...opts,
-      trackPageViews: true,
+      pageViewTracking: true,
     });
 
     return new Promise<void>((resolve) => {

--- a/packages/marketing-analytics-browser/test/plugins/context.test.ts
+++ b/packages/marketing-analytics-browser/test/plugins/context.test.ts
@@ -1,16 +1,17 @@
-import { Context } from '../../src/plugins/context';
+import { Config } from '@amplitude/analytics-types';
+import { context } from '../../src/plugins/context';
 
 describe('context', () => {
   describe('execute', () => {
     test('should execute plugin', async () => {
-      const context = new Context();
-      await context.setup();
+      const plugin = context();
+      await plugin.setup({} as Config);
 
-      const event = {
+      const e = {
         event_type: 'event_type',
       };
-      const contextEvent = await context.execute(event);
-      expect(contextEvent.library).toBeDefined();
+      const event = await plugin.execute(e);
+      expect(event.library).toMatch(/^amplitude-ma-ts\/.+/);
     });
   });
 });

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,8 @@
 {
   "entryPoints": [
     "packages/analytics-browser",
-    "packages/analytics-node"
+    "packages/analytics-node",
+    "packages/marketing-analytics-browser"
   ],
   "entryPointStrategy": "packages",
   "logLevel": "Error",


### PR DESCRIPTION
### Summary

* [fix: remove unintended options passed to browser SDK](https://github.com/amplitude/Amplitude-TypeScript/commit/6031faf694b3aa974a27e36b904db4a865dc0de7)
* [docs: update docs with new option key](https://github.com/amplitude/Amplitude-TypeScript/commit/f6f75eb3fcb6c27c6bfe0a48168c55a0878c00fc)
* [refactor: convert marketing analytics browser context plugin to fn de…](https://github.com/amplitude/Amplitude-TypeScript/commit/115ee546d9621f6e3d31c2f44aaa8dcb6fca5cd7) 
* [docs: add marketing analytics browser to type doc](https://github.com/amplitude/Amplitude-TypeScript/commit/9d47cd2dfba2db83a85e0bb641e7d8027726c4ae)

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
