### PR TITLE
build: prevents script loader update for beta version

### DIFF
--- a/scripts/version/create-snippet.js
+++ b/scripts/version/create-snippet.js
@@ -26,12 +26,15 @@ const algorithm = 'sha384';
 const encoding = 'base64';
 const inputText = fs.readFileSync(inputPath, 'utf-8');
 const integrity = algorithm + '-' + crypto.createHash(algorithm).update(inputText).digest(encoding);
+const version = getVersion() || '';
 const outputText = header + snippet(getName(), integrity, getVersion());
 const { code: transpiledOutputText } = babel.transformSync(outputText, {
   presets: ['env'],
 });
 
-// Write to disk
-fs.writeFileSync(outputPath, transpiledOutputText);
+if (!version.includes('beta')) {
+  // Write to disk
+  fs.writeFileSync(outputPath, transpiledOutputText);
+}
 
 console.log(`Generated ${outputFile}`);

--- a/scripts/version/create-snippet.js
+++ b/scripts/version/create-snippet.js
@@ -35,6 +35,5 @@ const { code: transpiledOutputText } = babel.transformSync(outputText, {
 if (!version.includes('beta')) {
   // Write to disk
   fs.writeFileSync(outputPath, transpiledOutputText);
+  console.log(`Generated ${outputFile}`);
 }
-
-console.log(`Generated ${outputFile}`);


### PR DESCRIPTION
### Summary

When publishing a new version, we update the script loader to include the latest version. The changes prevents this from happening when releasing a beta version. Production versions should update the script loader as usual.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
