### PR TITLE
docs: adds README.md for plugins

### DIFF
--- a/packages/plugin-page-view-tracking-browser/README.md
+++ b/packages/plugin-page-view-tracking-browser/README.md
@@ -1,0 +1,66 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>
+
+# @amplitude/plugin-page-view-tracking-browser
+
+Official Browser SDK plugin for page view tracking
+
+## Installation
+
+This package is published on NPM registry and is available to be installed using npm and yarn.
+
+```sh
+# npm
+npm install @amplitude/plugin-page-view-tracking-browser
+
+# yarn
+yarn add @amplitude/plugin-page-view-tracking-browser
+```
+
+## Usage
+
+This plugin works on top of Amplitude Browser SDK and adds page view tracking features to built-in features. To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.4.0` or later.
+
+### 1. Import Amplitude packages
+
+* `@amplitude/analytics-browser`
+* `@amplitude/plugin-page-view-tracking-browser`
+
+```typescript
+import * as amplitude from '@amplitude/analytics-browser';
+import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
+```
+
+### 2. Instantiate page view plugin
+
+The plugin requires 1 parameter, which is the `amplitude` instance. The plugin also accepts an optional second parameter, which is an `Object` to configure the plugin based on your use case.
+
+```typescript
+const pageViewTracking = pageViewTrackingPlugin(amplitude, {
+  trackOn: undefined,
+  trackHistoryChanges: undefined,
+});
+```
+
+#### Options
+
+|Name|Type|Default|Description|
+|-|-|-|-|
+|`trackOn`|`"attribution"` or `() => boolean`|`undefined`|Use this option to control when to track a page view event. By default, a page view event is sent on each SDK initialization.<br/><br/>Use `() => boolean` to control sending page view events using custom conditional logic.<br/><br/>Use `"attribution"` to send page view events with attribution events. This option requires using [@amplitude/plugin-web-attribution-browser](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/plugin-web-attribution-browser).|
+|`trackHistoryChanges`|`"all"` or `"pathOnly"`|`undefined`|Use this option to subscribe to page view changes in a single page application like React.js. By default, page view changes in single page applications does not trigger a page view event.<br/><br/>Use `"all"` to compare the full url changes.<br/><br/>Use "pathOnly" to compare only url path changes.|
+
+### 3. Install plugin to Amplitude SDK
+
+```typescript
+amplitude.add(pageViewTracking);
+```
+
+### 4. Initialize Amplitude SDK
+
+```typescript
+amplitude.init('API_KEY');
+```

--- a/packages/plugin-page-view-tracking-browser/README.md
+++ b/packages/plugin-page-view-tracking-browser/README.md
@@ -51,7 +51,7 @@ const pageViewTracking = pageViewTrackingPlugin(amplitude, {
 |Name|Type|Default|Description|
 |-|-|-|-|
 |`trackOn`|`"attribution"` or `() => boolean`|`undefined`|Use this option to control when to track a page view event. By default, a page view event is sent on each SDK initialization.<br/><br/>Use `() => boolean` to control sending page view events using custom conditional logic.<br/><br/>Use `"attribution"` to send page view events with attribution events. This option requires using [@amplitude/plugin-web-attribution-browser](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/plugin-web-attribution-browser).|
-|`trackHistoryChanges`|`"all"` or `"pathOnly"`|`undefined`|Use this option to subscribe to page view changes in a single page application like React.js. By default, page view changes in single page applications does not trigger a page view event.<br/><br/>Use `"all"` to compare the full url changes.<br/><br/>Use "pathOnly" to compare only url path changes.|
+|`trackHistoryChanges`|`"all"` or `"pathOnly"`|`undefined`|Use this option to subscribe to page view changes in a single page application like React.js. By default, page view changes in single page applications does not trigger a page view event.<br/><br/>Use `"all"` to compare the full url changes.<br/><br/>Use `"pathOnly"` to compare only url path changes.|
 
 ### 3. Install plugin to Amplitude SDK
 
@@ -64,3 +64,20 @@ amplitude.add(pageViewTracking);
 ```typescript
 amplitude.init('API_KEY');
 ```
+
+## Resulting page view event
+
+This plugin tracks page views based on your configuration. A page view event is composed of the following values:
+
+#### Event type
+* `"Page View"`
+
+#### Event properties
+
+|Property|Description|
+|-|-|
+|`page_domain`|The website's hostname or `location.hostname`|
+|`page_location`|The website's full url or `location.href`|
+|`page_path`|The website's pathname or `location.pathname`|
+|`page_title`|The website's title or `document.title`|
+|`page_url`|The website's url excluding query parameters|

--- a/packages/plugin-web-attribution-browser/README.md
+++ b/packages/plugin-web-attribution-browser/README.md
@@ -1,0 +1,70 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>
+
+# @amplitude/plugin-web-attribution-browser
+
+Official Browser SDK plugin for web attribution tracking
+
+## Installation
+
+This package is published on NPM registry and is available to be installed using npm and yarn.
+
+```sh
+# npm
+npm install @amplitude/plugin-web-attribution-browser
+
+# yarn
+yarn add @amplitude/plugin-web-attribution-browser
+```
+
+## Usage
+
+This plugin works on top of Amplitude Browser SDK and adds web attribution tracking features to built-in features. To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.4.0` or later.
+
+### 1. Import Amplitude packages
+
+* `@amplitude/analytics-browser`
+* `@amplitude/plugin-web-attribution-browser`
+
+```typescript
+import * as amplitude from '@amplitude/analytics-browser';
+import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
+```
+
+### 2. Instantiate page view plugin
+
+The plugin requires 1 parameter, which is the `amplitude` instance. The plugin also accepts an optional second parameter, which is an `Object` to configure the plugin based on your use case.
+
+```typescript
+const webAttributionTracking = webAttributionPlugin(amplitude, {
+  disabled: undefined,
+  excludeReferrers: undefined,
+  initialEmptyValue: undefined,
+  resetSessionOnNewCampaign: undefined,
+});
+```
+
+#### Options
+
+|Name|Type|Default|Description|
+|-|-|-|-|
+|`disabled`|`boolean`|`false`|Use this option to enable or disable web attribution tracking. By default, upon installing this plugin, web attribution tracking is enabled.|
+|`excludeReferrers`|`string[]`|`[]`|Use this option to prevent the plugin from tracking campaigns parameters from specific referrers. For example: `subdomain.domain.com`.|
+|`initialEmptyValue`|`string`|`"EMPTY"`|Use this option to specify empty values for [first-touch attribution](https://www.docs.developers.amplitude.com/data/sdks/marketing-analytics-browser/#first-touch-attribution).|
+|`resetSessionOnNewCampaign`|`boolean`|`false`|Use this option to control whether a new session should start on a new campaign.|
+
+### 3. Install plugin to Amplitude SDK
+
+```typescript
+amplitude.add(webAttributionTracking);
+```
+
+### 4. Initialize Amplitude SDK
+
+```typescript
+amplitude.init('API_KEY');
+```

--- a/packages/plugin-web-attribution-browser/README.md
+++ b/packages/plugin-web-attribution-browser/README.md
@@ -68,3 +68,31 @@ amplitude.add(webAttributionTracking);
 ```typescript
 amplitude.init('API_KEY');
 ```
+
+## Resulting web attribution event
+
+This plugin tracks campaign parameters based on your configuration. A web attribution event is composed of the following values:
+
+#### Event type
+* `"$idenfity"`
+
+#### User properties
+
+|Property|Description|
+|-|-|
+|`utm_source`|URL query parameter value for `utm_source`|
+|`utm_medium`|URL query parameter value for `utm_medium`|
+|`utm_campaign`|URL query parameter value for `utm_campaign`|
+|`utm_term`|URL query parameter value for `utm_term`|
+|`utm_content`|URL query parameter value for `utm_content`|
+|`referrer`|Referring webstite or `document.referrer`|
+|`referring_domain`|Referring website's domain, including subdomain|
+|`dclid`|URL query parameter value for `dclid`|
+|`gbraid`|URL query parameter value for `gbraid`|
+|`gclid`|URL query parameter value for `gclid`|
+|`fbclid`|URL query parameter value for `fbclid`|
+|`ko_click_id`|URL query parameter value for `ko_click_id`|
+|`msclkid`|URL query parameter value for `msclkid`|
+|`ttclid`|URL query parameter value for `ttclid`|
+|`twclid`|URL query parameter value for `twclid`|
+|`wbraid`|URL query parameter value for `wbraid`|


### PR DESCRIPTION
### Summary 

Add comprehensive docs for web attribution and page view tracking plugins

* https://github.com/amplitude/Amplitude-TypeScript/tree/plugin-docs/packages/plugin-web-attribution-browser
* https://github.com/amplitude/Amplitude-TypeScript/tree/plugin-docs/packages/plugin-page-view-tracking-browser

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
