### PR TITLE
fix: attach listener to nested nodes

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -58,6 +58,9 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
             if (node.nodeName === 'A') {
               addFileDownloadListener(node as HTMLAnchorElement);
             }
+            if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+              Array.from(node.querySelectorAll('a') as HTMLAnchorElement[]).map(addFileDownloadListener);
+            }
           });
         });
       });

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -64,6 +64,9 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
             if (node.nodeName === 'FORM') {
               addFormInteractionListener(node as HTMLFormElement);
             }
+            if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+              Array.from(node.querySelectorAll('form') as HTMLFormElement[]).map(addFormInteractionListener);
+            }
           });
         });
       });

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -99,6 +99,54 @@ describe('formInteractionTracking', () => {
     expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
+  test('should track form_start event for a dynamically added nested form tag', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = formInteractionTracking();
+    await plugin.setup(config, amplitude);
+
+    // add form elemen dynamically
+    const form = document.createElement('form');
+    form.setAttribute('id', 'my-form-2-id');
+    form.setAttribute('name', 'my-form-2-name');
+    form.setAttribute('action', '/submit');
+
+    const text = document.createElement('input');
+    text.setAttribute('type', 'text');
+    text.setAttribute('id', 'my-text-2-id');
+
+    const submit = document.createElement('input');
+    submit.setAttribute('type', 'submit');
+    submit.setAttribute('id', 'my-submit-2-id');
+
+    form.appendChild(text);
+    form.appendChild(submit);
+
+    const div = document.createElement('div');
+    div.appendChild(form);
+
+    document.body.appendChild(div);
+
+    // allow mutation observer to execute and event listener to be attached
+    await new Promise((r) => r(undefined)); // basically, await next clock tick
+    // trigger change event
+    form.dispatchEvent(new Event('change'));
+
+    // assert first event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
+      form_id: 'my-form-2-id',
+      form_name: 'my-form-2-name',
+      form_destination: 'http://localhost/submit',
+    });
+
+    // trigger change event again
+    form.dispatchEvent(new Event('change'));
+
+    // assert second event was not tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+  });
+
   test('should track form_start and form_submit events on change and submit', async () => {
     // setup
     const config = createConfigurationMock();


### PR DESCRIPTION
### Summary

Fixes how event listeners are attached to dynamically appended `<a>` and `<form>` tags

#### Issue

Previously we attach event listeners to dynamically appended nodes like this:

```ts
const observer = new MutationObserver((mutations) => {
  mutations.forEach((mutation) => {
    mutation.addedNodes.forEach((node) => {
      if (node.nodeName === 'A') {
        addFileDownloadListener(node as HTMLAnchorElement);
      }
    });
  });
});
```

This method loops through the `mutations` and `addedNodes` and checks if an added node is an anchor/form tag. If so, it adds an event listener to it.

This assumes that all newly mounted tags are included in the `addedNodes` array. However, `addedNodes` only include the the "root" node to represent itself and all its children. That means that if an anchor/form tag is appended [Case 1], it is part of `addedNodes` list, but if an anchor/form tag is nested under a parent tag and the parent tag is appended [Case 2], then only the part tag is part of `addedNodes`. When the parent tag is appended, the nested anchor/form tag will not be added new event listeners in the logic above.

Case 1: element appended as root
`<a>` is in `addedNodes` array

```diff
 <body>
   <div>
+  <a href="#"></a>
   </div>
 </body>
```

Case 2: element appended as child
`<div>` is in `addedNodes` array, `<a>` is not

```diff
 <body>
   <div>
+    <div>
+      <a href="#"></a>
+    </div>
   </div>
 </body>
```

#### Solution

The fix for this issue is to search through `addedNodes` for anchor/form tags using `querySelectorAll(...)`

```diff
 const observer = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
     mutation.addedNodes.forEach((node) => {
       if (node.nodeName === 'A') {
         addFileDownloadListener(node as HTMLAnchorElement);
       }
+      if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+        Array.from(node.querySelectorAll('a') as HTMLAnchorElement[]).map(addFileDownloadListener);
+      }
     });
   });
 });
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
