### PR TITLE
feat: make default event tracking enabled by default

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -16,6 +16,10 @@ describe('integration', () => {
   const userAgent = expect.any(String) as string;
   const defaultTracking = {
     attribution: false,
+    fileDownloads: false,
+    formInteractions: false,
+    pageViews: false,
+    sessions: false,
   };
 
   let apiKey = '';
@@ -130,6 +134,7 @@ describe('integration', () => {
       const trackPromise = client.track('Event Before Init').promise;
       await client.init(apiKey, undefined, {
         defaultTracking: {
+          ...defaultTracking,
           attribution: true,
           pageViews: {
             trackOn: 'attribution',
@@ -839,6 +844,7 @@ describe('integration', () => {
       });
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
+          ...defaultTracking,
           attribution: true,
           sessions: true,
         },
@@ -1134,6 +1140,7 @@ describe('integration', () => {
       });
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
+          ...defaultTracking,
           attribution: true,
           sessions: true,
         },
@@ -1435,7 +1442,7 @@ describe('integration', () => {
   });
 
   describe('default page view tracking', () => {
-    test('should send classic page view on attribution', () => {
+    test('should send page view on attribution', () => {
       let payload: any = undefined;
       const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -1452,6 +1459,7 @@ describe('integration', () => {
       });
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
+          ...defaultTracking,
           attribution: true,
           pageViews: {
             trackOn: 'attribution',
@@ -1544,7 +1552,7 @@ describe('integration', () => {
       });
     });
 
-    test('should send DET page view', () => {
+    test('should send page view', () => {
       let payload: any = undefined;
       const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -1596,115 +1604,6 @@ describe('integration', () => {
                 time: number,
                 user_agent: userAgent,
                 user_id: 'user1@amplitude.com',
-              },
-            ],
-            options: {
-              min_id_length: undefined,
-            },
-          });
-          resolve();
-        }, 2000);
-      });
-    });
-
-    test('should send DET page view on attribution', () => {
-      let payload: any = undefined;
-      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        payload = p;
-        return {
-          status: Status.Success,
-          statusCode: 200,
-          body: {
-            eventsIngested: 1,
-            payloadSizeBytes: 1,
-            serverUploadTime: 1,
-          },
-        };
-      });
-      client.init(apiKey, 'user1@amplitude.com', {
-        defaultTracking: {
-          attribution: true,
-          pageViews: {
-            trackOn: 'attribution',
-          },
-        },
-        transportProvider: {
-          send,
-        },
-      });
-
-      return new Promise<void>((resolve) => {
-        setTimeout(() => {
-          expect(payload).toEqual({
-            api_key: apiKey,
-            events: [
-              {
-                device_id: uuid,
-                event_id: 0,
-                event_properties: {
-                  '[Amplitude] Page Domain': '',
-                  '[Amplitude] Page Location': '',
-                  '[Amplitude] Page Path': '',
-                  '[Amplitude] Page Title': '',
-                  '[Amplitude] Page URL': '',
-                },
-                event_type: '[Amplitude] Page Viewed',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: 'user1@amplitude.com',
-                user_properties: {
-                  $setOnce: {
-                    initial_dclid: 'EMPTY',
-                    initial_fbclid: 'EMPTY',
-                    initial_gbraid: 'EMPTY',
-                    initial_gclid: 'EMPTY',
-                    initial_ko_click_id: 'EMPTY',
-                    initial_li_fat_id: 'EMPTY',
-                    initial_msclkid: 'EMPTY',
-                    initial_referrer: 'EMPTY',
-                    initial_referring_domain: 'EMPTY',
-                    initial_rtd_cid: 'EMPTY',
-                    initial_ttclid: 'EMPTY',
-                    initial_twclid: 'EMPTY',
-                    initial_utm_campaign: 'EMPTY',
-                    initial_utm_content: 'EMPTY',
-                    initial_utm_id: 'EMPTY',
-                    initial_utm_medium: 'EMPTY',
-                    initial_utm_source: 'EMPTY',
-                    initial_utm_term: 'EMPTY',
-                    initial_wbraid: 'EMPTY',
-                  },
-                  $unset: {
-                    dclid: '-',
-                    fbclid: '-',
-                    gbraid: '-',
-                    gclid: '-',
-                    ko_click_id: '-',
-                    li_fat_id: '-',
-                    msclkid: '-',
-                    referrer: '-',
-                    referring_domain: '-',
-                    rtd_cid: '-',
-                    ttclid: '-',
-                    twclid: '-',
-                    utm_campaign: '-',
-                    utm_content: '-',
-                    utm_id: '-',
-                    utm_medium: '-',
-                    utm_source: '-',
-                    utm_term: '-',
-                    wbraid: '-',
-                  },
-                },
               },
             ],
             options: {
@@ -1914,9 +1813,6 @@ describe('integration', () => {
       const scope2 = nock(url).post(path).reply(200, success);
       await client.init(apiKey, undefined, {
         disableCookies: false,
-        defaultTracking: {
-          attribution: true,
-        },
       }).promise;
       await client.identify(new amplitude.Identify().set('a', 'b')).promise;
       await client.track('Test Event').promise;

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -6,37 +6,39 @@ import {
   PageTrackingTrackOn,
 } from '@amplitude/analytics-types';
 
-export const isFileDownloadTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
+/**
+ * Returns false if defaultTracking === false or if defaultTracking[event],
+ * otherwise returns true
+ */
+const isTrackingEnabled = (
+  defaultTracking: DefaultTrackingOptions | boolean | undefined,
+  event: 'attribution' | 'fileDownloads' | 'formInteractions' | 'pageViews' | 'sessions',
+) => {
   if (typeof defaultTracking === 'boolean') {
     return defaultTracking;
   }
 
-  return defaultTracking?.fileDownloads !== false;
-};
-
-export const isFormInteractionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
-  if (typeof defaultTracking === 'boolean') {
-    return defaultTracking;
+  if (defaultTracking?.[event] === false) {
+    return false;
   }
 
-  return defaultTracking?.formInteractions !== false;
+  return true;
 };
 
-export const isPageViewTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
-  if (typeof defaultTracking === 'boolean') {
-    return defaultTracking;
-  }
+export const isAttributionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) =>
+  isTrackingEnabled(defaultTracking, 'attribution');
 
-  return defaultTracking?.pageViews !== false;
-};
+export const isFileDownloadTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) =>
+  isTrackingEnabled(defaultTracking, 'fileDownloads');
 
-export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
-  if (typeof defaultTracking === 'boolean') {
-    return defaultTracking;
-  }
+export const isFormInteractionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) =>
+  isTrackingEnabled(defaultTracking, 'formInteractions');
 
-  return defaultTracking?.sessions !== false;
-};
+export const isPageViewTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) =>
+  isTrackingEnabled(defaultTracking, 'pageViews');
+
+export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) =>
+  isTrackingEnabled(defaultTracking, 'sessions');
 
 export const getPageViewTrackingConfig = (config: BrowserOptions): PageTrackingOptions => {
   let trackOn: PageTrackingTrackOn | undefined = () => false;
@@ -73,14 +75,6 @@ export const getPageViewTrackingConfig = (config: BrowserOptions): PageTrackingO
     trackHistoryChanges,
     eventType,
   };
-};
-
-export const isAttributionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
-  if (typeof defaultTracking === 'boolean') {
-    return defaultTracking;
-  }
-
-  return defaultTracking?.attribution !== false;
 };
 
 export const getAttributionTrackingConfig = (

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -11,11 +11,7 @@ export const isFileDownloadTrackingEnabled = (defaultTracking: DefaultTrackingOp
     return defaultTracking;
   }
 
-  if (defaultTracking?.fileDownloads) {
-    return true;
-  }
-
-  return false;
+  return defaultTracking?.fileDownloads !== false;
 };
 
 export const isFormInteractionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
@@ -23,11 +19,7 @@ export const isFormInteractionTrackingEnabled = (defaultTracking: DefaultTrackin
     return defaultTracking;
   }
 
-  if (defaultTracking?.formInteractions) {
-    return true;
-  }
-
-  return false;
+  return defaultTracking?.formInteractions !== false;
 };
 
 export const isPageViewTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
@@ -35,14 +27,7 @@ export const isPageViewTrackingEnabled = (defaultTracking: DefaultTrackingOption
     return defaultTracking;
   }
 
-  if (
-    defaultTracking?.pageViews === true ||
-    (defaultTracking?.pageViews && typeof defaultTracking.pageViews === 'object')
-  ) {
-    return true;
-  }
-
-  return false;
+  return defaultTracking?.pageViews !== false;
 };
 
 export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions | boolean | undefined) => {
@@ -50,11 +35,7 @@ export const isSessionTrackingEnabled = (defaultTracking: DefaultTrackingOptions
     return defaultTracking;
   }
 
-  if (defaultTracking?.sessions) {
-    return true;
-  }
-
-  return false;
+  return defaultTracking?.sessions !== false;
 };
 
 export const getPageViewTrackingConfig = (config: BrowserOptions): PageTrackingOptions => {
@@ -99,11 +80,7 @@ export const isAttributionTrackingEnabled = (defaultTracking: DefaultTrackingOpt
     return defaultTracking;
   }
 
-  if (defaultTracking?.attribution) {
-    return true;
-  }
-
-  return false;
+  return defaultTracking?.attribution !== false;
 };
 
 export const getAttributionTrackingConfig = (

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -12,7 +12,7 @@ import {
  */
 const isTrackingEnabled = (
   defaultTracking: DefaultTrackingOptions | boolean | undefined,
-  event: 'attribution' | 'fileDownloads' | 'formInteractions' | 'pageViews' | 'sessions',
+  event: keyof DefaultTrackingOptions,
 ) => {
   if (typeof defaultTracking === 'boolean') {
     return defaultTracking;

--- a/packages/analytics-client-common/test/default-tracking.test.ts
+++ b/packages/analytics-client-common/test/default-tracking.test.ts
@@ -9,8 +9,16 @@ import {
 } from '../src/default-tracking';
 
 describe('isFileDownloadTrackingEnabled', () => {
-  test('should return true with boolean parameter', () => {
+  test('should return true with true parameter', () => {
     expect(isFileDownloadTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isFileDownloadTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isFileDownloadTrackingEnabled(false)).toBe(false);
   });
 
   test('should return true with object parameter', () => {
@@ -21,14 +29,26 @@ describe('isFileDownloadTrackingEnabled', () => {
     ).toBe(true);
   });
 
-  test('should return false', () => {
-    expect(isFileDownloadTrackingEnabled(undefined)).toBe(false);
+  test('should return false with object parameter', () => {
+    expect(
+      isFileDownloadTrackingEnabled({
+        fileDownloads: false,
+      }),
+    ).toBe(false);
   });
 });
 
 describe('isFormInteractionTrackingEnabled', () => {
-  test('should return true with boolean parameter', () => {
+  test('should return true with true parameter', () => {
     expect(isFormInteractionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isFormInteractionTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isFormInteractionTrackingEnabled(false)).toBe(false);
   });
 
   test('should return true with object parameter', () => {
@@ -39,14 +59,26 @@ describe('isFormInteractionTrackingEnabled', () => {
     ).toBe(true);
   });
 
-  test('should return false', () => {
-    expect(isFormInteractionTrackingEnabled(undefined)).toBe(false);
+  test('should return false with object parameter', () => {
+    expect(
+      isFormInteractionTrackingEnabled({
+        formInteractions: false,
+      }),
+    ).toBe(false);
   });
 });
 
 describe('isPageViewTrackingEnabled', () => {
-  test('should return true with boolean parameter', () => {
+  test('should return true with true parameter', () => {
     expect(isPageViewTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isPageViewTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return true with false parameter', () => {
+    expect(isPageViewTrackingEnabled(false)).toBe(false);
   });
 
   test('should return true with object parameter', () => {
@@ -57,24 +89,34 @@ describe('isPageViewTrackingEnabled', () => {
     ).toBe(true);
   });
 
+  test('should return false with object parameter', () => {
+    expect(
+      isPageViewTrackingEnabled({
+        pageViews: false,
+      }),
+    ).toBe(false);
+  });
+
   test('should return true with nested object parameter', () => {
     expect(
       isPageViewTrackingEnabled({
-        pageViews: {
-          trackOn: 'attribution',
-        },
+        pageViews: {},
       }),
     ).toBe(true);
-  });
-
-  test('should return false', () => {
-    expect(isPageViewTrackingEnabled(undefined)).toBe(false);
   });
 });
 
 describe('isSessionTrackingEnabled', () => {
-  test('should return true with boolean parameter', () => {
+  test('should return true with true parameter', () => {
     expect(isSessionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isSessionTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isSessionTrackingEnabled(false)).toBe(false);
   });
 
   test('should return true with object parameter', () => {
@@ -85,14 +127,26 @@ describe('isSessionTrackingEnabled', () => {
     ).toBe(true);
   });
 
-  test('should return false', () => {
-    expect(isSessionTrackingEnabled(undefined)).toBe(false);
+  test('should return false with object parameter', () => {
+    expect(
+      isSessionTrackingEnabled({
+        sessions: false,
+      }),
+    ).toBe(false);
   });
 });
 
 describe('isAttributionTrackingEnabled', () => {
-  test('should return true with boolean parameter', () => {
+  test('should return true with true parameter', () => {
     expect(isAttributionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isAttributionTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isAttributionTrackingEnabled(false)).toBe(false);
   });
 
   test('should return true with object parameter', () => {
@@ -103,13 +157,17 @@ describe('isAttributionTrackingEnabled', () => {
     ).toBe(true);
   });
 
-  test('should return false', () => {
-    expect(isAttributionTrackingEnabled(undefined)).toBe(false);
+  test('should return false with object parameter', () => {
+    expect(
+      isAttributionTrackingEnabled({
+        attribution: false,
+      }),
+    ).toBe(false);
   });
 });
 
 describe('getPageViewTrackingConfig', () => {
-  test('should return always track config', () => {
+  test('should return undefined trackOn config', () => {
     const config = getPageViewTrackingConfig({
       defaultTracking: {
         pageViews: true,
@@ -119,8 +177,12 @@ describe('getPageViewTrackingConfig', () => {
     expect(config.trackOn).toBe(undefined);
   });
 
-  test('should return never track config with default tracking', () => {
-    const config = getPageViewTrackingConfig({});
+  test('should return trackOn config returning false', () => {
+    const config = getPageViewTrackingConfig({
+      defaultTracking: {
+        pageViews: false,
+      },
+    });
 
     expect(typeof config.trackOn).toBe('function');
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -303,7 +303,9 @@ describe('react-native-client', () => {
   describe('reset', () => {
     test('should reset user id and generate new device id config', async () => {
       const client = new AmplitudeReactNative();
-      await client.init(API_KEY).promise;
+      await client.init(API_KEY, undefined, {
+        ...attributionConfig,
+      }).promise;
       client.setUserId(USER_ID);
       client.setDeviceId(DEVICE_ID);
       expect(client.getUserId()).toBe(USER_ID);

--- a/packages/marketing-analytics-browser/test/integration.test.ts
+++ b/packages/marketing-analytics-browser/test/integration.test.ts
@@ -24,6 +24,13 @@ describe('e2e', () => {
   const expectString = expect.any(String) as string;
   const expectLibrary = expect.stringMatching(/^amplitude-ma-ts\/.+/) as string;
   const expectNumber = expect.any(Number) as number;
+  const defaultTracking = {
+    attribution: false,
+    fileDownloads: false,
+    formInteractions: false,
+    pageViews: false,
+    sessions: false,
+  };
 
   beforeEach(() => {
     apiKey = UUID();
@@ -47,6 +54,7 @@ describe('e2e', () => {
     const client = createInstance();
     client.init(apiKey, undefined, {
       defaultTracking: {
+        ...defaultTracking,
         attribution: true,
       },
     });
@@ -138,6 +146,7 @@ describe('e2e', () => {
     const client = createInstance();
     client.init(apiKey, undefined, {
       defaultTracking: {
+        ...defaultTracking,
         attribution: true,
         pageViews: {
           trackOn: 'attribution',
@@ -239,6 +248,7 @@ describe('e2e', () => {
     const client = createInstance();
     client.init(apiKey, undefined, {
       defaultTracking: {
+        ...defaultTracking,
         attribution: false,
         pageViews: true,
       },
@@ -294,6 +304,7 @@ describe('e2e', () => {
     const client = createInstance();
     client.init(apiKey, undefined, {
       defaultTracking: {
+        ...defaultTracking,
         attribution: true,
         pageViews: true,
       },


### PR DESCRIPTION
## Summary

### Changes to @amplitude/analytics-browser

#### 1. Enables default event tracking by default

Updates default event tracking configuration to be opt-out instead of opt-in. This assists customers with instrumenting default events with one line init code.

Pattern 1: Opt-in to default event tracking using short config
```diff
- amplitude.init(API_KEY, undefined, {
-   defaultTracking: true,
- });
+ amplitude.init(API_KEY);
```

Pattern 2: Opt-in to default event tracking using verbose config
```diff
- amplitude.init(API_KEY, undefined, {
-   defaultTracking: {
-     attribution: true,
-     fileDownloadTracking: true,
-     formInteractionTracking: true,
-     pageViews: true,
-     sessions: true,
-   },
- });
+ amplitude.init(API_KEY);
```

Pattern 3: Opt-out of default event tracking using short config
```diff
- amplitude.init(API_KEY);
+ amplitude.init(API_KEY, undefined, {
+   defaultTracking: false,
+ });
```

Pattern 4: Opt-out of default event tracking using verbose config
```diff
- amplitude.init(API_KEY);
+ amplitude.init(API_KEY, undefined, {
+   defaultTracking: {
+     attribution: false,
+     fileDownloadTracking: false,
+     formInteractionTracking: false,
+     pageViews: false,
+     sessions: false,
+   },
+ });
```

Pattern 5: Partially opt-on/opt-out to/of default event tracking using verbose config
```diff
- amplitude.init(API_KEY, undefined,  {
-   defaultTracking: {
-     attribution: true,
-     pageViews: true,
-   },
- });
+ amplitude.init(API_KEY, undefined, {
+   defaultTracking: {
+     fileDownloadTracking: false,
+     formInteractionTracking: false,
+     sessions: false,
+   },
+ });
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes
