### PR TITLE
fix: extend session on new events

### DIFF
--- a/packages/analytics-browser/src/plugins/context.ts
+++ b/packages/analytics-browser/src/plugins/context.ts
@@ -34,6 +34,9 @@ export class Context implements BeforePlugin {
     const lastEventId = this.config.lastEventId ?? -1;
     const nextEventId = context.event_id ?? lastEventId + 1;
     this.config.lastEventId = nextEventId;
+    if (!context.time) {
+      this.config.lastEventTime = time;
+    }
 
     const event: Event = {
       user_id: this.config.userId,


### PR DESCRIPTION
### Summary

* Update `lastEventTime` in on new events to extend session on new events
* Added integration tests

Context: we've always had this but was removed in a recent PR

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
