### PR TITLE
build: remove plugin upload to s3

### DIFF
--- a/packages/plugin-page-view-tracking-browser/package.json
+++ b/packages/plugin-page-view-tracking-browser/package.json
@@ -28,7 +28,6 @@
     "lint": "yarn lint:eslint & yarn lint:prettier",
     "lint:eslint": "eslint '{src,test}/**/*.ts'",
     "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
-    "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json"
   },

--- a/packages/plugin-web-attribution-browser/package.json
+++ b/packages/plugin-web-attribution-browser/package.json
@@ -28,7 +28,6 @@
     "lint": "yarn lint:eslint & yarn lint:prettier",
     "lint:eslint": "eslint '{src,test}/**/*.ts'",
     "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
-    "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json"
   },


### PR DESCRIPTION
### Summary

Removes command to upload plugin packages to s3

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
