### PR TITLE
fix: run queued functions after attribution in browser-client.ts

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -134,14 +134,15 @@ describe('integration', () => {
       const send = jest.spyOn(transportProvider, 'send');
       const track = jest.fn();
 
-      amplitude.setUserId(userId);
-      amplitude.setDeviceId(deviceId);
-      amplitude.setSessionId(sessionId);
+      const client = amplitude.createInstance();
+      client.setUserId(userId);
+      client.setDeviceId(deviceId);
+      client.setSessionId(sessionId);
 
-      void amplitude.track('Event Before Init').promise.then((result) => {
+      void client.track('Event Before Init').promise.then((result) => {
         track(result.event.event_type);
       });
-      await amplitude.init('API_KEY', undefined, {
+      await client.init('API_KEY', undefined, {
         ...opts,
         transportProvider,
         attribution: {

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -37,7 +37,8 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
       lastEventTime: oldCookies.lastEventTime,
     });
 
-    const tempQ = this.getAndResetQueuedFunctions();
+    // delay running queued functions until after all initialization is complete
+    const delayedQ = this.getAndResetQueuedFunctions();
     await super._init(browserOptions);
 
     // Step 3: Manage session
@@ -85,7 +86,7 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
 
     // Step 7:
     // Run queued functions
-    this.q = [...tempQ, ...this.q];
+    this.q = [...delayedQ, ...this.q];
     await this.runQueuedFunctions();
   }
 

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -36,6 +36,8 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
       optOut: options?.optOut ?? oldCookies.optOut,
       lastEventTime: oldCookies.lastEventTime,
     });
+
+    const tempQ = this.getAndResetQueuedFunctions();
     await super._init(browserOptions);
 
     // Step 3: Manage session
@@ -80,6 +82,11 @@ export class AmplitudeBrowser extends AmplitudeCore<BrowserConfig> {
 
     // Step 6: Track attributions
     await this.runAttributionStrategy(browserOptions.attribution, isNewSession);
+
+    // Step 7:
+    // Run queued functions
+    this.q = [...tempQ, ...this.q];
+    await this.runQueuedFunctions();
   }
 
   async runAttributionStrategy(attributionConfig?: AttributionOptions, isNewSession = false) {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -38,8 +38,17 @@ export class AmplitudeCore<T extends Config> implements CoreClient<T> {
   async _init(config: T) {
     this.config = config;
     this.timeline.reset();
+    await this.runQueuedFunctions();
+  }
+
+  protected getAndResetQueuedFunctions() {
     const queuedFunctions = this.q;
     this.q = [];
+    return queuedFunctions;
+  }
+
+  protected async runQueuedFunctions() {
+    const queuedFunctions = this.getAndResetQueuedFunctions();
     for (const queuedFunction of queuedFunctions) {
       await queuedFunction();
     }


### PR DESCRIPTION
### Summary
Updated AmplitudeBrowser to run queued functions after other initialization completes.
 * There is now a separate pluginQueue for `add()` and `remove()` that runs before `this.q`
 * Added test for order of calls (identify with attribution, then track)
 * fixes #246 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
