### PR TITLE
feat: add named instances for google tag manager use case

### DIFF
--- a/packages/analytics-browser/src/snippet-index.ts
+++ b/packages/analytics-browser/src/snippet-index.ts
@@ -1,5 +1,6 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import * as amplitude from './index';
+import { createInstance } from './browser-client-factory';
 import { runQueuedFunctions } from './utils/snippet-helper';
 
 // https://developer.mozilla.org/en-US/docs/Glossary/IIFE
@@ -11,15 +12,30 @@ import { runQueuedFunctions } from './utils/snippet-helper';
     return;
   }
 
-  GlobalScope.amplitude = Object.assign(GlobalScope.amplitude || {}, amplitude);
+  const createNamedInstance = (instanceName?: string) => {
+    const instance = createInstance();
+    const GlobalScope = getGlobalScope();
+    if (GlobalScope && GlobalScope.amplitude && GlobalScope.amplitude._iq && instanceName) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      GlobalScope.amplitude._iq[instanceName] = instance;
+    }
+    return instance;
+  };
+
+  GlobalScope.amplitude = Object.assign(GlobalScope.amplitude || {}, amplitude, {
+    createInstance: createNamedInstance,
+  });
 
   if (GlobalScope.amplitude.invoked) {
     const queue = GlobalScope.amplitude._q;
     GlobalScope.amplitude._q = [];
     runQueuedFunctions(amplitude, queue);
 
-    for (let i = 0; i < GlobalScope.amplitude._iq.length; i++) {
-      const instance = Object.assign(GlobalScope.amplitude._iq[i], amplitude.createInstance());
+    const instanceNames = Object.keys(GlobalScope.amplitude._iq) || [];
+    for (let i = 0; i < instanceNames.length; i++) {
+      const instanceName = instanceNames[i];
+      const instance = Object.assign(GlobalScope.amplitude._iq[instanceName], createNamedInstance(instanceName));
       const queue = instance._q;
       instance._q = [];
       runQueuedFunctions(instance, queue);

--- a/packages/analytics-types/src/proxy.ts
+++ b/packages/analytics-types/src/proxy.ts
@@ -10,5 +10,5 @@ export type QueueProxy = Array<ProxyItem>;
 
 export interface InstanceProxy {
   _q: QueueProxy;
-  _iq: InstanceProxy[];
+  _iq: Record<string, InstanceProxy>;
 }

--- a/packages/marketing-analytics-browser/src/snippet-index.ts
+++ b/packages/marketing-analytics-browser/src/snippet-index.ts
@@ -1,5 +1,6 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import * as amplitude from './index';
+import { createInstance } from './browser-client';
 import { runQueuedFunctions } from '@amplitude/analytics-browser';
 
 // https://developer.mozilla.org/en-US/docs/Glossary/IIFE
@@ -11,15 +12,30 @@ import { runQueuedFunctions } from '@amplitude/analytics-browser';
     return;
   }
 
-  GlobalScope.amplitude = Object.assign(GlobalScope.amplitude || {}, amplitude);
+  const createNamedInstance = (instanceName?: string) => {
+    const instance = createInstance();
+    const GlobalScope = getGlobalScope();
+    if (GlobalScope && GlobalScope.amplitude && GlobalScope.amplitude._iq && instanceName) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      GlobalScope.amplitude._iq[instanceName] = instance;
+    }
+    return instance;
+  };
+
+  GlobalScope.amplitude = Object.assign(GlobalScope.amplitude || {}, amplitude, {
+    createInstance: createNamedInstance,
+  });
 
   if (GlobalScope.amplitude.invoked) {
     const queue = GlobalScope.amplitude._q;
     GlobalScope.amplitude._q = [];
     runQueuedFunctions(amplitude, queue);
 
-    for (let i = 0; i < GlobalScope.amplitude._iq.length; i++) {
-      const instance = Object.assign(GlobalScope.amplitude._iq[i], amplitude.createInstance());
+    const instanceNames = Object.keys(GlobalScope.amplitude._iq) || [];
+    for (let i = 0; i < instanceNames.length; i++) {
+      const instanceName = instanceNames[i];
+      const instance = Object.assign(GlobalScope.amplitude._iq[instanceName], createNamedInstance(instanceName));
       const queue = instance._q;
       instance._q = [];
       runQueuedFunctions(instance, queue);

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -90,7 +90,6 @@ export const snippet = {
   plugins: [
     createSnippet(),
     terser(),
-    execute(`node ${base}/scripts/version/create-snippet-instructions.js`),
-    execute(`node ${base}/scripts/version/update-readme.js`),
+    execute(`node ${base}/scripts/version/create-snippet-instructions.js && node ${base}/scripts/version/update-readme.js`),
   ],
 };

--- a/scripts/templates/browser-snippet.template.js
+++ b/scripts/templates/browser-snippet.template.js
@@ -1,6 +1,6 @@
 const snippet = (name, integrity, version) => `
 !(function (window, document) {
-  var amplitude = window.amplitude || { _q: [], _iq: [] };
+  var amplitude = window.amplitude || { _q: [], _iq: {} };
   if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');
   else {
     amplitude.invoked = true;
@@ -113,10 +113,10 @@ const snippet = (name, integrity, version) => `
       }
     }
     setUpProxy(amplitude);
-    amplitude.createInstance = function () {
-      var index = amplitude._iq.push({ _q: [] }) - 1;
-      setUpProxy(amplitude._iq[index]);
-      return amplitude._iq[index];
+    amplitude.createInstance = function (instanceName) {
+      amplitude._iq[instanceName] = { _q: [] };
+      setUpProxy(amplitude._iq[instanceName]);
+      return amplitude._iq[instanceName];
     };
     window.amplitude = amplitude;
   }


### PR DESCRIPTION
### Summary

Adds named instances for google tag manager use case

* If no name is provided, instance is anonymous and not accessible in `amplitude._iq` (See code below)
* Named instances is not available in `npm` installation
* Amplitude GTM template to consume named instances is in progress
  * Template will store an instance name
  * Template will access instance when executing a command
  * Template to pass `$default_instance` name when not provided

```js
// create instance
const instance = createInstance('my-instance-name')

// access instance
amplitude._iq['my-instance-name']
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
