### PR TITLE
fix: remove client parameter requirement for page view tracking plaugin

### DIFF
--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -73,7 +73,7 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (
       // Turn off sending page view event by "runAttributionStrategy" function
       if (config.attribution?.trackPageViews) {
         loggerProvider.warn(
-          `@amplitude/plugin-page-view-tracking-browser overrides page view tracking behavior defined in @amplitude/analytics-browser.Resolve by disabling page view tracking in @amplitude/analytics-browser.`,
+          `@amplitude/plugin-page-view-tracking-browser overrides page view tracking behavior defined in @amplitude/analytics-browser. Resolve by disabling page view tracking in @amplitude/analytics-browser.`,
         );
         config.attribution.trackPageViews = false;
       }

--- a/packages/plugin-page-view-tracking-browser/src/typings/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/typings/page-view-tracking.ts
@@ -1,3 +1,5 @@
+import { EnrichmentPlugin, BrowserClient } from '@amplitude/analytics-types';
+
 export interface Options {
   trackOn?: PageTrackingTrackOn;
   trackHistoryChanges?: PageTrackingHistoryChanges;
@@ -6,3 +8,10 @@ export interface Options {
 export type PageTrackingTrackOn = 'attribution' | (() => boolean);
 
 export type PageTrackingHistoryChanges = 'all' | 'pathOnly';
+
+export interface CreatePageViewTrackingPlugin {
+  (client: BrowserClient, options?: Options): EnrichmentPlugin;
+  (options?: Options): EnrichmentPlugin;
+}
+
+export type CreatePageViewTrackingPluginParameters = [BrowserClient, Options?] | [Options?];

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -1,4 +1,5 @@
 import { createInstance } from '@amplitude/analytics-browser';
+import { Config, Logger } from '@amplitude/analytics-types';
 import { pageViewTrackingPlugin, shouldTrackHistoryPageView } from '../src/page-view-tracking';
 
 describe('pageViewTrackingPlugin', () => {
@@ -27,6 +28,55 @@ describe('pageViewTrackingPlugin', () => {
   const USER_ID = 'USER_ID';
 
   describe('setup', () => {
+    let instance = createInstance();
+
+    beforeEach(async () => {
+      instance = createInstance();
+      await instance.init(API_KEY, USER_ID, {
+        attribution: {
+          disabled: true,
+        },
+      }).promise;
+    });
+
+    test('should handle expected BrowserClient, but got Options', async () => {
+      const track = jest.spyOn(instance, 'track');
+      const loggerProvider: Partial<Logger> = {
+        error: jest.fn(),
+      };
+      const config: Partial<Config> = {
+        loggerProvider: loggerProvider as Logger,
+      };
+
+      const plugin = pageViewTrackingPlugin({});
+      await plugin.setup(config as Config);
+
+      expect(track).toHaveBeenCalledTimes(0);
+      expect(loggerProvider.error).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.error).toHaveBeenCalledWith(
+        `Argument of type 'Options' is not assignable to parameter of type 'BrowserClient'.`,
+      );
+    });
+
+    test('should handle expected BrowserClient, but got undefined', async () => {
+      const track = jest.spyOn(instance, 'track');
+      const loggerProvider: Partial<Logger> = {
+        error: jest.fn(),
+      };
+      const config: Partial<Config> = {
+        loggerProvider: loggerProvider as Logger,
+      };
+
+      const plugin = pageViewTrackingPlugin();
+      await plugin.setup(config as Config);
+
+      expect(track).toHaveBeenCalledTimes(0);
+      expect(loggerProvider.error).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.error).toHaveBeenCalledWith(
+        `Argument of type 'undefined' is not assignable to parameter of type 'BrowserClient'.`,
+      );
+    });
+
     describe('should send a page view event', () => {
       test('when attribution event is sent and trackOn is "attribution"', async () => {
         const instance = createInstance();

--- a/packages/plugin-web-attribution-browser/src/web-attribution.ts
+++ b/packages/plugin-web-attribution-browser/src/web-attribution.ts
@@ -56,7 +56,7 @@ export const webAttributionPlugin: CreateWebAttributionPlugin = function (
       // Disable "runAttributionStrategy" function
       if (!config.attribution?.disabled) {
         config.loggerProvider.warn(
-          '@amplitude/plugin-web-attribution-browser overrides web attribution behavior defined in @amplitude/analytics-browser.',
+          '@amplitude/plugin-web-attribution-browser overrides web attribution behavior defined in @amplitude/analytics-browser. Resolve by disabling web attribution tracking in @amplitude/analytics-browser.',
         );
         config.attribution = {
           disabled: true,


### PR DESCRIPTION
### Summary

Creates flexible interface for page view tracking with client instance now optional. This flexibility is only compatible with future (unreleased as of the moment) version of the browser SDK.

```ts
// implicitly using the same instance
const instanceA = createInstance();
instanceA.add(pageViewTrackingPlugin())
```

```ts
// explicitly using the same instance
const instanceA = createInstance();
instanceA.add(pageViewTrackingPlugin(instanceA))
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
