### PR TITLE
feat: ignore subdomains when comparing newness of campaigns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,14 +7,11 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2018,
-    project: "packages/*/tsconfig.json",
+    project: 'packages/*/tsconfig.json',
     sourceType: 'module',
     tsconfigRootDir: __dirname,
   },
-  plugins: [
-    '@typescript-eslint',
-    'jest',
-  ],
+  plugins: ['@typescript-eslint', 'jest'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
@@ -26,12 +23,13 @@ module.exports = {
   rules: {
     '@typescript-eslint/member-delimiter-style': 0,
     '@typescript-eslint/no-explicit-any': 0,
+    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
     '@typescript-eslint/semi': 0,
     '@typescript-eslint/space-before-function-paren': 0,
     '@typescript-eslint/require-await': 0,
     'comma-dangle': 0,
     'new-cap': 0,
-    'eol-last': [2, "always"],
+    'eol-last': [2, 'always'],
     'no-multiple-empty-lines': [2, { max: 1, maxEOF: 0 }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/member-delimiter-style': 0,
     '@typescript-eslint/no-explicit-any': 0,
-    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
+    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'none', ignoreRestSiblings: true }],
     '@typescript-eslint/semi': 0,
     '@typescript-eslint/space-before-function-paren': 0,
     '@typescript-eslint/require-await': 0,

--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -42,11 +42,7 @@ export class CampaignTracker implements ICampaignTracker {
     this.initialEmptyValue = options.initialEmptyValue ?? EMPTY_VALUE;
   }
 
-  isNewCampaign(
-    current: Campaign,
-    previous: Campaign | undefined,
-    removeSubdomainsWhenComparingReferringDomains = false,
-  ) {
+  isNewCampaign(current: Campaign, previous: Campaign | undefined, ignoreSubdomainInReferrer = false) {
     const { referrer, referring_domain, ...currentCampaign } = current;
     const { referrer: _previous_referrer, referring_domain: prevReferringDomain, ...previousCampaign } = previous || {};
 
@@ -55,7 +51,7 @@ export class CampaignTracker implements ICampaignTracker {
     }
 
     const hasNewCampaign = JSON.stringify(currentCampaign) !== JSON.stringify(previousCampaign);
-    const hasNewDomain = removeSubdomainsWhenComparingReferringDomains
+    const hasNewDomain = ignoreSubdomainInReferrer
       ? domainWithoutSubdomain(referring_domain || '') !== domainWithoutSubdomain(prevReferringDomain || '')
       : referring_domain !== prevReferringDomain;
 

--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -42,7 +42,11 @@ export class CampaignTracker implements ICampaignTracker {
     this.initialEmptyValue = options.initialEmptyValue ?? EMPTY_VALUE;
   }
 
-  isNewCampaign(current: Campaign, previous: Campaign | undefined) {
+  isNewCampaign(
+    current: Campaign,
+    previous: Campaign | undefined,
+    removeSubdomainsWhenComparingReferringDomains = false,
+  ) {
     const { referrer, referring_domain, ...currentCampaign } = current;
     const { referrer: _previous_referrer, referring_domain: prevReferringDomain, ...previousCampaign } = previous || {};
 
@@ -51,9 +55,11 @@ export class CampaignTracker implements ICampaignTracker {
     }
 
     const hasNewCampaign = JSON.stringify(currentCampaign) !== JSON.stringify(previousCampaign);
-    const hasNewDomain = domainWithoutSubdomain(referring_domain || "") !== domainWithoutSubdomain(prevReferringDomain || "");
+    const hasNewDomain = removeSubdomainsWhenComparingReferringDomains
+      ? domainWithoutSubdomain(referring_domain || '') !== domainWithoutSubdomain(prevReferringDomain || '')
+      : referring_domain !== prevReferringDomain;
 
-    return (!previous || hasNewCampaign || hasNewDomain);
+    return !previous || hasNewCampaign || hasNewDomain;
   }
 
   async saveCampaignToStorage(campaign: Campaign): Promise<void> {
@@ -118,4 +124,4 @@ const domainWithoutSubdomain = (domain: string) => {
   }
 
   return parts.slice(parts.length - 2, parts.length).join('.');
-}
+};

--- a/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
+++ b/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
@@ -343,7 +343,7 @@ describe('CampaignTracker', () => {
     });
   });
 
-  describe('domain comparison', () => {
+  describe('domain comparison without subdomains', () => {
     const cases = [
       ['amplitude.com', 'www.amplitude.com', false] as const,
       ['google.com', 'amplitude.com', true] as const,
@@ -362,6 +362,7 @@ describe('CampaignTracker', () => {
         const result = campaignTracker.isNewCampaign(
           { referring_domain: domain1 } as Campaign,
           { referring_domain: domain2 } as Campaign,
+          true,
         );
         expect(result).toBe(isNewCampaign);
       });

--- a/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
+++ b/packages/analytics-client-common/test/attribution/campaign-tracker.test.ts
@@ -342,4 +342,29 @@ describe('CampaignTracker', () => {
       expect(saveCampaignToStorage).toHaveBeenCalledTimes(0);
     });
   });
+
+  describe('domain comparison', () => {
+    const cases = [
+      ['amplitude.com', 'www.amplitude.com', false] as const,
+      ['google.com', 'amplitude.com', true] as const,
+      ['', '', false] as const,
+      ['www.amplitude.com', 'www.amplitude.com', false] as const,
+      ['', 'www.amplitude.com', true] as const,
+    ];
+    for (const [domain1, domain2, isNewCampaign] of cases) {
+      test(`for "${domain1}" and "${domain2}", should track new campaign: ${isNewCampaign.toString()} `, () => {
+        const config = {
+          storage: new MemoryStorage<Campaign>(),
+          track: jest.fn(),
+          onNewCampaign: () => false,
+        };
+        const campaignTracker = new CampaignTracker(API_KEY, config);
+        const result = campaignTracker.isNewCampaign(
+          { referring_domain: domain1 } as Campaign,
+          { referring_domain: domain2 } as Campaign,
+        );
+        expect(result).toBe(isNewCampaign);
+      });
+    }
+  });
 });

--- a/packages/plugin-web-attribution-browser/src/plugin-campaign-tracker.ts
+++ b/packages/plugin-web-attribution-browser/src/plugin-campaign-tracker.ts
@@ -33,6 +33,7 @@ export class PluginCampaignTracker {
     const isNewCampaign = this.campaignTracker.isNewCampaign(
       currentCampaign,
       await this.campaignTracker.getCampaignFromStorage(),
+      true,
     );
     return {
       isNewCampaign,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

For attribution plugin, don't reset session or campaign when subdomain changes.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
