### PR TITLE
fix: set cookie expiration from options

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -259,7 +259,10 @@ export const createCookieStorage = <T>(
       return new MemoryStorage<T>();
     case 'cookie':
     default:
-      return new CookieStorage<T>(cookieOptions);
+      return new CookieStorage<T>({
+        ...cookieOptions,
+        expirationDays: cookieOptions.expiration,
+      });
   }
 };
 


### PR DESCRIPTION
### Summary

Fixes cookie expiration. It was not setting it property due to incorrect property mapping from options to `CookieStorage` fields

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No