### PR TITLE
fix: add support for exactOptionalPropertyTypes TypeScript compiler option to BaseEvent

### DIFF
--- a/packages/analytics-types/src/base-event.ts
+++ b/packages/analytics-types/src/base-event.ts
@@ -3,10 +3,10 @@ import { IngestionMetadataEventProperty } from './ingestion-metadata';
 
 export interface BaseEvent extends EventOptions {
   event_type: string;
-  event_properties?: { [key: string]: any };
-  user_properties?: { [key: string]: any };
-  group_properties?: { [key: string]: any };
-  groups?: { [key: string]: any };
+  event_properties?: { [key: string]: any } | undefined;
+  user_properties?: { [key: string]: any } | undefined;
+  group_properties?: { [key: string]: any } | undefined;
+  groups?: { [key: string]: any } | undefined;
 }
 
 export interface EventOptions {


### PR DESCRIPTION
### Summary

Add support for [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) compiler option.

Only `BaseEvent` type is updated. Maybe all public types should be updated in the same way.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
