### PR TITLE
chore: added tests unsetting the user id in Browser SDK

### DIFF
--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -364,6 +364,31 @@ describe('browser-client', () => {
         client.setUserId('user@amplitude.com');
       });
     });
+
+    test('should be able to unset user id to undefined', async () => {
+      const client = new AmplitudeBrowser();
+      await client.init(API_KEY, USER_ID, {
+        ...attributionConfig,
+      }).promise;
+      expect(client.getUserId()).toBe(USER_ID);
+
+      client.setUserId(undefined);
+      expect(client.getUserId()).toBe(undefined);
+    });
+
+    test('should be able to unset user id to undefined after setUserId()', async () => {
+      const client = new AmplitudeBrowser();
+      await client.init(API_KEY, undefined, {
+        ...attributionConfig,
+      }).promise;
+      expect(client.getUserId()).toBe(undefined);
+
+      client.setUserId(USER_ID);
+      expect(client.getUserId()).toBe(USER_ID);
+
+      client.setUserId(undefined);
+      expect(client.getUserId()).toBe(undefined);
+    });
   });
 
   describe('getDeviceId', () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -369,25 +369,32 @@ describe('browser-client', () => {
       const client = new AmplitudeBrowser();
       await client.init(API_KEY, USER_ID, {
         ...attributionConfig,
+        deviceId: DEVICE_ID,
       }).promise;
       expect(client.getUserId()).toBe(USER_ID);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
 
       client.setUserId(undefined);
       expect(client.getUserId()).toBe(undefined);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
     });
 
     test('should be able to unset user id to undefined after setUserId()', async () => {
       const client = new AmplitudeBrowser();
       await client.init(API_KEY, undefined, {
         ...attributionConfig,
+        deviceId: DEVICE_ID,
       }).promise;
       expect(client.getUserId()).toBe(undefined);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
 
       client.setUserId(USER_ID);
       expect(client.getUserId()).toBe(USER_ID);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
 
       client.setUserId(undefined);
       expect(client.getUserId()).toBe(undefined);
+      expect(client.getDeviceId()).toBe(DEVICE_ID);
     });
   });
 


### PR DESCRIPTION
### Summary
added tests unsetting the user id in Browser SDK via `setUserId(undefined)`

https://amplitude.atlassian.net/browse/DXOC-633

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
