### PR TITLE
fix: avoid loading types node

### DIFF
--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -35,7 +35,7 @@ export class Destination implements DestinationPlugin {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   config: Config;
-  scheduled: ReturnType<typeof setTimeout> | null = null;
+  private scheduled: ReturnType<typeof setTimeout> | null = null;
   queue: Context[] = [];
 
   async setup(config: Config): Promise<undefined> {

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -110,7 +110,8 @@ describe('destination', () => {
 
     test('should schedule a flush', async () => {
       const destination = new Destination();
-      destination.scheduled = null;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (destination as any).scheduled = null;
       destination.queue = [
         {
           event: { event_type: 'event_type' },
@@ -122,7 +123,8 @@ describe('destination', () => {
       const flush = jest
         .spyOn(destination, 'flush')
         .mockImplementationOnce(() => {
-          destination.scheduled = null;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (destination as any).scheduled = null;
           return Promise.resolve(undefined);
         })
         .mockReturnValueOnce(Promise.resolve(undefined));
@@ -138,7 +140,8 @@ describe('destination', () => {
 
     test('should not schedule if one is already in progress', () => {
       const destination = new Destination();
-      destination.scheduled = setTimeout(jest.fn, 0);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (destination as any).scheduled = setTimeout(jest.fn, 0);
       const flush = jest.spyOn(destination, 'flush').mockReturnValueOnce(Promise.resolve(undefined));
       destination.schedule(0);
       expect(flush).toHaveBeenCalledTimes(0);

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -30,7 +30,7 @@ const END_SESSION_EVENT = 'session_end';
 
 export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
   appState: AppStateStatus = 'background';
-  private appStateChangeHandler: NativeEventSubscription | undefined | void;
+  private appStateChangeHandler: NativeEventSubscription | undefined;
   explicitSessionId: number | undefined;
 
   async init(apiKey = '', userId?: string, options?: ReactNativeOptions) {

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -30,7 +30,7 @@ const END_SESSION_EVENT = 'session_end';
 
 export class AmplitudeReactNative extends AmplitudeCore<ReactNativeConfig> {
   appState: AppStateStatus = 'background';
-  private appStateChangeHandler: NativeEventSubscription | undefined;
+  private appStateChangeHandler: NativeEventSubscription | undefined | void;
   explicitSessionId: number | undefined;
 
   async init(apiKey = '', userId?: string, options?: ReactNativeOptions) {


### PR DESCRIPTION
### Summary
- fix: avoid loading types node

https://github.com/amplitude/Amplitude-TypeScript/issues/281, update the `scheduled` seems working for my local.

Add `void` to `appStateChangeHandler` for fixing the building error:
```
@amplitude/analytics-react-native: src/react-native-client.ts:83:5 - error TS2322: Type 'void' is not assignable to type 'NativeEventSubscription | undefined'.
@amplitude/analytics-react-native: 83     this.appStateChangeHandler = AppState.addEventListener('change', this.handleAppStateChange);
@amplitude/analytics-react-native:        ~~~~~~~~~~~~~~~~~~~~~~~~~~
@amplitude/analytics-react-native: Found 1 error.
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
