### PR TITLE
build: update default dist-tag and pre-dist-tag

### DIFF
--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -112,6 +112,6 @@ jobs:
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --dist-tag latest --pre-dist-tag next
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --pre-dist-tag beta
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -112,6 +112,6 @@ jobs:
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --pre-dist-tag beta
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --pre-dist-tag v1-beta
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -111,6 +111,6 @@ jobs:
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --dist-tag latest@2 --pre-dist-tag next@2
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --pre-dist-tag beta
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}

--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -14,7 +14,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-client-common/package.json
+++ b/packages/analytics-client-common/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-node/package.json
+++ b/packages/analytics-node/package.json
@@ -10,6 +10,9 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "private": true,
+  "publishConfig": {
+    "tag": "beta"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -17,6 +17,9 @@
   "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "private": true,
+  "publishConfig": {
+    "tag": "beta"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"

--- a/packages/analytics-types/package.json
+++ b/packages/analytics-types/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-page-view-tracking-browser/package.json
+++ b/packages/plugin-page-view-tracking-browser/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-web-attribution-browser/package.json
+++ b/packages/plugin-web-attribution-browser/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary

- All beta version will have a `beta` [dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag)
- All non-beta versions (except for node and react-native, currently private) will have `latest` [dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag)
- I configured node and react-native to have `beta` [dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag) on any version to protect ourselves for tagging the next published version (likely to be beta) as `latest` once it is no longer private. This config should be changed to `latest` when team is ready.

v1 counterpart: https://github.com/amplitude/Amplitude-TypeScript/pull/418

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
