### PR TITLE
build: update dist-tag

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -14,7 +14,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-client-common/package.json
+++ b/packages/analytics-client-common/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-node/package.json
+++ b/packages/analytics-node/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -17,7 +17,8 @@
   "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -18,7 +18,7 @@
   "react-native": "src/index",
   "publishConfig": {
     "access": "public",
-    "tag": "v1"
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/analytics-types/package.json
+++ b/packages/analytics-types/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",

--- a/packages/marketing-analytics-browser/package.json
+++ b/packages/marketing-analytics-browser/package.json
@@ -14,7 +14,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-page-view-tracking-browser/package.json
+++ b/packages/plugin-page-view-tracking-browser/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-web-attribution-browser/package.json
+++ b/packages/plugin-web-attribution-browser/package.json
@@ -10,7 +10,8 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary

- All non-beta versions (except for node and react-native) will have `v1` [dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag)
- I configured node and react-native to have `latest` [dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag) on any version because 2.0 is not ready. This config should be changed to `v1` when team for node and react native SDK 2.0.

V2 counterpart: https://github.com/amplitude/Amplitude-TypeScript/pull/417

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
