### PR TITLE
build: update node 18 version on pr build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.15.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
### Summary

It appears that react-native tests isn't working for Node version 18.16. Pinning Node version for PR build to 18.15 as workaround.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No