### PR TITLE
feat: add session start/end event tracker

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -49,7 +49,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
   cookieSecure: boolean;
   cookieUpgrade: boolean;
   cookieStorage: Storage<UserSession>;
-  defaultTracking?: DefaultTrackingOptions;
+  defaultTracking?: DefaultTrackingOptions | boolean;
   disableCookies: boolean;
   domain: string;
   partnerId?: string;
@@ -89,6 +89,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     this.cookieSameSite = options?.cookieSameSite ?? defaultConfig.cookieSameSite;
     this.cookieSecure = options?.cookieSecure ?? defaultConfig.cookieSecure;
     this.cookieUpgrade = options?.cookieUpgrade ?? defaultConfig.cookieUpgrade;
+    this.defaultTracking = options?.defaultTracking;
     this.disableCookies = options?.disableCookies ?? defaultConfig.disableCookies;
     this.domain = options?.domain ?? defaultConfig.domain;
     this.partnerId = options?.partnerId;

--- a/packages/analytics-browser/src/plugins/context.ts
+++ b/packages/analytics-browser/src/plugins/context.ts
@@ -34,15 +34,6 @@ export class Context implements BeforePlugin {
   }
 
   async execute(context: Event): Promise<Event> {
-    /**
-     * Manages user session triggered by new events
-     */
-    if (!this.isSessionValid()) {
-      // Creates new session
-      this.config.sessionId = Date.now();
-    } // else use previously creates session
-    // Updates last event time to extend time-based session
-    this.config.lastEventTime = Date.now();
     const time = new Date().getTime();
     const osName = this.uaResult.browser.name;
     const osVersion = this.uaResult.browser.version;
@@ -76,11 +67,5 @@ export class Context implements BeforePlugin {
       library: this.library,
     };
     return event;
-  }
-
-  isSessionValid() {
-    const lastEventTime = this.config.lastEventTime || Date.now();
-    const timeSinceLastEvent = Date.now() - lastEventTime;
-    return timeSinceLastEvent < this.config.sessionTimeout;
   }
 }

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -4,7 +4,7 @@ import { BrowserConfig } from '../config';
 const FILE_DOWNLOAD_EVENT = 'file_download';
 
 export const fileDownloadTracking = (): EnrichmentPlugin => {
-  const name = 'fileDownloadTracking';
+  const name = '@amplitude/plugin-file-download-tracking-browser';
   const type = PluginType.ENRICHMENT;
   const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
     /* istanbul ignore if */

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -5,7 +5,7 @@ const FORM_START_EVENT = 'form_start';
 const FORM_SUBMIT_EVENT = 'form_submit';
 
 export const formInteractionTracking = (): EnrichmentPlugin => {
-  const name = 'formInteractionTracking';
+  const name = '@amplitude/plugin-form-interaction-tracking-browser';
   const type = PluginType.ENRICHMENT;
   const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
     /* istanbul ignore if */

--- a/packages/analytics-browser/src/plugins/session-handler.ts
+++ b/packages/analytics-browser/src/plugins/session-handler.ts
@@ -1,0 +1,55 @@
+import { BeforePlugin, BrowserClient, BrowserConfig, Event, PluginType } from '@amplitude/analytics-types';
+
+export const START_SESSION_EVENT = 'session_start';
+export const END_SESSION_EVENT = 'session_end';
+
+export const sessionHandlerPlugin = (): BeforePlugin => {
+  // browserConfig is defined in setup() which will always be called first
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  let browserConfig: BrowserConfig;
+  // amplitude is defined in setup() which will always be called first
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  let amplitude: BrowserClient;
+
+  const name = '@amplitude/plugin-session-handler';
+
+  const type = PluginType.BEFORE;
+
+  const setup = async (config: BrowserConfig, client: BrowserClient) => {
+    browserConfig = config;
+    amplitude = client;
+  };
+
+  const execute = async (event: Event) => {
+    const now = Date.now();
+
+    if (event.event_type === START_SESSION_EVENT || event.event_type === END_SESSION_EVENT) {
+      browserConfig.lastEventTime = now;
+      return event;
+    }
+
+    const lastEventTime = browserConfig.lastEventTime || now;
+    const timeSinceLastEvent = now - lastEventTime;
+
+    if (timeSinceLastEvent > browserConfig.sessionTimeout) {
+      // assigns new session
+      amplitude.setSessionId(now);
+      event.session_id = amplitude.getSessionId();
+      event.time = now;
+    } // else use existing session
+
+    // updates last event time to extend time-based session
+    browserConfig.lastEventTime = now;
+
+    return event;
+  };
+
+  return {
+    name,
+    type,
+    setup,
+    execute,
+  };
+};

--- a/packages/analytics-browser/test/plugins/context.test.ts
+++ b/packages/analytics-browser/test/plugins/context.test.ts
@@ -26,7 +26,6 @@ describe('context', () => {
   describe('execute', () => {
     test('should execute plugin', async () => {
       const context = new Context();
-      jest.spyOn(context, 'isSessionValid').mockReturnValue(true);
       const config = useDefaultConfig({
         deviceId: 'deviceId',
         sessionId: 1,
@@ -58,7 +57,6 @@ describe('context', () => {
 
     test('should not return the properties when the tracking options are false', async () => {
       const context = new Context();
-      jest.spyOn(context, 'isSessionValid').mockReturnValue(true);
       const config = useDefaultConfig({
         deviceId: 'deviceId',
         sessionId: 1,
@@ -101,7 +99,6 @@ describe('context', () => {
 
     test('should be overwritten by the context', async () => {
       const context = new Context();
-      jest.spyOn(context, 'isSessionValid').mockReturnValue(true);
       const config = useDefaultConfig({
         deviceId: 'deviceId',
         sessionId: 1,
@@ -123,21 +120,6 @@ describe('context', () => {
 
       const secondContextEvent = await context.execute(event);
       expect(secondContextEvent.event_id).toEqual(1);
-    });
-
-    test('should create new session', async () => {
-      const plugin = new Context();
-      jest.spyOn(plugin, 'isSessionValid').mockReturnValue(false);
-      const config = useDefaultConfig({
-        sessionId: 1,
-        userId: 'user@amplitude.com',
-      });
-      await plugin.setup(config);
-      const context = {
-        event_type: 'event_type',
-      };
-      const event = await plugin.execute(context);
-      expect(event.session_id).not.toBe(1);
     });
 
     describe('ingestionMetadata config', () => {

--- a/packages/analytics-browser/test/plugins/session-handler.test.ts
+++ b/packages/analytics-browser/test/plugins/session-handler.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import { createAmplitudeMock, createConfigurationMock } from '../helpers/mock';
+import { sessionHandlerPlugin } from '../../src/plugins/session-handler';
+
+describe('sessionHandlerPlugin', () => {
+  let amplitude = createAmplitudeMock();
+
+  beforeEach(() => {
+    amplitude = createAmplitudeMock();
+  });
+
+  test('should use the existing session', async () => {
+    const plugin = sessionHandlerPlugin();
+    const time = Date.now();
+    const config = createConfigurationMock({
+      sessionId: 1,
+      lastEventTime: time - 999,
+      sessionTimeout: 1000,
+    });
+    await plugin.setup(config, amplitude);
+    await plugin.execute({
+      event_type: 'Test Event',
+    });
+
+    // assert session id is unchanged
+    expect(config.sessionId).toBe(1);
+
+    // assert last event time was updated
+    expect(config.lastEventTime).not.toBe(time - 999);
+
+    // assert no events are instrumented
+    expect(amplitude.track).toHaveBeenCalledTimes(0);
+  });
+
+  test('should use the existing session with no lastEventTime', async () => {
+    const plugin = sessionHandlerPlugin();
+    const config = createConfigurationMock({
+      sessionId: 1,
+      lastEventTime: undefined,
+      sessionTimeout: 1000,
+    });
+    await plugin.setup(config, amplitude);
+    await plugin.execute({
+      event_type: 'Test Event',
+    });
+
+    // assert session id is unchanged
+    expect(config.sessionId).toBe(1);
+
+    // assert last event time was updated
+    expect(config.lastEventTime).not.toBeUndefined();
+
+    // assert no events are instrumented
+    expect(amplitude.track).toHaveBeenCalledTimes(0);
+  });
+
+  test('should assign new session', async () => {
+    const plugin = sessionHandlerPlugin();
+    const time = Date.now();
+    const config = createConfigurationMock({
+      sessionId: 1,
+      lastEventTime: time - 1001,
+      sessionTimeout: 1000,
+      defaultTracking: {
+        sessions: true,
+      },
+    });
+    await plugin.setup(config, amplitude);
+    await plugin.execute({
+      event_type: 'Test Event',
+    });
+
+    // assert session id was changed
+    expect(amplitude.setSessionId).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(['session_start', 'session_end'])('should handle session events', async (eventType) => {
+    const plugin = sessionHandlerPlugin();
+    const time = Date.now();
+    const config = createConfigurationMock({
+      sessionId: 1,
+      lastEventTime: time - 1001,
+      sessionTimeout: 1000,
+      defaultTracking: {
+        sessions: true,
+      },
+    });
+    await plugin.setup(config, amplitude);
+    await plugin.execute({
+      event_type: eventType,
+    });
+
+    // assert session id was changed
+    expect(amplitude.setSessionId).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
### Summary

Sends session start and session end events when a new session is assigned. Additionally, a new session is assigned when a new user is assigned

#### Testing

```ts
amplitude.init(API_KEY, USER_ID, {
  defaultTracking: {
    sessions: true,
  },
  sessionTimeout: 500,
});
// If previous session exists, sends `session_end` event
// Sends `session_start` event
amplitude.track('Event in first session');

setTimeout(() => {
  amplitude.track('Event in next session');
  // Sends `session_end` event for previous session
  // Sends `session_start` event for next session
}, 1000);

setTimeout(() => {
  amplitude.setUserId(USER_ID_2); // effectively creates a new session
  // Sends `session_end` event for previous user and session
  // Sends `session_start` event for next user and session
}, 2000);
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
