### PR TITLE
chore: 1.x version

### DIFF
--- a/packages/analytics-browser-test/package.json
+++ b/packages/analytics-browser-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/analytics-browser-test",
-  "version": "2.7.0",
+  "version": "1.4.0-beta.0",
   "private": true,
   "description": "",
   "author": "Amplitude Inc",
@@ -16,7 +16,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^1.10.3"
+    "@amplitude/analytics-browser": "^1.10.5"
   },
   "devDependencies": {
     "nock": "^13.2.4"

--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -43,11 +43,11 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^0.7.0",
-    "@amplitude/analytics-core": "^0.13.3",
-    "@amplitude/analytics-types": "^0.20.0",
-    "@amplitude/plugin-page-view-tracking-browser": "^0.8.2",
-    "@amplitude/plugin-web-attribution-browser": "^0.7.0",
+    "@amplitude/analytics-client-common": "^1.0.0-beta.0",
+    "@amplitude/analytics-core": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
+    "@amplitude/plugin-page-view-tracking-browser": "^1.0.0-beta.0",
+    "@amplitude/plugin-web-attribution-browser": "^1.0.0-beta.0",
     "@amplitude/ua-parser-js": "^0.7.31",
     "tslib": "^2.4.1"
   },

--- a/packages/analytics-client-common/package.json
+++ b/packages/analytics-client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/analytics-client-common",
-  "version": "0.7.0",
+  "version": "1.0.0-beta.0",
   "description": "",
   "author": "Amplitude Inc",
   "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@amplitude/analytics-connector": "^1.4.5",
-    "@amplitude/analytics-core": "^0.13.3",
-    "@amplitude/analytics-types": "^0.20.0",
+    "@amplitude/analytics-core": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
     "tslib": "^2.4.1"
   },
   "files": [

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/analytics-core",
-  "version": "0.13.3",
+  "version": "1.0.0-beta.0",
   "description": "",
   "author": "Amplitude Inc",
   "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
@@ -34,7 +34,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-types": "^0.20.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
     "tslib": "^2.4.1"
   },
   "files": [

--- a/packages/analytics-node-test/package.json
+++ b/packages/analytics-node-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/analytics-node-test",
-  "version": "0.1.14",
+  "version": "1.0.0-beta.0",
   "private": true,
   "description": "",
   "author": "Amplitude Inc",

--- a/packages/analytics-node/package.json
+++ b/packages/analytics-node/package.json
@@ -36,8 +36,8 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-core": "^0.13.3",
-    "@amplitude/analytics-types": "^0.20.0",
+    "@amplitude/analytics-core": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
     "tslib": "^2.4.1"
   },
   "files": [

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -57,9 +57,9 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^0.7.0",
-    "@amplitude/analytics-core": "^0.13.3",
-    "@amplitude/analytics-types": "^0.20.0",
+    "@amplitude/analytics-client-common": "^1.0.0-beta.0",
+    "@amplitude/analytics-core": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
     "@amplitude/ua-parser-js": "^0.7.31",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "tslib": "^2.4.1"

--- a/packages/analytics-types/package.json
+++ b/packages/analytics-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/analytics-types",
-  "version": "0.20.0",
+  "version": "1.0.0-beta.0",
   "description": "",
   "author": "Amplitude Inc",
   "homepage": "https://github.com/amplitude/Amplitude-TypeScript",

--- a/packages/marketing-analytics-browser/package.json
+++ b/packages/marketing-analytics-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/marketing-analytics-browser",
-  "version": "0.8.2",
+  "version": "1.0.0-beta.0",
   "description": "Official Amplitude SDK for Web and Marketing Analytics",
   "keywords": [
     "analytics",
@@ -43,11 +43,11 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^1.10.5",
-    "@amplitude/analytics-client-common": "^0.7.0",
-    "@amplitude/analytics-core": "^0.13.3",
-    "@amplitude/analytics-types": "^0.20.0",
-    "@amplitude/plugin-page-view-tracking-browser": "^0.8.2",
-    "@amplitude/plugin-web-attribution-browser": "^0.7.0",
+    "@amplitude/analytics-client-common": "^1.0.0-beta.0",
+    "@amplitude/analytics-core": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
+    "@amplitude/plugin-page-view-tracking-browser": "^1.0.0-beta.0",
+    "@amplitude/plugin-web-attribution-browser": "^1.0.0-beta.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-page-view-tracking-browser/package.json
+++ b/packages/plugin-page-view-tracking-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/plugin-page-view-tracking-browser",
-  "version": "0.8.2",
+  "version": "1.0.0-beta.0",
   "description": "",
   "author": "Amplitude Inc",
   "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
@@ -36,8 +36,8 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^0.7.0",
-    "@amplitude/analytics-types": "^0.20.0",
+    "@amplitude/analytics-client-common": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-web-attribution-browser/package.json
+++ b/packages/plugin-web-attribution-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/plugin-web-attribution-browser",
-  "version": "0.7.0",
+  "version": "1.0.0-beta.0",
   "description": "",
   "author": "Amplitude Inc",
   "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
@@ -36,12 +36,12 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^0.7.0",
-    "@amplitude/analytics-types": "^0.20.0",
+    "@amplitude/analytics-client-common": "^1.0.0-beta.0",
+    "@amplitude/analytics-types": "^1.0.0-beta.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "@amplitude/analytics-browser": "^1.10.3",
+    "@amplitude/analytics-browser": "^1.10.5",
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",


### PR DESCRIPTION
### Summary

Cleans up all package versions to be on version 1.x
* New 1.x versions are on beta first
* However, release workflow should graduate these versions

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Np
