### PR TITLE
fix: don't automatically start new session on setUserId

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -982,16 +982,6 @@ describe('integration', () => {
                 eventType: 'Event in next session',
                 userId: 'user1@amplitude.com',
               },
-              {
-                eventType: 'session_end',
-                userId: 'user1@amplitude.com',
-              },
-            ],
-            [
-              {
-                eventType: 'session_start',
-                userId: 'user2@amplitude.com',
-              },
             ],
           ]);
           expect(payload).toEqual({
@@ -1154,44 +1144,6 @@ describe('integration', () => {
                 time: number,
                 user_agent: userAgent,
                 user_id: 'user1@amplitude.com',
-              },
-              {
-                device_id: uuid,
-                device_manufacturer: undefined,
-                event_id: 6,
-                event_type: 'session_end',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                os_name: 'WebKit',
-                os_version: '537.36',
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: 'user1@amplitude.com',
-              },
-              {
-                device_id: uuid,
-                device_manufacturer: undefined,
-                event_id: 7,
-                event_type: 'session_start',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                os_name: 'WebKit',
-                os_version: '537.36',
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: 'user2@amplitude.com',
               },
             ],
             options: {
@@ -1282,8 +1234,6 @@ describe('integration', () => {
           expect(deviceIds[2]).toEqual(deviceIds[3]);
           expect(deviceIds[3]).toEqual(deviceIds[4]);
           expect(deviceIds[4]).toEqual(deviceIds[5]);
-          expect(deviceIds[5]).not.toBe(deviceIds[6]);
-          expect(deviceIds[6]).not.toBe(deviceIds[7]);
           // The order of events in the payload is sorted by time of track fn invokation
           // and not consistent with the time property
           // Session events have overwritten time property
@@ -1320,18 +1270,6 @@ describe('integration', () => {
               {
                 eventType: 'Event in next session',
                 userId: 'user1@amplitude.com',
-                deviceId: uuid,
-              },
-              {
-                eventType: 'session_end',
-                userId: 'user1@amplitude.com',
-                deviceId: uuid,
-              },
-            ],
-            [
-              {
-                eventType: 'session_start',
-                userId: undefined,
                 deviceId: uuid,
               },
             ],
@@ -1496,44 +1434,6 @@ describe('integration', () => {
                 time: number,
                 user_agent: userAgent,
                 user_id: 'user1@amplitude.com',
-              },
-              {
-                device_id: uuid,
-                device_manufacturer: undefined,
-                event_id: 6,
-                event_type: 'session_end',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                os_name: 'WebKit',
-                os_version: '537.36',
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: 'user1@amplitude.com',
-              },
-              {
-                device_id: uuid,
-                device_manufacturer: undefined,
-                event_id: 7,
-                event_type: 'session_start',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                os_name: 'WebKit',
-                os_version: '537.36',
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: undefined,
               },
             ],
             options: {

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -1282,7 +1282,7 @@ describe('integration', () => {
           expect(deviceIds[2]).toEqual(deviceIds[3]);
           expect(deviceIds[3]).toEqual(deviceIds[4]);
           expect(deviceIds[4]).toEqual(deviceIds[5]);
-          expect(deviceIds[5]).toEqual(deviceIds[6]);
+          expect(deviceIds[5]).not.toBe(deviceIds[6]);
           expect(deviceIds[6]).not.toEqual(deviceIds[7]);
           // The order of events in the payload is sorted by time of track fn invokation
           // and not consistent with the time property

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -920,7 +920,7 @@ describe('integration', () => {
       }, 1000);
 
       setTimeout(() => {
-        client.setUserId('user2@amplitude.com', true); // effectively creates a new session
+        client.setUserId('user2@amplitude.com'); // effectively creates a new session
         // Sends `session_end` event for previous user and session
         // Sends `session_start` event for next user and session
       }, 2000);

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -920,7 +920,7 @@ describe('integration', () => {
       }, 1000);
 
       setTimeout(() => {
-        client.setUserId('user2@amplitude.com'); // effectively creates a new session
+        client.setUserId('user2@amplitude.com', true); // effectively creates a new session
         // Sends `session_end` event for previous user and session
         // Sends `session_start` event for next user and session
       }, 2000);

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -1283,7 +1283,7 @@ describe('integration', () => {
           expect(deviceIds[3]).toEqual(deviceIds[4]);
           expect(deviceIds[4]).toEqual(deviceIds[5]);
           expect(deviceIds[5]).not.toBe(deviceIds[6]);
-          expect(deviceIds[6]).not.toEqual(deviceIds[7]);
+          expect(deviceIds[6]).not.toBe(deviceIds[7]);
           // The order of events in the payload is sorted by time of track fn invokation
           // and not consistent with the time property
           // Session events have overwritten time property

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -157,14 +157,16 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     return this.config?.userId;
   }
 
-  setUserId(userId: string | undefined) {
+  setUserId(userId: string | undefined, startNewSession = false) {
     if (!this.config) {
       this.q.push(this.setUserId.bind(this, userId));
       return;
     }
     if (userId !== this.config.userId || userId === undefined) {
       this.config.userId = userId;
-      this.setSessionId(Date.now());
+      if (startNewSession) {
+        this.setSessionId(Date.now());
+      }
       setConnectorUserId(userId);
     }
   }

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -159,15 +159,15 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
   setUserId(userId: string | undefined, startNewSession = false) {
     if (!this.config) {
-      this.q.push(this.setUserId.bind(this, userId));
+      this.q.push(this.setUserId.bind(this, userId, startNewSession));
       return;
     }
     if (userId !== this.config.userId || userId === undefined) {
       this.config.userId = userId;
-      if (startNewSession) {
-        this.setSessionId(Date.now());
-      }
       setConnectorUserId(userId);
+    }
+    if (startNewSession) {
+      this.setSessionId(Date.now());
     }
   }
 

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -157,17 +157,14 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     return this.config?.userId;
   }
 
-  setUserId(userId: string | undefined, startNewSession = false) {
+  setUserId(userId: string | undefined) {
     if (!this.config) {
-      this.q.push(this.setUserId.bind(this, userId, startNewSession));
+      this.q.push(this.setUserId.bind(this, userId));
       return;
     }
     if (userId !== this.config.userId || userId === undefined) {
       this.config.userId = userId;
       setConnectorUserId(userId);
-    }
-    if (startNewSession) {
-      this.setSessionId(Date.now());
     }
   }
 

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -345,7 +345,7 @@ describe('browser-client', () => {
       // We do not want to depend on init behavior
       track.mockReset();
 
-      client.setUserId(undefined);
+      client.setUserId(undefined, true);
       expect(client.getUserId()).toBe(undefined);
       expect(track).toHaveBeenCalledTimes(2);
     });

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -315,7 +315,7 @@ describe('browser-client', () => {
       expect(client.getUserId()).toBe(USER_ID);
     });
 
-    test('should set user and session id with start and end session event', async () => {
+    test('should not send session events on set user', async () => {
       jest.spyOn(CookieMigration, 'parseLegacyCookies').mockResolvedValueOnce({
         optOut: false,
         sessionId: 1,
@@ -347,7 +347,7 @@ describe('browser-client', () => {
 
       client.setUserId(undefined);
       expect(client.getUserId()).toBe(undefined);
-      expect(track).toHaveBeenCalledTimes(2);
+      expect(track).toHaveBeenCalledTimes(0);
     });
 
     test('should defer set user id', () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -345,7 +345,7 @@ describe('browser-client', () => {
       // We do not want to depend on init behavior
       track.mockReset();
 
-      client.setUserId(undefined, true);
+      client.setUserId(undefined);
       expect(client.getUserId()).toBe(undefined);
       expect(track).toHaveBeenCalledTimes(2);
     });

--- a/packages/analytics-types/src/client/web-client.ts
+++ b/packages/analytics-types/src/client/web-client.ts
@@ -21,6 +21,7 @@ interface Client extends CoreClient {
    * ```
    */
   setUserId(userId: string | undefined): void;
+  setUserId(userId: string | undefined, startNewSession: boolean): void;
 
   /**
    * Returns current device ID.

--- a/packages/analytics-types/src/client/web-client.ts
+++ b/packages/analytics-types/src/client/web-client.ts
@@ -21,7 +21,6 @@ interface Client extends CoreClient {
    * ```
    */
   setUserId(userId: string | undefined): void;
-  setUserId(userId: string | undefined, startNewSession: boolean): void;
 
   /**
    * Returns current device ID.


### PR DESCRIPTION
### Summary

Update TS SDK to match the default session handling of JS SDK on `setUserId()`.
* By default, changing userId will NOT start a new session
* Users can call `setSessionId(Date.now())` start a new session if desired
* https://amplitude.atlassian.net/browse/AMP-76240

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Technically yes as this changes the current default behavior, however considering this is a bug fix to make work like JS SDK
