### PR TITLE
feat: track page dynamic page views in single page applications be de…

### DIFF
--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -61,7 +61,7 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
       loggerProvider = config.loggerProvider;
       loggerProvider.log('Installing @amplitude/plugin-page-view-tracking-browser');
 
-      if (options.trackHistoryChanges && globalScope) {
+      if (globalScope) {
         /* istanbul ignore next */
         globalScope.addEventListener('popstate', () => {
           void trackHistoryPageView();

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -229,7 +229,44 @@ describe('pageViewTrackingPlugin', () => {
       expect(track).toHaveBeenCalledTimes(1);
     });
 
-    test('track SPA page view on history push', async () => {
+    test('should add popstate event listener with default options', async () => {
+      // Note: existence of popstate event listener validates that client-side routing changes are tracked
+      // unless prevented by `options.trackOn`
+      const amplitude = createInstance();
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+      const plugin = pageViewTrackingPlugin();
+      await plugin.setup(mockConfig, amplitude);
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith('popstate', expect.any(Function));
+    });
+
+    test('should add popstate event listener with trackHistoryChanges: "all"', async () => {
+      // Note: existence of popstate event listener validates that client-side routing changes are tracked
+      // unless prevented by `options.trackOn`
+      const amplitude = createInstance();
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+      const plugin = pageViewTrackingPlugin({
+        trackHistoryChanges: 'all',
+      });
+      await plugin.setup(mockConfig, amplitude);
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith('popstate', expect.any(Function));
+    });
+
+    test('should add popstate event listener with trackHistoryChanges: "pathOnly"', async () => {
+      // Note: existence of popstate event listener validates that client-side routing changes are tracked
+      // unless prevented by `options.trackOn` or non-path changes to the URL
+      const amplitude = createInstance();
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+      const plugin = pageViewTrackingPlugin({
+        trackHistoryChanges: 'pathOnly',
+      });
+      await plugin.setup(mockConfig, amplitude);
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith('popstate', expect.any(Function));
+    });
+
+    test('should track SPA page view on history push', async () => {
       const amplitude = createInstance();
       const track = jest.spyOn(amplitude, 'track').mockReturnValue({
         promise: Promise.resolve({


### PR DESCRIPTION
## Summary

### Changes to @amplitude/analytics-browser

#### 1. Enables SPA page view tracking by default

By default, page views are only tracked on initial load by default. To track dynamic page views (navigation through client-side routing), amplitude must be configured using `options.defaultTracking.pageViews.trackHistoryChanges`, and setting a value of either "all" or "pathOnly". Without a value, this feature is disabled.

With this change, initial and dynamic page loads are considered the same, and are enabled/disabled the same way. Although what remains to be configurable is how dynamic page views are defined to allow flexibility on client-side routing mechanism.

Enable SPA page view tracking (similar to how initial page view is enabled)

```diff
  amplitude.init(API_KEY, undefined, {
    defaultTracking: {
-     pageViews: {
-       trackHistoryChanges: 'all', // or 'pathOnly'
-     },
+     pageViews: true,
  },
});
```

Disables SPA page view tracking (similar to how dynamic page view is enabled)

```diff
  amplitude.init(API_KEY, undefined, {
    defaultTracking: {
-     pageViews: {
-       trackHistoryChanges: undefined, // or omit
-     },
+     pageViews: false,
  },
});
```

### Changes to @amplitude/plugin-page-view-tracking-browser

Same as above

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes
