### PR TITLE
fix: improve error handling for file download tracking

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -18,8 +18,10 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
     const addFileDownloadListener = (a: HTMLAnchorElement) => {
       let url: URL;
       try {
-        url = new URL(a.href);
+        // eslint-disable-next-line no-restricted-globals
+        url = new URL(a.href, window.location.href);
       } catch {
+        /* istanbul ignore next */
         return;
       }
       const result = ext.exec(url.href);

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -16,26 +16,27 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
     }
 
     const addFileDownloadListener = (a: HTMLAnchorElement) => {
+      let url: URL;
       try {
-        const url = new URL(a.href);
-        const result = ext.exec(url.href);
-        const fileExtension = result?.[1];
-
-        if (fileExtension) {
-          a.addEventListener('click', () => {
-            if (fileExtension) {
-              amplitude.track(DEFAULT_FILE_DOWNLOAD_EVENT, {
-                file_extension: fileExtension,
-                file_name: url.pathname,
-                link_id: a.id,
-                link_text: a.text,
-                link_url: a.href,
-              });
-            }
-          });
-        }
+        url = new URL(a.href);
       } catch {
-        config.loggerProvider.error(`Something went wrong. File download events are not tracked for a#{a.id}`);
+        return;
+      }
+      const result = ext.exec(url.href);
+      const fileExtension = result?.[1];
+
+      if (fileExtension) {
+        a.addEventListener('click', () => {
+          if (fileExtension) {
+            amplitude.track(DEFAULT_FILE_DOWNLOAD_EVENT, {
+              file_extension: fileExtension,
+              file_name: url.pathname,
+              link_id: a.id,
+              link_text: a.text,
+              link_url: a.href,
+            });
+          }
+        });
       }
     };
 


### PR DESCRIPTION
### Summary

Suppress error for malformed URL value in href property of an anchor tag. The error is not useful and the malformed URL might be intentional.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
