### PR TITLE
fix: set React Native default session timeout to 5 minutes (same for other mobile devices)

### DIFF
--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -39,7 +39,7 @@ export const getDefaultConfig = () => {
     disableCookies: false,
     domain: '',
     sessionManager: new SessionManager(cookieStorage, ''),
-    sessionTimeout: 30 * 60 * 1000,
+    sessionTimeout: 5 * 60 * 1000,
     storageProvider: new MemoryStorage<Event[]>(),
     trackingOptions,
     transportProvider: new FetchTransport(),

--- a/packages/analytics-react-native/test/config.test.ts
+++ b/packages/analytics-react-native/test/config.test.ts
@@ -46,7 +46,7 @@ describe('config', () => {
         serverUrl: 'https://api2.amplitude.com/2/httpapi',
         serverZone: 'US',
         sessionManager,
-        sessionTimeout: 1800000,
+        sessionTimeout: 300000,
         storageProvider: new core.MemoryStorage(),
         trackingOptions: {
           adid: true,
@@ -106,7 +106,7 @@ describe('config', () => {
         serverUrl: 'https://api2.amplitude.com/2/httpapi',
         serverZone: 'US',
         sessionManager,
-        sessionTimeout: 1800000,
+        sessionTimeout: 300000,
         storageProvider: new core.MemoryStorage(),
         trackingOptions: {
           adid: true,

--- a/packages/analytics-react-native/test/helpers/default.ts
+++ b/packages/analytics-react-native/test/helpers/default.ts
@@ -44,5 +44,5 @@ export const DEFAULT_OPTIONS: InitOptions<IReactNativeConfig> = {
     send: () => Promise.resolve(null),
   },
   sessionManager: new SessionManager(cookieStorage, API_KEY),
-  sessionTimeout: 30 * 60 * 1000,
+  sessionTimeout: 5 * 60 * 1000,
 };


### PR DESCRIPTION
### Summary

Set React Native default session timeout to 5 minutes (same for other mobile devices)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
