### PR TITLE
fix: dyanamic page view tracking to run after navigation

### DIFF
--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -51,7 +51,7 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (
   const shouldTrackOnPageLoad = () =>
     typeof options.trackOn === 'undefined' || (typeof options.trackOn === 'function' && options.trackOn());
 
-  let previousURL: string | null = null;
+  let previousURL: string | null = location.href;
 
   const trackHistoryPageView = async (): Promise<void> => {
     const newURL = location.href;
@@ -103,9 +103,8 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (
         // eslint-disable-next-line @typescript-eslint/unbound-method
         globalScope.history.pushState = new Proxy(globalScope.history.pushState, {
           apply: (target, thisArg, [state, unused, url]) => {
+            target.apply(thisArg, [state, unused, url]);
             void trackHistoryPageView();
-
-            return target.apply(thisArg, [state, unused, url]);
           },
         });
       }


### PR DESCRIPTION
### Summary

Refer to: https://github.com/amplitude/Amplitude-TypeScript/pull/395

This PR applies the change to Browser SDK V1.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
