### PR TITLE
fix: clear open timeouts when flush is called

### DIFF
--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -110,7 +110,7 @@ describe('destination', () => {
 
     test('should schedule a flush', async () => {
       const destination = new Destination();
-      destination.scheduled = false;
+      destination.scheduled = null;
       destination.queue = [
         {
           event: { event_type: 'event_type' },
@@ -121,7 +121,10 @@ describe('destination', () => {
       ];
       const flush = jest
         .spyOn(destination, 'flush')
-        .mockReturnValueOnce(Promise.resolve(undefined))
+        .mockImplementationOnce(() => {
+          destination.scheduled = null;
+          return Promise.resolve(undefined);
+        })
         .mockReturnValueOnce(Promise.resolve(undefined));
       destination.schedule(0);
       // exhause first setTimeout
@@ -135,7 +138,7 @@ describe('destination', () => {
 
     test('should not schedule if one is already in progress', () => {
       const destination = new Destination();
-      destination.scheduled = true;
+      destination.scheduled = setTimeout(jest.fn, 0);
       const flush = jest.spyOn(destination, 'flush').mockReturnValueOnce(Promise.resolve(undefined));
       destination.schedule(0);
       expect(flush).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
### Summary

#### Issue
When calling `amplitude.flush()`, events are flushed immediately but a timeout remains open, created by `amplitude.track()`, which keeps the Node process running. Consider the following situation:

```ts
amplitude.track('Event 1');
// `Event 1` is now queued
// Destination plugin opened a timeout for `config.flushIntervalMillis` or 10000ms (default)

amplitude.track('Event 2');
// `Event 2` is now queued
// Destination plugin detects previously opened timeout, and does not open a new one

await amplitude.flush().promise;
// `Event 1` and `Event 2` are immediately sent
// `track()` promises for `Event 1` and `Event 2` are resolved
// Destination plugin has the timeout still open for the next `config.flushIntervalMillis` or 10000ms (default)
// The timeout keeps the Node process running instead of exiting
```

#### Solution

1. Clear the timeout on each plugin.flush call
2. Re-purpose existing `this.scheduled` as this field is used to ensure only 1 timeout is created at a time

```ts
amplitude.track('Event 1');
// `Event 1` is now queued
// Destination plugin opened a timeout for `config.flushIntervalMillis` or 10000ms (default)

amplitude.track('Event 2');
// `Event 2` is now queued
// Destination plugin detects previously opened timeout, and does not open a new one

await amplitude.flush().promise;
// `Event 1` and `Event 2` are immediately sent
// `track()` promises for `Event 1` and `Event 2` are resolved
// Destination plugin closes timeout immediately
```

This should work similarly when letting the timeout pass

```ts
amplitude.track('Event 1');
// `Event 1` is now queued
// Destination plugin opened a timeout for `config.flushIntervalMillis` or 10000ms (default)

amplitude.track('Event 2');
// `Event 2` is now queued
// Destination plugin detects previously opened timeout, and does not open a new one

// After `config.flushIntervalMillis` or 10000ms (default)...
// Destination plugin will call flush by itself and close the timeout
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
