### PR TITLE
build: remove unnecessary beta script guard

### DIFF
--- a/scripts/version/create-snippet.js
+++ b/scripts/version/create-snippet.js
@@ -4,9 +4,9 @@ const path = require('path');
 const { snippet } = require('../templates/browser-snippet.template');
 const { getName, getVersion } = require('../utils');
 const babel = require('@babel/core');
-const yargs = require('yargs/yargs')
-const { hideBin } = require('yargs/helpers')
-const argv = yargs(hideBin(process.argv)).argv
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+const argv = yargs(hideBin(process.argv)).argv;
 
 // Setup input
 const inputDir = 'lib/scripts';
@@ -33,13 +33,11 @@ const encoding = 'base64';
 const inputText = fs.readFileSync(inputPath, 'utf-8');
 const integrity = algorithm + '-' + crypto.createHash(algorithm).update(inputText).digest(encoding);
 const version = getVersion() || '';
-const outputText = header + snippet(getName()+nameSuffix, integrity, getVersion(), globalVar);
+const outputText = header + snippet(getName() + nameSuffix, integrity, getVersion(), globalVar);
 const { code: transpiledOutputText } = babel.transformSync(outputText, {
   presets: ['env'],
 });
 
-if (!version.includes('beta')) {
-  // Write to disk
-  fs.writeFileSync(outputPath, transpiledOutputText);
-  console.log(`Generated ${outputFile}`);
-}
+// Write to disk
+fs.writeFileSync(outputPath, transpiledOutputText);
+console.log(`Generated ${outputFile}`);


### PR DESCRIPTION
### Summary

I recently added dist tags to published versions. The dist tag should label `latest` or `next` (beta) tags appropriately. The guard to prevent generating beta script loaders is not needed, and would not be visible in the npm package's homepage because of dist tags.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No