### PR TITLE
feat: added extendSession() method to Browser Client

### DIFF
--- a/packages/analytics-browser/src/browser-client-factory.ts
+++ b/packages/analytics-browser/src/browser-client-factory.ts
@@ -107,6 +107,12 @@ export const createInstance = (): BrowserClient => {
       getClientLogConfig(client),
       getClientStates(client, ['config']),
     ),
+    extendSession: debugWrapper(
+      client.extendSession.bind(client),
+      'extendSession',
+      getClientLogConfig(client),
+      getClientStates(client, ['config']),
+    ),
     setOptOut: debugWrapper(
       client.setOptOut.bind(client),
       'setOptOut',

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -221,6 +221,10 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     }
   }
 
+  extendSession() {
+    this.config.lastEventTime = Date.now();
+  }
+
   setTransport(transport: TransportType) {
     if (!this.config) {
       this.q.push(this.setTransport.bind(this, transport));

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -222,6 +222,10 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   }
 
   extendSession() {
+    if (!this.config) {
+      this.q.push(this.extendSession.bind(this));
+      return;
+    }
     this.config.lastEventTime = Date.now();
   }
 

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -3,6 +3,7 @@ import client from './browser-client-factory';
 export { createInstance } from './browser-client-factory';
 export const {
   add,
+  extendSession,
   flush,
   getDeviceId,
   getSessionId,

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -570,7 +570,7 @@ describe('browser-client', () => {
       const eventTime1 = client.config.lastEventTime ?? -1;
       expect(eventTime1 > 0).toBeTruthy();
 
-      // wait for session to almost expire
+      // wait for session to almost expire, then extend it
       await new Promise<void>((resolve) =>
         setTimeout(() => {
           client.extendSession();
@@ -578,29 +578,32 @@ describe('browser-client', () => {
         }, 15),
       );
 
+      // assert session id is unchanged
+      expect(client.config.sessionId).toBe(firstSessionId);
       // assert last event time was updated
       const extendedLastEventTime = client.config.lastEventTime ?? -1;
-      expect(client.config.sessionId).toBe(firstSessionId);
       expect(extendedLastEventTime > 0).toBeTruthy();
       expect(extendedLastEventTime > eventTime1).toBeTruthy();
 
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      // send another event just before session expires (again)
       await new Promise<void>((resolve) =>
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         setTimeout(async () => {
           await client.track('test 2').promise;
           resolve();
         }, 15),
       );
 
-      const eventTime2 = client.config.lastEventTime ?? -1;
       // assert session id is unchanged
       expect(client.config.sessionId).toBe(firstSessionId);
+      // assert last event time was updated
+      const eventTime2 = client.config.lastEventTime ?? -1;
       expect(eventTime2 > 0).toBeTruthy();
       expect(eventTime2 > extendedLastEventTime).toBeTruthy();
 
       // Wait for session to timeout, without extendSession()
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       await new Promise<void>((resolve) =>
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         setTimeout(async () => {
           await client.track('test 3').promise;
           resolve();

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -561,7 +561,7 @@ describe('browser-client', () => {
         flushQueueSize: 1,
         flushIntervalMillis: 1,
       }).promise;
-      // assert last event time was updated
+      // assert sessionId is set
       expect(client.config.sessionId).toBe(firstSessionId);
       expect(client.config.lastEventTime).toBeUndefined();
 

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -613,6 +613,28 @@ describe('browser-client', () => {
       expect(client.config.sessionId).not.toBe(firstSessionId);
       expect(client.config.sessionId ?? -1 > firstSessionId).toBeTruthy();
     });
+
+    test('should extendSession using proxy', async () => {
+      const firstSessionId = 1;
+      const client = new AmplitudeBrowser();
+
+      // call extendSession() before init()
+      client.extendSession();
+
+      // init
+      await client.init(API_KEY, undefined, {
+        sessionTimeout: 20,
+        sessionId: firstSessionId,
+        flushQueueSize: 1,
+        flushIntervalMillis: 1,
+        lastEventTime: 0,
+      }).promise;
+
+      // assert sessionId is unchanged
+      expect(client.config.sessionId).toBe(firstSessionId);
+      // assert last event time was updated
+      expect(client.config.lastEventTime).not.toBe(0);
+    });
   });
 
   describe('setTransport', () => {

--- a/packages/analytics-browser/test/helpers/mock.ts
+++ b/packages/analytics-browser/test/helpers/mock.ts
@@ -19,6 +19,7 @@ export const createAmplitudeMock = (): jest.MockedObject<BrowserClient> => ({
   setDeviceId: jest.fn(),
   getSessionId: jest.fn(),
   setSessionId: jest.fn(),
+  extendSession: jest.fn(),
   reset: jest.fn(),
   setTransport: jest.fn(),
 });

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -1,6 +1,7 @@
 import {
   add,
   createInstance,
+  extendSession,
   flush,
   getDeviceId,
   getSessionId,
@@ -28,6 +29,7 @@ describe('index', () => {
   test('should expose apis', () => {
     expect(typeof add).toBe('function');
     expect(typeof createInstance).toBe('function');
+    expect(typeof extendSession).toBe('function');
     expect(typeof flush).toBe('function');
     expect(typeof groupIdentify).toBe('function');
     expect(typeof getDeviceId).toBe('function');

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -183,6 +183,14 @@ export class AmplitudeReactNative extends AmplitudeCore {
     void this.setSessionIdInternal(sessionId, this.currentTimeMillis());
   }
 
+  extendSession() {
+    if (!this.config) {
+      this.q.push(this.extendSession.bind(this));
+      return;
+    }
+    this.config.lastEventTime = this.currentTimeMillis();
+  }
+
   private setSessionIdInternal(sessionId: number, eventTime: number) {
     const previousSessionId = this.config.sessionId;
     if (previousSessionId === sessionId) {
@@ -384,6 +392,12 @@ export const createInstance = (): ReactNativeClient => {
     setSessionId: debugWrapper(
       client.setSessionId.bind(client),
       'setSessionId',
+      getClientLogConfig(client),
+      getClientStates(client, ['config']),
+    ),
+    extendSession: debugWrapper(
+      client.extendSession.bind(client),
+      'extendSession',
       getClientLogConfig(client),
       getClientStates(client, ['config']),
     ),

--- a/packages/analytics-types/src/client/web-client.ts
+++ b/packages/analytics-types/src/client/web-client.ts
@@ -53,13 +53,25 @@ interface Client extends CoreClient {
 
   /**
    * Sets a new session ID.
-   * When settign a custom session ID, make sure the value is in milliseconds since epoch (Unix Timestamp).
+   * When setting a custom session ID, make sure the value is in milliseconds since epoch (Unix Timestamp).
    *
    * ```typescript
    * setSessionId(Date.now());
    * ```
    */
   setSessionId(sessionId: number): void;
+
+  /**
+   * Extends the current session (advanced)
+   *
+   * Normally sessions are extended automatically by track()'ing events. If you want to extend the session without
+   * tracking and event, this will set the last user interaction to the current time.
+   *
+   * ```typescript
+   * extendSession();
+   * ```
+   */
+  extendSession(): void;
 
   /**
    * Anonymizes users after they log out, by:


### PR DESCRIPTION
### Summary

** Add extendSession() method to Browser SDK to allow customers to extend the current session without sending events / using quota.

```typescript
amplitude.extendSession();
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
