### PR TITLE
feat: retrofit web attribution and page view plugins to browser SDK

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -117,13 +117,6 @@ describe('integration', () => {
           return true;
         })
         .reply(200, success);
-      let requestBody2: Record<string, any> = {};
-      const scope2 = nock(url)
-        .post(path, (body: Record<string, any>) => {
-          requestBody2 = body;
-          return true;
-        })
-        .reply(200, success);
 
       // NOTE: Values to assert on
       const sessionId = Date.now() - 1000;
@@ -139,6 +132,7 @@ describe('integration', () => {
         ...opts,
         attribution: {
           disabled: false,
+          trackPageViews: true,
         },
       }).promise;
       await trackPromise;
@@ -157,7 +151,14 @@ describe('integration', () => {
             language: 'en-US',
             ip: '$remote',
             insert_id: uuid,
-            event_type: '$identify',
+            event_type: 'Page View',
+            event_properties: {
+              page_domain: '',
+              page_location: '',
+              page_path: '',
+              page_title: '',
+              page_url: '',
+            },
             user_properties: {
               $setOnce: {
                 initial_dclid: 'EMPTY',
@@ -201,12 +202,6 @@ describe('integration', () => {
             event_id: 0,
             library: library,
           },
-        ],
-        options: {},
-      });
-      expect(requestBody2).toEqual({
-        api_key: apiKey,
-        events: [
           {
             device_id: deviceId,
             session_id: sessionId,
@@ -226,7 +221,6 @@ describe('integration', () => {
         options: {},
       });
       scope1.done();
-      scope2.done();
     });
   });
 

--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -46,6 +46,8 @@
     "@amplitude/analytics-client-common": "^0.5.4",
     "@amplitude/analytics-core": "^0.11.4",
     "@amplitude/analytics-types": "^0.16.0",
+    "@amplitude/plugin-page-view-tracking-browser": "^0.5.7",
+    "@amplitude/plugin-web-attribution-browser": "^0.5.7",
     "@amplitude/ua-parser-js": "^0.7.31",
     "tslib": "^2.4.1"
   },

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -3,6 +3,7 @@ import {
   Event,
   BrowserOptions,
   BrowserConfig as IBrowserConfig,
+  DefaultTrackingOptions,
   Storage,
   TrackingOptions,
   TransportType,
@@ -48,6 +49,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
   cookieSecure: boolean;
   cookieUpgrade: boolean;
   cookieStorage: Storage<UserSession>;
+  defaultTracking?: DefaultTrackingOptions;
   disableCookies: boolean;
   domain: string;
   partnerId?: string;

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -33,6 +33,18 @@ describe('browser-client', () => {
       expect(parseOldCookies).toHaveBeenCalledTimes(1);
     });
 
+    test('should initialize with existing session', async () => {
+      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
+        optOut: false,
+        lastEventTime: Date.now(),
+      });
+      const client = new AmplitudeBrowser();
+      await client.init(API_KEY, USER_ID, {
+        sessionId: Date.now(),
+      }).promise;
+      expect(parseOldCookies).toHaveBeenCalledTimes(1);
+    });
+
     test('should initialize without error when apiKey is undefined', async () => {
       const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
         optOut: false,
@@ -108,37 +120,6 @@ describe('browser-client', () => {
       expect(useBrowserConfig).toHaveBeenCalledTimes(1);
     });
 
-    test('should track attributions', async () => {
-      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
-        optOut: false,
-      });
-      const client = new AmplitudeBrowser();
-      const runAttributionStrategy = jest
-        .spyOn(client, 'runAttributionStrategy')
-        .mockReturnValueOnce(Promise.resolve(undefined));
-      await client.init(API_KEY, USER_ID).promise;
-      expect(parseOldCookies).toHaveBeenCalledTimes(1);
-      expect(runAttributionStrategy).toHaveBeenCalledTimes(1);
-    });
-
-    test('should track attributions with config', async () => {
-      const parseOldCookies = jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({
-        optOut: false,
-      });
-      const client = new AmplitudeBrowser();
-      const runAttributionStrategy = jest
-        .spyOn(client, 'runAttributionStrategy')
-        .mockReturnValueOnce(Promise.resolve(undefined));
-      await client.init(API_KEY, USER_ID, {
-        attribution: {
-          excludeReferrers: [],
-          initialEmptyValue: '',
-        },
-      }).promise;
-      expect(parseOldCookies).toHaveBeenCalledTimes(1);
-      expect(runAttributionStrategy).toHaveBeenCalledTimes(1);
-    });
-
     test('should set user id and device id in analytics connector', async () => {
       const cookieStorage = new core.MemoryStorage<UserSession>();
       jest.spyOn(cookieStorage, 'set').mockResolvedValue(undefined);
@@ -181,29 +162,6 @@ describe('browser-client', () => {
           k: 'v',
         },
       });
-      expect(track).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('trackCampaign', () => {
-    test('should track campaign', async () => {
-      const client = new AmplitudeBrowser();
-      const track = jest.spyOn(client, 'track').mockReturnValueOnce({
-        promise: Promise.resolve({
-          code: 200,
-          message: '',
-          event: {
-            event_type: 'event_type',
-          },
-        }),
-      });
-      await client.init(API_KEY, USER_ID, {
-        attribution: {
-          disabled: false,
-        },
-      }).promise;
-      const result = await client.runAttributionStrategy();
-      expect(result).toBe(undefined);
       expect(track).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -1,0 +1,77 @@
+import { BrowserOptions, DefaultTrackingOptions } from '@amplitude/analytics-types';
+
+export const isFileDownloadTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
+  if (typeof defaultTracking === 'boolean') {
+    return defaultTracking;
+  }
+
+  if (defaultTracking?.fileDownloads) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isFormInteractionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
+  if (typeof defaultTracking === 'boolean') {
+    return defaultTracking;
+  }
+
+  if (defaultTracking?.formInteractions) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isPageViewTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
+  if (typeof defaultTracking === 'boolean') {
+    return defaultTracking;
+  }
+
+  if (defaultTracking?.pageViews) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
+  if (typeof defaultTracking === 'boolean') {
+    return defaultTracking;
+  }
+
+  if (defaultTracking?.sessions) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Returns page view tracking config
+ *
+ * if config.attribution.trackPageViews and config.defaultTracking.pageViews are both TRUE
+ * then always track page views
+ *
+ * if config.attribution.trackPageViews is TRUE and config.defaultTracking.pageViews is FALSE
+ * then only track page views on attribution
+ *
+ * if config.attribution.trackPageViews is FALSE and config.defaultTracking.pageViews is TRUE
+ * then always track page views
+ *
+ * if config.attribution.trackPageViews and config.defaultTracking.pageViews are both FALSE
+ * then never track page views
+ */
+export const getPageViewTrackingConfig = (config: BrowserOptions) => {
+  let trackOn = config.attribution?.trackPageViews ? ('attribution' as const) : () => false;
+
+  const isDefaultPageViewTrackingEnabled = isPageViewTrackingEnabled(config.defaultTracking);
+  if (isDefaultPageViewTrackingEnabled) {
+    trackOn = () => true;
+  }
+
+  return {
+    trackOn,
+  };
+};

--- a/packages/analytics-client-common/src/index.ts
+++ b/packages/analytics-client-common/src/index.ts
@@ -9,3 +9,10 @@ export { IdentityEventSender } from './plugins/identity';
 export { getLanguage } from './language';
 export { BASE_CAMPAIGN } from './attribution/constants';
 export { getGlobalScope } from './global-scope';
+export {
+  getPageViewTrackingConfig,
+  isFileDownloadTrackingEnabled,
+  isFormInteractionTrackingEnabled,
+  isPageViewTrackingEnabled,
+  isSessionTrackingEnabled,
+} from './default-tracking';

--- a/packages/analytics-client-common/test/default-tracking.test.ts
+++ b/packages/analytics-client-common/test/default-tracking.test.ts
@@ -1,0 +1,122 @@
+import {
+  getPageViewTrackingConfig,
+  isFileDownloadTrackingEnabled,
+  isFormInteractionTrackingEnabled,
+  isPageViewTrackingEnabled,
+  isSessionTrackingEnabled,
+} from '../src/default-tracking';
+
+describe('isFileDownloadTrackingEnabled', () => {
+  test('should return true with boolean parameter', () => {
+    expect(isFileDownloadTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isFileDownloadTrackingEnabled({
+        fileDownloads: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false', () => {
+    expect(isFileDownloadTrackingEnabled(undefined)).toBe(false);
+  });
+});
+
+describe('isFormInteractionTrackingEnabled', () => {
+  test('should return true with boolean parameter', () => {
+    expect(isFormInteractionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isFormInteractionTrackingEnabled({
+        formInteractions: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false', () => {
+    expect(isFormInteractionTrackingEnabled(undefined)).toBe(false);
+  });
+});
+
+describe('isPageViewTrackingEnabled', () => {
+  test('should return true with boolean parameter', () => {
+    expect(isPageViewTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isPageViewTrackingEnabled({
+        pageViews: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false', () => {
+    expect(isPageViewTrackingEnabled(undefined)).toBe(false);
+  });
+});
+
+describe('isSessionTrackingEnabled', () => {
+  test('should return true with boolean parameter', () => {
+    expect(isSessionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isSessionTrackingEnabled({
+        sessions: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false', () => {
+    expect(isSessionTrackingEnabled(undefined)).toBe(false);
+  });
+});
+
+describe('getPageViewTrackingConfig', () => {
+  test('should return track on attribution config', () => {
+    const config = getPageViewTrackingConfig({
+      attribution: {
+        trackPageViews: true,
+      },
+    });
+
+    expect(config.trackOn).toBe('attribution');
+  });
+
+  test('should return never track config', () => {
+    const config = getPageViewTrackingConfig({});
+
+    expect(typeof config.trackOn).toBe('function');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore asserts that track on is a function that returns a boolean
+    expect(config.trackOn()).toBe(false);
+  });
+
+  test('should return always track config', () => {
+    const config = getPageViewTrackingConfig({
+      defaultTracking: {
+        pageViews: true,
+      },
+    });
+
+    expect(typeof config.trackOn).toBe('function');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore asserts that track on is a function that returns a boolean
+    expect(config.trackOn()).toBe(true);
+  });
+
+  test('should return never track config with default tracking', () => {
+    const config = getPageViewTrackingConfig({});
+
+    expect(typeof config.trackOn).toBe('function');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore asserts that track on is a function that returns a boolean
+    expect(config.trackOn()).toBe(false);
+  });
+});

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -6,6 +6,7 @@ import { Config } from './core';
 export interface BrowserConfig extends Config {
   appVersion?: string;
   attribution?: AttributionOptions;
+  defaultTracking?: boolean | DefaultTrackingOptions;
   deviceId?: string;
   cookieExpiration: number;
   cookieSameSite: string;
@@ -20,6 +21,13 @@ export interface BrowserConfig extends Config {
   sessionTimeout: number;
   trackingOptions: TrackingOptions;
   userId?: string;
+}
+
+export interface DefaultTrackingOptions {
+  fileDownloads?: boolean;
+  formInteractions?: boolean;
+  pageViews?: boolean;
+  sessions?: boolean;
 }
 
 export interface TrackingOptions {
@@ -37,6 +45,7 @@ export interface AttributionOptions {
   disabled?: boolean;
   excludeReferrers?: string[];
   initialEmptyValue?: string;
+  resetSessionOnNewCampaign?: boolean;
   trackNewCampaigns?: boolean;
   trackPageViews?: boolean;
 }

--- a/packages/analytics-types/src/config/index.ts
+++ b/packages/analytics-types/src/config/index.ts
@@ -1,4 +1,4 @@
 export { Config, Options } from './core';
-export { BrowserConfig, TrackingOptions, AttributionOptions, BrowserOptions } from './browser';
+export { BrowserConfig, DefaultTrackingOptions, TrackingOptions, AttributionOptions, BrowserOptions } from './browser';
 export { NodeConfig, NodeOptions } from './node';
 export { ReactNativeConfig, ReactNativeTrackingOptions, ReactNativeOptions } from './react-native';

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -16,6 +16,7 @@ export {
   BrowserConfig,
   BrowserOptions,
   Config,
+  DefaultTrackingOptions,
   Options,
   NodeConfig,
   NodeOptions,

--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -70,8 +70,7 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (
 
       options.trackOn = config.attribution?.trackPageViews ? 'attribution' : options.trackOn;
 
-      // Turn off sending page view event by "runAttributionStrategy" function
-      if (config.attribution?.trackPageViews) {
+      if (!client && config.attribution?.trackPageViews) {
         loggerProvider.warn(
           `@amplitude/plugin-page-view-tracking-browser overrides page view tracking behavior defined in @amplitude/analytics-browser. Resolve by disabling page view tracking in @amplitude/analytics-browser.`,
         );


### PR DESCRIPTION
### Summary

* Replaces browser SDK logic for attribution and page view tracking with first-party plugins
* Old logic for attribution and page view tracking is still supported
* New logic for page view tracking is enabled when using new config

To configure with old logic for page view tracking,

```ts
amplitude.init(API_KEY, USER_ID, {
  attribution: {
    trackPageViews: true,
  },
});
```

To configure with new logic for page view tracking,

```ts
amplitude.init(API_KEY, USER_ID, {
  defaultTracking: {
    pageViews: true,
  },
});
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
