### PR TITLE
feat: implement DET for link clicks

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -10,6 +10,7 @@ import {
   getQueryParams,
   setConnectorDeviceId,
   setConnectorUserId,
+  isClickTrackingEnabled,
 } from '@amplitude/analytics-client-common';
 import {
   BrowserClient,
@@ -30,6 +31,7 @@ import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-bro
 import { sessionHandlerPlugin } from './plugins/session-handler';
 import { formInteractionTracking } from './plugins/form-interaction-tracking';
 import { fileDownloadTracking } from './plugins/file-download-tracking';
+import { clickTracking } from './plugins/click-tracking';
 import { DEFAULT_PAGE_VIEW_EVENT, DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from './constants';
 import { defaultPageViewEventEnrichment } from './plugins/default-page-view-event-enrichment';
 
@@ -117,6 +119,10 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     if (isFormInteractionTrackingEnabled(this.config.defaultTracking)) {
       await this.add(formInteractionTracking()).promise;
+    }
+
+    if (isClickTrackingEnabled(this.config.defaultTracking)) {
+      await this.add(clickTracking()).promise;
     }
 
     // Add web attribution plugin

--- a/packages/analytics-browser/src/constants.ts
+++ b/packages/analytics-browser/src/constants.ts
@@ -4,11 +4,14 @@ export const DEFAULT_PAGE_VIEW_EVENT = `${DEFAULT_EVENT_PREFIX} Page Viewed`;
 export const DEFAULT_FORM_START_EVENT = `${DEFAULT_EVENT_PREFIX} Form Started`;
 export const DEFAULT_FORM_SUBMIT_EVENT = `${DEFAULT_EVENT_PREFIX} Form Submitted`;
 export const DEFAULT_FILE_DOWNLOAD_EVENT = `${DEFAULT_EVENT_PREFIX} File Downloaded`;
+export const DEFAULT_LINK_CLICKED_EVENT = `${DEFAULT_EVENT_PREFIX} Link Clicked`;
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';
 
 export const FILE_EXTENSION = `${DEFAULT_EVENT_PREFIX} File Extension`;
 export const FILE_NAME = `${DEFAULT_EVENT_PREFIX} File Name`;
+export const LINK_CLASSES = `${DEFAULT_EVENT_PREFIX} Link Classes`;
+export const LINK_DOMAIN = `${DEFAULT_EVENT_PREFIX} Link Domain`;
 export const LINK_ID = `${DEFAULT_EVENT_PREFIX} Link ID`;
 export const LINK_TEXT = `${DEFAULT_EVENT_PREFIX} Link Text`;
 export const LINK_URL = `${DEFAULT_EVENT_PREFIX} Link URL`;

--- a/packages/analytics-browser/src/plugins/click-tracking.ts
+++ b/packages/analytics-browser/src/plugins/click-tracking.ts
@@ -1,0 +1,70 @@
+import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { DEFAULT_LINK_CLICKED_EVENT, LINK_CLASSES, LINK_DOMAIN, LINK_ID, LINK_URL } from '../constants';
+import { BrowserConfig } from '../config';
+
+export const clickTracking = (): EnrichmentPlugin => {
+  const name = '@amplitude/plugin-click-tracking-browser';
+  const type = PluginType.ENRICHMENT;
+  const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
+    /* istanbul ignore if */
+    if (!amplitude) {
+      config.loggerProvider.warn(
+        'Click tracking requires @amplitude/analytics-browser >= 1.9.1. Click events are not tracked.',
+      );
+      return;
+    }
+
+    const addClickListener = (a: HTMLAnchorElement) => {
+      let url: URL;
+      try {
+        // eslint-disable-next-line no-restricted-globals
+        url = new URL(a.href, window.location.href);
+      } catch {
+        /* istanbul ignore next */
+        return;
+      }
+      a.addEventListener('click', () => {
+        amplitude.track(DEFAULT_LINK_CLICKED_EVENT, {
+          [LINK_CLASSES]: a.className.length > 0 ? a.className.split(' ') : '',
+          [LINK_DOMAIN]: url.hostname,
+          [LINK_ID]: a.id,
+          [LINK_URL]: a.href,
+        });
+      });
+    };
+
+    // Adds listener to existing anchor tags
+    const links = Array.from(document.getElementsByTagName('a'));
+    links.forEach(addClickListener);
+
+    // Adds listener to anchor tags added after initial load
+    /* istanbul ignore else */
+    if (typeof MutationObserver !== 'undefined') {
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node) => {
+            if (node.nodeName === 'A') {
+              addClickListener(node as HTMLAnchorElement);
+            }
+            if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+              Array.from(node.querySelectorAll('a') as HTMLAnchorElement[]).map(addClickListener);
+            }
+          });
+        });
+      });
+
+      observer.observe(document.body, {
+        subtree: true,
+        childList: true,
+      });
+    }
+  };
+  const execute = async (event: Event) => event;
+
+  return {
+    name,
+    type,
+    setup,
+    execute,
+  };
+};

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -57,6 +57,18 @@ export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions
   return false;
 };
 
+export const isClickTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
+  if (typeof defaultTracking === 'boolean') {
+    return defaultTracking;
+  }
+
+  if (defaultTracking?.clicks) {
+    return true;
+  }
+
+  return false;
+};
+
 /**
  * Returns page view tracking config
  *

--- a/packages/analytics-client-common/src/index.ts
+++ b/packages/analytics-client-common/src/index.ts
@@ -15,4 +15,5 @@ export {
   isFormInteractionTrackingEnabled,
   isPageViewTrackingEnabled,
   isSessionTrackingEnabled,
+  isClickTrackingEnabled,
 } from './default-tracking';

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -29,6 +29,7 @@ export interface DefaultTrackingOptions {
   formInteractions?: boolean;
   pageViews?: boolean | PageTrackingOptions;
   sessions?: boolean;
+  clicks?: boolean;
 }
 
 export interface TrackingOptions {


### PR DESCRIPTION
### Summary

* Adds default event tracking for link clicks

|Event Type|Description|
|--------|--------|
| [Amplitude] Link Clicked | Event is tracked each time a user clicks a link that navigates to a different url. |

|Event Property|Description|
|--------|--------|
| [Amplitude] Link Classes | `Array<string>`. This property contains he HTML `class` attribute for a link or file download. For example, if a user clicks a link `<a class="primary" href="www.youtube.com">`, this dimension returns `["primary"]`. |
| [Amplitude] Link Domain | `String`. This property contains the destination domain of a link or file download. For example, if a user clicks a link `<a href="www.youtube.com">`, this dimension returns `"www.youtube.com"` |
| [Amplitude] Link ID | `String`. This property contains the HTML `id` attribute for a link or file download. For example, if a user clicks a link `<a id="socialLinks" href="www.youtube.com">`, this dimension returns `"socialLinks"`. |
| [Amplitude] Link Url | `String`. This property contains the full URL for a link or file download. For example, if a user clicks a link `<a href="https://www.youtube.com/results?search_query=analytics">`, this dimension returns `"https://www.youtube.com/results?search_query=analytics"`. |

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
