### PR TITLE
feat: add file download tracker

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,0 +1,77 @@
+import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { BrowserConfig } from '../config';
+
+const FILE_DOWNLOAD_EVENT = 'file_download';
+
+export const fileDownloadTracking = (): EnrichmentPlugin => {
+  const name = 'fileDownloadTracking';
+  const type = PluginType.ENRICHMENT;
+  const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
+    /* istanbul ignore if */
+    if (!amplitude) {
+      // TODO: Add required minimum version of @amplitude/analytics-browser
+      config.loggerProvider.warn(
+        'File download tracking requires a later version of @amplitude/analytics-browser. File download events are not tracked.',
+      );
+      return;
+    }
+
+    const addFileDownloadListener = (a: HTMLAnchorElement) => {
+      try {
+        const url = new URL(a.href);
+        const result = ext.exec(url.href);
+        const fileExtension = result?.[1];
+
+        if (fileExtension) {
+          a.addEventListener('click', () => {
+            if (fileExtension) {
+              amplitude.track(FILE_DOWNLOAD_EVENT, {
+                file_extension: fileExtension,
+                file_name: url.pathname,
+                link_id: a.id,
+                link_text: a.text,
+                link_url: a.href,
+              });
+            }
+          });
+        }
+      } catch {
+        config.loggerProvider.error(`Something went wrong. File download events are not tracked for a#{a.id}`);
+      }
+    };
+
+    const ext =
+      /\.(pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma)$/;
+
+    // Adds listener to existing anchor tags
+    const links = Array.from(document.getElementsByTagName('a'));
+    links.forEach(addFileDownloadListener);
+
+    // Adds listener to anchor tags added after initial load
+    /* istanbul ignore else */
+    if (typeof MutationObserver !== 'undefined') {
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node) => {
+            if (node.nodeName == 'A') {
+              addFileDownloadListener(node as HTMLAnchorElement);
+            }
+          });
+        });
+      });
+
+      observer.observe(document.body, {
+        subtree: true,
+        childList: true,
+      });
+    }
+  };
+  const execute = async (event: Event) => event;
+
+  return {
+    name,
+    type,
+    setup,
+    execute,
+  };
+};

--- a/packages/analytics-browser/test/helpers/mock.ts
+++ b/packages/analytics-browser/test/helpers/mock.ts
@@ -1,0 +1,88 @@
+import { SessionManager } from '@amplitude/analytics-client-common';
+import { Logger, MemoryStorage, UUID } from '@amplitude/analytics-core';
+import { BrowserClient, BrowserConfig, LogLevel, UserSession } from '@amplitude/analytics-types';
+
+export const createAmplitudeMock = (): jest.MockedObject<BrowserClient> => ({
+  init: jest.fn(),
+  add: jest.fn(),
+  remove: jest.fn(),
+  track: jest.fn(),
+  logEvent: jest.fn(),
+  identify: jest.fn(),
+  groupIdentify: jest.fn(),
+  setGroup: jest.fn(),
+  revenue: jest.fn(),
+  setOptOut: jest.fn(),
+  flush: jest.fn(),
+  getUserId: jest.fn(),
+  setUserId: jest.fn(),
+  getDeviceId: jest.fn(),
+  setDeviceId: jest.fn(),
+  getSessionId: jest.fn(),
+  setSessionId: jest.fn(),
+  reset: jest.fn(),
+  setTransport: jest.fn(),
+});
+
+export const createConfigurationMock = (options?: Partial<BrowserConfig>) => {
+  const apiKey = options?.apiKey ?? UUID();
+  const cookieStorage = new MemoryStorage<UserSession>();
+  const sessionStorage = new SessionManager(cookieStorage, apiKey);
+
+  return {
+    // core config
+    apiKey: apiKey,
+    flushIntervalMillis: 1000,
+    flushMaxRetries: 5,
+    flushQueueSize: 10,
+    logLevel: LogLevel.Warn,
+    loggerProvider: new Logger(),
+    minIdLength: undefined,
+    optOut: false,
+    plan: undefined,
+    ingestionMetadata: undefined,
+    serverUrl: undefined,
+    serverZone: undefined,
+    storageProvider: {
+      isEnabled: async () => true,
+      get: jest.fn(),
+      set: jest.fn(),
+      remove: jest.fn(),
+      reset: jest.fn(),
+      getRaw: jest.fn(),
+    },
+    transportProvider: {
+      send: jest.fn(),
+    },
+    useBatch: false,
+
+    // browser config
+    appVersion: undefined,
+    attribution: undefined,
+    deviceId: undefined,
+    cookieExpiration: 365,
+    cookieSameSite: 'Lax',
+    cookieSecure: false,
+    cookieStorage: cookieStorage,
+    cookieUpgrade: undefined,
+    disableCookies: false,
+    domain: '',
+    lastEventTime: undefined,
+    partnerId: undefined,
+    sessionId: undefined,
+    sessionManager: sessionStorage,
+    sessionTimeout: 30 * 60 * 1000,
+    trackingOptions: {
+      deviceManufacturer: true,
+      deviceModel: true,
+      ipAddress: true,
+      language: true,
+      osName: true,
+      osVersion: true,
+      platform: true,
+    },
+    trackingSessionEvents: false,
+    userId: undefined,
+    ...options,
+  };
+};

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import { createAmplitudeMock, createConfigurationMock } from '../helpers/mock';
+import { fileDownloadTracking } from '../../src/plugins/file-download-tracking';
+
+describe('fileDownloadTracking', () => {
+  let amplitude = createAmplitudeMock();
+
+  beforeEach(() => {
+    amplitude = createAmplitudeMock();
+
+    const link = document.createElement('a');
+    link.setAttribute('id', 'my-link-id');
+    link.setAttribute('class', 'my-link-class');
+    link.text = 'my-link-text';
+
+    document.body.appendChild(link);
+  });
+
+  afterEach(() => {
+    document.querySelector('a#my-link-id')?.remove();
+  });
+
+  test('should track file_download event', async () => {
+    // setup
+    document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');
+    const config = createConfigurationMock();
+    const plugin = fileDownloadTracking();
+    await plugin.setup(config, amplitude);
+
+    // trigger change event
+    document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+    // assert file download event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'file_download', {
+      file_extension: 'pdf',
+      file_name: '/files/my-file.pdf',
+      link_id: 'my-link-id',
+      link_text: 'my-link-text',
+      link_url: 'https://analytics.amplitude.com/files/my-file.pdf',
+    });
+  });
+
+  test('should track file_download event for a dynamically added achor tag', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = fileDownloadTracking();
+    await plugin.setup(config, amplitude);
+
+    // add anchor element dynamically
+    const link = document.createElement('a');
+    link.setAttribute('id', 'my-link-2-id');
+    link.setAttribute('class', 'my-link-2-class');
+    link.setAttribute('href', 'https://analytics.amplitude.com/files/my-file-2.pdf');
+    link.text = 'my-link-2-text';
+    document.body.appendChild(link);
+
+    // allow mutation observer to execute and event listener to be attached
+    await new Promise((r) => r(undefined)); // basically, await next clock tick
+    // trigger change event
+    link.dispatchEvent(new Event('click'));
+
+    // assert file download event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'file_download', {
+      file_extension: 'pdf',
+      file_name: '/files/my-file-2.pdf',
+      link_id: 'my-link-2-id',
+      link_text: 'my-link-2-text',
+      link_url: 'https://analytics.amplitude.com/files/my-file-2.pdf',
+    });
+  });
+
+  test('should not track file_download event', async () => {
+    // setup
+    document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.png');
+    const config = createConfigurationMock();
+    const plugin = fileDownloadTracking();
+    await plugin.setup(config, amplitude);
+
+    // trigger change event
+    document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+    // assert file download event was not tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(0);
+  });
+
+  test('should not enrich events', async () => {
+    const input = {
+      event_type: 'page_view',
+    };
+    const plugin = fileDownloadTracking();
+    const result = await plugin.execute(input);
+    expect(result).toEqual(input);
+  });
+});

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -1,6 +1,7 @@
 import { Event } from './event';
 import { Config } from './config';
 import { Result } from './result';
+import { BaseClient } from './client/base-client';
 
 export enum PluginType {
   BEFORE = 'before',
@@ -8,24 +9,24 @@ export enum PluginType {
   DESTINATION = 'destination',
 }
 
-export interface BeforePlugin {
+export interface BeforePlugin<T = BaseClient> {
   name: string;
   type: PluginType.BEFORE;
-  setup(config: Config): Promise<void>;
+  setup(config: Config, client?: T): Promise<void>;
   execute(context: Event): Promise<Event>;
 }
 
-export interface EnrichmentPlugin {
+export interface EnrichmentPlugin<T = BaseClient> {
   name: string;
   type: PluginType.ENRICHMENT;
-  setup(config: Config): Promise<void>;
+  setup(config: Config, client?: T): Promise<void>;
   execute(context: Event): Promise<Event>;
 }
 
-export interface DestinationPlugin {
+export interface DestinationPlugin<T = BaseClient> {
   name: string;
   type: PluginType.DESTINATION;
-  setup(config: Config): Promise<void>;
+  setup(config: Config, client?: T): Promise<void>;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
 }


### PR DESCRIPTION
### Summary

This set of changes adds a internal plugin for tracking file downloads.

#### Example

Considering the following `<a>` tag:

```html
<a
  id="my-link-id"
  href="https://analytics.amplitude.com/files/my-file.pdf"
  target="_blank"
  rel="noopener noreferrer"
>
  Download
</a>
```

The plugin tracks  the following event:

```json
{
  "event_type": "file_download",
  "event_properties": {
    "file_extension": "pdf",
    "file_name": "/files/my-file.pdf",
    "link_id": "my-link-id",
    "link_text": "my-link-text",
    "link_url": "https://analytics.amplitude.com/files/my-file.pdf"
}
```

#### How to track
1. The download button must be an anchor tag
1. The download button must contain an href property
1. The href property must point to a file with the following file types
    - `pdf`, `xls`, `xlsx`, `doc`, `docx`, `txt`, `rtf`, `csv`, `exe`, `key`, `pps`, `ppt`, `pptx)`, `7z`, `pkg`, `rar`, `gz`, `zip`, `avi`, `mov`, `mp4`, `mpe`, `mpeg`, `wmv`, `mid`, `midi`, `mp3`, `wav`, `wma`
1. The download button must be clicked
1. All the rules above must be fulfilled to track a file download event

#### How not to track
1. The plugin does not support download button in an HTML form that lead to a file download
2. The plugin does not support download button in button element that lead to a file download
3. The plugin does not support download button `onclick` attributes that lead to a file download

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
