### PR TITLE
fix: move 'group' and 'group_properties' from BaseEvent to EventOptions

### DIFF
--- a/packages/analytics-core/test/utils/event-builder.test.ts
+++ b/packages/analytics-core/test/utils/event-builder.test.ts
@@ -44,6 +44,39 @@ describe('event-builder', () => {
         event_type: 'track event',
       });
     });
+
+    test('should include group info from event options and ignore from event', () => {
+      const eventType = 'track event';
+      const event = createTrackEvent(
+        {
+          event_type: eventType,
+          groups: { a: 'c' },
+          group_properties: {
+            $set: {
+              z: 'y',
+            },
+          },
+        },
+        undefined,
+        {
+          groups: { a: 'b' },
+          group_properties: {
+            $set: {
+              x: 'y',
+            },
+          },
+        },
+      );
+      expect(event).toEqual({
+        event_type: 'track event',
+        groups: { a: 'b' },
+        group_properties: {
+          $set: {
+            x: 'y',
+          },
+        },
+      });
+    });
   });
 
   describe('createIdentifyEvent', () => {

--- a/packages/analytics-types/src/base-event.ts
+++ b/packages/analytics-types/src/base-event.ts
@@ -5,8 +5,6 @@ export interface BaseEvent extends EventOptions {
   event_type: string;
   event_properties?: { [key: string]: any } | undefined;
   user_properties?: { [key: string]: any } | undefined;
-  group_properties?: { [key: string]: any } | undefined;
-  groups?: { [key: string]: any } | undefined;
 }
 
 export interface EventOptions {
@@ -47,4 +45,6 @@ export interface EventOptions {
   ingestion_metadata?: IngestionMetadataEventProperty;
   partner_id?: string;
   extra?: { [key: string]: any };
+  group_properties?: { [key: string]: any } | undefined;
+  groups?: { [key: string]: any } | undefined;
 }


### PR DESCRIPTION
### Summary

Moves 'group' and 'group_properties' from BaseEvent to EventOptions

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
