### PR TITLE
fix: simplify plugins and eliminate enums

### DIFF
--- a/examples/plugins/page-view-tracking-enrichment/index.test.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.test.ts
@@ -1,36 +1,13 @@
-import { FetchTransport } from '@amplitude/analytics-client-common';
-import { Logger } from '@amplitude/analytics-core';
-import { LogLevel } from '@amplitude/analytics-types';
 import { pageViewTrackingEnrichment } from './';
 
 describe('page-view-tracking-enrichment', () => {
-  describe('setup', () => {
-    test('should return undefined', async () => {
-      const mockConfig = {
-        apiKey: '',
-        flushIntervalMillis: 0,
-        flushMaxRetries: 0,
-        flushQueueSize: 0,
-        logLevel: LogLevel.None,
-        loggerProvider: new Logger(),
-        optOut: false,
-        serverUrl: undefined,
-        transportProvider: new FetchTransport(),
-        useBatch: false,
-      };
-      const plugin = pageViewTrackingEnrichment();
-      const result = await plugin.setup(mockConfig);
-      expect(result).toBeUndefined();
-    });
-  });
-
   describe('execute', () => {
     test('should enrich page view event', async () => {
       const mockEvent = {
         event_type: 'Page View',
       };
       const plugin = pageViewTrackingEnrichment();
-      const result = await plugin.execute(mockEvent);
+      const result = await plugin.execute?.(mockEvent);
       expect(result).toEqual({
         event_type: 'Page View',
         event_properties: {
@@ -44,7 +21,7 @@ describe('page-view-tracking-enrichment', () => {
         event_type: 'Not Page View',
       };
       const plugin = pageViewTrackingEnrichment();
-      const result = await plugin.execute(mockEvent);
+      const result = await plugin.execute?.(mockEvent);
       expect(result).toEqual({
         event_type: 'Not Page View',
       });

--- a/examples/plugins/page-view-tracking-enrichment/index.ts
+++ b/examples/plugins/page-view-tracking-enrichment/index.ts
@@ -1,5 +1,5 @@
 import { createInstance } from '@amplitude/analytics-browser';
-import { EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
+import { EnrichmentPlugin } from '@amplitude/analytics-types';
 
 /**
  * This is an example plugin that enriches events with event_type "Page View" by adding
@@ -10,7 +10,7 @@ import { EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
 export const pageViewTrackingEnrichment = (): EnrichmentPlugin => {
   return {
     name: 'page-view-tracking-enrichment',
-    type: PluginType.ENRICHMENT,
+    type: 'enrichment',
     setup: async () => undefined,
     execute: async (event) => {
       if (event.event_type !== 'Page View') {

--- a/examples/plugins/remove-event-key/index.test.ts
+++ b/examples/plugins/remove-event-key/index.test.ts
@@ -8,7 +8,7 @@ describe('remove-event-key-enrichment', () => {
         event_type: 'Custom Event',
         time: Date.now(),
       };
-      const result = await plugin.execute(mockEvent);
+      const result = await plugin.execute?.(mockEvent);
       expect(result?.time).toBeUndefined();
     });
 
@@ -18,7 +18,7 @@ describe('remove-event-key-enrichment', () => {
         event_type: 'Custom Event',
         time: Date.now(),
       };
-      const result = await plugin.execute(mockEvent);
+      const result = await plugin.execute?.(mockEvent);
       expect(result?.time).toBeDefined();
     });
   });

--- a/examples/plugins/remove-event-key/index.ts
+++ b/examples/plugins/remove-event-key/index.ts
@@ -1,5 +1,5 @@
 import { createInstance } from '@amplitude/analytics-browser';
-import { EnrichmentPlugin, PluginType } from '@amplitude/analytics-types';
+import { EnrichmentPlugin } from '@amplitude/analytics-types';
 import { BaseEvent } from '@amplitude/analytics-types/src';
 
 type KeyOfEvent = keyof BaseEvent;
@@ -19,7 +19,7 @@ type KeyOfEvent = keyof BaseEvent;
 export const removeEventKeyEnrichment = (keysToRemove: KeyOfEvent[] = []): EnrichmentPlugin => {
   return {
     name: 'remove-event-key-enrichment',
-    type: PluginType.ENRICHMENT,
+    type: 'enrichment',
     setup: async () => undefined,
     execute: async (event) => {
       for (var key of keysToRemove) {

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -6,7 +6,7 @@ import { default as nock } from 'nock';
 import { success } from './responses';
 import 'isomorphic-fetch';
 import { path, SUCCESS_MESSAGE, url, uuidPattern } from './constants';
-import { PluginType, LogLevel, BaseEvent, Status } from '@amplitude/analytics-types';
+import { LogLevel, BaseEvent } from '@amplitude/analytics-types';
 import { UUID } from '@amplitude/analytics-core';
 
 describe('integration', () => {
@@ -73,7 +73,7 @@ describe('integration', () => {
         client.setDeviceId(deviceId);
         client.setSessionId(sessionId);
         client.add({
-          type: PluginType.ENRICHMENT,
+          type: 'enrichment',
           name: 'custom',
           setup: async () => {
             return undefined;
@@ -829,27 +829,17 @@ describe('integration', () => {
   describe('session handler', () => {
     test('should send session events and replaced with known user', () => {
       let payload: any = undefined;
-      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        payload = p;
-        return {
-          status: Status.Success,
-          statusCode: 200,
-          body: {
-            eventsIngested: 1,
-            payloadSizeBytes: 1,
-            serverUploadTime: 1,
-          },
-        };
-      });
+      const scope = nock(url)
+        .post(path, (body: Record<string, any>) => {
+          payload = body;
+          return true;
+        })
+        .reply(200, success);
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
           ...defaultTracking,
           attribution: true,
           sessions: true,
-        },
-        transportProvider: {
-          send,
         },
         sessionTimeout: 500,
         flushIntervalMillis: 3000,
@@ -1118,6 +1108,7 @@ describe('integration', () => {
               min_id_length: undefined,
             },
           });
+          scope.done();
           resolve();
         }, 4000);
       });
@@ -1125,27 +1116,17 @@ describe('integration', () => {
 
     test('should send session events and replaced with unknown user', () => {
       let payload: any = undefined;
-      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        payload = p;
-        return {
-          status: Status.Success,
-          statusCode: 200,
-          body: {
-            eventsIngested: 1,
-            payloadSizeBytes: 1,
-            serverUploadTime: 1,
-          },
-        };
-      });
+      const scope = nock(url)
+        .post(path, (body: Record<string, any>) => {
+          payload = body;
+          return true;
+        })
+        .reply(200, success);
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
           ...defaultTracking,
           attribution: true,
           sessions: true,
-        },
-        transportProvider: {
-          send,
         },
         sessionTimeout: 500,
         flushIntervalMillis: 3000,
@@ -1435,6 +1416,7 @@ describe('integration', () => {
               min_id_length: undefined,
             },
           });
+          scope.done();
           resolve();
         }, 4000);
       });
@@ -1444,19 +1426,12 @@ describe('integration', () => {
   describe('default page view tracking', () => {
     test('should send page view on attribution', () => {
       let payload: any = undefined;
-      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        payload = p;
-        return {
-          status: Status.Success,
-          statusCode: 200,
-          body: {
-            eventsIngested: 1,
-            payloadSizeBytes: 1,
-            serverUploadTime: 1,
-          },
-        };
-      });
+      const scope = nock(url)
+        .post(path, (body: Record<string, any>) => {
+          payload = body;
+          return true;
+        })
+        .reply(200, success);
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
           ...defaultTracking,
@@ -1464,9 +1439,6 @@ describe('integration', () => {
           pageViews: {
             trackOn: 'attribution',
           },
-        },
-        transportProvider: {
-          send,
         },
       });
 
@@ -1547,6 +1519,7 @@ describe('integration', () => {
               min_id_length: undefined,
             },
           });
+          scope.done();
           resolve();
         }, 2000);
       });
@@ -1554,26 +1527,16 @@ describe('integration', () => {
 
     test('should send page view', () => {
       let payload: any = undefined;
-      const send = jest.fn().mockImplementationOnce(async (_endpoint, p) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        payload = p;
-        return {
-          status: Status.Success,
-          statusCode: 200,
-          body: {
-            eventsIngested: 1,
-            payloadSizeBytes: 1,
-            serverUploadTime: 1,
-          },
-        };
-      });
+      const scope = nock(url)
+        .post(path, (body: Record<string, any>) => {
+          payload = body;
+          return true;
+        })
+        .reply(200, success);
       client.init(apiKey, 'user1@amplitude.com', {
         defaultTracking: {
           ...defaultTracking,
           pageViews: true,
-        },
-        transportProvider: {
-          send,
         },
       });
 
@@ -1610,6 +1573,7 @@ describe('integration', () => {
               min_id_length: undefined,
             },
           });
+          scope.done();
           resolve();
         }, 2000);
       });

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -7,7 +7,6 @@ import {
   TrackingOptions,
   TransportType,
   UserSession,
-  Transport,
   Logger as ILogger,
   LogLevel,
   Plan,
@@ -72,11 +71,10 @@ export class BrowserConfig extends Config implements IBrowserConfig {
       platform: true,
     },
     public transport: 'fetch' | 'xhr' | 'beacon' = 'fetch',
-    public transportProvider: Transport = new FetchTransport(),
     public useBatch: boolean = false,
     userId?: string,
   ) {
-    super({ apiKey, storageProvider, transportProvider });
+    super({ apiKey, storageProvider, transportProvider: createTransport(transport) });
     this._cookieStorage = cookieStorage;
     this.deviceId = deviceId;
     this.lastEventId = lastEventId;
@@ -245,7 +243,6 @@ export const useBrowserConfig = async (
     options.storageProvider,
     trackingOptions,
     options.transport,
-    options.transportProvider,
     options.useBatch,
     userId,
   );
@@ -266,11 +263,11 @@ export const createCookieStorage = <T>(
   }
 };
 
-export const createTransport = (transport?: TransportType | keyof typeof TransportType) => {
-  if (transport === TransportType.XHR) {
+export const createTransport = (transport?: TransportType) => {
+  if (transport === 'xhr') {
     return new XHRTransport();
   }
-  if (transport === TransportType.SendBeacon) {
+  if (transport === 'beacon') {
     return new SendBeaconTransport();
   }
   return new FetchTransport();

--- a/packages/analytics-browser/src/plugins/context.ts
+++ b/packages/analytics-browser/src/plugins/context.ts
@@ -1,4 +1,4 @@
-import { BeforePlugin, BrowserConfig, Event, PluginType } from '@amplitude/analytics-types';
+import { BeforePlugin, BrowserConfig, Event } from '@amplitude/analytics-types';
 import { UUID } from '@amplitude/analytics-core';
 import { getLanguage } from '@amplitude/analytics-client-common';
 import { VERSION } from '../version';
@@ -6,8 +6,8 @@ import { VERSION } from '../version';
 const BROWSER_PLATFORM = 'Web';
 const IP_ADDRESS = '$remote';
 export class Context implements BeforePlugin {
-  name = 'context';
-  type = PluginType.BEFORE as const;
+  name = '@amplitude/plugin-context-browser';
+  type = 'before' as const;
 
   // this.config is defined in setup() which will always be called first
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,11 +1,11 @@
-import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { BrowserClient, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { DEFAULT_FILE_DOWNLOAD_EVENT, FILE_EXTENSION, FILE_NAME, LINK_ID, LINK_TEXT, LINK_URL } from '../constants';
 import { BrowserConfig } from '../config';
 
 export const fileDownloadTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-file-download-tracking-browser';
-  const type = PluginType.ENRICHMENT;
-  const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
+  const type = 'enrichment';
+  const setup = async (config: BrowserConfig, amplitude: BrowserClient) => {
     /* istanbul ignore if */
     if (!amplitude) {
       // TODO: Add required minimum version of @amplitude/analytics-browser

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -1,4 +1,4 @@
-import { BrowserClient, PluginType, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { BrowserClient, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import {
   DEFAULT_FORM_START_EVENT,
   DEFAULT_FORM_SUBMIT_EVENT,
@@ -10,8 +10,8 @@ import { BrowserConfig } from '../config';
 
 export const formInteractionTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-form-interaction-tracking-browser';
-  const type = PluginType.ENRICHMENT;
-  const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
+  const type = 'enrichment';
+  const setup = async (config: BrowserConfig, amplitude: BrowserClient) => {
     /* istanbul ignore if */
     if (!amplitude) {
       // TODO: Add required minimum version of @amplitude/analytics-browser

--- a/packages/analytics-browser/src/plugins/session-handler.ts
+++ b/packages/analytics-browser/src/plugins/session-handler.ts
@@ -1,4 +1,4 @@
-import { BeforePlugin, BrowserClient, BrowserConfig, Event, PluginType } from '@amplitude/analytics-types';
+import { BeforePlugin, BrowserClient, BrowserConfig, Event } from '@amplitude/analytics-types';
 import { DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from '../constants';
 
 export const sessionHandlerPlugin = (): BeforePlugin => {
@@ -13,7 +13,7 @@ export const sessionHandlerPlugin = (): BeforePlugin => {
 
   const name = '@amplitude/plugin-session-handler';
 
-  const type = PluginType.BEFORE;
+  const type = 'before';
 
   const setup = async (config: BrowserConfig, client: BrowserClient) => {
     browserConfig = config;

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -1,7 +1,7 @@
 import * as Config from '../src/config';
 import * as LocalStorageModule from '../src/storage/local-storage';
 import * as core from '@amplitude/analytics-core';
-import { LogLevel, Storage, TransportType, UserSession } from '@amplitude/analytics-types';
+import { LogLevel, Storage, UserSession } from '@amplitude/analytics-types';
 import * as BrowserUtils from '@amplitude/analytics-client-common';
 import { getCookieName, FetchTransport } from '@amplitude/analytics-client-common';
 import { XHRTransport } from '../src/transports/xhr';
@@ -73,6 +73,11 @@ describe('config', () => {
         transportProvider: new FetchTransport(),
         useBatch: false,
       });
+    });
+
+    test('shoud return _optOut', () => {
+      const config = new Config.BrowserConfig(apiKey);
+      expect(config.optOut).toBe(false);
     });
   });
 
@@ -254,15 +259,15 @@ describe('config', () => {
 
   describe('createTransport', () => {
     test('should return xhr', () => {
-      expect(createTransport(TransportType.XHR)).toBeInstanceOf(XHRTransport);
+      expect(createTransport('xhr')).toBeInstanceOf(XHRTransport);
     });
 
     test('should return beacon', () => {
-      expect(createTransport(TransportType.SendBeacon)).toBeInstanceOf(SendBeaconTransport);
+      expect(createTransport('beacon')).toBeInstanceOf(SendBeaconTransport);
     });
 
     test('should return fetch', () => {
-      expect(createTransport(TransportType.Fetch)).toBeInstanceOf(FetchTransport);
+      expect(createTransport('fetch')).toBeInstanceOf(FetchTransport);
     });
   });
 

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -27,7 +27,7 @@ describe('fileDownloadTracking', () => {
     document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // trigger change event
     document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
@@ -47,7 +47,7 @@ describe('fileDownloadTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // add anchor element dynamically
     const link = document.createElement('a');
@@ -77,7 +77,7 @@ describe('fileDownloadTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // add anchor element dynamically
     const link = document.createElement('a');
@@ -113,7 +113,7 @@ describe('fileDownloadTracking', () => {
     document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.png');
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // trigger change event
     document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
@@ -127,7 +127,7 @@ describe('fileDownloadTracking', () => {
       event_type: 'page_view',
     };
     const plugin = fileDownloadTracking();
-    const result = await plugin.execute(input);
+    const result = await plugin.execute?.(input);
     expect(result).toEqual(input);
   });
 });

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -36,7 +36,7 @@ describe('formInteractionTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // trigger change event
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
@@ -60,7 +60,7 @@ describe('formInteractionTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // add form elemen dynamically
     const form = document.createElement('form');
@@ -104,7 +104,7 @@ describe('formInteractionTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // add form elemen dynamically
     const form = document.createElement('form');
@@ -152,7 +152,7 @@ describe('formInteractionTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // trigger change event
     document.getElementById('my-form-id')?.dispatchEvent(new Event('submit'));
@@ -175,7 +175,7 @@ describe('formInteractionTracking', () => {
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
-    await plugin.setup(config, amplitude);
+    await plugin.setup?.(config, amplitude);
 
     // trigger change event again
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
@@ -205,7 +205,7 @@ describe('formInteractionTracking', () => {
       event_type: 'page_view',
     };
     const plugin = formInteractionTracking();
-    const result = await plugin.execute(input);
+    const result = await plugin.execute?.(input);
     expect(result).toEqual(input);
   });
 });

--- a/packages/analytics-browser/test/plugins/session-handler.test.ts
+++ b/packages/analytics-browser/test/plugins/session-handler.test.ts
@@ -18,8 +18,8 @@ describe('sessionHandlerPlugin', () => {
       lastEventTime: time - 999,
       sessionTimeout: 1000,
     });
-    await plugin.setup(config, amplitude);
-    await plugin.execute({
+    await plugin.setup?.(config, amplitude);
+    await plugin.execute?.({
       event_type: 'Test Event',
     });
 
@@ -40,8 +40,8 @@ describe('sessionHandlerPlugin', () => {
       lastEventTime: undefined,
       sessionTimeout: 1000,
     });
-    await plugin.setup(config, amplitude);
-    await plugin.execute({
+    await plugin.setup?.(config, amplitude);
+    await plugin.execute?.({
       event_type: 'Test Event',
     });
 
@@ -66,8 +66,8 @@ describe('sessionHandlerPlugin', () => {
         sessions: true,
       },
     });
-    await plugin.setup(config, amplitude);
-    await plugin.execute({
+    await plugin.setup?.(config, amplitude);
+    await plugin.execute?.({
       event_type: 'Test Event',
     });
 
@@ -86,8 +86,8 @@ describe('sessionHandlerPlugin', () => {
         sessions: true,
       },
     });
-    await plugin.setup(config, amplitude);
-    await plugin.execute({
+    await plugin.setup?.(config, amplitude);
+    await plugin.execute?.({
       event_type: eventType,
     });
 

--- a/packages/analytics-client-common/src/plugins/identity.ts
+++ b/packages/analytics-client-common/src/plugins/identity.ts
@@ -1,9 +1,9 @@
-import { BeforePlugin, Config, Event, PluginType } from '@amplitude/analytics-types';
+import { BeforePlugin, Config, Event } from '@amplitude/analytics-types';
 import { getAnalyticsConnector } from '../analytics-connector';
 
 export class IdentityEventSender implements BeforePlugin {
   name = 'identity';
-  type = PluginType.BEFORE as const;
+  type = 'before' as const;
 
   identityStore = getAnalyticsConnector().identityStore;
 

--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -7,8 +7,8 @@ import {
   Transport,
   Plan,
   IngestionMetadata,
-  ServerZone,
   Options,
+  ServerZoneType,
 } from '@amplitude/analytics-types';
 import {
   AMPLITUDE_SERVER_URL,
@@ -27,7 +27,7 @@ export const getDefaultConfig = () => ({
   loggerProvider: new Logger(),
   optOut: false,
   serverUrl: AMPLITUDE_SERVER_URL,
-  serverZone: ServerZone.US,
+  serverZone: 'US' as ServerZoneType,
   useBatch: false,
 });
 
@@ -42,7 +42,7 @@ export class Config implements IConfig {
   plan?: Plan;
   ingestionMetadata?: IngestionMetadata;
   serverUrl: string | undefined;
-  serverZone?: keyof typeof ServerZone;
+  serverZone?: ServerZoneType;
   transportProvider: Transport;
   storageProvider?: Storage<Event[]>;
   useBatch: boolean;
@@ -80,8 +80,8 @@ export class Config implements IConfig {
   }
 }
 
-export const getServerUrl = (serverZone: keyof typeof ServerZone, useBatch: boolean) => {
-  if (serverZone === ServerZone.EU) {
+export const getServerUrl = (serverZone: ServerZoneType, useBatch: boolean) => {
+  if (serverZone === 'EU') {
     return useBatch ? EU_AMPLITUDE_BATCH_SERVER_URL : EU_AMPLITUDE_SERVER_URL;
   }
   return useBatch ? AMPLITUDE_BATCH_SERVER_URL : AMPLITUDE_SERVER_URL;
@@ -89,7 +89,7 @@ export const getServerUrl = (serverZone: keyof typeof ServerZone, useBatch: bool
 
 export const createServerConfig = (
   serverUrl = '',
-  serverZone: keyof typeof ServerZone = getDefaultConfig().serverZone,
+  serverZone: ServerZoneType = getDefaultConfig().serverZone,
   useBatch: boolean = getDefaultConfig().useBatch,
 ) => {
   if (serverUrl) {

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -5,7 +5,6 @@ import {
   Event,
   InvalidResponse,
   PayloadTooLargeResponse,
-  PluginType,
   RateLimitResponse,
   Response,
   Result,
@@ -26,7 +25,7 @@ import { createServerConfig } from '../config';
 
 export class Destination implements DestinationPlugin {
   name = 'amplitude';
-  type = PluginType.DESTINATION as const;
+  type = 'destination' as const;
 
   retryTimeout = 1000;
   throttleTimeout = 30000;

--- a/packages/analytics-core/test/config.test.ts
+++ b/packages/analytics-core/test/config.test.ts
@@ -1,4 +1,4 @@
-import { LogLevel, ServerZone } from '@amplitude/analytics-types';
+import { LogLevel } from '@amplitude/analytics-types';
 import {
   AMPLITUDE_BATCH_SERVER_URL,
   AMPLITUDE_SERVER_URL,
@@ -79,16 +79,16 @@ describe('config', () => {
 
   describe('getServerUrl', () => {
     test('should return eu batch url', () => {
-      expect(getServerUrl(ServerZone.EU, true)).toBe(EU_AMPLITUDE_BATCH_SERVER_URL);
+      expect(getServerUrl('EU', true)).toBe(EU_AMPLITUDE_BATCH_SERVER_URL);
     });
     test('should return eu http url', () => {
-      expect(getServerUrl(ServerZone.EU, false)).toBe(EU_AMPLITUDE_SERVER_URL);
+      expect(getServerUrl('EU', false)).toBe(EU_AMPLITUDE_SERVER_URL);
     });
     test('should return us batch url', () => {
-      expect(getServerUrl(ServerZone.US, true)).toBe(AMPLITUDE_BATCH_SERVER_URL);
+      expect(getServerUrl('US', true)).toBe(AMPLITUDE_BATCH_SERVER_URL);
     });
     test('should return us http url', () => {
-      expect(getServerUrl(ServerZone.US, false)).toBe(AMPLITUDE_SERVER_URL);
+      expect(getServerUrl('US', false)).toBe(AMPLITUDE_SERVER_URL);
     });
   });
 
@@ -104,7 +104,7 @@ describe('config', () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore to test invalid values
       expect(createServerConfig('', '', undefined)).toEqual({
-        serverZone: ServerZone.US,
+        serverZone: 'US',
         serverUrl: AMPLITUDE_SERVER_URL,
       });
     });

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { Event, Plugin, PluginType, Status } from '@amplitude/analytics-types';
+import { Event, Plugin, Status } from '@amplitude/analytics-types';
 import { AmplitudeCore, Identify, Revenue } from '../src/index';
 import { useDefaultConfig } from './helpers/default';
 import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from '../src/messages';
@@ -76,7 +76,7 @@ describe('core-client', () => {
       const execute = jest.fn();
       const plugin: Plugin = {
         name: 'plugin',
-        type: PluginType.BEFORE,
+        type: 'before',
         setup: setup,
         execute: execute,
       };
@@ -86,7 +86,7 @@ describe('core-client', () => {
       expect(register).toHaveBeenCalledTimes(1);
 
       // remove
-      await client.remove(plugin.name).promise;
+      await client.remove('plugin').promise;
       expect(deregister).toHaveBeenCalledTimes(1);
     });
 
@@ -96,7 +96,7 @@ describe('core-client', () => {
       const deregister = jest.spyOn(client.timeline, 'deregister');
       await client.add({
         name: 'example',
-        type: PluginType.BEFORE,
+        type: 'before',
         setup: jest.fn(),
         execute: jest.fn(),
       }).promise;
@@ -235,7 +235,7 @@ describe('core-client', () => {
       const execute = jest.fn();
       const plugin: Plugin = {
         name: 'plugin',
-        type: PluginType.DESTINATION,
+        type: 'destination',
         setup: setup,
         execute: execute,
       };

--- a/packages/analytics-node/src/plugins/context.ts
+++ b/packages/analytics-node/src/plugins/context.ts
@@ -1,10 +1,10 @@
-import { BeforePlugin, NodeConfig, Event, PluginType } from '@amplitude/analytics-types';
+import { BeforePlugin, NodeConfig, Event } from '@amplitude/analytics-types';
 import { UUID } from '@amplitude/analytics-core';
 import { VERSION } from '../version';
 
 export class Context implements BeforePlugin {
-  name = 'context';
-  type = PluginType.BEFORE as const;
+  name = '@amplitude/plugin-context-node';
+  type = 'before' as const;
 
   // this.config is defined in setup() which will always be called first
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@types/react": "^18.0.26",
     "@types/react-native": "0.70.8",
+    "@types/ua-parser-js": "^0.7.36",
     "react": "18.2.0",
     "react-native": "0.70.6",
     "react-native-builder-bob": "^0.20.3"

--- a/packages/analytics-react-native/src/plugins/context.ts
+++ b/packages/analytics-react-native/src/plugins/context.ts
@@ -1,4 +1,4 @@
-import { BeforePlugin, ReactNativeConfig, Event, PluginType } from '@amplitude/analytics-types';
+import { BeforePlugin, ReactNativeConfig, Event } from '@amplitude/analytics-types';
 import UAParser from '@amplitude/ua-parser-js';
 import { UUID } from '@amplitude/analytics-core';
 import { getLanguage } from '@amplitude/analytics-client-common';
@@ -26,8 +26,8 @@ export interface AmplitudeReactNative {
 }
 
 export class Context implements BeforePlugin {
-  name = 'context';
-  type = PluginType.BEFORE as const;
+  name = '@amplitude/plugin-context-react-native';
+  type = 'before' as const;
 
   // this.config is defined in setup() which will always be called first
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/analytics-types/src/client/core-client.ts
+++ b/packages/analytics-types/src/client/core-client.ts
@@ -12,7 +12,7 @@ export interface CoreClient {
    * ```typescript
    * const plugin = {
    *   name: 'myPlugin',
-   *   type: PluginType.ENRICHMENT,
+   *   type: 'enrichment',
    *   setup(config: Config) {
    *     return;
    *   },

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -55,7 +55,7 @@ export interface CookieOptions {
   upgrade?: boolean;
 }
 
-type HiddenOptions = 'apiKey';
+type HiddenOptions = 'apiKey' | 'transportProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface BrowserOptions extends Omit<Partial<ExternalBrowserConfig>, HiddenOptions> {}

--- a/packages/analytics-types/src/config/core.ts
+++ b/packages/analytics-types/src/config/core.ts
@@ -1,7 +1,7 @@
 import { Event } from '../event';
 import { IngestionMetadata } from '../ingestion-metadata';
 import { Plan } from '../plan';
-import { ServerZone } from '../server-zone';
+import { ServerZoneType } from '../server-zone';
 import { Storage } from '../storage';
 import { Transport } from '../transport';
 import { Logger, LogLevel } from '../logger';
@@ -18,7 +18,7 @@ export interface Config {
   plan?: Plan;
   ingestionMetadata?: IngestionMetadata;
   serverUrl?: string;
-  serverZone?: keyof typeof ServerZone;
+  serverZone?: ServerZoneType;
   storageProvider?: Storage<Event[]>;
   transportProvider: Transport;
   useBatch: boolean;

--- a/packages/analytics-types/src/config/react-native.ts
+++ b/packages/analytics-types/src/config/react-native.ts
@@ -47,5 +47,5 @@ export interface ReactNativeAttributionOptions {
 type HiddenOptions = 'apiKey' | 'lastEventId';
 
 export interface ReactNativeOptions extends Omit<Partial<ReactNativeConfig>, HiddenOptions> {
-  transport?: TransportType | keyof typeof TransportType;
+  transport?: TransportType;
 }

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -52,7 +52,7 @@ export { Plugin, BeforePlugin, EnrichmentPlugin, DestinationPlugin, PluginType }
 export { Result } from './result';
 export { Response, SuccessResponse, InvalidResponse, PayloadTooLargeResponse, RateLimitResponse } from './response';
 export { QueueProxy, InstanceProxy } from './proxy';
-export { ServerZone, ServerZoneType } from './server-zone';
+export { ServerZoneType } from './server-zone';
 export { Status } from './status';
 export { CookieStorageOptions, IdentityStorageType, Storage } from './storage';
 export { Transport, TransportType } from './transport';

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -3,30 +3,29 @@ import { Config } from './config';
 import { Result } from './result';
 import { CoreClient } from './client/core-client';
 
-export enum PluginType {
-  BEFORE = 'before',
-  ENRICHMENT = 'enrichment',
-  DESTINATION = 'destination',
+type BeforePluginType = 'before';
+type EnrichmentPluginType = 'enrichment';
+type DestinationPluginType = 'destination';
+export type PluginType = BeforePluginType | EnrichmentPluginType | DestinationPluginType;
+
+interface PluginBase<T = CoreClient> {
+  name?: string;
+  type?: PluginType;
+  setup?(config: Config, client: T): Promise<void>;
 }
 
-export interface BeforePlugin<T = CoreClient> {
-  name: string;
-  type: PluginType.BEFORE;
-  setup(config: Config, client?: T): Promise<void>;
-  execute(context: Event): Promise<Event | null>;
+export interface BeforePlugin extends PluginBase {
+  type: BeforePluginType;
+  execute?(context: Event): Promise<Event | null>;
 }
 
-export interface EnrichmentPlugin<T = CoreClient> {
-  name: string;
-  type: PluginType.ENRICHMENT;
-  setup(config: Config, client?: T): Promise<void>;
-  execute(context: Event): Promise<Event | null>;
+export interface EnrichmentPlugin extends PluginBase {
+  type?: EnrichmentPluginType;
+  execute?(context: Event): Promise<Event | null>;
 }
 
-export interface DestinationPlugin<T = CoreClient> {
-  name: string;
-  type: PluginType.DESTINATION;
-  setup(config: Config, client?: T): Promise<void>;
+export interface DestinationPlugin extends PluginBase {
+  type: DestinationPluginType;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
 }

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -3,10 +3,10 @@ import { Config } from './config';
 import { Result } from './result';
 import { CoreClient } from './client/core-client';
 
-type BeforePluginType = 'before';
-type EnrichmentPluginType = 'enrichment';
-type DestinationPluginType = 'destination';
-export type PluginType = BeforePluginType | EnrichmentPluginType | DestinationPluginType;
+type PluginTypeBefore = 'before';
+type PluginTypeEnrichment = 'enrichment';
+type PluginTypeDestination = 'destination';
+export type PluginType = PluginTypeBefore | PluginTypeEnrichment | PluginTypeDestination;
 
 interface PluginBase<T = CoreClient> {
   name?: string;
@@ -15,17 +15,17 @@ interface PluginBase<T = CoreClient> {
 }
 
 export interface BeforePlugin extends PluginBase {
-  type: BeforePluginType;
+  type: PluginTypeBefore;
   execute?(context: Event): Promise<Event | null>;
 }
 
 export interface EnrichmentPlugin extends PluginBase {
-  type?: EnrichmentPluginType;
+  type?: PluginTypeEnrichment;
   execute?(context: Event): Promise<Event | null>;
 }
 
 export interface DestinationPlugin extends PluginBase {
-  type: DestinationPluginType;
+  type: PluginTypeDestination;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
 }

--- a/packages/analytics-types/src/server-zone.ts
+++ b/packages/analytics-types/src/server-zone.ts
@@ -1,9 +1,1 @@
-/**
- * @deprecated
- */
-export enum ServerZone {
-  US = 'US',
-  EU = 'EU',
-}
-
 export type ServerZoneType = 'US' | 'EU';

--- a/packages/analytics-types/src/transport.ts
+++ b/packages/analytics-types/src/transport.ts
@@ -5,11 +5,4 @@ export interface Transport {
   send(serverUrl: string, payload: Payload): Promise<Response | null>;
 }
 
-/**
- * @deprecated
- */
-export enum TransportType {
-  XHR = 'xhr',
-  SendBeacon = 'beacon',
-  Fetch = 'fetch',
-}
+export type TransportType = 'xhr' | 'beacon' | 'fetch';

--- a/packages/marketing-analytics-browser/src/plugins/context.ts
+++ b/packages/marketing-analytics-browser/src/plugins/context.ts
@@ -1,11 +1,11 @@
-import { Event, PluginType, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { VERSION } from '../version';
 
 export const context = (): EnrichmentPlugin => {
   const library = `amplitude-ma-ts/${VERSION}`;
   return {
     name: 'context',
-    type: PluginType.ENRICHMENT,
+    type: 'enrichment',
     setup: async () => undefined,
     execute: async (context: Event) => ({
       ...context,

--- a/packages/marketing-analytics-browser/test/plugins/context.test.ts
+++ b/packages/marketing-analytics-browser/test/plugins/context.test.ts
@@ -1,16 +1,18 @@
 import { Config } from '@amplitude/analytics-types';
 import { context } from '../../src/plugins/context';
+import { createInstance } from '@amplitude/analytics-browser';
 
 describe('context', () => {
   describe('execute', () => {
     test('should execute plugin', async () => {
+      const amplitude = createInstance();
       const plugin = context();
-      await plugin.setup({} as Config);
+      await plugin.setup?.({} as Config, amplitude);
 
       const e = {
         event_type: 'event_type',
       };
-      const event = await plugin.execute(e);
+      const event = await plugin.execute?.(e);
       expect(event?.library).toMatch(/^amplitude-ma-ts\/.+/);
     });
   });

--- a/packages/plugin-page-view-tracking-browser/rollup.config.js
+++ b/packages/plugin-page-view-tracking-browser/rollup.config.js
@@ -1,6 +1,3 @@
-import { umd, iife } from '../../scripts/build/rollup.config';
+import { umd } from '../../scripts/build/rollup.config';
 
-iife.input = umd.input;
-iife.output.name = 'pageViewTracking';
-
-export default [umd, iife];
+export default [umd];

--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -2,11 +2,11 @@ import { CampaignParser, getGlobalScope } from '@amplitude/analytics-client-comm
 import {
   BrowserClient,
   BrowserConfig,
+  EnrichmentPlugin,
   Event,
   IdentifyOperation,
   IdentifyUserProperties,
   Logger,
-  PluginType,
 } from '@amplitude/analytics-types';
 import { BASE_CAMPAIGN } from '@amplitude/analytics-client-common';
 import { CreatePageViewTrackingPlugin, Options } from './typings/page-view-tracking';
@@ -52,9 +52,9 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
     previousURL = newURL;
   };
 
-  const plugin = {
+  const plugin: EnrichmentPlugin = {
     name: '@amplitude/plugin-page-view-tracking-browser',
-    type: PluginType.ENRICHMENT as const,
+    type: 'enrichment',
 
     setup: async (config: BrowserConfig, client: BrowserClient) => {
       amplitude = client;

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -82,7 +82,7 @@ describe('pageViewTrackingPlugin', () => {
         }),
       });
       const plugin = pageViewTrackingPlugin(options);
-      await plugin.setup(mockConfig, amplitude);
+      await plugin.setup?.(mockConfig, amplitude);
       expect(track).toHaveBeenCalledWith({
         event_properties: {
           '[Amplitude] Page Domain': hostname,
@@ -112,7 +112,7 @@ describe('pageViewTrackingPlugin', () => {
       const amplitude = createInstance();
       const track = jest.spyOn(amplitude, 'track');
       const plugin = pageViewTrackingPlugin(options);
-      await plugin.setup(mockConfig, amplitude);
+      await plugin.setup?.(mockConfig, amplitude);
       expect(track).toHaveBeenCalledTimes(0);
     });
 
@@ -136,7 +136,7 @@ describe('pageViewTrackingPlugin', () => {
       mockWindowLocationFromURL(oldURL);
 
       const plugin = pageViewTrackingPlugin(options);
-      await plugin.setup(mockConfig, amplitude);
+      await plugin.setup?.(mockConfig, amplitude);
 
       const newURL = new URL('https://www.example.com/about');
       mockWindowLocationFromURL(newURL);
@@ -182,7 +182,7 @@ describe('pageViewTrackingPlugin', () => {
       mockWindowLocationFromURL(oldURL);
 
       const plugin = pageViewTrackingPlugin(options);
-      await plugin.setup(mockConfig, amplitude);
+      await plugin.setup?.(mockConfig, amplitude);
 
       const newURL = new URL('https://www.example.com?page=about');
       mockWindowLocationFromURL(newURL);
@@ -201,7 +201,7 @@ describe('pageViewTrackingPlugin', () => {
       const plugin = pageViewTrackingPlugin({
         trackOn: 'attribution',
       });
-      const event = await plugin.execute({
+      const event = await plugin.execute?.({
         event_type: '$identify',
         user_properties: {
           $set: {
@@ -261,7 +261,7 @@ describe('pageViewTrackingPlugin', () => {
         event_type: '$identify',
         user_properties: {},
       };
-      const event = await plugin.execute(sentEvent);
+      const event = await plugin.execute?.(sentEvent);
       expect(event).toBe(sentEvent);
     });
 
@@ -273,7 +273,7 @@ describe('pageViewTrackingPlugin', () => {
       const sentEvent = {
         event_type: '$identify',
       };
-      const event = await plugin.execute(sentEvent);
+      const event = await plugin.execute?.(sentEvent);
       expect(event).toBe(sentEvent);
     });
 
@@ -285,7 +285,7 @@ describe('pageViewTrackingPlugin', () => {
       const sentEvent = {
         event_type: '[Amplitude] Page Viewed',
       };
-      const event = await plugin.execute(sentEvent);
+      const event = await plugin.execute?.(sentEvent);
       expect(event).toBe(sentEvent);
     });
   });

--- a/packages/plugin-web-attribution-browser/rollup.config.js
+++ b/packages/plugin-web-attribution-browser/rollup.config.js
@@ -1,6 +1,3 @@
-import { umd, iife } from '../../scripts/build/rollup.config';
+import { umd } from '../../scripts/build/rollup.config';
 
-iife.input = umd.input;
-iife.output.name = 'webAttribution';
-
-export default [umd, iife];
+export default [umd];

--- a/packages/plugin-web-attribution-browser/src/web-attribution.ts
+++ b/packages/plugin-web-attribution-browser/src/web-attribution.ts
@@ -1,20 +1,12 @@
 import { CampaignParser } from '@amplitude/analytics-client-common';
-import {
-  BeforePlugin,
-  BrowserClient,
-  BrowserConfig,
-  Campaign,
-  Event,
-  PluginType,
-  Storage,
-} from '@amplitude/analytics-types';
+import { BeforePlugin, BrowserClient, BrowserConfig, Campaign, Event, Storage } from '@amplitude/analytics-types';
 import { createCampaignEvent, getDefaultExcludedReferrers, getStorageKey, isNewCampaign } from './helpers';
 import { CreateWebAttributionPlugin, Options } from './typings/web-attribution';
 
 export const webAttributionPlugin: CreateWebAttributionPlugin = function (options: Options = {}) {
   const plugin: BeforePlugin = {
     name: '@amplitude/plugin-web-attribution-browser',
-    type: PluginType.BEFORE,
+    type: 'before',
 
     setup: async function (config: BrowserConfig, amplitude: BrowserClient) {
       const pluginConfig = {

--- a/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
+++ b/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
@@ -59,7 +59,7 @@ describe('webAttributionPlugin', () => {
           ...mockConfig,
           cookieOptions: undefined,
         };
-        await plugin.setup(overrideMockConfig, amplitude);
+        await plugin.setup?.(overrideMockConfig, amplitude);
         expect(track).toHaveBeenCalledWith({
           event_type: '$identify',
           user_properties: {
@@ -134,7 +134,7 @@ describe('webAttributionPlugin', () => {
         const plugin = webAttributionPlugin({
           resetSessionOnNewCampaign: true,
         });
-        await plugin.setup(mockConfig, amplitude);
+        await plugin.setup?.(mockConfig, amplitude);
         expect(track).toHaveBeenCalledWith({
           event_type: '$identify',
           user_properties: {
@@ -210,7 +210,7 @@ describe('webAttributionPlugin', () => {
         const plugin = webAttributionPlugin({
           excludeReferrers: [],
         });
-        await plugin.setup(mockConfig, amplitude);
+        await plugin.setup?.(mockConfig, amplitude);
         expect(track).toHaveBeenCalledTimes(0);
       });
     });
@@ -240,7 +240,7 @@ describe('webAttributionPlugin', () => {
       },
     };
     const plugin = webAttributionPlugin();
-    await plugin.setup(overrideMockConfig, amplitude);
+    await plugin.setup?.(overrideMockConfig, amplitude);
     expect(track).toHaveBeenCalledTimes(0);
   });
 
@@ -260,7 +260,7 @@ describe('webAttributionPlugin', () => {
         },
         event_type: '[Amplitude] Page Viewed',
       };
-      const result = await plugin.execute(event);
+      const result = await plugin.execute?.(event);
 
       expect(result).toBe(event);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,6 +4011,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
+"@types/ua-parser-js@^0.7.36":
+  version "0.7.36"
+  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
+  integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"


### PR DESCRIPTION
## Summary

### Changes to @amplitude/analytics-browser

#### Simplify enums plugin development

Previously creating plugins require 4 properties/methods specifically `name`, `type`, `setup`, and `execute`. With this change, `name` defaults to a UUID, type defaults to `"enrichment"`, setup defaults to a no-op fn. for enrichment plugin, `execute` defaults to a passthrough fn. for destination plugin, `execute` is required. Below is the summary of changes:

| Field | Required? | Default |
|--------|--------|--------|
| name | No | UUID |
| type | No | `"enrichment"` | 
| setup | No | no-op | 
| execute | For destination plugin only | passthrough | 

```diff
const enrichmentPlugin: EnrichmentPlugin = {
-  // the values below are the new defaults. omitting will achieve similar results.
-   name: UUID(),
-   type: 'enrichment',
-   setup: async () => undefined,
-   execute: async (e) => e,
};
```

#### Eliminate enums

Removes enums for `TransportType` `ServerZone` and `PluginType`. Removes overhead of learning how to import and use enum. Replaces with old enum's literal values.

**Setting transport provider on initialization**

```diff
  import * as amplitude from '@amplitude/analytics-browser';

  amplitude.init(API_KEY, USER_ID, {
-   transport: amplitude.Types.TransportType.Fetch,
+   transport: 'fetch',
  });
```

**Setting transport provider using `setTransport()`**

```diff
  import * as amplitude from '@amplitude/analytics-browser';

- amplitude.setTransport(amplitude.Types.TransportProvider.Fetch);
+ amplitude.setTransport('fetch');
```

**Setting server zone on initialization**

```diff
  import * as amplitude from '@amplitude/analytics-browser';

  amplitude.init(API_KEY, USER_ID, {
-   serverZone: amplitude.Types.ServerZone.US,
+   serverZone: 'US',
  });
```

**Creating plugins**

```diff
import * as amplitude from '@amplitude/analytics-browser';

const plugin: EnrichmentPlugin = {
  name: 'my-plugin',
-   type: amplitude.Types.PluginType.ENRICHMENT;
+  type: 'enrichment'; 
  setup: async () => undefined;
  execute: async (e) => e;
};
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes
