### PR TITLE
fix: globalThis polyfill

### DIFF
--- a/packages/analytics-browser/jest.config.js
+++ b/packages/analytics-browser/jest.config.js
@@ -6,5 +6,5 @@ module.exports = {
   displayName: package.name,
   rootDir: '.',
   testEnvironment: 'jsdom',
-  coveragePathIgnorePatterns: ['snippet-index.ts'],
+  coveragePathIgnorePatterns: ['snippet-index.ts', 'global-scope.ts'],
 };

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -23,5 +23,6 @@ export const {
   track,
 } = client;
 export { runQueuedFunctions } from './utils/snippet-helper';
+export { GlobalScope } from './utils/global-scope';
 export { Revenue, Identify } from '@amplitude/analytics-core';
 export * as Types from '@amplitude/analytics-types';

--- a/packages/analytics-browser/src/snippet-index.ts
+++ b/packages/analytics-browser/src/snippet-index.ts
@@ -1,15 +1,16 @@
 import * as amplitude from './index';
 import { runQueuedFunctions } from './utils/snippet-helper';
+import { GlobalScope } from './utils/global-scope';
 
-globalThis.amplitude = Object.assign(globalThis.amplitude || {}, amplitude);
+GlobalScope.amplitude = Object.assign(GlobalScope.amplitude || {}, amplitude);
 
-if (globalThis.amplitude.invoked) {
-  const queue = globalThis.amplitude._q;
-  globalThis.amplitude._q = [];
+if (GlobalScope.amplitude.invoked) {
+  const queue = GlobalScope.amplitude._q;
+  GlobalScope.amplitude._q = [];
   runQueuedFunctions(amplitude, queue);
 
-  for (let i = 0; i < globalThis.amplitude._iq.length; i++) {
-    const instance = Object.assign(globalThis.amplitude._iq[i], amplitude.createInstance());
+  for (let i = 0; i < GlobalScope.amplitude._iq.length; i++) {
+    const instance = Object.assign(GlobalScope.amplitude._iq[i], amplitude.createInstance());
     const queue = instance._q;
     instance._q = [];
     runQueuedFunctions(instance, queue);

--- a/packages/analytics-browser/src/utils/global-scope.ts
+++ b/packages/analytics-browser/src/utils/global-scope.ts
@@ -1,0 +1,13 @@
+/* global globalThis */
+export const GlobalScope: typeof globalThis = (() => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  return global;
+})();

--- a/packages/analytics-browser/test/utils/global-scope.test.ts
+++ b/packages/analytics-browser/test/utils/global-scope.test.ts
@@ -1,0 +1,7 @@
+import { GlobalScope } from '../../src';
+
+describe('global-scope', () => {
+  test('should be defined', () => {
+    expect(GlobalScope).toBeDefined();
+  });
+});

--- a/packages/marketing-analytics-browser/src/snippet-index.ts
+++ b/packages/marketing-analytics-browser/src/snippet-index.ts
@@ -1,15 +1,15 @@
 import * as amplitude from './index';
-import { runQueuedFunctions } from '@amplitude/analytics-browser';
+import { runQueuedFunctions, GlobalScope } from '@amplitude/analytics-browser';
 
-globalThis.amplitude = Object.assign(globalThis.amplitude || {}, amplitude);
+GlobalScope.amplitude = Object.assign(GlobalScope.amplitude || {}, amplitude);
 
-if (globalThis.amplitude.invoked) {
-  const queue = globalThis.amplitude._q;
-  globalThis.amplitude._q = [];
+if (GlobalScope.amplitude.invoked) {
+  const queue = GlobalScope.amplitude._q;
+  GlobalScope.amplitude._q = [];
   runQueuedFunctions(amplitude, queue);
 
-  for (let i = 0; i < globalThis.amplitude._iq.length; i++) {
-    const instance = Object.assign(globalThis.amplitude._iq[i], amplitude.createInstance());
+  for (let i = 0; i < GlobalScope.amplitude._iq.length; i++) {
+    const instance = Object.assign(GlobalScope.amplitude._iq[i], amplitude.createInstance());
     const queue = instance._q;
     instance._q = [];
     runQueuedFunctions(instance, queue);


### PR DESCRIPTION
### Summary

Replace `globalThis` (unsupported in some legacy browsers) with `GlobalScope` polyfill (from Amplitude-JavaScript)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
