### PR TITLE
feat: add form interaction and file download plugins

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -98,21 +98,22 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     }
 
     // Add web attribution plugin
-    const webAttribution = webAttributionPlugin({
-      disabled: this.config.attribution?.disabled,
-      excludeReferrers: this.config.attribution?.excludeReferrers,
-      initialEmptyValue: this.config.attribution?.initialEmptyValue,
-      resetSessionOnNewCampaign: this.config.attribution?.resetSessionOnNewCampaign,
-    });
+    if (!this.config.attribution?.disabled) {
+      const webAttribution = webAttributionPlugin({
+        excludeReferrers: this.config.attribution?.excludeReferrers,
+        initialEmptyValue: this.config.attribution?.initialEmptyValue,
+        resetSessionOnNewCampaign: this.config.attribution?.resetSessionOnNewCampaign,
+      });
 
-    // For Amplitude-internal functionality
-    // if pluginEnabledOverride === undefined then use plugin default logic
-    // if pluginEnabledOverride === true then track attribution
-    // if pluginEnabledOverride === false then do not track attribution
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    (webAttribution as any).__pluginEnabledOverride =
-      isNewSession || this.config.attribution?.trackNewCampaigns ? undefined : false;
-    await this.add(webAttribution).promise;
+      // For Amplitude-internal functionality
+      // if pluginEnabledOverride === undefined then use plugin default logic
+      // if pluginEnabledOverride === true then track attribution
+      // if pluginEnabledOverride === false then do not track attribution
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (webAttribution as any).__pluginEnabledOverride =
+        isNewSession || this.config.attribution?.trackNewCampaigns ? undefined : false;
+      await this.add(webAttribution).promise;
+    }
 
     // Add page view plugin
     await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -4,6 +4,8 @@ import {
   getPageViewTrackingConfig,
   IdentityEventSender,
   isSessionTrackingEnabled,
+  isFileDownloadTrackingEnabled,
+  isFormInteractionTrackingEnabled,
 } from '@amplitude/analytics-client-common';
 import {
   BrowserClient,
@@ -21,6 +23,8 @@ import { parseOldCookies } from './cookie-migration';
 import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
 import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
 import { sessionHandlerPlugin, START_SESSION_EVENT, END_SESSION_EVENT } from './plugins/session-handler';
+import { formInteractionTracking } from './plugins/form-interaction-tracking';
+import { fileDownloadTracking } from './plugins/file-download-tracking';
 
 export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -84,6 +88,14 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     await this.add(new Context()).promise;
     await this.add(sessionHandlerPlugin()).promise;
     await this.add(new IdentityEventSender()).promise;
+
+    if (isFileDownloadTrackingEnabled(this.config.defaultTracking)) {
+      await this.add(fileDownloadTracking()).promise;
+    }
+
+    if (isFormInteractionTrackingEnabled(this.config.defaultTracking)) {
+      await this.add(formInteractionTracking()).promise;
+    }
 
     // Add web attribution plugin
     const webAttribution = webAttributionPlugin({

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -91,6 +91,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     this.cookieUpgrade = options?.cookieUpgrade ?? defaultConfig.cookieUpgrade;
     this.defaultTracking = options?.defaultTracking;
     this.disableCookies = options?.disableCookies ?? defaultConfig.disableCookies;
+    this.defaultTracking = options?.defaultTracking;
     this.domain = options?.domain ?? defaultConfig.domain;
     this.partnerId = options?.partnerId;
     this.sessionTimeout = options?.sessionTimeout ?? defaultConfig.sessionTimeout;

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,7 +1,7 @@
 import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { BrowserConfig } from '../config';
 
-const FILE_DOWNLOAD_EVENT = 'file_download';
+const FILE_DOWNLOAD_EVENT = '[Amplitude] File Download';
 
 export const fileDownloadTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-file-download-tracking-browser';

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -1,8 +1,8 @@
 import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { BrowserConfig } from '../config';
 
-const FORM_START_EVENT = 'form_start';
-const FORM_SUBMIT_EVENT = 'form_submit';
+const FORM_START_EVENT = '[Amplitude] Form Start';
+const FORM_SUBMIT_EVENT = '[Amplitude] Form Submit';
 
 export const formInteractionTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-form-interaction-tracking-browser';

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -5,6 +5,8 @@ import * as CookieMigration from '../src/cookie-migration';
 import { Status, TransportType, UserSession } from '@amplitude/analytics-types';
 import { FetchTransport, getAnalyticsConnector } from '@amplitude/analytics-client-common';
 import * as SnippetHelper from '../src/utils/snippet-helper';
+import * as fileDownloadTracking from '../src/plugins/file-download-tracking';
+import * as formInteractionTracking from '../src/plugins/form-interaction-tracking';
 
 describe('browser-client', () => {
   const API_KEY = 'API_KEY';
@@ -163,6 +165,34 @@ describe('browser-client', () => {
         },
       });
       expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    test('should add file download and form interaction tracking plugins', async () => {
+      const client = new AmplitudeBrowser();
+      const fileDownloadTrackingPlugin = jest.spyOn(fileDownloadTracking, 'fileDownloadTracking');
+      const formInteractionTrackingPlugin = jest.spyOn(formInteractionTracking, 'formInteractionTracking');
+      await client.init(API_KEY, USER_ID, {
+        optOut: false,
+        ...attributionConfig,
+        autoTracking: {
+          fileDownloads: true,
+          formInteractions: true,
+        },
+      }).promise;
+      expect(fileDownloadTrackingPlugin).toHaveBeenCalledTimes(1);
+      expect(formInteractionTrackingPlugin).toHaveBeenCalledTimes(1);
+    });
+
+    test('should NOT add file download and form interaction tracking plugins', async () => {
+      const client = new AmplitudeBrowser();
+      const fileDownloadTrackingPlugin = jest.spyOn(fileDownloadTracking, 'fileDownloadTracking');
+      const formInteractionTrackingPlugin = jest.spyOn(formInteractionTracking, 'formInteractionTracking');
+      await client.init(API_KEY, USER_ID, {
+        optOut: false,
+        ...attributionConfig,
+      }).promise;
+      expect(fileDownloadTrackingPlugin).toHaveBeenCalledTimes(0);
+      expect(formInteractionTrackingPlugin).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -33,7 +33,7 @@ describe('fileDownloadTracking', () => {
 
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'file_download', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Download', {
       file_extension: 'pdf',
       file_name: '/files/my-file.pdf',
       link_id: 'my-link-id',
@@ -63,7 +63,7 @@ describe('fileDownloadTracking', () => {
 
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'file_download', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Download', {
       file_extension: 'pdf',
       file_name: '/files/my-file-2.pdf',
       link_id: 'my-link-2-id',

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -42,7 +42,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'form_start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
@@ -86,7 +86,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'form_start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
       form_id: 'my-form-2-id',
       form_name: 'my-form-2-name',
       form_destination: 'http://localhost/submit',
@@ -110,12 +110,12 @@ describe('formInteractionTracking', () => {
 
     // assert both events were tracked
     expect(amplitude.track).toHaveBeenCalledTimes(2);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'form_start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
     });
-    expect(amplitude.track).toHaveBeenNthCalledWith(2, 'form_submit', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submit', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
@@ -133,7 +133,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, 'form_start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
@@ -144,7 +144,7 @@ describe('formInteractionTracking', () => {
 
     // assert second event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(2);
-    expect(amplitude.track).toHaveBeenNthCalledWith(2, 'form_submit', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submit', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -29,7 +29,7 @@ export const isPageViewTrackingEnabled = (defaultTracking: DefaultTrackingOption
     return defaultTracking;
   }
 
-  if (defaultTracking?.pageViews) {
+  if (defaultTracking?.pageViews === true || typeof defaultTracking?.pageViews === 'object') {
     return true;
   }
 
@@ -64,14 +64,28 @@ export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions
  * then never track page views
  */
 export const getPageViewTrackingConfig = (config: BrowserOptions) => {
-  let trackOn = config.attribution?.trackPageViews ? ('attribution' as const) : () => false;
+  let trackOn: undefined | 'attribution' | (() => boolean) = config.attribution?.trackPageViews
+    ? 'attribution'
+    : () => false;
+  let trackHistoryChanges: undefined | 'all' | 'pathOnly' = undefined;
 
   const isDefaultPageViewTrackingEnabled = isPageViewTrackingEnabled(config.defaultTracking);
   if (isDefaultPageViewTrackingEnabled) {
     trackOn = () => true;
+
+    if (typeof config.defaultTracking === 'object' && typeof config.defaultTracking.pageViews === 'object') {
+      if ('trackOn' in config.defaultTracking.pageViews) {
+        trackOn = config.defaultTracking.pageViews.trackOn;
+      }
+
+      if ('trackHistoryChanges' in config.defaultTracking.pageViews) {
+        trackHistoryChanges = config.defaultTracking.pageViews.trackHistoryChanges;
+      }
+    }
   }
 
   return {
     trackOn,
+    trackHistoryChanges,
   };
 };

--- a/packages/analytics-client-common/test/default-tracking.test.ts
+++ b/packages/analytics-client-common/test/default-tracking.test.ts
@@ -55,6 +55,16 @@ describe('isPageViewTrackingEnabled', () => {
     ).toBe(true);
   });
 
+  test('should return true with nested object parameter', () => {
+    expect(
+      isPageViewTrackingEnabled({
+        pageViews: {
+          trackOn: 'attribution',
+        },
+      }),
+    ).toBe(true);
+  });
+
   test('should return false', () => {
     expect(isPageViewTrackingEnabled(undefined)).toBe(false);
   });
@@ -118,5 +128,20 @@ describe('getPageViewTrackingConfig', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore asserts that track on is a function that returns a boolean
     expect(config.trackOn()).toBe(false);
+  });
+
+  test('should return advanced options', () => {
+    const config = getPageViewTrackingConfig({
+      defaultTracking: {
+        pageViews: {
+          trackOn: 'attribution',
+          trackHistoryChanges: 'all',
+        },
+      },
+    });
+
+    expect(typeof config.trackOn).toBe('string');
+    expect(config.trackOn).toBe('attribution');
+    expect(config.trackHistoryChanges).toBe('all');
   });
 });

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -26,7 +26,12 @@ export interface BrowserConfig extends Config {
 export interface DefaultTrackingOptions {
   fileDownloads?: boolean;
   formInteractions?: boolean;
-  pageViews?: boolean;
+  pageViews?:
+    | boolean
+    | {
+        trackOn?: 'attribution' | (() => boolean);
+        trackHistoryChanges?: 'all' | 'pathOnly';
+      };
   sessions?: boolean;
 }
 

--- a/packages/marketing-analytics-browser/src/typings/browser-client.ts
+++ b/packages/marketing-analytics-browser/src/typings/browser-client.ts
@@ -10,7 +10,7 @@ export interface Client extends AnalyticsBrowserClient {
   init(apiKey: string, userId?: string, options?: Options): AmplitudeReturn<void>;
 }
 
-export type Options = AnalyticsBrowserOptions & AttributionOptions & PageViewTracking;
+export type Options = Omit<AnalyticsBrowserOptions, 'defaultTracking'> & AttributionOptions & PageViewTracking;
 
 export type AttributionOptions = {
   attribution?: WebAttributionPluginTypes.Options;

--- a/packages/marketing-analytics-browser/test/browser-client.test.ts
+++ b/packages/marketing-analytics-browser/test/browser-client.test.ts
@@ -83,36 +83,7 @@ describe('browser-client', () => {
       expect(init).toHaveBeenCalledTimes(1);
     });
 
-    test('should add page view tracking plugin when pageViewTracking is true', async () => {
-      const init = jest.fn().mockImplementation(() => ({
-        promise: Promise.resolve(),
-      }));
-      const add = jest.fn().mockImplementation(() => ({
-        promise: Promise.resolve(),
-      }));
-
-      jest.spyOn(browser, 'createInstance').mockImplementation(() => {
-        const client = {} as BrowserClient;
-        client.init = init;
-        client.add = add;
-
-        return client;
-      });
-
-      const client = createInstance();
-
-      await client.init(API_KEY, USER_ID, {
-        attribution: {
-          disabled: true,
-        },
-        pageViewTracking: true,
-      }).promise;
-
-      expect(add).toHaveBeenCalledTimes(2);
-      expect(init).toHaveBeenCalledTimes(1);
-    });
-
-    test('should add page view tracking plugin when pageViewTracking is set', async () => {
+    test('should transform config for page view tracking', async () => {
       const init = jest.fn().mockImplementation(() => ({
         promise: Promise.resolve(),
       }));
@@ -139,37 +110,18 @@ describe('browser-client', () => {
         },
       }).promise;
 
-      expect(add).toHaveBeenCalledTimes(2);
+      expect(add).toHaveBeenCalledTimes(1);
       expect(init).toHaveBeenCalledTimes(1);
-    });
-
-    test('should not add page view tracking plugin when pageViewTracking is false', async () => {
-      const init = jest.fn().mockImplementation(() => ({
-        promise: Promise.resolve(),
-      }));
-      const add = jest.fn().mockImplementation(() => ({
-        promise: Promise.resolve(),
-      }));
-
-      jest.spyOn(browser, 'createInstance').mockImplementation(() => {
-        const client = {} as BrowserClient;
-        client.init = init;
-        client.add = add;
-
-        return client;
-      });
-
-      const client = createInstance();
-
-      await client.init(API_KEY, USER_ID, {
+      expect(init).toHaveBeenNthCalledWith(1, API_KEY, USER_ID, {
         attribution: {
           disabled: true,
         },
-        pageViewTracking: false,
-      }).promise;
-
-      expect(add).toHaveBeenCalledTimes(1);
-      expect(init).toHaveBeenCalledTimes(1);
+        defaultTracking: {
+          pageViews: {
+            trackOn: 'attribution',
+          },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
### Summary

Add form interaction and file download plugins
* Transform marketing analytics page view config to default event tracking config
* `form_start` -> `[Amplitude] Form Start`
* `form_submit` -> `[Amplitude] Form Submit`
* `file_download` -> `[Amplitude] File Download`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
