### PR TITLE
feat: allow opt out of deleting legacy sdk cookies

### DIFF
--- a/packages/analytics-browser-test/package.json
+++ b/packages/analytics-browser-test/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
   },
   "scripts": {
-    "test": "jest -i"
+    "test": "jest"
   },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -38,6 +38,7 @@ export const getDefaultConfig = () => {
     cookieSameSite: 'Lax',
     cookieSecure: false,
     cookieStorage,
+    cookieUpgrade: true,
     disableCookies: false,
     domain: '',
     sessionManager: new SessionManager(cookieStorage, ''),
@@ -54,6 +55,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
   cookieExpiration: number;
   cookieSameSite: string;
   cookieSecure: boolean;
+  cookieUpgrade: boolean;
   cookieStorage: Storage<UserSession>;
   disableCookies: boolean;
   domain: string;
@@ -82,6 +84,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     this.cookieExpiration = options?.cookieExpiration ?? defaultConfig.cookieExpiration;
     this.cookieSameSite = options?.cookieSameSite ?? defaultConfig.cookieSameSite;
     this.cookieSecure = options?.cookieSecure ?? defaultConfig.cookieSecure;
+    this.cookieUpgrade = options?.cookieUpgrade ?? defaultConfig.cookieUpgrade;
     this.deviceId = options?.deviceId;
     this.disableCookies = options?.disableCookies ?? defaultConfig.disableCookies;
     this.domain = options?.domain ?? defaultConfig.domain;

--- a/packages/analytics-browser/src/cookie-migration/index.ts
+++ b/packages/analytics-browser/src/cookie-migration/index.ts
@@ -1,5 +1,6 @@
 import { BrowserOptions, Storage, UserSession } from '@amplitude/analytics-types';
 import { getOldCookieName, CookieStorage } from '@amplitude/analytics-client-common';
+import { getDefaultConfig } from '../config';
 import { LocalStorage } from '../storage/local-storage';
 
 export const parseOldCookies = async (apiKey: string, options?: BrowserOptions): Promise<UserSession> => {
@@ -22,7 +23,9 @@ export const parseOldCookies = async (apiKey: string, options?: BrowserOptions):
     };
   }
 
-  await storage.remove(oldCookieName);
+  if (options?.cookieUpgrade ?? getDefaultConfig().cookieUpgrade) {
+    await storage.remove(oldCookieName);
+  }
   const [deviceId, userId, optOut, sessionId, lastEventTime] = cookies.split('.');
   return {
     deviceId,

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -32,6 +32,7 @@ describe('config', () => {
         cookieExpiration: 365,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieUpgrade: true,
         disableCookies: false,
         domain: '',
         flushIntervalMillis: 1000,
@@ -88,6 +89,7 @@ describe('config', () => {
         cookieExpiration: 365,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieUpgrade: true,
         disableCookies: false,
         domain: '',
         flushIntervalMillis: 1000,
@@ -144,6 +146,7 @@ describe('config', () => {
           sourceVersion: '2.0.0',
         },
         sessionTimeout: 1,
+        cookieUpgrade: false,
       });
       expect(config).toEqual({
         apiKey: API_KEY,
@@ -152,6 +155,7 @@ describe('config', () => {
         cookieExpiration: 365,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieUpgrade: false,
         disableCookies: false,
         domain: '',
         flushIntervalMillis: 1000,

--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -36,6 +36,7 @@ export const getDefaultConfig = () => {
     cookieSameSite: 'Lax',
     cookieSecure: false,
     cookieStorage,
+    cookieUpgrade: true,
     disableCookies: false,
     domain: '',
     sessionManager: new SessionManager(cookieStorage, ''),
@@ -53,6 +54,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
   cookieSameSite: string;
   cookieSecure: boolean;
   cookieStorage: Storage<UserSession>;
+  cookieUpgrade: boolean;
   disableCookies: boolean;
   domain: string;
   partnerId?: string;
@@ -80,6 +82,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
     this.cookieExpiration = options?.cookieExpiration ?? defaultConfig.cookieExpiration;
     this.cookieSameSite = options?.cookieSameSite ?? defaultConfig.cookieSameSite;
     this.cookieSecure = options?.cookieSecure ?? defaultConfig.cookieSecure;
+    this.cookieUpgrade = options?.cookieUpgrade ?? defaultConfig.cookieUpgrade;
     this.deviceId = options?.deviceId;
     this.disableCookies = options?.disableCookies ?? defaultConfig.disableCookies;
     this.domain = options?.domain ?? defaultConfig.domain;

--- a/packages/analytics-react-native/src/cookie-migration/index.ts
+++ b/packages/analytics-react-native/src/cookie-migration/index.ts
@@ -1,6 +1,7 @@
 import { BrowserOptions, Storage, UserSession } from '@amplitude/analytics-types';
 import { getOldCookieName, CookieStorage } from '@amplitude/analytics-client-common';
 import { LocalStorage } from '../storage/local-storage';
+import { getDefaultConfig } from '../config';
 
 export const parseOldCookies = async (apiKey: string, options?: BrowserOptions): Promise<UserSession> => {
   let storage: Storage<string> = new CookieStorage<string>();
@@ -22,7 +23,9 @@ export const parseOldCookies = async (apiKey: string, options?: BrowserOptions):
     };
   }
 
-  await storage.remove(oldCookieName);
+  if (options?.cookieUpgrade ?? getDefaultConfig().cookieUpgrade) {
+    await storage.remove(oldCookieName);
+  }
   const [deviceId, userId, optOut, sessionId, lastEventTime] = cookies.split('.');
   return {
     deviceId,

--- a/packages/analytics-react-native/test/config.test.ts
+++ b/packages/analytics-react-native/test/config.test.ts
@@ -30,6 +30,7 @@ describe('config', () => {
         cookieExpiration: 365,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieUpgrade: true,
         disableCookies: false,
         domain: '',
         flushIntervalMillis: 1000,
@@ -89,6 +90,7 @@ describe('config', () => {
         cookieExpiration: 365,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieUpgrade: true,
         disableCookies: false,
         domain: '',
         flushIntervalMillis: 1000,
@@ -148,6 +150,7 @@ describe('config', () => {
           sourceVersion: '2.0.0',
         },
         sessionTimeout: 1,
+        cookieUpgrade: false,
       });
       expect(config).toEqual({
         apiKey: API_KEY,
@@ -156,6 +159,7 @@ describe('config', () => {
         cookieExpiration: 365,
         cookieSameSite: 'Lax',
         cookieSecure: false,
+        cookieUpgrade: false,
         disableCookies: false,
         domain: '',
         flushIntervalMillis: 1000,

--- a/packages/analytics-react-native/test/cookie-migration/index.test.ts
+++ b/packages/analytics-react-native/test/cookie-migration/index.test.ts
@@ -1,4 +1,5 @@
-import { getOldCookieName } from '@amplitude/analytics-client-common';
+import { CookieStorage, getOldCookieName } from '@amplitude/analytics-client-common';
+import { Storage } from '@amplitude/analytics-types';
 import { decode, parseOldCookies, parseTime } from '../../src/cookie-migration';
 import * as LocalStorageModule from '../../src/storage/local-storage';
 import { isWeb } from '../../src/utils/platform';
@@ -37,13 +38,16 @@ describe('cookie-migration', () => {
      * Tested function is only available on web.
      */
     if (isWeb()) {
-      test('should old cookies', async () => {
+      test('should remove old cookies', async () => {
         const timestamp = 1650949309508;
         const time = timestamp.toString(32);
         const userId = 'userId';
         const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
-        document.cookie = `${getOldCookieName(API_KEY)}=deviceId.${encodedUserId}..${time}.${time}`;
-        const cookies = await parseOldCookies(API_KEY);
+        const oldCookieName = getOldCookieName(API_KEY);
+        document.cookie = `${oldCookieName}=deviceId.${encodedUserId}..${time}.${time}`;
+        const cookies = await parseOldCookies(API_KEY, {
+          cookieUpgrade: true,
+        });
         expect(cookies).toEqual({
           deviceId: 'deviceId',
           userId: 'userId',
@@ -51,6 +55,33 @@ describe('cookie-migration', () => {
           lastEventTime: timestamp,
           optOut: false,
         });
+
+        const storage: Storage<string> = new CookieStorage<string>();
+        const cookies2 = await storage.getRaw(oldCookieName);
+        expect(cookies2).toBeUndefined();
+      });
+
+      test('should keep old cookies', async () => {
+        const timestamp = 1650949309508;
+        const time = timestamp.toString(32);
+        const userId = 'userId';
+        const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
+        const oldCookieName = getOldCookieName(API_KEY);
+        document.cookie = `${oldCookieName}=deviceId.${encodedUserId}..${time}.${time}`;
+        const cookies = await parseOldCookies(API_KEY, {
+          cookieUpgrade: false,
+        });
+        expect(cookies).toEqual({
+          deviceId: 'deviceId',
+          userId: 'userId',
+          sessionId: timestamp,
+          lastEventTime: timestamp,
+          optOut: false,
+        });
+
+        const storage: Storage<string> = new CookieStorage<string>();
+        const cookies2 = await storage.getRaw(oldCookieName);
+        expect(cookies2).toBe(`deviceId.${encodedUserId}..${time}.${time}`);
       });
     }
   });

--- a/packages/analytics-types/src/config.ts
+++ b/packages/analytics-types/src/config.ts
@@ -38,6 +38,7 @@ export interface BrowserConfig extends Config {
   cookieSameSite: string;
   cookieSecure: boolean;
   cookieStorage: Storage<UserSession>;
+  cookieUpgrade?: boolean;
   disableCookies: boolean;
   domain: string;
   lastEventTime?: number;


### PR DESCRIPTION
### Summary

1. Adds `config.cookieUpgrade` to retain old SDK cookie and treat as source of truth.
3. This allows parallel instrumentation of legacy and new SDK
4. Best practice is to remove `config.cookieUpgrade` when no longer in parallel instrumentation
5. [BONUS] Integration tests for `@amplitude/analytics-browser` now runs faster and in parallel

#### Migration guide

**Step 0: Pre migration**
This assumes customer is instrumenting solely using `amplitude-js`

```ts
import amplitude from 'amplitude-js';
amplitude.getInstance().init(...);
```

**Step 1: Parallel instrumentation and partial migration**
This assumes customer is instrumenting using both `amplitude-js` and `@amplitude/analytics-browser`

```ts
import amplitude from 'amplitude-js';
import * as amplitude2 from '@amplitude/analytics-browser';

amplitude.getInstance().init(apiKey, userId, config, () => {
  // hold off init until legacy SDK cookies are persisted
  amplitude2.init(..., {
    cookieUpgrade: false, // reads and retains legacy SDK cookies
  });
});
```

**Step 2: Bye amplitude-js and full migration**
This assumes customer is instrumenting solely using `@amplitude/analytics-browser`

```ts
import * as amplitude from '@amplitude/analytics-browser';

amplitude2.init(...);
// options.cookieUpgrade can be explicitly set to `true` or completely omitted
// this effectively reads and deletes legacy SDK cookies
// moving forward, new SDK solely maintain its own cookies
```

cc @jackmccloy

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
