### PR TITLE
fix: inconsistent user and device id on session events

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -174,12 +174,14 @@ export const useBrowserConfig = async (apiKey: string, options?: BrowserOptions)
   const optOut = options?.optOut;
   const sessionId = options?.sessionId;
   const userId = options?.userId;
+  const cookieStorage = options?.cookieStorage;
+  const domain = options?.domain;
 
   return new BrowserConfig(apiKey, {
     ...options,
-    cookieStorage: options?.cookieStorage,
+    cookieStorage,
     deviceId,
-    domain: options?.domain,
+    domain,
     lastEventTime,
     optOut,
     sessionId,

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -10,7 +10,7 @@ import {
   UserSession,
 } from '@amplitude/analytics-types';
 import { Config, MemoryStorage, UUID } from '@amplitude/analytics-core';
-import { CookieStorage, getCookieName, getQueryParams, FetchTransport } from '@amplitude/analytics-client-common';
+import { CookieStorage, getCookieName, FetchTransport } from '@amplitude/analytics-client-common';
 
 import { LocalStorage } from './storage/local-storage';
 import { XHRTransport } from './transports/xhr';
@@ -168,24 +168,18 @@ export class BrowserConfig extends Config implements IBrowserConfig {
 export const useBrowserConfig = async (apiKey: string, options?: BrowserOptions): Promise<IBrowserConfig> => {
   const defaultConfig = getDefaultConfig();
 
-  // create cookie storage
-  const domain = options?.disableCookies ? '' : options?.domain ?? (await getTopLevelDomain());
-  const cookieStorage = await createCookieStorage<UserSession>({ ...options, domain });
-  const previousCookies = await cookieStorage.get(getCookieName(apiKey));
-  const queryParams = getQueryParams();
-
   // reconcile user session
-  const deviceId = options?.deviceId ?? queryParams.deviceId ?? previousCookies?.deviceId ?? UUID();
-  const lastEventTime = options?.lastEventTime ?? previousCookies?.lastEventTime;
-  const optOut = options?.optOut ?? Boolean(previousCookies?.optOut);
-  const sessionId = options?.sessionId ?? previousCookies?.sessionId;
-  const userId = options?.userId ?? previousCookies?.userId;
+  const deviceId = options?.deviceId ?? UUID();
+  const lastEventTime = options?.lastEventTime;
+  const optOut = options?.optOut;
+  const sessionId = options?.sessionId;
+  const userId = options?.userId;
 
   return new BrowserConfig(apiKey, {
     ...options,
-    cookieStorage,
+    cookieStorage: options?.cookieStorage,
     deviceId,
-    domain,
+    domain: options?.domain,
     lastEventTime,
     optOut,
     sessionId,

--- a/packages/analytics-browser/src/cookie-migration/index.ts
+++ b/packages/analytics-browser/src/cookie-migration/index.ts
@@ -1,12 +1,9 @@
 import { BrowserOptions, UserSession } from '@amplitude/analytics-types';
 import { getOldCookieName } from '@amplitude/analytics-client-common';
-import { createCookieStorage, getDefaultConfig, getTopLevelDomain } from '../config';
+import { createCookieStorage, getDefaultConfig } from '../config';
 
-export const parseOldCookies = async (apiKey: string, options?: BrowserOptions): Promise<UserSession> => {
-  const storage = await createCookieStorage<string>({
-    ...options,
-    domain: options?.disableCookies ? '' : options?.domain ?? (await getTopLevelDomain()),
-  });
+export const parseLegacyCookies = async (apiKey: string, options?: BrowserOptions): Promise<UserSession> => {
+  const storage = await createCookieStorage<string>(options);
   const oldCookieName = getOldCookieName(apiKey);
   const cookies = await storage.getRaw(oldCookieName);
 

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -64,7 +64,6 @@ describe('config', () => {
 
   describe('useBrowserConfig', () => {
     test('should create default config', async () => {
-      jest.spyOn(Config, 'createCookieStorage').mockResolvedValueOnce(new core.MemoryStorage());
       jest.spyOn(Config, 'createEventsStorage').mockResolvedValueOnce(new core.MemoryStorage());
       const logger = new core.Logger();
       logger.enable(LogLevel.Warn);
@@ -112,17 +111,20 @@ describe('config', () => {
     test('should create using cookies/overwrite', async () => {
       const cookieStorage = new core.MemoryStorage<UserSession>();
       await cookieStorage.set(getCookieName(API_KEY), {
-        deviceId: 'deviceIdFromCookies',
-        lastEventTime: 1,
+        deviceId: 'device-device-device',
         sessionId: -1,
-        userId: 'userIdFromCookies',
+        userId: 'user-user-user',
+        lastEventTime: 1,
         optOut: false,
       });
-      jest.spyOn(Config, 'createCookieStorage').mockResolvedValueOnce(cookieStorage);
       jest.spyOn(Config, 'createEventsStorage').mockResolvedValueOnce(new core.MemoryStorage());
       const logger = new core.Logger();
       logger.enable(LogLevel.Warn);
       const config = await Config.useBrowserConfig(API_KEY, {
+        deviceId: 'device-device-device',
+        sessionId: -1,
+        userId: 'user-user-user',
+        lastEventTime: 1,
         partnerId: 'partnerId',
         plan: {
           version: '0',
@@ -143,7 +145,7 @@ describe('config', () => {
         cookieSameSite: 'Lax',
         cookieSecure: false,
         cookieUpgrade: false,
-        _deviceId: 'deviceIdFromCookies',
+        _deviceId: 'device-device-device',
         disableCookies: true,
         domain: '',
         flushIntervalMillis: 1000,
@@ -178,7 +180,7 @@ describe('config', () => {
         },
         transportProvider: new FetchTransport(),
         useBatch: false,
-        _userId: 'userIdFromCookies',
+        _userId: 'user-user-user',
       });
     });
 

--- a/packages/analytics-browser/test/cookie-migration/index.test.ts
+++ b/packages/analytics-browser/test/cookie-migration/index.test.ts
@@ -1,6 +1,6 @@
 import { CookieStorage, getOldCookieName } from '@amplitude/analytics-client-common';
 import { Storage } from '@amplitude/analytics-types';
-import { decode, parseOldCookies, parseTime } from '../../src/cookie-migration';
+import { decode, parseLegacyCookies, parseTime } from '../../src/cookie-migration';
 import * as LocalStorageModule from '../../src/storage/local-storage';
 
 describe('cookie-migration', () => {
@@ -10,9 +10,9 @@ describe('cookie-migration', () => {
     document.cookie = `${getOldCookieName(API_KEY)}=null; expires=-1`;
   });
 
-  describe('parseOldCookies', () => {
+  describe('parseLegacyCookies', () => {
     test('should return default values', async () => {
-      const cookies = await parseOldCookies(API_KEY, { disableCookies: true });
+      const cookies = await parseLegacyCookies(API_KEY, { disableCookies: true });
       expect(cookies).toEqual({
         optOut: false,
       });
@@ -27,7 +27,7 @@ describe('cookie-migration', () => {
         remove: async () => undefined,
         reset: async () => undefined,
       });
-      const cookies = await parseOldCookies(API_KEY, { disableCookies: true });
+      const cookies = await parseLegacyCookies(API_KEY, { disableCookies: true });
       expect(cookies).toEqual({
         optOut: false,
       });
@@ -40,7 +40,7 @@ describe('cookie-migration', () => {
       const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
       const oldCookieName = getOldCookieName(API_KEY);
       document.cookie = `${oldCookieName}=deviceId.${encodedUserId}..${time}.${time}`;
-      const cookies = await parseOldCookies(API_KEY);
+      const cookies = await parseLegacyCookies(API_KEY);
       expect(cookies).toEqual({
         deviceId: 'deviceId',
         userId: 'userId',
@@ -61,7 +61,7 @@ describe('cookie-migration', () => {
       const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
       const oldCookieName = getOldCookieName(API_KEY);
       document.cookie = `${oldCookieName}=deviceId.${encodedUserId}..${time}.${time}`;
-      const cookies = await parseOldCookies(API_KEY, {
+      const cookies = await parseLegacyCookies(API_KEY, {
         cookieUpgrade: true,
       });
       expect(cookies).toEqual({
@@ -84,7 +84,7 @@ describe('cookie-migration', () => {
       const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
       const oldCookieName = getOldCookieName(API_KEY);
       document.cookie = `${oldCookieName}=deviceId.${encodedUserId}..${time}.${time}`;
-      const cookies = await parseOldCookies(API_KEY, {
+      const cookies = await parseLegacyCookies(API_KEY, {
         cookieUpgrade: false,
       });
       expect(cookies).toEqual({


### PR DESCRIPTION
### Summary

session end and session start shares may share user id or device id on `reset()` or `setUserId()`

#### Issue
```
Session Start
Event 1
Event 2
// User calls amplitude.reset() or amplitude.setUserId() 
Session End // has user id or device id of next session
Session Start
Event 3
Event 4
```

#### Solution
```
Session Start // store user id and event id
Event 1
Event 2
// User calls amplitude.reset() or amplitude.setUserId() 
Session End // use previously stored user id and event id
Session Start // store user id and event id
Event 3
Event 4
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
