### PR TITLE
docs: adds example for enriching page view events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
         run: |
           yarn test
 
+      - name: Test all examples
+        run: |
+          yarn test:examples
+
       - name: Lint all packages
         run: |
           yarn lint

--- a/examples/plugins/page-view-tracking-enrichment/index.test.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.test.ts
@@ -1,0 +1,42 @@
+import { FetchTransport } from '@amplitude/analytics-client-common';
+import { Logger } from '@amplitude/analytics-core';
+import { LogLevel } from '@amplitude/analytics-types';
+import { pageViewTrackingEnrichment } from './';
+
+describe('pageViewTrackingEnrichment', () => {
+  describe('setup', () => {
+    test('should return undefined', async () => {
+      const mockConfig = {
+        apiKey: '',
+        flushIntervalMillis: 0,
+        flushMaxRetries: 0,
+        flushQueueSize: 0,
+        logLevel: LogLevel.None,
+        loggerProvider: new Logger(),
+        optOut: false,
+        serverUrl: undefined,
+        transportProvider: new FetchTransport(),
+        useBatch: false,
+      };
+      const plugin = pageViewTrackingEnrichment();
+      const result = await plugin.setup(mockConfig);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('execute', () => {
+    test('should enrich page view event', async () => {
+      const mockEvent = {
+        event_type: 'Page View',
+      };
+      const plugin = pageViewTrackingEnrichment();
+      const result = await plugin.execute(mockEvent);
+      expect(result).toEqual({
+        event_type: 'Page View',
+        event_properties: {
+          new_property: 'new_value',
+        },
+      });
+    });
+  });
+});

--- a/examples/plugins/page-view-tracking-enrichment/index.test.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.test.ts
@@ -3,7 +3,7 @@ import { Logger } from '@amplitude/analytics-core';
 import { LogLevel } from '@amplitude/analytics-types';
 import { pageViewTrackingEnrichment } from './';
 
-describe('pageViewTrackingEnrichment', () => {
+describe('page-view-tracking-enrichment', () => {
   describe('setup', () => {
     test('should return undefined', async () => {
       const mockConfig = {
@@ -36,6 +36,17 @@ describe('pageViewTrackingEnrichment', () => {
         event_properties: {
           new_property: 'new_value',
         },
+      });
+    });
+
+    test('should not enrich other events', async () => {
+      const mockEvent = {
+        event_type: 'Not Page View',
+      };
+      const plugin = pageViewTrackingEnrichment();
+      const result = await plugin.execute(mockEvent);
+      expect(result).toEqual({
+        event_type: 'Not Page View',
       });
     });
   });

--- a/examples/plugins/page-view-tracking-enrichment/index.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.ts
@@ -28,7 +28,10 @@ export const pageViewTrackingEnrichment = (): EnrichmentPlugin => {
   };
 };
 
-// install plugin
+/**
+ * IMPORTANT: install plugin before calling init to make sure plugin is added by the time
+ * init function sends out the "Page View" event
+ */
 instance.add(pageViewTrackingEnrichment());
 
 // initialize sdk

--- a/examples/plugins/page-view-tracking-enrichment/index.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.ts
@@ -1,0 +1,35 @@
+import { createInstance } from '@amplitude/analytics-browser';
+import { EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
+
+const instance = createInstance();
+
+/**
+ * This is example plugin that enriches events with event_type "Page View" by adding
+ * more event_properties on top of what @amplitude/analytics-browser provides out of the box
+ *
+ * @returns EnrichmentPlugin
+ */
+export const pageViewTrackingEnrichment = (): EnrichmentPlugin => {
+  return {
+    name: 'page-view-tracking-enrichment',
+    type: PluginType.ENRICHMENT,
+    setup: async () => undefined,
+    execute: async (event) => {
+      if (event.event_type !== 'Page View') {
+        return event;
+      }
+      event.event_properties = {
+        ...event.event_properties,
+        // TODO: Add new event properties here
+        new_property: 'new_value',
+      };
+      return event;
+    },
+  };
+};
+
+// install plugin
+instance.add(pageViewTrackingEnrichment());
+
+// initialize sdk
+instance.init('API_KEY');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:staged": "lint-staged",
     "postinstall": "husky install",
     "test": "lerna run test --stream",
+    "test:examples": "jest --env=jsdom --coverage=false examples",
     "test:unit": "lerna run test --stream --ignore @amplitude/analytics-browser-test",
     "test:e2e": "lerna run test --stream --scope @amplitude/analytics-browser-test",
     "version": "git add -A"


### PR DESCRIPTION
### Summary

Adds an example plugin that enriches events with event_type "Page View" by adding more event_properties on top of what `@amplitude/analytics-browser` provides out of the box

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
