### PR TITLE
docs: adds plugin example for removing keys from event payload

### DIFF
--- a/examples/plugins/page-view-tracking-enrichment/index.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.ts
@@ -1,10 +1,8 @@
 import { createInstance } from '@amplitude/analytics-browser';
 import { EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
 
-const instance = createInstance();
-
 /**
- * This is example plugin that enriches events with event_type "Page View" by adding
+ * This is an example plugin that enriches events with event_type "Page View" by adding
  * more event_properties on top of what @amplitude/analytics-browser provides out of the box
  *
  * @returns EnrichmentPlugin
@@ -27,6 +25,8 @@ export const pageViewTrackingEnrichment = (): EnrichmentPlugin => {
     },
   };
 };
+
+const instance = createInstance();
 
 /**
  * IMPORTANT: install plugin before calling init to make sure plugin is added by the time

--- a/examples/plugins/remove-event-key/index.test.ts
+++ b/examples/plugins/remove-event-key/index.test.ts
@@ -1,0 +1,25 @@
+import { removeEventKeyEnrichment } from './';
+
+describe('remove-event-key-enrichment', () => {
+  describe('execute', () => {
+    test('should remove keys from event payload', async () => {
+      const plugin = removeEventKeyEnrichment(['time']);
+      const mockEvent = {
+        event_type: 'Custom Event',
+        time: Date.now(),
+      };
+      const result = await plugin.execute(mockEvent);
+      expect(result.time).toBeUndefined();
+    });
+
+    test('should not remove keys from event payload', async () => {
+      const plugin = removeEventKeyEnrichment();
+      const mockEvent = {
+        event_type: 'Custom Event',
+        time: Date.now(),
+      };
+      const result = await plugin.execute(mockEvent);
+      expect(result.time).toBeDefined();
+    });
+  });
+});

--- a/examples/plugins/remove-event-key/index.ts
+++ b/examples/plugins/remove-event-key/index.ts
@@ -34,9 +34,11 @@ export const removeEventKeyEnrichment = (keysToRemove: KeyOfEvent[] = []): Enric
  * This is an example plugin that enriches all events by removing `event.time` from all events.
  * `event.time` uses `Date.now()` which is controlled by the device where the browser runs on.
  * With `event.time` being `undefined`, the time of the event is determined when the event was sent
- * by the browser, determined by the server clock, rather then when the event occurred which can be
+ * successfully by the browser ("Client Upload Time"), determined by the server clock, rather than
+ * when the event actually occurred. On majority of the cases, "Client Upload Time" can be
  * off by up to the configured `config.flushIntervalMillis`. By default `config.flushIntervalMillis`
- * is set to 1000 milliseconds.
+ * is set to 1000 milliseconds. In rare cases where initial request to Amplitude fails due to
+ * bad payload, throttled request, server error, etc, the time difference can be extended.
  */
 const removeTimeEnrichment = removeEventKeyEnrichment(['time']);
 

--- a/examples/plugins/remove-event-key/index.ts
+++ b/examples/plugins/remove-event-key/index.ts
@@ -1,0 +1,52 @@
+import { createInstance } from '@amplitude/analytics-browser';
+import { EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
+import { BaseEvent } from '@amplitude/analytics-types/src';
+
+type KeyOfEvent = keyof BaseEvent;
+
+/**
+ * This is an example plugin that enriches all events by removing a list of keys from the
+ * event payload. This plugin is helpful in cases where users prefer not to use default
+ * values set by the @amplitude/analytics-browser library, for example:
+ * - `event.time`
+ * - `event.idfa`
+ * - `event.idva`
+ * - `event.ip`
+ *
+ * @param keysToRemove
+ * @returns EnrichmentPlugin
+ */
+export const removeEventKeyEnrichment = (keysToRemove: KeyOfEvent[] = []): EnrichmentPlugin => {
+  return {
+    name: 'remove-event-key-enrichment',
+    type: PluginType.ENRICHMENT,
+    setup: async () => undefined,
+    execute: async (event) => {
+      for (var key of keysToRemove) {
+        delete event[key];
+      }
+      return event;
+    },
+  };
+};
+
+/**
+ * This is an example plugin that enriches all events by removing `event.time` from all events.
+ * `event.time` uses `Date.now()` which is controlled by the device where the browser runs on.
+ * With `event.time` being `undefined`, the time of the event is determined when the event was sent
+ * by the browser, determined by the server clock, rather then when the event occurred which can be
+ * off by up to the configured `config.flushIntervalMillis`. By default `config.flushIntervalMillis`
+ * is set to 1000 milliseconds.
+ */
+const removeTimeEnrichment = removeEventKeyEnrichment(['time']);
+
+const instance = createInstance();
+
+/**
+ * IMPORTANT: install plugin before calling init to make sure plugin is added by the time
+ * init function is called, and events are flushed.
+ */
+instance.add(removeTimeEnrichment);
+
+// initialize sdk
+instance.init('API_KEY');

--- a/examples/plugins/remove-event-key/index.ts
+++ b/examples/plugins/remove-event-key/index.ts
@@ -33,6 +33,7 @@ export const removeEventKeyEnrichment = (keysToRemove: KeyOfEvent[] = []): Enric
 /**
  * This is an example plugin that enriches all events by removing `event.time` from all events.
  * `event.time` uses `Date.now()` which is controlled by the device where the browser runs on.
+ * The device clock can be easily manipulated yielding events having unreasonable time values.
  * With `event.time` being `undefined`, the time of the event is determined when the event was sent
  * successfully by the browser ("Client Upload Time"), determined by the server clock, rather than
  * when the event actually occurred. On majority of the cases, "Client Upload Time" can be


### PR DESCRIPTION
### Summary

* adds plugin example for removing keys from event payload
* adds an actual example for removing `event.time` from event payload

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
