### PR TITLE
feat: persisted event identifiers (React Native)

### DIFF
--- a/packages/analytics-client-common/src/session-manager.ts
+++ b/packages/analytics-client-common/src/session-manager.ts
@@ -78,4 +78,12 @@ export class SessionManager implements ISessionManager {
   setOptOut(optOut: boolean): void {
     this.setSession({ optOut });
   }
+
+  getLastEventId(): number | undefined {
+    return this.cache.lastEventId;
+  }
+
+  setLastEventId(lastEventId: number) {
+    this.setSession({ lastEventId });
+  }
 }

--- a/packages/analytics-client-common/test/session-manager.test.ts
+++ b/packages/analytics-client-common/test/session-manager.test.ts
@@ -76,10 +76,19 @@ describe('session-manager', () => {
   });
 
   describe('setOptOut/getOptOut', () => {
-    test('should set/get last event time', async () => {
+    test('should set/get OptOut', async () => {
       const sessionManager = await new SessionManager(new MemoryStorage(), API_KEY).load();
       sessionManager.setOptOut(true);
       expect(sessionManager.getOptOut()).toBe(true);
+    });
+  });
+
+  describe('setLastEventId/getLastEventId', () => {
+    test('should set/get last event id', async () => {
+      const sessionManager = await new SessionManager(new MemoryStorage(), API_KEY).load();
+      expect(sessionManager.getLastEventId()).toBeUndefined();
+      sessionManager.setLastEventId(12345);
+      expect(sessionManager.getLastEventId()).toBe(12345);
     });
   });
 });

--- a/packages/analytics-react-native/src/plugins/context.ts
+++ b/packages/analytics-react-native/src/plugins/context.ts
@@ -33,7 +33,6 @@ export class Context implements BeforePlugin {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   config: ReactNativeConfig;
-  eventId = 0;
   uaResult: UAParser.IResult;
   nativeModule: AmplitudeReactNative | undefined = NativeModules.AmplitudeReactNative as
     | AmplitudeReactNative
@@ -92,7 +91,6 @@ export class Context implements BeforePlugin {
         },
       }),
       ...context,
-      event_id: this.eventId++,
       library: this.library,
     };
     return event;

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -218,6 +218,12 @@ export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
       if (event.session_id == undefined) {
         event.session_id = this.getSessionId();
       }
+
+      if (event.event_id === undefined) {
+        const eventId = (this.config.sessionManager.getLastEventId() ?? -1) + 1;
+        event = { ...event, event_id: eventId };
+        this.config.sessionManager.setLastEventId(eventId);
+      }
     }
 
     return super.process(event);

--- a/packages/analytics-react-native/test/plugins/context.test.ts
+++ b/packages/analytics-react-native/test/plugins/context.test.ts
@@ -10,7 +10,6 @@ describe('context', () => {
       config.appVersion = '1.0.0';
       await context.setup(config);
       expect(context.config.appVersion).toEqual('1.0.0');
-      expect(context.eventId).toEqual(0);
       expect(context.uaResult).toBeDefined();
     });
 
@@ -19,7 +18,6 @@ describe('context', () => {
       const config = useDefaultConfig();
       await context.setup(config);
       expect(context.config.appVersion).toBeUndefined();
-      expect(context.eventId).toEqual(0);
       expect(context.uaResult).toBeDefined();
     });
   });
@@ -39,7 +37,6 @@ describe('context', () => {
       };
       const firstContextEvent = await context.execute(event);
       expect(firstContextEvent.app_version).toEqual('1.0.0');
-      expect(firstContextEvent.event_id).toEqual(0);
       expect(firstContextEvent.event_type).toEqual('event_type');
       expect(firstContextEvent.insert_id).toBeDefined();
       /*
@@ -55,7 +52,8 @@ describe('context', () => {
       expect(firstContextEvent.user_id).toEqual('user@amplitude.com');
 
       const secondContextEvent = await context.execute(event);
-      expect(secondContextEvent.event_id).toEqual(1);
+      expect(secondContextEvent.insert_id).toBeDefined();
+      expect(secondContextEvent.insert_id).not.toEqual(firstContextEvent.insert_id);
     });
 
     test('should not return the properties when the tracking options are false', async () => {
@@ -83,7 +81,6 @@ describe('context', () => {
       };
       const firstContextEvent = await context.execute(event);
       expect(firstContextEvent.app_version).toEqual('1.0.0');
-      expect(firstContextEvent.event_id).toEqual(0);
       expect(firstContextEvent.event_type).toEqual('event_type');
       expect(firstContextEvent.insert_id).toBeDefined();
 
@@ -98,7 +95,8 @@ describe('context', () => {
       expect(firstContextEvent.user_id).toEqual('user@amplitude.com');
 
       const secondContextEvent = await context.execute(event);
-      expect(secondContextEvent.event_id).toEqual(1);
+      expect(secondContextEvent.insert_id).toBeDefined();
+      expect(secondContextEvent.insert_id).not.toEqual(firstContextEvent.insert_id);
     });
 
     test('should be overwritten by the context', async () => {
@@ -116,13 +114,13 @@ describe('context', () => {
       };
       const firstContextEvent = await context.execute(event);
       expect(firstContextEvent.app_version).toEqual('1.0.0');
-      expect(firstContextEvent.event_id).toEqual(0);
       expect(firstContextEvent.event_type).toEqual('event_type');
       expect(firstContextEvent.insert_id).toBeDefined();
       expect(firstContextEvent.device_id).toEqual('new deviceId');
 
       const secondContextEvent = await context.execute(event);
-      expect(secondContextEvent.event_id).toEqual(1);
+      expect(secondContextEvent.insert_id).toBeDefined();
+      expect(secondContextEvent.insert_id).not.toEqual(firstContextEvent.insert_id);
     });
 
     describe('ingestionMetadata config', () => {
@@ -142,7 +140,6 @@ describe('context', () => {
           event_type: 'event_type',
         };
         const firstContextEvent = await context.execute(event);
-        expect(firstContextEvent.event_id).toEqual(0);
         expect(firstContextEvent.event_type).toEqual('event_type');
         expect(firstContextEvent.ingestion_metadata?.source_name).toEqual(sourceName);
         expect(firstContextEvent.ingestion_metadata?.source_version).toEqual(sourceVersion);
@@ -162,7 +159,6 @@ describe('context', () => {
           event_type: 'event_type',
         };
         const firstContextEvent = await context.execute(event);
-        expect(firstContextEvent.event_id).toEqual(0);
         expect(firstContextEvent.ingestion_metadata?.source_name).toBeUndefined();
         expect(firstContextEvent.ingestion_metadata?.source_version).toEqual(sourceVersion);
       });
@@ -181,7 +177,6 @@ describe('context', () => {
           event_type: 'event_type',
         };
         const firstContextEvent = await context.execute(event);
-        expect(firstContextEvent.event_id).toEqual(0);
         expect(firstContextEvent.ingestion_metadata?.source_name).toEqual(sourceName);
         expect(firstContextEvent.ingestion_metadata?.source_version).toBeUndefined();
       });

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -505,28 +505,39 @@ describe('react-native-client', () => {
 
       expect(client1.config.sessionId).toEqual(1000);
       expect(client1.config.lastEventTime).toEqual(1000);
+      expect(client1.config.sessionManager.getLastEventId()).toEqual(2);
 
       void client1.track({ event_type: 'event-1', time: 1200 });
 
       expect(client1.config.sessionId).toEqual(1000);
       expect(client1.config.lastEventTime).toEqual(1200);
+      expect(client1.config.sessionManager.getLastEventId()).toEqual(3);
 
       const client2 = new AmplitudeReactNativeTest(1250);
       await client2.init(API_KEY, undefined, clientOptions(send, cookieStorage, true));
 
       expect(client2.config.sessionId).toEqual(1000);
       expect(client2.config.lastEventTime).toEqual(1250);
+      expect(client2.config.sessionManager.getLastEventId()).toEqual(3);
+
+      void client2.track({ event_type: 'event-2', time: 1270 });
+
+      expect(client2.config.sessionId).toEqual(1000);
+      expect(client2.config.lastEventTime).toEqual(1270);
+      expect(client2.config.sessionManager.getLastEventId()).toEqual(4);
 
       const client3 = new AmplitudeReactNativeTest(1300);
       await client3.init(API_KEY, undefined, clientOptions(send, cookieStorage, true));
 
       expect(client3.config.sessionId).toEqual(1000);
       expect(client3.config.lastEventTime).toEqual(1300);
+      expect(client3.config.sessionManager.getLastEventId()).toEqual(4);
 
       client3.setActive(1500);
 
       expect(client3.config.sessionId).toEqual(1500);
       expect(client3.config.lastEventTime).toEqual(1500);
+      expect(client3.config.sessionManager.getLastEventId()).toEqual(6);
     });
 
     describe('track session events', () => {
@@ -559,6 +570,7 @@ describe('react-native-client', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const events = send.mock.calls.flatMap((call) => call[1].events as Event[]);
         expect(events.length).toEqual(18);
+        events.forEach((event, i) => expect(event.event_id).toEqual(i));
 
         expect(events[0].event_type).toEqual('session_end');
         expect(events[0].session_id).toEqual(500);
@@ -671,6 +683,7 @@ describe('react-native-client', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const events = send.mock.calls.flatMap((call) => call[1].events as Event[]);
         expect(events.length).toEqual(14);
+        events.forEach((event, i) => expect(event.event_id).toEqual(i));
 
         expect(events[0].event_type).toEqual('session_end');
         expect(events[0].session_id).toEqual(500);
@@ -760,6 +773,7 @@ describe('react-native-client', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const events = send.mock.calls.flatMap((call) => call[1].events as Event[]);
         expect(events.length).toEqual(8);
+        events.forEach((event, i) => expect(event.event_id).toEqual(i));
 
         expect(events[0].event_type).toEqual('event-1');
         expect(events[0].session_id).toEqual(950);
@@ -832,6 +846,7 @@ describe('react-native-client', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const events = send.mock.calls.flatMap((call) => call[1].events as Event[]);
         expect(events.length).toEqual(8);
+        events.forEach((event, i) => expect(event.event_id).toEqual(i));
 
         expect(events[0].event_type).toEqual('event-1');
         expect(events[0].session_id).toEqual(1000);

--- a/packages/analytics-types/src/session-manager.ts
+++ b/packages/analytics-types/src/session-manager.ts
@@ -4,6 +4,7 @@ export interface UserSession {
   sessionId?: number;
   lastEventTime?: number;
   optOut: boolean;
+  lastEventId?: number;
 }
 
 export interface SessionManagerOptions {
@@ -23,4 +24,6 @@ export interface SessionManager {
   setLastEventTime(lastEventTime?: number): void;
   getOptOut(): boolean;
   setOptOut(optOut: boolean): void;
+  getLastEventId(): number | undefined;
+  setLastEventId(lastEventId: number): void;
 }


### PR DESCRIPTION
### Summary

The event id is persisted and read from storage, not each time just start from 0.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
