### PR TITLE
fix: add connector event listener after plugins and queued functions

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -98,9 +98,6 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     // Send events from the experiment SDK and forward identifies to the
     // identity store.
     const connector = getAnalyticsConnector();
-    connector.eventBridge.setEventReceiver((event) => {
-      void this.track(event.eventType, event.eventProperties);
-    });
     connector.identityStore.setIdentity({
       userId: this.config.userId,
       deviceId: this.config.deviceId,
@@ -149,6 +146,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     // Step 6: Run queued dispatch functions
     await this.runQueuedFunctions('dispatchQ');
+
+    // Step 7: Add the event receiver after running remaining queued functions.
+    connector.eventBridge.setEventReceiver((event) => {
+      void this.track(event.eventType, event.eventProperties);
+    });
   }
 
   getUserId() {

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -71,9 +71,6 @@ export class AmplitudeReactNative extends AmplitudeCore {
     // Send events from the experiment SDK and forward identifies to the
     // identity store.
     const connector = getAnalyticsConnector();
-    connector.eventBridge.setEventReceiver((event) => {
-      void this.track(event.eventType, event.eventProperties);
-    });
     connector.identityStore.setIdentity({
       userId: this.config.userId,
       deviceId: this.config.deviceId,
@@ -102,6 +99,11 @@ export class AmplitudeReactNative extends AmplitudeCore {
 
     // Step 6: Run queued functions
     await this.runQueuedFunctions('dispatchQ');
+
+    // Step 7: Add the event receiver after running remaining queued functions.
+    connector.eventBridge.setEventReceiver((event) => {
+      void this.track(event.eventType, event.eventProperties);
+    });
   }
 
   shutdown() {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

The event bridge connector listener was being added before the plugins were added and setup. This would cause exposures to get sent and fail due to the lack of plugins to add user info to the event.

This change moves adding the event bridge listener to after plugins get added and after queued events are run.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
