### PR TITLE
fix: event types for default events

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -1497,6 +1497,294 @@ describe('integration', () => {
     });
   });
 
+  describe('default page view tracking', () => {
+    test('should send classic page view on attribution', () => {
+      let payload: any = undefined;
+      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload = p;
+        return {
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        };
+      });
+      client.init(apiKey, 'user1@amplitude.com', {
+        attribution: {
+          trackPageViews: true,
+        },
+        transportProvider: {
+          send,
+        },
+        trackingOptions: {
+          deviceModel: false,
+        },
+      });
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(payload).toEqual({
+            api_key: apiKey,
+            events: [
+              {
+                device_id: uuid,
+                device_manufacturer: undefined,
+                event_id: 0,
+                event_properties: {
+                  page_domain: '',
+                  page_location: '',
+                  page_path: '',
+                  page_title: '',
+                  page_url: '',
+                },
+                event_type: 'Page View',
+                insert_id: uuid,
+                ip: '$remote',
+                language: 'en-US',
+                library,
+                os_name: 'WebKit',
+                os_version: '537.36',
+                partner_id: undefined,
+                plan: undefined,
+                platform: 'Web',
+                session_id: number,
+                time: number,
+                user_id: 'user1@amplitude.com',
+                user_properties: {
+                  $setOnce: {
+                    initial_dclid: 'EMPTY',
+                    initial_fbclid: 'EMPTY',
+                    initial_gbraid: 'EMPTY',
+                    initial_gclid: 'EMPTY',
+                    initial_ko_click_id: 'EMPTY',
+                    initial_msclkid: 'EMPTY',
+                    initial_referrer: 'EMPTY',
+                    initial_referring_domain: 'EMPTY',
+                    initial_ttclid: 'EMPTY',
+                    initial_twclid: 'EMPTY',
+                    initial_utm_campaign: 'EMPTY',
+                    initial_utm_content: 'EMPTY',
+                    initial_utm_id: 'EMPTY',
+                    initial_utm_medium: 'EMPTY',
+                    initial_utm_source: 'EMPTY',
+                    initial_utm_term: 'EMPTY',
+                    initial_wbraid: 'EMPTY',
+                  },
+                  $unset: {
+                    dclid: '-',
+                    fbclid: '-',
+                    gbraid: '-',
+                    gclid: '-',
+                    ko_click_id: '-',
+                    msclkid: '-',
+                    referrer: '-',
+                    referring_domain: '-',
+                    ttclid: '-',
+                    twclid: '-',
+                    utm_campaign: '-',
+                    utm_content: '-',
+                    utm_id: '-',
+                    utm_medium: '-',
+                    utm_source: '-',
+                    utm_term: '-',
+                    wbraid: '-',
+                  },
+                },
+              },
+            ],
+            options: {
+              min_id_length: undefined,
+            },
+          });
+          resolve();
+        }, 2000);
+      });
+    });
+
+    test('should send DET page view', () => {
+      let payload: any = undefined;
+      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload = p;
+        return {
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        };
+      });
+      client.init(apiKey, 'user1@amplitude.com', {
+        attribution: {
+          disabled: true,
+        },
+        defaultTracking: {
+          pageViews: true,
+        },
+        transportProvider: {
+          send,
+        },
+        trackingOptions: {
+          deviceModel: false,
+        },
+      });
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(payload).toEqual({
+            api_key: apiKey,
+            events: [
+              {
+                device_id: uuid,
+                device_manufacturer: undefined,
+                event_id: 0,
+                event_properties: {
+                  '[Amplitude] Page Domain': '',
+                  '[Amplitude] Page Location': '',
+                  '[Amplitude] Page Path': '',
+                  '[Amplitude] Page Title': '',
+                  '[Amplitude] Page URL': '',
+                },
+                event_type: '[Amplitude] Page Viewed',
+                insert_id: uuid,
+                ip: '$remote',
+                language: 'en-US',
+                library,
+                os_name: 'WebKit',
+                os_version: '537.36',
+                partner_id: undefined,
+                plan: undefined,
+                platform: 'Web',
+                session_id: number,
+                time: number,
+                user_id: 'user1@amplitude.com',
+              },
+            ],
+            options: {
+              min_id_length: undefined,
+            },
+          });
+          resolve();
+        }, 2000);
+      });
+    });
+
+    test('should send DET page view on attribution', () => {
+      let payload: any = undefined;
+      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload = p;
+        return {
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        };
+      });
+      client.init(apiKey, 'user1@amplitude.com', {
+        defaultTracking: {
+          pageViews: {
+            trackOn: 'attribution',
+          },
+        },
+        transportProvider: {
+          send,
+        },
+        trackingOptions: {
+          deviceModel: false,
+        },
+      });
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(payload).toEqual({
+            api_key: apiKey,
+            events: [
+              {
+                device_id: uuid,
+                device_manufacturer: undefined,
+                event_id: 0,
+                event_properties: {
+                  '[Amplitude] Page Domain': '',
+                  '[Amplitude] Page Location': '',
+                  '[Amplitude] Page Path': '',
+                  '[Amplitude] Page Title': '',
+                  '[Amplitude] Page URL': '',
+                },
+                event_type: '[Amplitude] Page Viewed',
+                insert_id: uuid,
+                ip: '$remote',
+                language: 'en-US',
+                library,
+                os_name: 'WebKit',
+                os_version: '537.36',
+                partner_id: undefined,
+                plan: undefined,
+                platform: 'Web',
+                session_id: number,
+                time: number,
+                user_id: 'user1@amplitude.com',
+                user_properties: {
+                  $setOnce: {
+                    initial_dclid: 'EMPTY',
+                    initial_fbclid: 'EMPTY',
+                    initial_gbraid: 'EMPTY',
+                    initial_gclid: 'EMPTY',
+                    initial_ko_click_id: 'EMPTY',
+                    initial_msclkid: 'EMPTY',
+                    initial_referrer: 'EMPTY',
+                    initial_referring_domain: 'EMPTY',
+                    initial_ttclid: 'EMPTY',
+                    initial_twclid: 'EMPTY',
+                    initial_utm_campaign: 'EMPTY',
+                    initial_utm_content: 'EMPTY',
+                    initial_utm_id: 'EMPTY',
+                    initial_utm_medium: 'EMPTY',
+                    initial_utm_source: 'EMPTY',
+                    initial_utm_term: 'EMPTY',
+                    initial_wbraid: 'EMPTY',
+                  },
+                  $unset: {
+                    dclid: '-',
+                    fbclid: '-',
+                    gbraid: '-',
+                    gclid: '-',
+                    ko_click_id: '-',
+                    msclkid: '-',
+                    referrer: '-',
+                    referring_domain: '-',
+                    ttclid: '-',
+                    twclid: '-',
+                    utm_campaign: '-',
+                    utm_content: '-',
+                    utm_id: '-',
+                    utm_medium: '-',
+                    utm_source: '-',
+                    utm_term: '-',
+                    wbraid: '-',
+                  },
+                },
+              },
+            ],
+            options: {
+              min_id_length: undefined,
+            },
+          });
+          resolve();
+        }, 2000);
+      });
+    });
+  });
+
   describe('cookie migration', () => {
     test('should use old cookies', async () => {
       const scope = nock(url).post(path).reply(200, success);

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -29,6 +29,7 @@ import { sessionHandlerPlugin } from './plugins/session-handler';
 import { formInteractionTracking } from './plugins/form-interaction-tracking';
 import { fileDownloadTracking } from './plugins/file-download-tracking';
 import { DEFAULT_PAGE_VIEW_EVENT, DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from './constants';
+import { defaultPageViewEventEnrichment } from './plugins/default-page-view-event-enrichment';
 
 export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -138,6 +139,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     const pageViewTrackingOptions = getPageViewTrackingConfig(this.config);
     pageViewTrackingOptions.eventType = pageViewTrackingOptions.eventType || DEFAULT_PAGE_VIEW_EVENT;
     await this.add(pageViewTrackingPlugin(pageViewTrackingOptions)).promise;
+    await this.add(defaultPageViewEventEnrichment()).promise;
 
     this.initializing = false;
 

--- a/packages/analytics-browser/src/constants.ts
+++ b/packages/analytics-browser/src/constants.ts
@@ -1,6 +1,6 @@
-export const DEFAULT_PAGE_VIEW_EVENT = '[Amplitude] Page View';
+export const DEFAULT_PAGE_VIEW_EVENT = '[Amplitude] Page Viewed';
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';
-export const DEFAULT_FORM_START_EVENT = '[Amplitude] Form Start';
-export const DEFAULT_FORM_SUBMIT_EVENT = '[Amplitude] Form Submit';
-export const DEFAULT_FILE_DOWNLOAD_EVENT = '[Amplitude] File Download';
+export const DEFAULT_FORM_START_EVENT = '[Amplitude] Form Started';
+export const DEFAULT_FORM_SUBMIT_EVENT = '[Amplitude] Form Submitted';
+export const DEFAULT_FILE_DOWNLOAD_EVENT = '[Amplitude] File Downloaded';

--- a/packages/analytics-browser/src/constants.ts
+++ b/packages/analytics-browser/src/constants.ts
@@ -1,18 +1,18 @@
-const PREFIX = '[Amplitude]';
+export const DEFAULT_EVENT_PREFIX = '[Amplitude]';
 
-export const DEFAULT_PAGE_VIEW_EVENT = `${PREFIX} Page Viewed`;
-export const DEFAULT_FORM_START_EVENT = `${PREFIX} Form Started`;
-export const DEFAULT_FORM_SUBMIT_EVENT = `${PREFIX} Form Submitted`;
-export const DEFAULT_FILE_DOWNLOAD_EVENT = `${PREFIX} File Downloaded`;
+export const DEFAULT_PAGE_VIEW_EVENT = `${DEFAULT_EVENT_PREFIX} Page Viewed`;
+export const DEFAULT_FORM_START_EVENT = `${DEFAULT_EVENT_PREFIX} Form Started`;
+export const DEFAULT_FORM_SUBMIT_EVENT = `${DEFAULT_EVENT_PREFIX} Form Submitted`;
+export const DEFAULT_FILE_DOWNLOAD_EVENT = `${DEFAULT_EVENT_PREFIX} File Downloaded`;
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';
 
-export const FILE_EXTENSION = `${PREFIX} File Extension`;
-export const FILE_NAME = `${PREFIX} File Name`;
-export const LINK_ID = `${PREFIX} Link ID`;
-export const LINK_TEXT = `${PREFIX} Link Text`;
-export const LINK_URL = `${PREFIX} Link URL`;
+export const FILE_EXTENSION = `${DEFAULT_EVENT_PREFIX} File Extension`;
+export const FILE_NAME = `${DEFAULT_EVENT_PREFIX} File Name`;
+export const LINK_ID = `${DEFAULT_EVENT_PREFIX} Link ID`;
+export const LINK_TEXT = `${DEFAULT_EVENT_PREFIX} Link Text`;
+export const LINK_URL = `${DEFAULT_EVENT_PREFIX} Link URL`;
 
-export const FORM_ID = `${PREFIX} Form ID`;
-export const FORM_NAME = `${PREFIX} Form Name`;
-export const FORM_DESTINATION = `${PREFIX} Form Destination`;
+export const FORM_ID = `${DEFAULT_EVENT_PREFIX} Form ID`;
+export const FORM_NAME = `${DEFAULT_EVENT_PREFIX} Form Name`;
+export const FORM_DESTINATION = `${DEFAULT_EVENT_PREFIX} Form Destination`;

--- a/packages/analytics-browser/src/constants.ts
+++ b/packages/analytics-browser/src/constants.ts
@@ -1,6 +1,18 @@
-export const DEFAULT_PAGE_VIEW_EVENT = '[Amplitude] Page Viewed';
+const PREFIX = '[Amplitude]';
+
+export const DEFAULT_PAGE_VIEW_EVENT = `${PREFIX} Page Viewed`;
+export const DEFAULT_FORM_START_EVENT = `${PREFIX} Form Started`;
+export const DEFAULT_FORM_SUBMIT_EVENT = `${PREFIX} Form Submitted`;
+export const DEFAULT_FILE_DOWNLOAD_EVENT = `${PREFIX} File Downloaded`;
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';
-export const DEFAULT_FORM_START_EVENT = '[Amplitude] Form Started';
-export const DEFAULT_FORM_SUBMIT_EVENT = '[Amplitude] Form Submitted';
-export const DEFAULT_FILE_DOWNLOAD_EVENT = '[Amplitude] File Downloaded';
+
+export const FILE_EXTENSION = `${PREFIX} File Extension`;
+export const FILE_NAME = `${PREFIX} File Name`;
+export const LINK_ID = `${PREFIX} Link ID`;
+export const LINK_TEXT = `${PREFIX} Link Text`;
+export const LINK_URL = `${PREFIX} Link URL`;
+
+export const FORM_ID = `${PREFIX} Form ID`;
+export const FORM_NAME = `${PREFIX} Form Name`;
+export const FORM_DESTINATION = `${PREFIX} Form Destination`;

--- a/packages/analytics-browser/src/plugins/default-page-view-event-enrichment.ts
+++ b/packages/analytics-browser/src/plugins/default-page-view-event-enrichment.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { BaseEvent, Campaign, EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
+import { BaseEvent, EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
 import { DEFAULT_EVENT_PREFIX, DEFAULT_PAGE_VIEW_EVENT } from '../constants';
 
-interface PageViewEventProperties extends Required<Campaign> {
+interface PageViewEventProperties extends Record<string, string | undefined> {
   page_domain: string;
   page_location: string;
   page_path: string;
@@ -11,23 +11,6 @@ interface PageViewEventProperties extends Required<Campaign> {
 }
 
 const eventPropertyMap: PageViewEventProperties = {
-  utm_campaign: `${DEFAULT_EVENT_PREFIX} UTM Campaign`,
-  utm_content: `${DEFAULT_EVENT_PREFIX} UTM Content`,
-  utm_id: `${DEFAULT_EVENT_PREFIX} UTM ID`,
-  utm_medium: `${DEFAULT_EVENT_PREFIX} UTM Medium`,
-  utm_source: `${DEFAULT_EVENT_PREFIX} UTM Source`,
-  utm_term: `${DEFAULT_EVENT_PREFIX} UTM Term`,
-  referrer: `${DEFAULT_EVENT_PREFIX} Referrer`,
-  referring_domain: `${DEFAULT_EVENT_PREFIX} Referring Domain`,
-  dclid: `${DEFAULT_EVENT_PREFIX} DCLID`,
-  gbraid: `${DEFAULT_EVENT_PREFIX} GBRAID`,
-  gclid: `${DEFAULT_EVENT_PREFIX} GCLID`,
-  fbclid: `${DEFAULT_EVENT_PREFIX} FBCLID`,
-  ko_click_id: `${DEFAULT_EVENT_PREFIX} KO Click ID`,
-  msclkid: `${DEFAULT_EVENT_PREFIX} MSCLKID`,
-  ttclid: `${DEFAULT_EVENT_PREFIX} TTCLID`,
-  twclid: `${DEFAULT_EVENT_PREFIX} TWCLID`,
-  wbraid: `${DEFAULT_EVENT_PREFIX} WBRAID`,
   page_domain: `${DEFAULT_EVENT_PREFIX} Page Domain`,
   page_location: `${DEFAULT_EVENT_PREFIX} Page Location`,
   page_path: `${DEFAULT_EVENT_PREFIX} Page Path`,

--- a/packages/analytics-browser/src/plugins/default-page-view-event-enrichment.ts
+++ b/packages/analytics-browser/src/plugins/default-page-view-event-enrichment.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { BaseEvent, Campaign, EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
+import { DEFAULT_EVENT_PREFIX, DEFAULT_PAGE_VIEW_EVENT } from '../constants';
+
+interface PageViewEventProperties extends Required<Campaign> {
+  page_domain: string;
+  page_location: string;
+  page_path: string;
+  page_title: string;
+  page_url: string;
+}
+
+const eventPropertyMap: PageViewEventProperties = {
+  utm_campaign: `${DEFAULT_EVENT_PREFIX} UTM Campaign`,
+  utm_content: `${DEFAULT_EVENT_PREFIX} UTM Content`,
+  utm_id: `${DEFAULT_EVENT_PREFIX} UTM ID`,
+  utm_medium: `${DEFAULT_EVENT_PREFIX} UTM Medium`,
+  utm_source: `${DEFAULT_EVENT_PREFIX} UTM Source`,
+  utm_term: `${DEFAULT_EVENT_PREFIX} UTM Term`,
+  referrer: `${DEFAULT_EVENT_PREFIX} Referrer`,
+  referring_domain: `${DEFAULT_EVENT_PREFIX} Referring Domain`,
+  dclid: `${DEFAULT_EVENT_PREFIX} DCLID`,
+  gbraid: `${DEFAULT_EVENT_PREFIX} GBRAID`,
+  gclid: `${DEFAULT_EVENT_PREFIX} GCLID`,
+  fbclid: `${DEFAULT_EVENT_PREFIX} FBCLID`,
+  ko_click_id: `${DEFAULT_EVENT_PREFIX} KO Click ID`,
+  msclkid: `${DEFAULT_EVENT_PREFIX} MSCLKID`,
+  ttclid: `${DEFAULT_EVENT_PREFIX} TTCLID`,
+  twclid: `${DEFAULT_EVENT_PREFIX} TWCLID`,
+  wbraid: `${DEFAULT_EVENT_PREFIX} WBRAID`,
+  page_domain: `${DEFAULT_EVENT_PREFIX} Page Domain`,
+  page_location: `${DEFAULT_EVENT_PREFIX} Page Location`,
+  page_path: `${DEFAULT_EVENT_PREFIX} Page Path`,
+  page_title: `${DEFAULT_EVENT_PREFIX} Page Title`,
+  page_url: `${DEFAULT_EVENT_PREFIX} Page URL`,
+};
+
+export const defaultPageViewEventEnrichment = (): EnrichmentPlugin => {
+  const name = '@amplitude/plugin-default-page-view-event-enrichment-browser';
+  const type = PluginType.ENRICHMENT;
+  const setup = async () => undefined;
+  const execute = async (event: BaseEvent) => {
+    if (event.event_type === DEFAULT_PAGE_VIEW_EVENT && event.event_properties) {
+      event.event_properties = Object.entries(event.event_properties).reduce<{
+        [key: string]: any;
+      }>((acc, [key, value]) => {
+        const transformedPropertyName = eventPropertyMap[key];
+        if (transformedPropertyName) {
+          acc[transformedPropertyName] = value;
+        } else {
+          acc[key] = value;
+        }
+        return acc;
+      }, {});
+    }
+    return event;
+  };
+
+  return {
+    name,
+    type,
+    setup,
+    execute,
+  };
+};

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,5 +1,5 @@
 import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
-import { DEFAULT_FILE_DOWNLOAD_EVENT } from '../constants';
+import { DEFAULT_FILE_DOWNLOAD_EVENT, FILE_EXTENSION, FILE_NAME, LINK_ID, LINK_TEXT, LINK_URL } from '../constants';
 import { BrowserConfig } from '../config';
 
 export const fileDownloadTracking = (): EnrichmentPlugin => {
@@ -31,11 +31,11 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
         a.addEventListener('click', () => {
           if (fileExtension) {
             amplitude.track(DEFAULT_FILE_DOWNLOAD_EVENT, {
-              file_extension: fileExtension,
-              file_name: url.pathname,
-              link_id: a.id,
-              link_text: a.text,
-              link_url: a.href,
+              [FILE_EXTENSION]: fileExtension,
+              [FILE_NAME]: url.pathname,
+              [LINK_ID]: a.id,
+              [LINK_TEXT]: a.text,
+              [LINK_URL]: a.href,
             });
           }
         });

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -1,5 +1,11 @@
 import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
-import { DEFAULT_FORM_START_EVENT, DEFAULT_FORM_SUBMIT_EVENT } from '../constants';
+import {
+  DEFAULT_FORM_START_EVENT,
+  DEFAULT_FORM_SUBMIT_EVENT,
+  FORM_ID,
+  FORM_NAME,
+  FORM_DESTINATION,
+} from '../constants';
 import { BrowserConfig } from '../config';
 
 export const formInteractionTracking = (): EnrichmentPlugin => {
@@ -23,9 +29,9 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
         () => {
           if (!hasFormChanged) {
             amplitude.track(DEFAULT_FORM_START_EVENT, {
-              form_id: form.id,
-              form_name: form.name,
-              form_destination: form.action,
+              [FORM_ID]: form.id,
+              [FORM_NAME]: form.name,
+              [FORM_DESTINATION]: form.action,
             });
           }
           hasFormChanged = true;
@@ -36,16 +42,16 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       form.addEventListener('submit', () => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
-            form_id: form.id,
-            form_name: form.name,
-            form_destination: form.action,
+            [FORM_ID]: form.id,
+            [FORM_NAME]: form.name,
+            [FORM_DESTINATION]: form.action,
           });
         }
 
         amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
-          form_id: form.id,
-          form_name: form.name,
-          form_destination: form.action,
+          [FORM_ID]: form.id,
+          [FORM_NAME]: form.name,
+          [FORM_DESTINATION]: form.action,
         });
         hasFormChanged = false;
       });

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -184,7 +184,7 @@ describe('browser-client', () => {
       }).promise;
       expect(pageViewTracking).toHaveBeenCalledTimes(1);
       expect(pageViewTracking).toHaveBeenNthCalledWith(1, {
-        eventType: '[Amplitude] Page View',
+        eventType: '[Amplitude] Page Viewed',
       });
     });
 

--- a/packages/analytics-browser/test/plugins/default-page-view-event-enrichment.test.ts
+++ b/packages/analytics-browser/test/plugins/default-page-view-event-enrichment.test.ts
@@ -21,21 +21,19 @@ describe('defaultPageViewEventEnrichment', () => {
           page_path: '/',
           page_title: 'Amplitude',
           page_url: 'https://amplitude.com/',
-          not_transformed: 'not_transformed',
         },
       };
       const plugin = defaultPageViewEventEnrichment();
       expect(await plugin.execute(event)).toEqual({
         event_type: '[Amplitude] Page Viewed',
         event_properties: {
-          '[Amplitude] UTM Campaign': 'google',
-          '[Amplitude] UTM ID': '123',
+          utm_campaign: 'google',
+          utm_id: '123',
           '[Amplitude] Page Domain': 'amplitude.com',
           '[Amplitude] Page Location': 'https://amplitude.com/',
           '[Amplitude] Page Path': '/',
           '[Amplitude] Page Title': 'Amplitude',
           '[Amplitude] Page URL': 'https://amplitude.com/',
-          not_transformed: 'not_transformed',
         },
       });
     });

--- a/packages/analytics-browser/test/plugins/default-page-view-event-enrichment.test.ts
+++ b/packages/analytics-browser/test/plugins/default-page-view-event-enrichment.test.ts
@@ -1,0 +1,81 @@
+import { createConfigurationMock } from '../helpers/mock';
+import { defaultPageViewEventEnrichment } from '../../src/plugins/default-page-view-event-enrichment';
+
+describe('defaultPageViewEventEnrichment', () => {
+  describe('setup', () => {
+    test('should return undefined', async () => {
+      const plugin = defaultPageViewEventEnrichment();
+      expect(await plugin.setup(createConfigurationMock())).toBe(undefined);
+    });
+  });
+
+  describe('execute', () => {
+    test('should return enriched page view event', async () => {
+      const event = {
+        event_type: '[Amplitude] Page Viewed',
+        event_properties: {
+          utm_campaign: 'google',
+          utm_id: '123',
+          page_domain: 'amplitude.com',
+          page_location: 'https://amplitude.com/',
+          page_path: '/',
+          page_title: 'Amplitude',
+          page_url: 'https://amplitude.com/',
+          not_transformed: 'not_transformed',
+        },
+      };
+      const plugin = defaultPageViewEventEnrichment();
+      expect(await plugin.execute(event)).toEqual({
+        event_type: '[Amplitude] Page Viewed',
+        event_properties: {
+          '[Amplitude] UTM Campaign': 'google',
+          '[Amplitude] UTM ID': '123',
+          '[Amplitude] Page Domain': 'amplitude.com',
+          '[Amplitude] Page Location': 'https://amplitude.com/',
+          '[Amplitude] Page Path': '/',
+          '[Amplitude] Page Title': 'Amplitude',
+          '[Amplitude] Page URL': 'https://amplitude.com/',
+          not_transformed: 'not_transformed',
+        },
+      });
+    });
+
+    test('should handle no event properties', async () => {
+      const event = {
+        event_type: '[Amplitude] Page Viewed',
+      };
+      const plugin = defaultPageViewEventEnrichment();
+      expect(await plugin.execute(event)).toEqual({
+        event_type: '[Amplitude] Page Viewed',
+      });
+    });
+
+    test('should not enrich non-default page view event', async () => {
+      const event = {
+        event_type: 'Page View',
+        event_properties: {
+          utm_campaign: 'google',
+          utm_id: '123',
+          page_domain: 'amplitude.com',
+          page_location: 'https://amplitude.com/',
+          page_path: '/',
+          page_title: 'Amplitude',
+          page_url: 'https://amplitude.com/',
+        },
+      };
+      const plugin = defaultPageViewEventEnrichment();
+      expect(await plugin.execute(event)).toEqual({
+        event_type: 'Page View',
+        event_properties: {
+          utm_campaign: 'google',
+          utm_id: '123',
+          page_domain: 'amplitude.com',
+          page_location: 'https://amplitude.com/',
+          page_path: '/',
+          page_title: 'Amplitude',
+          page_url: 'https://amplitude.com/',
+        },
+      });
+    });
+  });
+});

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -2,6 +2,7 @@
 
 import { createAmplitudeMock, createConfigurationMock } from '../helpers/mock';
 import { fileDownloadTracking } from '../../src/plugins/file-download-tracking';
+import { FILE_EXTENSION, FILE_NAME, LINK_ID, LINK_TEXT, LINK_URL } from '../../src/constants';
 
 describe('fileDownloadTracking', () => {
   let amplitude = createAmplitudeMock();
@@ -34,11 +35,11 @@ describe('fileDownloadTracking', () => {
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Downloaded', {
-      file_extension: 'pdf',
-      file_name: '/files/my-file.pdf',
-      link_id: 'my-link-id',
-      link_text: 'my-link-text',
-      link_url: 'https://analytics.amplitude.com/files/my-file.pdf',
+      [FILE_EXTENSION]: 'pdf',
+      [FILE_NAME]: '/files/my-file.pdf',
+      [LINK_ID]: 'my-link-id',
+      [LINK_TEXT]: 'my-link-text',
+      [LINK_URL]: 'https://analytics.amplitude.com/files/my-file.pdf',
     });
   });
 
@@ -64,11 +65,11 @@ describe('fileDownloadTracking', () => {
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Downloaded', {
-      file_extension: 'pdf',
-      file_name: '/files/my-file-2.pdf',
-      link_id: 'my-link-2-id',
-      link_text: 'my-link-2-text',
-      link_url: 'https://analytics.amplitude.com/files/my-file-2.pdf',
+      [FILE_EXTENSION]: 'pdf',
+      [FILE_NAME]: '/files/my-file-2.pdf',
+      [LINK_ID]: 'my-link-2-id',
+      [LINK_TEXT]: 'my-link-2-text',
+      [LINK_URL]: 'https://analytics.amplitude.com/files/my-file-2.pdf',
     });
   });
 
@@ -99,11 +100,11 @@ describe('fileDownloadTracking', () => {
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Downloaded', {
-      file_extension: 'pdf',
-      file_name: '/files/my-file-2.pdf',
-      link_id: 'my-link-2-id',
-      link_text: 'my-link-2-text',
-      link_url: 'https://analytics.amplitude.com/files/my-file-2.pdf',
+      [FILE_EXTENSION]: 'pdf',
+      [FILE_NAME]: '/files/my-file-2.pdf',
+      [LINK_ID]: 'my-link-2-id',
+      [LINK_TEXT]: 'my-link-2-text',
+      [LINK_URL]: 'https://analytics.amplitude.com/files/my-file-2.pdf',
     });
   });
 

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -33,7 +33,7 @@ describe('fileDownloadTracking', () => {
 
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Download', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Downloaded', {
       file_extension: 'pdf',
       file_name: '/files/my-file.pdf',
       link_id: 'my-link-id',
@@ -63,7 +63,7 @@ describe('fileDownloadTracking', () => {
 
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Download', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Downloaded', {
       file_extension: 'pdf',
       file_name: '/files/my-file-2.pdf',
       link_id: 'my-link-2-id',
@@ -98,7 +98,7 @@ describe('fileDownloadTracking', () => {
 
     // assert file download event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Download', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] File Downloaded', {
       file_extension: 'pdf',
       file_name: '/files/my-file-2.pdf',
       link_id: 'my-link-2-id',

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -42,7 +42,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
@@ -86,7 +86,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
       form_id: 'my-form-2-id',
       form_name: 'my-form-2-name',
       form_destination: 'http://localhost/submit',
@@ -134,7 +134,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
       form_id: 'my-form-2-id',
       form_name: 'my-form-2-name',
       form_destination: 'http://localhost/submit',
@@ -158,12 +158,12 @@ describe('formInteractionTracking', () => {
 
     // assert both events were tracked
     expect(amplitude.track).toHaveBeenCalledTimes(2);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
     });
-    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submit', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submitted', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
@@ -181,7 +181,7 @@ describe('formInteractionTracking', () => {
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Start', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',
@@ -192,7 +192,7 @@ describe('formInteractionTracking', () => {
 
     // assert second event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(2);
-    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submit', {
+    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submitted', {
       form_id: 'my-form-id',
       form_name: 'my-form-name',
       form_destination: 'http://localhost/submit',

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -2,6 +2,7 @@
 
 import { createAmplitudeMock, createConfigurationMock } from '../helpers/mock';
 import { formInteractionTracking } from '../../src/plugins/form-interaction-tracking';
+import { FORM_DESTINATION, FORM_ID, FORM_NAME } from '../../src/constants';
 
 describe('formInteractionTracking', () => {
   let amplitude = createAmplitudeMock();
@@ -43,9 +44,9 @@ describe('formInteractionTracking', () => {
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
-      form_id: 'my-form-id',
-      form_name: 'my-form-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
 
     // trigger change event again
@@ -87,9 +88,9 @@ describe('formInteractionTracking', () => {
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
-      form_id: 'my-form-2-id',
-      form_name: 'my-form-2-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-2-id',
+      [FORM_NAME]: 'my-form-2-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
 
     // trigger change event again
@@ -135,9 +136,9 @@ describe('formInteractionTracking', () => {
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
-      form_id: 'my-form-2-id',
-      form_name: 'my-form-2-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-2-id',
+      [FORM_NAME]: 'my-form-2-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
 
     // trigger change event again
@@ -159,14 +160,14 @@ describe('formInteractionTracking', () => {
     // assert both events were tracked
     expect(amplitude.track).toHaveBeenCalledTimes(2);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
-      form_id: 'my-form-id',
-      form_name: 'my-form-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
     expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submitted', {
-      form_id: 'my-form-id',
-      form_name: 'my-form-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
   });
 
@@ -182,9 +183,9 @@ describe('formInteractionTracking', () => {
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
     expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
-      form_id: 'my-form-id',
-      form_name: 'my-form-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
 
     // trigger submit event
@@ -193,9 +194,9 @@ describe('formInteractionTracking', () => {
     // assert second event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(2);
     expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submitted', {
-      form_id: 'my-form-id',
-      form_name: 'my-form-name',
-      form_destination: 'http://localhost/submit',
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
     });
   });
 

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -38,7 +38,7 @@ export class Destination implements DestinationPlugin {
   private scheduled: ReturnType<typeof setTimeout> | null = null;
   queue: Context[] = [];
 
-  async setup(config: Config): Promise<undefined> {
+  async setup(config: Config): Promise<void> {
     this.config = config;
 
     this.storageKey = `${STORAGE_PREFIX}_${this.config.apiKey.substring(0, 10)}`;
@@ -48,7 +48,7 @@ export class Destination implements DestinationPlugin {
       void Promise.all(unsent.map((event) => this.execute(event))).catch();
     }
 
-    return Promise.resolve(undefined);
+    return Promise.resolve();
   }
 
   execute(event: Event): Promise<Result> {

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -38,7 +38,7 @@ export class Destination implements DestinationPlugin {
   private scheduled: ReturnType<typeof setTimeout> | null = null;
   queue: Context[] = [];
 
-  async setup(config: Config): Promise<void> {
+  async setup(config: Config): Promise<undefined> {
     this.config = config;
 
     this.storageKey = `${STORAGE_PREFIX}_${this.config.apiKey.substring(0, 10)}`;
@@ -48,7 +48,7 @@ export class Destination implements DestinationPlugin {
       void Promise.all(unsent.map((event) => this.execute(event))).catch();
     }
 
-    return Promise.resolve();
+    return Promise.resolve(undefined);
   }
 
   execute(event: Event): Promise<Result> {

--- a/packages/marketing-analytics-browser/test/browser-client.test.ts
+++ b/packages/marketing-analytics-browser/test/browser-client.test.ts
@@ -119,6 +119,7 @@ describe('browser-client', () => {
         defaultTracking: {
           pageViews: {
             trackOn: 'attribution',
+            trackHistoryChanges: undefined,
             eventType: 'Page View',
           },
         },

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -285,7 +285,7 @@ describe('pageViewTrackingPlugin', () => {
         await instance.add(
           pageViewTrackingPlugin(instance, {
             trackOn: () => true,
-            eventType: '[Amplitude] Page View',
+            eventType: '[Amplitude] Page Viewed',
           }),
         ).promise;
 
@@ -303,7 +303,7 @@ describe('pageViewTrackingPlugin', () => {
             page_title: '',
             page_url: '',
           },
-          event_type: '[Amplitude] Page View',
+          event_type: '[Amplitude] Page Viewed',
         });
         expect(track).toHaveBeenCalledTimes(1);
       });


### PR DESCRIPTION
### Summary

Use Amplitude naming convention for default events and properties

For page views:

```diff
 {
-  event_type: '[Amplitude] Page View',
+  event_type: '[Amplitude] Page Viewed',
   event_properties: {
-      page_domain: '',
-      page_location: '',
-      page_path: '',
-      page_title: '',
-      page_url: '',
+      '[Amplitude] Page Domain': '',
+      '[Amplitude] Page Location': '',
+      '[Amplitude] Page Path': '',
+      '[Amplitude] Page Title': '',
+      '[Amplitude] Page URL': '',
      },
    },
 }
```

For file downloads:

```diff
{
-  event_type: '[Amplitude] File Download',
+  event_type: '[Amplitude] File Downloaded',
   event_properties: {
-      file_extension: '',
-      file_name: '',
-      link_id: '',
-      link_text: '',
-      link_url: '',
+      '[Amplitude] File Extension': '',
+      '[Amplitude] File Name': '',
+      '[Amplitude] Link ID': '',
+      '[Amplitude] Link Text': '',
+      '[Amplitude] Link URL': '',
     },
   },
}
```

For form interaction:

```diff
{
-  event_type: '[Amplitude] Form Start',
+  event_type: '[Amplitude] Form Started',
   event_properties: {
-      form_id: '',
-      form_name: '',
-      form_destination: '',
+      '[Amplitude] Form ID': '',
+      '[Amplitude] Form Name': '',
+      '[Amplitude] Form Destination': '',
     },
   },
}
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
