### PR TITLE
feat: simplify init interface

### DIFF
--- a/packages/analytics-browser-test/test/in-memory-storage.test.ts
+++ b/packages/analytics-browser-test/test/in-memory-storage.test.ts
@@ -27,7 +27,7 @@ describe('Storage options', () => {
     const scope = nock(url).post(path).reply(200, success);
 
     const amplitude = createInstance();
-    await amplitude.init(apiKey, undefined, {
+    await amplitude.init(apiKey, {
       defaultTracking,
     }).promise;
 
@@ -51,7 +51,7 @@ describe('Storage options', () => {
     const scope = nock(url).post(path).reply(200, success);
 
     const amplitude = createInstance();
-    await amplitude.init(apiKey, undefined, {
+    await amplitude.init(apiKey, {
       defaultTracking,
       identityStorage: 'localStorage',
     }).promise;
@@ -78,7 +78,7 @@ describe('Storage options', () => {
     const scope = nock(url).post(path).reply(200, success);
 
     const amplitude = createInstance();
-    await amplitude.init(apiKey, undefined, {
+    await amplitude.init(apiKey, {
       defaultTracking,
       identityStorage: 'none',
       storageProvider: new MemoryStorage(),

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -106,7 +106,7 @@ describe('integration', () => {
           scope.done();
           resolve(undefined);
         });
-        client.init(apiKey, undefined, {
+        client.init(apiKey, {
           defaultTracking,
           serverUrl: url + path,
         });
@@ -132,7 +132,7 @@ describe('integration', () => {
       client.setSessionId(sessionId);
 
       const trackPromise = client.track('Event Before Init').promise;
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking: {
           ...defaultTracking,
           attribution: true,
@@ -236,7 +236,7 @@ describe('integration', () => {
     test('should track event', async () => {
       const scope = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const response = await client.track('test event', {
@@ -297,7 +297,7 @@ describe('integration', () => {
     test('should track event with event options', async () => {
       const scope = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const response = await client.track('test event', undefined, {
@@ -330,7 +330,7 @@ describe('integration', () => {
 
       const sourceName = 'ampli';
       const sourceVersion = '2.0.0';
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
         ingestionMetadata: {
           sourceName,
@@ -369,7 +369,7 @@ describe('integration', () => {
     test('should track event with base event', async () => {
       const scope = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const response = await client.track(
@@ -421,7 +421,7 @@ describe('integration', () => {
         });
       const second = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         logLevel: 0,
         defaultTracking,
       }).promise;
@@ -476,7 +476,7 @@ describe('integration', () => {
       });
       const second = nock(url).post(path).times(2).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         logLevel: 0,
         flushQueueSize: 2,
         defaultTracking,
@@ -532,7 +532,7 @@ describe('integration', () => {
         });
       const second = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         logLevel: 0,
         defaultTracking,
       }).promise;
@@ -586,7 +586,7 @@ describe('integration', () => {
       });
       const second = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         logLevel: 0,
         defaultTracking,
       }).promise;
@@ -634,7 +634,7 @@ describe('integration', () => {
         code: 500,
       });
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         logLevel: 0,
         flushMaxRetries: 3,
         defaultTracking,
@@ -672,7 +672,7 @@ describe('integration', () => {
     });
 
     test('should handle client opt out', async () => {
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         logLevel: 0,
         defaultTracking,
       }).promise;
@@ -687,7 +687,7 @@ describe('integration', () => {
     test('should track event', async () => {
       const scope = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const id = new amplitude.Identify();
@@ -751,7 +751,7 @@ describe('integration', () => {
     test('should track event', async () => {
       const scope = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const rev = new amplitude.Revenue();
@@ -793,7 +793,7 @@ describe('integration', () => {
     test('should track event', async () => {
       const scope = nock(url).post(path).reply(200, success);
 
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const response = await client.setGroup('org', 'engineering').promise;
@@ -1588,7 +1588,7 @@ describe('integration', () => {
       const userId = 'userId';
       const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
       document.cookie = `amp_${apiKey.substring(0, 6)}=deviceId.${encodedUserId}..${time}.${time}`;
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const response = await client.track('test event', {
@@ -1625,7 +1625,7 @@ describe('integration', () => {
       const userId = 'userId';
       const encodedUserId = btoa(unescape(encodeURIComponent(userId)));
       document.cookie = `amp_${apiKey.substring(0, 6)}=deviceId.${encodedUserId}..${time}.${time}`;
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
         cookieOptions: {
           upgrade: false,
@@ -1665,7 +1665,7 @@ describe('integration', () => {
         const serverUrl = 'https://domain.com';
         const scope = nock(serverUrl).post(path).reply(200, success);
 
-        await client.init(apiKey, undefined, {
+        await client.init(apiKey, {
           defaultTracking,
           serverUrl: serverUrl + path,
         }).promise;
@@ -1703,7 +1703,7 @@ describe('integration', () => {
           warn: jest.fn(),
           error: jest.fn(),
         };
-        await client.init(apiKey, undefined, {
+        await client.init(apiKey, {
           defaultTracking,
           loggerProvider: logger,
           logLevel: LogLevel.Debug,
@@ -1750,7 +1750,7 @@ describe('integration', () => {
           warn: jest.fn(),
           error: jest.fn(),
         };
-        await client.init(apiKey, undefined, {
+        await client.init(apiKey, {
           defaultTracking,
           loggerProvider: logger,
           logLevel: LogLevel.Debug,
@@ -1777,7 +1777,7 @@ describe('integration', () => {
       const scope1 = nock(url).post(path).reply(200, success);
       // intercept for test event
       const scope2 = nock(url).post(path).reply(200, success);
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         identityStorage: 'cookie',
       }).promise;
       await client.identify(new amplitude.Identify().set('a', 'b')).promise;
@@ -1793,7 +1793,7 @@ describe('integration', () => {
       const scope1 = nock(url).post(path).reply(200, success);
       // intercept for test event
       const scope2 = nock(url).post(path).reply(200, success);
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         identityStorage: 'localStorage',
       }).promise;
       await client.identify(new amplitude.Identify().set('a', 'b')).promise;

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -45,6 +45,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       userId = userIdOrOptions;
       options = maybeOptions;
     } else {
+      userId = userIdOrOptions?.userId;
       options = userIdOrOptions;
     }
     return returnWrapper(this._init({ ...options, userId, apiKey }));

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -41,10 +41,10 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     let userId: string | undefined;
     let options: BrowserOptions | undefined;
 
-    if (arguments.length === 3) {
+    if (arguments.length > 2) {
       userId = userIdOrOptions as string | undefined;
       options = maybeOptions;
-    } else if (arguments.length === 2) {
+    } else {
       if (typeof userIdOrOptions === 'string') {
         userId = userIdOrOptions;
         options = undefined;

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -37,7 +37,16 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   previousSessionDeviceId: string | undefined;
   previousSessionUserId: string | undefined;
 
-  init(apiKey = '', userId?: string, options?: BrowserOptions) {
+  init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {
+    let userId: string | undefined;
+    let options: BrowserOptions | undefined;
+
+    if (typeof userIdOrOptions === 'string') {
+      userId = userIdOrOptions;
+      options = maybeOptions;
+    } else {
+      options = userIdOrOptions;
+    }
     return returnWrapper(this._init({ ...options, userId, apiKey }));
   }
   protected async _init(options: BrowserOptions & { apiKey: string }) {

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -41,12 +41,17 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     let userId: string | undefined;
     let options: BrowserOptions | undefined;
 
-    if (typeof userIdOrOptions === 'string') {
-      userId = userIdOrOptions;
+    if (arguments.length === 3) {
+      userId = userIdOrOptions as string | undefined;
       options = maybeOptions;
-    } else {
-      userId = userIdOrOptions?.userId;
-      options = userIdOrOptions;
+    } else if (arguments.length === 2) {
+      if (typeof userIdOrOptions === 'string') {
+        userId = userIdOrOptions;
+        options = undefined;
+      } else {
+        userId = userIdOrOptions?.userId;
+        options = userIdOrOptions;
+      }
     }
     return returnWrapper(this._init({ ...options, userId, apiKey }));
   }

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -51,6 +51,34 @@ describe('browser-client', () => {
       expect(parseLegacyCookies).toHaveBeenCalledTimes(1);
     });
 
+    test('should set user id using top level parameter', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey, userId).promise;
+      expect(client.getUserId()).toBe(userId);
+    });
+
+    test('should set user id using config', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey, {
+        userId,
+      }).promise;
+      expect(client.getUserId()).toBe(userId);
+    });
+
+    test('should set user id using top level parameter as priority', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey, userId, {
+        userId: 'user@amplitude.com',
+      }).promise;
+      expect(client.getUserId()).toBe(userId);
+    });
+
+    test('should not set user id', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey).promise;
+      expect(client.getUserId()).toBe(undefined);
+    });
+
     test('should initialize with existing session', async () => {
       const parseLegacyCookies = jest.spyOn(CookieMigration, 'parseLegacyCookies').mockResolvedValueOnce({
         optOut: false,

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -51,13 +51,25 @@ describe('browser-client', () => {
       expect(parseLegacyCookies).toHaveBeenCalledTimes(1);
     });
 
-    test('should set user id using top level parameter 1', async () => {
+    test('should initialize w/o user id and config', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey).promise;
+      expect(client.getUserId()).toBe(undefined);
+    });
+
+    test('should set initalize with undefined user id', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey, undefined).promise;
+      expect(client.getUserId()).toBe(undefined);
+    });
+
+    test('should initialize w/o config', async () => {
       client.setOptOut(true);
       await client.init(apiKey, userId).promise;
       expect(client.getUserId()).toBe(userId);
     });
 
-    test('should set user id using top level parameter 2', async () => {
+    test('should set user id with top level parameter', async () => {
       client.setOptOut(true);
       await client.init(apiKey, undefined, {
         userId,
@@ -65,13 +77,7 @@ describe('browser-client', () => {
       expect(client.getUserId()).toBe(undefined);
     });
 
-    test('should set user id to undefined using top level parameter 1', async () => {
-      client.setOptOut(true);
-      await client.init(apiKey, undefined).promise;
-      expect(client.getUserId()).toBe(undefined);
-    });
-
-    test('should set user id using config 1', async () => {
+    test('should set user to options.userId', async () => {
       client.setOptOut(true);
       await client.init(apiKey, {
         userId,
@@ -85,12 +91,6 @@ describe('browser-client', () => {
         userId: 'user@amplitude.com',
       }).promise;
       expect(client.getUserId()).toBe(userId);
-    });
-
-    test('should not set user id', async () => {
-      client.setOptOut(true);
-      await client.init(apiKey).promise;
-      expect(client.getUserId()).toBe(undefined);
     });
 
     test('should initialize with existing session', async () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -51,13 +51,27 @@ describe('browser-client', () => {
       expect(parseLegacyCookies).toHaveBeenCalledTimes(1);
     });
 
-    test('should set user id using top level parameter', async () => {
+    test('should set user id using top level parameter 1', async () => {
       client.setOptOut(true);
       await client.init(apiKey, userId).promise;
       expect(client.getUserId()).toBe(userId);
     });
 
-    test('should set user id using config', async () => {
+    test('should set user id using top level parameter 2', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey, undefined, {
+        userId,
+      }).promise;
+      expect(client.getUserId()).toBe(undefined);
+    });
+
+    test('should set user id to undefined using top level parameter 1', async () => {
+      client.setOptOut(true);
+      await client.init(apiKey, undefined).promise;
+      expect(client.getUserId()).toBe(undefined);
+    });
+
+    test('should set user id using config 1', async () => {
       client.setOptOut(true);
       await client.init(apiKey, {
         userId,

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -103,7 +103,7 @@ describe('browser-client', () => {
         sessionId: 1,
         userId,
       });
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       expect(client.getUserId()).toBe(userId);
@@ -234,7 +234,7 @@ describe('browser-client', () => {
 
   describe('setUserId', () => {
     test('should set user id', async () => {
-      await client.init(apiKey, undefined, { defaultTracking }).promise;
+      await client.init(apiKey, { defaultTracking }).promise;
       expect(client.getUserId()).toBe(undefined);
       client.setUserId(userId);
       expect(client.getUserId()).toBe(userId);
@@ -291,7 +291,7 @@ describe('browser-client', () => {
 
     test('should defer set user id', () => {
       return new Promise<void>((resolve) => {
-        void client.init(apiKey, undefined, { defaultTracking }).promise.then(() => {
+        void client.init(apiKey, { defaultTracking }).promise.then(() => {
           expect(client.getUserId()).toBe('user@amplitude.com');
           resolve();
         });
@@ -313,7 +313,7 @@ describe('browser-client', () => {
     });
 
     test('should be able to unset user id to undefined after setUserId()', async () => {
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
         deviceId,
       }).promise;
@@ -332,7 +332,7 @@ describe('browser-client', () => {
 
   describe('getDeviceId', () => {
     test('should get device id', async () => {
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
         deviceId,
       }).promise;
@@ -346,14 +346,14 @@ describe('browser-client', () => {
 
   describe('setDeviceId', () => {
     test('should set device id config', async () => {
-      await client.init(apiKey, undefined, { defaultTracking }).promise;
+      await client.init(apiKey, { defaultTracking }).promise;
       client.setDeviceId(deviceId);
       expect(client.getDeviceId()).toBe(deviceId);
     });
 
     test('should defer set device id', () => {
       return new Promise<void>((resolve) => {
-        void client.init(apiKey, undefined, { defaultTracking }).promise.then(() => {
+        void client.init(apiKey, { defaultTracking }).promise.then(() => {
           expect(client.getDeviceId()).toBe('asdfg');
           resolve();
         });
@@ -364,7 +364,7 @@ describe('browser-client', () => {
 
   describe('reset', () => {
     test('should reset user id and generate new device id config', async () => {
-      await client.init(apiKey, undefined, { defaultTracking }).promise;
+      await client.init(apiKey, { defaultTracking }).promise;
       client.setUserId(userId);
       client.setDeviceId(deviceId);
       expect(client.getUserId()).toBe(userId);
@@ -377,7 +377,7 @@ describe('browser-client', () => {
 
   describe('getSessionId', () => {
     test('should get session id', async () => {
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
         sessionId: 1,
       }).promise;
@@ -391,7 +391,7 @@ describe('browser-client', () => {
 
   describe('setSessionId', () => {
     test('should set session id', async () => {
-      await client.init(apiKey, undefined, { defaultTracking }).promise;
+      await client.init(apiKey, { defaultTracking }).promise;
       client.setSessionId(1);
       expect(client.getSessionId()).toBe(1);
     });
@@ -407,7 +407,7 @@ describe('browser-client', () => {
         }),
       };
       const track = jest.spyOn(client, 'track').mockReturnValue(result);
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         sessionId: 1,
         defaultTracking: {
           ...defaultTracking,
@@ -437,7 +437,7 @@ describe('browser-client', () => {
         }),
       };
       const track = jest.spyOn(client, 'track').mockReturnValue(result);
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         sessionTimeout: 5000,
         defaultTracking: {
           ...defaultTracking,
@@ -453,7 +453,7 @@ describe('browser-client', () => {
 
     test('should defer set session id', () => {
       return new Promise<void>((resolve) => {
-        void client.init(apiKey, undefined, { defaultTracking }).promise.then(() => {
+        void client.init(apiKey, { defaultTracking }).promise.then(() => {
           expect(client.getSessionId()).toBe(1);
           resolve();
         });
@@ -466,7 +466,7 @@ describe('browser-client', () => {
     test('should set transport', async () => {
       const fetch = new FetchTransport();
       const createTransport = jest.spyOn(Config, 'createTransport').mockReturnValueOnce(fetch);
-      await client.init(apiKey, undefined, { defaultTracking }).promise;
+      await client.init(apiKey, { defaultTracking }).promise;
       client.setTransport('fetch');
       expect(createTransport).toHaveBeenCalledTimes(2);
     });
@@ -475,7 +475,7 @@ describe('browser-client', () => {
       return new Promise<void>((resolve) => {
         const fetch = new FetchTransport();
         const createTransport = jest.spyOn(Config, 'createTransport').mockReturnValueOnce(fetch);
-        void client.init(apiKey, undefined, { defaultTracking }).promise.then(() => {
+        void client.init(apiKey, { defaultTracking }).promise.then(() => {
           expect(createTransport).toHaveBeenCalledTimes(2);
           resolve();
         });
@@ -495,7 +495,7 @@ describe('browser-client', () => {
           },
         }),
       );
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const identifyObject = new core.Identify();
@@ -517,7 +517,7 @@ describe('browser-client', () => {
       const convertProxyObjectToRealObject = jest
         .spyOn(SnippetHelper, 'convertProxyObjectToRealObject')
         .mockReturnValueOnce(new core.Identify());
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const identifyObject = {
@@ -543,7 +543,7 @@ describe('browser-client', () => {
           },
         }),
       );
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const identifyObject = new core.Identify();
@@ -565,7 +565,7 @@ describe('browser-client', () => {
       const convertProxyObjectToRealObject = jest
         .spyOn(SnippetHelper, 'convertProxyObjectToRealObject')
         .mockReturnValueOnce(new core.Identify());
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const identifyObject = {
@@ -591,7 +591,7 @@ describe('browser-client', () => {
           },
         }),
       );
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const revenueObject = new core.Revenue();
@@ -613,7 +613,7 @@ describe('browser-client', () => {
       const convertProxyObjectToRealObject = jest
         .spyOn(SnippetHelper, 'convertProxyObjectToRealObject')
         .mockReturnValueOnce(new core.Revenue());
-      await client.init(apiKey, undefined, {
+      await client.init(apiKey, {
         defaultTracking,
       }).promise;
       const revenueObject = {

--- a/packages/analytics-types/src/client/web-client.ts
+++ b/packages/analytics-types/src/client/web-client.ts
@@ -87,6 +87,7 @@ export interface BrowserClient extends Client {
    * await init(API_KEY, options).promise;
    * ```
    */
+  init(apiKey: string, options?: BrowserOptions): AmplitudeReturn<void>;
   init(apiKey: string, userId?: string, options?: BrowserOptions): AmplitudeReturn<void>;
 
   /**


### PR DESCRIPTION
### Summary

Backward compatible simplification on init function signature. Extends current interface to allow omitting `userId` as top level parameter.

```ts
init(apiKey: string, options?: BrowserOptions): AmplitudeReturn<void>;
init(apiKey: string, userId?: string, options?: BrowserOptions): AmplitudeReturn<void>;
```

#### Setting user id through init()

Method 1: Omit user id
```ts
amplitude.init(apiKey);
```

```ts
amplitude.init(apiKey, {
  defaultTracking: false,
});
```

Method 2: Setting via top level parameter
```ts
amplitude.init(apiKey, userId);
```

Method 3: Setting via options
```ts
amplitude.init(apiKey, {
  userId
});
```

Method 4: Setting to undefined
```ts
amplitude.init(apiKey, undefined);
```

```ts
amplitude.init(apiKey, {
  userId: undefined,
});
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
