### PR TITLE
feat: log response body from API to logger

### DIFF
--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -169,7 +169,8 @@ export class Destination implements DestinationPlugin {
     const { status } = res;
     let responseBodyString;
     try {
-      responseBodyString = 'body' in res ? JSON.stringify(res.body) : undefined;
+      responseBodyString =
+        'body' in res ? JSON.stringify({ code: res.statusCode, ...res.body }) : { code: res.statusCode };
     } catch {
       // to avoid crash, but don't care about the error, add comment to avoid empty block lint error
     }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -193,7 +193,9 @@ export class Destination implements DestinationPlugin {
         break;
       }
       default: {
+        // log intermediate event status before retry
         this.config.loggerProvider.warn(`{code: 0, error: "Status '${status}' provided for ${list.length} events"}`);
+
         this.handleOtherResponse(list);
         break;
       }
@@ -277,9 +279,6 @@ export class Destination implements DestinationPlugin {
   }
 
   handleOtherResponse(list: Context[]) {
-    // log intermediate event status before retry
-    this.config.loggerProvider.warn(`{code: 0, error: "${UNEXPECTED_ERROR_MESSAGE}"}`);
-
     this.addToQueue(
       ...list.map((context) => {
         context.timeout = context.attempts * this.retryTimeout;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -160,8 +160,9 @@ export class Destination implements DestinationPlugin {
       }
       this.handleResponse(res, list);
     } catch (e) {
-      this.config.loggerProvider.error(getErrorMessage(e));
-      this.fulfillRequest(list, 0, String(e));
+      const errorMessage = getErrorMessage(e);
+      this.config.loggerProvider.error(errorMessage);
+      this.fulfillRequest(list, 0, errorMessage);
     }
   }
 

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -178,7 +178,6 @@ export class Destination implements DestinationPlugin {
 
     switch (status) {
       case Status.Success: {
-        this.config.loggerProvider.log(responseBodyString);
         this.handleSuccessResponse(res, list);
         break;
       }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -158,14 +158,14 @@ export class Destination implements DestinationPlugin {
         }
         return;
       }
-      this.handleReponse(res, list);
+      this.handleResponse(res, list);
     } catch (e) {
       this.config.loggerProvider.error(getErrorMessage(e));
       this.fulfillRequest(list, 0, String(e));
     }
   }
 
-  handleReponse(res: Response, list: Context[]) {
+  handleResponse(res: Response, list: Context[]) {
     const { status } = res;
     let responseBodyString;
     try {
@@ -198,7 +198,7 @@ export class Destination implements DestinationPlugin {
       }
       default: {
         this.config.loggerProvider.warn(`{code: 0, error: "Status '${status}' provided for ${list.length} events"}`);
-        this.handleOtherReponse(list);
+        this.handleOtherResponse(list);
         break;
       }
     }
@@ -267,7 +267,7 @@ export class Destination implements DestinationPlugin {
     this.addToQueue(...retry);
   }
 
-  handleOtherReponse(list: Context[]) {
+  handleOtherResponse(list: Context[]) {
     this.addToQueue(
       ...list.map((context) => {
         context.timeout = context.attempts * this.retryTimeout;

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -977,7 +977,7 @@ describe('destination', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/unbound-method,@typescript-eslint/restrict-template-expressions
-      expect(loggerProvider.warn).toHaveBeenCalledWith(JSON.stringify(response.body));
+      expect(loggerProvider.warn).toHaveBeenCalledWith(JSON.stringify({ code: statusCode, ...response.body }));
     });
 
     test.each([

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -985,7 +985,7 @@ describe('destination', () => {
           code: 200,
         });
 
-        expect(transportProvider.send).toHaveBeenCalledTimes(eventCount == 1 ? 2 : 3);
+        expect(transportProvider.send).toHaveBeenCalledTimes(eventCount + 1);
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
         // eslint-disable-next-line @typescript-eslint/unbound-method,@typescript-eslint/restrict-template-expressions

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -983,7 +983,7 @@ describe('destination', () => {
     test.each([
       { err: new Error('Error'), message: 'Error' },
       { err: 'string error', message: 'string error' },
-    ])('should log unexpected error "%message"', async ({ err, message }) => {
+    ])('should log unexpected error "$message"', async ({ err, message }) => {
       const destination = new Destination();
       const callback = jest.fn();
       const context = {

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -27,7 +27,7 @@ export class Http extends BaseTransport implements Transport {
       port: url.port,
       protocol: url.protocol,
     };
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const req = protocol.request(options, (res) => {
         res.setEncoding('utf8');
         let responsePayload = '';
@@ -43,13 +43,13 @@ export class Http extends BaseTransport implements Transport {
               const result = this.buildResponse(parsedResponsePayload);
               resolve(result);
               return;
-            } catch {
-              resolve(null);
+            } catch (e) {
+              reject(e);
             }
           }
         });
       });
-      req.on('error', this.buildResponse.bind(this));
+      req.on('error', reject);
       req.end(requestPayload);
     });
   }

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -27,7 +27,7 @@ export class Http extends BaseTransport implements Transport {
       port: url.port,
       protocol: url.protocol,
     };
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const req = protocol.request(options, (res) => {
         res.setEncoding('utf8');
         let responsePayload = '';
@@ -43,13 +43,13 @@ export class Http extends BaseTransport implements Transport {
               const result = this.buildResponse(parsedResponsePayload);
               resolve(result);
               return;
-            } catch (e) {
-              reject(e);
+            } catch {
+              resolve(null);
             }
           }
         });
       });
-      req.on('error', reject);
+      req.on('error', () => resolve(null));
       req.end(requestPayload);
     });
   }

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -121,7 +121,7 @@ describe('http transport', () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
-  test('should handle unexpected error', async () => {
+  test('should re-throw unexpected error', async () => {
     const provider = new Http();
     const url = 'http://localhost:3000';
     const payload = {
@@ -151,8 +151,7 @@ describe('http transport', () => {
       } as any;
     });
 
-    const response = await provider.send(url, payload);
-    expect(response).toBe(null);
+    await expect(provider.send(url, payload)).rejects.toThrow('Unexpected token < in JSON at position 0');
     expect(request).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -121,7 +121,7 @@ describe('http transport', () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
-  test('should re-throw unexpected error', async () => {
+  test('should handle unexpected error', async () => {
     const provider = new Http();
     const url = 'http://localhost:3000';
     const payload = {
@@ -151,7 +151,8 @@ describe('http transport', () => {
       } as any;
     });
 
-    await expect(provider.send(url, payload)).rejects.toThrow('Unexpected token < in JSON at position 0');
+    const response = await provider.send(url, payload);
+    expect(response).toBe(null);
     expect(request).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/analytics-types/src/response.ts
+++ b/packages/analytics-types/src/response.ts
@@ -65,7 +65,7 @@ export interface TimeoutResponse {
   statusCode: number;
 }
 
-export interface OtherReponse {
+export interface OtherResponse {
   status: Exclude<Status, StatusWithResponseBody>;
   statusCode: number;
 }
@@ -76,4 +76,4 @@ export type Response =
   | PayloadTooLargeResponse
   | RateLimitResponse
   | TimeoutResponse
-  | OtherReponse;
+  | OtherResponse;


### PR DESCRIPTION
### Summary
* [AMP-77375](https://amplitude.atlassian.net/browse/AMP-77375) FIX: Correctly [resolve `send()` promise on error](https://github.com/amplitude/Amplitude-TypeScript/pull/415/files#r1223588296)
* [AMP-77261](https://amplitude.atlassian.net/browse/AMP-77261) log intermediate response body to logger on retries for Node SDK

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


[AMP-77375]: https://amplitude.atlassian.net/browse/AMP-77375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMP-77261]: https://amplitude.atlassian.net/browse/AMP-77261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ