### PR TITLE
fix: exclude '__mocks__' from typescript declarations

### DIFF
--- a/packages/analytics-react-native/tsconfig.build.json
+++ b/packages/analytics-react-native/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["test"],
+  "exclude": ["test", "__mocks__"],
 }


### PR DESCRIPTION
### Summary

Excludes `__mocks__` folder from typescript declarations

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
