### PR TITLE
feat: allow custom page view event type

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -22,9 +22,10 @@ import { useBrowserConfig, createTransport } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
 import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
-import { sessionHandlerPlugin, START_SESSION_EVENT, END_SESSION_EVENT } from './plugins/session-handler';
+import { sessionHandlerPlugin } from './plugins/session-handler';
 import { formInteractionTracking } from './plugins/form-interaction-tracking';
 import { fileDownloadTracking } from './plugins/file-download-tracking';
+import { DEFAULT_PAGE_VIEW_EVENT, DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from './constants';
 
 export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -116,7 +117,9 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     }
 
     // Add page view plugin
-    await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;
+    const pageViewTrackingOptions = getPageViewTrackingConfig(this.config);
+    pageViewTrackingOptions.eventType = pageViewTrackingOptions.eventType || DEFAULT_PAGE_VIEW_EVENT;
+    await this.add(pageViewTrackingPlugin(pageViewTrackingOptions)).promise;
 
     this.initializing = false;
 
@@ -181,11 +184,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
         if (this.previousSessionUserId) {
           eventOptions.user_id = this.previousSessionUserId;
         }
-        this.track(END_SESSION_EVENT, undefined, eventOptions);
+        this.track(DEFAULT_SESSION_END_EVENT, undefined, eventOptions);
         this.previousSessionUserId = undefined;
       }
 
-      this.track(START_SESSION_EVENT, undefined, {
+      this.track(DEFAULT_SESSION_START_EVENT, undefined, {
         session_id: sessionId,
         time: sessionId - 1,
       });

--- a/packages/analytics-browser/src/constants.ts
+++ b/packages/analytics-browser/src/constants.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_PAGE_VIEW_EVENT = '[Amplitude] Page View';
+export const DEFAULT_SESSION_START_EVENT = 'session_start';
+export const DEFAULT_SESSION_END_EVENT = 'session_end';
+export const DEFAULT_FORM_START_EVENT = '[Amplitude] Form Start';
+export const DEFAULT_FORM_SUBMIT_EVENT = '[Amplitude] Form Submit';
+export const DEFAULT_FILE_DOWNLOAD_EVENT = '[Amplitude] File Download';

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,7 +1,6 @@
 import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { DEFAULT_FILE_DOWNLOAD_EVENT } from '../constants';
 import { BrowserConfig } from '../config';
-
-const FILE_DOWNLOAD_EVENT = '[Amplitude] File Download';
 
 export const fileDownloadTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-file-download-tracking-browser';
@@ -25,7 +24,7 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
         if (fileExtension) {
           a.addEventListener('click', () => {
             if (fileExtension) {
-              amplitude.track(FILE_DOWNLOAD_EVENT, {
+              amplitude.track(DEFAULT_FILE_DOWNLOAD_EVENT, {
                 file_extension: fileExtension,
                 file_name: url.pathname,
                 link_id: a.id,

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -1,8 +1,6 @@
 import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { DEFAULT_FORM_START_EVENT, DEFAULT_FORM_SUBMIT_EVENT } from '../constants';
 import { BrowserConfig } from '../config';
-
-const FORM_START_EVENT = '[Amplitude] Form Start';
-const FORM_SUBMIT_EVENT = '[Amplitude] Form Submit';
 
 export const formInteractionTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-form-interaction-tracking-browser';
@@ -24,7 +22,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
         'change',
         () => {
           if (!hasFormChanged) {
-            amplitude.track(FORM_START_EVENT, {
+            amplitude.track(DEFAULT_FORM_START_EVENT, {
               form_id: form.id,
               form_name: form.name,
               form_destination: form.action,
@@ -37,14 +35,14 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
 
       form.addEventListener('submit', () => {
         if (!hasFormChanged) {
-          amplitude.track(FORM_START_EVENT, {
+          amplitude.track(DEFAULT_FORM_START_EVENT, {
             form_id: form.id,
             form_name: form.name,
             form_destination: form.action,
           });
         }
 
-        amplitude.track(FORM_SUBMIT_EVENT, {
+        amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
           form_id: form.id,
           form_name: form.name,
           form_destination: form.action,

--- a/packages/analytics-browser/src/plugins/session-handler.ts
+++ b/packages/analytics-browser/src/plugins/session-handler.ts
@@ -1,7 +1,5 @@
 import { BeforePlugin, BrowserClient, BrowserConfig, Event, PluginType } from '@amplitude/analytics-types';
-
-export const START_SESSION_EVENT = 'session_start';
-export const END_SESSION_EVENT = 'session_end';
+import { DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from '../constants';
 
 export const sessionHandlerPlugin = (): BeforePlugin => {
   // browserConfig is defined in setup() which will always be called first
@@ -25,7 +23,7 @@ export const sessionHandlerPlugin = (): BeforePlugin => {
   const execute = async (event: Event) => {
     const now = Date.now();
 
-    if (event.event_type === START_SESSION_EVENT || event.event_type === END_SESSION_EVENT) {
+    if (event.event_type === DEFAULT_SESSION_START_EVENT || event.event_type === DEFAULT_SESSION_END_EVENT) {
       browserConfig.lastEventTime = now;
       return event;
     }

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -8,6 +8,7 @@ import * as SnippetHelper from '../src/utils/snippet-helper';
 import * as fileDownloadTracking from '../src/plugins/file-download-tracking';
 import * as formInteractionTracking from '../src/plugins/form-interaction-tracking';
 import * as webAttributionPlugin from '@amplitude/plugin-web-attribution-browser';
+import * as pageViewTrackingPlugin from '@amplitude/plugin-page-view-tracking-browser';
 
 describe('browser-client', () => {
   const API_KEY = 'API_KEY';
@@ -166,6 +167,22 @@ describe('browser-client', () => {
         },
       });
       expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    test('should add page view tracking with default event type', async () => {
+      const client = new AmplitudeBrowser();
+      const pageViewTracking = jest.spyOn(pageViewTrackingPlugin, 'pageViewTrackingPlugin');
+      await client.init(API_KEY, USER_ID, {
+        optOut: false,
+        ...attributionConfig,
+        defaultTracking: {
+          pageViews: {},
+        },
+      }).promise;
+      expect(pageViewTracking).toHaveBeenCalledTimes(1);
+      expect(pageViewTracking).toHaveBeenNthCalledWith(1, {
+        eventType: '[Amplitude] Page View',
+      });
     });
 
     test('should add file download and form interaction tracking plugins', async () => {

--- a/packages/analytics-client-common/test/default-tracking.test.ts
+++ b/packages/analytics-client-common/test/default-tracking.test.ts
@@ -115,10 +115,7 @@ describe('getPageViewTrackingConfig', () => {
       },
     });
 
-    expect(typeof config.trackOn).toBe('function');
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore asserts that track on is a function that returns a boolean
-    expect(config.trackOn()).toBe(true);
+    expect(config.trackOn).toBe(undefined);
   });
 
   test('should return never track config with default tracking', () => {
@@ -136,6 +133,7 @@ describe('getPageViewTrackingConfig', () => {
         pageViews: {
           trackOn: 'attribution',
           trackHistoryChanges: 'all',
+          eventType: 'Page View',
         },
       },
     });
@@ -143,5 +141,6 @@ describe('getPageViewTrackingConfig', () => {
     expect(typeof config.trackOn).toBe('string');
     expect(config.trackOn).toBe('attribution');
     expect(config.trackHistoryChanges).toBe('all');
+    expect(config.eventType).toBe('Page View');
   });
 });

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -2,6 +2,7 @@ import { UserSession } from '../user-session';
 import { Storage } from '../storage';
 import { TransportType } from '../transport';
 import { Config } from './core';
+import { PageTrackingOptions } from '../page-view-tracking';
 
 export interface BrowserConfig extends Config {
   appVersion?: string;
@@ -26,12 +27,7 @@ export interface BrowserConfig extends Config {
 export interface DefaultTrackingOptions {
   fileDownloads?: boolean;
   formInteractions?: boolean;
-  pageViews?:
-    | boolean
-    | {
-        trackOn?: 'attribution' | (() => boolean);
-        trackHistoryChanges?: 'all' | 'pathOnly';
-      };
+  pageViews?: boolean | PageTrackingOptions;
   sessions?: boolean;
 }
 

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -58,3 +58,4 @@ export { CookieStorageOptions, Storage } from './storage';
 export { Transport, TransportType } from './transport';
 export { UserSession } from './user-session';
 export { UTMData } from './utm';
+export { PageTrackingOptions, PageTrackingTrackOn, PageTrackingHistoryChanges } from './page-view-tracking';

--- a/packages/analytics-types/src/page-view-tracking.ts
+++ b/packages/analytics-types/src/page-view-tracking.ts
@@ -1,0 +1,9 @@
+export interface PageTrackingOptions {
+  trackOn?: PageTrackingTrackOn;
+  trackHistoryChanges?: PageTrackingHistoryChanges;
+  eventType?: string;
+}
+
+export type PageTrackingTrackOn = 'attribution' | (() => boolean);
+
+export type PageTrackingHistoryChanges = 'all' | 'pathOnly';

--- a/packages/marketing-analytics-browser/src/browser-client.ts
+++ b/packages/marketing-analytics-browser/src/browser-client.ts
@@ -24,6 +24,7 @@ export const createInstance = (): Client => {
 
     await client.add(context()).promise;
 
+    delete browserOptions.defaultTracking;
     if (pageViewTracking === true) {
       browserOptions.defaultTracking = {
         pageViews: {

--- a/packages/marketing-analytics-browser/src/browser-client.ts
+++ b/packages/marketing-analytics-browser/src/browser-client.ts
@@ -24,9 +24,21 @@ export const createInstance = (): Client => {
 
     await client.add(context()).promise;
 
-    browserOptions.defaultTracking = {
-      pageViews: pageViewTracking,
-    };
+    if (pageViewTracking === true) {
+      browserOptions.defaultTracking = {
+        pageViews: {
+          eventType: 'Page View',
+        },
+      };
+    } else if (typeof pageViewTracking === 'object' && pageViewTracking) {
+      browserOptions.defaultTracking = {
+        pageViews: {
+          trackOn: pageViewTracking.trackOn,
+          trackHistoryChanges: pageViewTracking.trackHistoryChanges,
+          eventType: pageViewTracking.eventType || 'Page View',
+        },
+      };
+    }
 
     await client.init(options.apiKey, options.userId, browserOptions).promise;
   };

--- a/packages/marketing-analytics-browser/test/browser-client.test.ts
+++ b/packages/marketing-analytics-browser/test/browser-client.test.ts
@@ -119,6 +119,7 @@ describe('browser-client', () => {
         defaultTracking: {
           pageViews: {
             trackOn: 'attribution',
+            eventType: 'Page View',
           },
         },
       });

--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -1,6 +1,5 @@
 import { CampaignParser, getGlobalScope } from '@amplitude/analytics-client-common';
 import {
-  BaseEvent,
   BrowserClient,
   BrowserConfig,
   Event,
@@ -34,6 +33,20 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (
   } else if (clientOrOptions) {
     options = clientOrOptions;
   }
+
+  const createPageViewEvent = async (): Promise<Event> => {
+    return {
+      event_type: options.eventType ?? 'Page View',
+      event_properties: {
+        ...(await getCampaignParams()),
+        page_domain: /* istanbul ignore next */ (typeof location !== 'undefined' && location.hostname) || '',
+        page_location: /* istanbul ignore next */ (typeof location !== 'undefined' && location.href) || '',
+        page_path: /* istanbul ignore next */ (typeof location !== 'undefined' && location.pathname) || '',
+        page_title: /* istanbul ignore next */ (typeof document !== 'undefined' && document.title) || '',
+        page_url: /* istanbul ignore next */ (typeof location !== 'undefined' && location.href.split('?')[0]) || '',
+      },
+    };
+  };
 
   const shouldTrackOnPageLoad = () =>
     typeof options.trackOn === 'undefined' || (typeof options.trackOn === 'function' && options.trackOn());
@@ -127,21 +140,6 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (
 };
 
 const getCampaignParams = async () => omitUndefined(await new CampaignParser().parse());
-
-const createPageViewEvent = async (): Promise<Event> => {
-  const pageViewEvent: BaseEvent = {
-    event_type: 'Page View',
-    event_properties: {
-      ...(await getCampaignParams()),
-      page_domain: /* istanbul ignore next */ (typeof location !== 'undefined' && location.hostname) || '',
-      page_location: /* istanbul ignore next */ (typeof location !== 'undefined' && location.href) || '',
-      page_path: /* istanbul ignore next */ (typeof location !== 'undefined' && location.pathname) || '',
-      page_title: /* istanbul ignore next */ (typeof document !== 'undefined' && document.title) || '',
-      page_url: /* istanbul ignore next */ (typeof location !== 'undefined' && location.href.split('?')[0]) || '',
-    },
-  };
-  return pageViewEvent;
-};
 
 const isCampaignEvent = (event: Event) => {
   if (event.event_type === '$identify' && event.user_properties) {

--- a/packages/plugin-page-view-tracking-browser/src/typings/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/typings/page-view-tracking.ts
@@ -1,13 +1,10 @@
-import { EnrichmentPlugin, BrowserClient } from '@amplitude/analytics-types';
+import { EnrichmentPlugin, BrowserClient, PageTrackingOptions as Options } from '@amplitude/analytics-types';
 
-export interface Options {
-  trackOn?: PageTrackingTrackOn;
-  trackHistoryChanges?: PageTrackingHistoryChanges;
-}
-
-export type PageTrackingTrackOn = 'attribution' | (() => boolean);
-
-export type PageTrackingHistoryChanges = 'all' | 'pathOnly';
+export {
+  PageTrackingOptions as Options,
+  PageTrackingTrackOn,
+  PageTrackingHistoryChanges,
+} from '@amplitude/analytics-types';
 
 export interface CreatePageViewTrackingPlugin {
   (client: BrowserClient, options?: Options): EnrichmentPlugin;

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -285,6 +285,7 @@ describe('pageViewTrackingPlugin', () => {
         await instance.add(
           pageViewTrackingPlugin(instance, {
             trackOn: () => true,
+            eventType: '[Amplitude] Page View',
           }),
         ).promise;
 
@@ -302,7 +303,7 @@ describe('pageViewTrackingPlugin', () => {
             page_title: '',
             page_url: '',
           },
-          event_type: 'Page View',
+          event_type: '[Amplitude] Page View',
         });
         expect(track).toHaveBeenCalledTimes(1);
       });


### PR DESCRIPTION
### Summary

* Adds `eventType` config nested under page view tracking config to specify custom page view event type (see code sample)
* Various clean up

```ts
// Browser SDK
amplitude.init(API_KEY, undefined, {
  defaultTracking: {
    pageViews: {
      eventType: 'Page Viewed',
    },
  },
});

// Marketing Analytics SDK
amplitude.init(API_KEY, undefined, {
  pageViewTracking: {
    eventType: 'Page Viewed',
  },
});

// Page view tracking plugin
pageViewTrackingPlugin(
  eventType: 'Page Viewed',
);
```

#### Notable items

When `Page View` is default vs when `[Amplitude] Page View` is default

1. The configuration below is new with default events and yields page view events with event type `[Amplitude] Page View`.
```ts
amplitude.init(API_KEY, undefined, {
  defaultTracking: {
    pageViews: true,
  },
});
```

2. The configuration below has been supported prior to default events and yields page view events with event type `Page View`.
```ts
amplitude.init(API_KEY, undefined, {
  attribution: {
    trackPageViews: true,
  },
});
```

3. For marketing analytics SDK, the configuration below has been supported prior to default events and yields page view events with event type `Page View`.
```ts
amplitude.init(API_KEY, undefined, {
  pageViewTracking: true
});
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
