### PR TITLE
feat: adds session storage option for identity storage

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -24,6 +24,7 @@ import { parseLegacyCookies } from './cookie-migration';
 import { CookieOptions } from '@amplitude/analytics-types/lib/esm/config/browser';
 import { DEFAULT_IDENTITY_STORAGE, DEFAULT_SERVER_ZONE } from './constants';
 import { AmplitudeBrowser } from './browser-client';
+import { SessionStorage } from './storage/session-storage';
 
 // Exported for testing purposes only. Do not expose to public interface.
 export class BrowserConfig extends Config implements IBrowserConfig {
@@ -258,6 +259,8 @@ export const createCookieStorage = <T>(
   switch (identityStorage) {
     case 'localStorage':
       return new LocalStorage<T>();
+    case 'sessionStorage':
+      return new SessionStorage<T>();
     case 'none':
       return new MemoryStorage<T>();
     case 'cookie':

--- a/packages/analytics-browser/src/storage/session-storage.ts
+++ b/packages/analytics-browser/src/storage/session-storage.ts
@@ -1,0 +1,67 @@
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { Storage } from '@amplitude/analytics-types';
+
+export class SessionStorage<T> implements Storage<T> {
+  async isEnabled(): Promise<boolean> {
+    /* istanbul ignore if */
+    if (!getGlobalScope()) {
+      return false;
+    }
+
+    const random = String(Date.now());
+    const testStorage = new SessionStorage<string>();
+    const testKey = 'AMP_TEST';
+    try {
+      await testStorage.set(testKey, random);
+      const value = await testStorage.get(testKey);
+      return value === random;
+    } catch {
+      /* istanbul ignore next */
+      return false;
+    } finally {
+      await testStorage.remove(testKey);
+    }
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    try {
+      const value = await this.getRaw(key);
+      if (!value) {
+        return undefined;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return JSON.parse(value);
+    } catch {
+      /* istanbul ignore next */
+      return undefined;
+    }
+  }
+
+  async getRaw(key: string): Promise<string | undefined> {
+    return getGlobalScope()?.sessionStorage.getItem(key) || undefined;
+  }
+
+  async set(key: string, value: T): Promise<void> {
+    try {
+      getGlobalScope()?.sessionStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      //
+    }
+  }
+
+  async remove(key: string): Promise<void> {
+    try {
+      getGlobalScope()?.sessionStorage.removeItem(key);
+    } catch {
+      //
+    }
+  }
+
+  async reset(): Promise<void> {
+    try {
+      getGlobalScope()?.sessionStorage.clear();
+    } catch {
+      //
+    }
+  }
+}

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -1,5 +1,6 @@
 import * as Config from '../src/config';
 import * as LocalStorageModule from '../src/storage/local-storage';
+import * as SessionStorageModule from '../src/storage/session-storage';
 import * as core from '@amplitude/analytics-core';
 import { LogLevel, Storage, UserSession } from '@amplitude/analytics-types';
 import * as BrowserUtils from '@amplitude/analytics-client-common';
@@ -248,12 +249,17 @@ describe('config', () => {
       expect(storage).toBeInstanceOf(BrowserUtils.CookieStorage);
     });
 
-    test('should use return storage', async () => {
+    test('should return local storage', async () => {
       const storage = Config.createCookieStorage('localStorage');
       expect(storage).toBeInstanceOf(LocalStorageModule.LocalStorage);
     });
 
-    test('should use memory', async () => {
+    test('should return session storage', async () => {
+      const storage = Config.createCookieStorage('sessionStorage');
+      expect(storage).toBeInstanceOf(SessionStorageModule.SessionStorage);
+    });
+
+    test('should return memory storage', async () => {
       const storage = Config.createCookieStorage('none');
       expect(storage).toBeInstanceOf(core.MemoryStorage);
     });

--- a/packages/analytics-browser/test/storage/session-storage.test.ts
+++ b/packages/analytics-browser/test/storage/session-storage.test.ts
@@ -1,0 +1,80 @@
+import { SessionStorage } from '../../src/storage/session-storage';
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+
+describe('local-storage', () => {
+  describe('isEnabled', () => {
+    test('should return true', async () => {
+      const sessionStorage = new SessionStorage();
+      expect(await sessionStorage.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    test('should return undefined if not set', async () => {
+      const sessionStorage = new SessionStorage();
+      expect(await sessionStorage.get('1')).toBe(undefined);
+    });
+
+    test('should return object', async () => {
+      const sessionStorage = new SessionStorage<Record<string, number>>();
+      await sessionStorage.set('1', { a: 1 });
+      expect(await sessionStorage.get('1')).toEqual({ a: 1 });
+    });
+
+    test('should return array', async () => {
+      const sessionStorage = new SessionStorage<number[]>();
+      await sessionStorage.set('1', [1]);
+      expect(await sessionStorage.get('1')).toEqual([1]);
+    });
+  });
+
+  describe('set', () => {
+    test('should set value', async () => {
+      const sessionStorage = new SessionStorage();
+      await sessionStorage.set('1', 'a');
+      expect(await sessionStorage.get('1')).toBe('a');
+    });
+  });
+
+  describe('remove', () => {
+    test('should remove value of key', async () => {
+      const sessionStorage = new SessionStorage();
+      await sessionStorage.set('1', 'a');
+      await sessionStorage.set('2', 'b');
+      expect(await sessionStorage.get('1')).toBe('a');
+      expect(await sessionStorage.get('2')).toBe('b');
+      await sessionStorage.remove('1');
+      expect(await sessionStorage.get('1')).toBe(undefined);
+      expect(await sessionStorage.get('2')).toBe('b');
+    });
+
+    test('should handle when GlobalScope is not defined', async () => {
+      const sessionStorage = new SessionStorage<number[]>();
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      await sessionStorage.set('1', [1]);
+      expect(await sessionStorage.get('1')).toEqual(undefined);
+      await sessionStorage.remove('1');
+    });
+  });
+
+  describe('reset', () => {
+    test('should remove all values', async () => {
+      const sessionStorage = new SessionStorage();
+      await sessionStorage.set('1', 'a');
+      await sessionStorage.set('2', 'b');
+      expect(await sessionStorage.get('1')).toBe('a');
+      expect(await sessionStorage.get('2')).toBe('b');
+      await sessionStorage.reset();
+      expect(await sessionStorage.get('1')).toBe(undefined);
+      expect(await sessionStorage.get('2')).toBe(undefined);
+    });
+
+    test('should handle when GlobalScope is not defined', async () => {
+      const sessionStorage = new SessionStorage<number[]>();
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      await sessionStorage.set('1', [1]);
+      expect(await sessionStorage.get('1')).toEqual(undefined);
+      await sessionStorage.reset();
+    });
+  });
+});

--- a/packages/analytics-types/src/storage.ts
+++ b/packages/analytics-types/src/storage.ts
@@ -14,4 +14,4 @@ export interface CookieStorageOptions {
   secure?: boolean;
 }
 
-export type IdentityStorageType = 'cookie' | 'localStorage' | 'none';
+export type IdentityStorageType = 'cookie' | 'localStorage' | 'sessionStorage' | 'none';


### PR DESCRIPTION
### Summary

Resolves #434

Add a new identity storage option: `sessionStorage`.

```ts
amplitude.init(<YOUR_API_KEY>, {
  identityStorage: 'sessionStorage',
});
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
