### PR TITLE
build: add basic automate node type loading check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,19 @@ jobs:
         run: |
           yarn build
 
+      # https://github.com/amplitude/Amplitude-TypeScript/issues/281
+      - name: Check module dependencies
+        run: |
+          if grep -rnw 'packages/analytics-core/lib' -e '/// <reference types="node" />'; then
+            exit 1
+          elif grep -rnw 'packages/analytics-browser/lib' -e '/// <reference types="node" />'; then
+            exit 1
+          elif grep -rnw 'packages/analytics-marketing-analytics-browser/lib' -e '/// <reference types="node" />'; then
+            exit 1
+          elif grep -rnw 'packages/analytics-react-native/lib' -e '/// <reference types="node" />'; then
+            exit 1
+          fi
+
       - name: Build docs
         run: |
           yarn docs:check


### PR DESCRIPTION
### Summary
- build: add basic automate node type loading check

Use the very basic `grep` to check the import, I didn't find an existing lib/plugin to do this though

Tests
- Pass case: https://github.com/amplitude/Amplitude-TypeScript/actions/runs/3935359357/jobs/6730974668
- Fail case: https://github.com/amplitude/Amplitude-TypeScript/actions/runs/3935384751/jobs/6731021353

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
