### PR TITLE
fix: types for plugins to be env specific

### DIFF
--- a/packages/analytics-types/src/client/node-client.ts
+++ b/packages/analytics-types/src/client/node-client.ts
@@ -1,6 +1,7 @@
 import { AmplitudeReturn } from '../amplitude-promise';
-import { NodeOptions } from '../config';
+import { NodeConfig, NodeOptions } from '../config';
 import { CoreClient } from './core-client';
+import { Plugin } from '../plugin';
 
 export interface NodeClient extends CoreClient {
   /**
@@ -12,4 +13,23 @@ export interface NodeClient extends CoreClient {
    * ```
    */
   init(apiKey: string, options?: NodeOptions): AmplitudeReturn<void>;
+
+  /**
+   * Adds a new plugin.
+   *
+   * ```typescript
+   * const plugin = {
+   *   name: 'my-plugin',
+   *   type: 'enrichment',
+   *   async setup(config: NodeConfig, amplitude: NodeClient) {
+   *     return;
+   *   },
+   *   async execute(event: Event) {
+   *     return event;
+   *   },
+   * };
+   * amplitude.add(plugin);
+   * ```
+   */
+  add(plugin: Plugin<NodeClient, NodeConfig>): AmplitudeReturn<void>;
 }

--- a/packages/analytics-types/src/client/web-client.ts
+++ b/packages/analytics-types/src/client/web-client.ts
@@ -1,7 +1,8 @@
 import { AmplitudeReturn } from '../amplitude-promise';
-import { BrowserOptions, ReactNativeOptions } from '../config';
+import { BrowserConfig, BrowserOptions, ReactNativeConfig, ReactNativeOptions } from '../config';
 import { TransportType } from '../transport';
 import { CoreClient } from './core-client';
+import { Plugin } from '../plugin';
 
 interface Client extends CoreClient {
   /**
@@ -117,6 +118,25 @@ export interface BrowserClient extends Client {
    * ```
    */
   setTransport(transport: TransportType): void;
+
+  /**
+   * Adds a new plugin.
+   *
+   * ```typescript
+   * const plugin = {
+   *   name: 'my-plugin',
+   *   type: 'enrichment',
+   *   async setup(config: BrowserConfig, amplitude: BrowserClient) {
+   *     return;
+   *   },
+   *   async execute(event: Event) {
+   *     return event;
+   *   },
+   * };
+   * amplitude.add(plugin);
+   * ```
+   */
+  add(plugin: Plugin<BrowserClient, BrowserConfig>): AmplitudeReturn<void>;
 }
 
 export interface ReactNativeClient extends Client {
@@ -129,4 +149,23 @@ export interface ReactNativeClient extends Client {
    * ```
    */
   init(apiKey: string, userId?: string, options?: ReactNativeOptions): AmplitudeReturn<void>;
+
+  /**
+   * Adds a new plugin.
+   *
+   * ```typescript
+   * const plugin = {
+   *   name: 'my-plugin',
+   *   type: 'enrichment',
+   *   async setup(config: ReactNativeConfig, amplitude: ReactNativeClient) {
+   *     return;
+   *   },
+   *   async execute(event: Event) {
+   *     return event;
+   *   },
+   * };
+   * amplitude.add(plugin);
+   * ```
+   */
+  add(plugin: Plugin<ReactNativeClient, ReactNativeConfig>): AmplitudeReturn<void>;
 }

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -8,26 +8,26 @@ type PluginTypeEnrichment = 'enrichment';
 type PluginTypeDestination = 'destination';
 export type PluginType = PluginTypeBefore | PluginTypeEnrichment | PluginTypeDestination;
 
-interface PluginBase<T = CoreClient> {
+interface PluginBase<T = CoreClient, U = Config> {
   name?: string;
   type?: PluginType;
-  setup?(config: Config, client: T): Promise<void>;
+  setup?(config: U, client: T): Promise<void>;
 }
 
-export interface BeforePlugin extends PluginBase {
+export interface BeforePlugin<T = CoreClient, U = Config> extends PluginBase<T, U> {
   type: PluginTypeBefore;
   execute?(context: Event): Promise<Event | null>;
 }
 
-export interface EnrichmentPlugin extends PluginBase {
+export interface EnrichmentPlugin<T = CoreClient, U = Config> extends PluginBase<T, U> {
   type?: PluginTypeEnrichment;
   execute?(context: Event): Promise<Event | null>;
 }
 
-export interface DestinationPlugin extends PluginBase {
+export interface DestinationPlugin<T = CoreClient, U = Config> extends PluginBase<T, U> {
   type: PluginTypeDestination;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
 }
 
-export type Plugin = BeforePlugin | EnrichmentPlugin | DestinationPlugin;
+export type Plugin<T = CoreClient, U = Config> = BeforePlugin<T, U> | EnrichmentPlugin<T, U> | DestinationPlugin<T, U>;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

* Type hints for `amplitude.add()` shows core interface instead of env specific interface both for config and client parameters

**Before:**
_config_
![Screenshot 2023-06-16 at 12 46 24 PM](https://github.com/amplitude/Amplitude-TypeScript/assets/20634289/8e1d3e1e-9305-4245-af48-b48b8b68532d)

_client_
![Screenshot 2023-06-16 at 12 50 33 PM](https://github.com/amplitude/Amplitude-TypeScript/assets/20634289/447b4d72-f3fe-4d22-b495-2526723a05d8)


**After:**
_config_
![Screenshot 2023-06-16 at 12 44 01 PM](https://github.com/amplitude/Amplitude-TypeScript/assets/20634289/9db5bfcb-60fe-4740-aa1f-c3a62444fdb5)


_client_
![Screenshot 2023-06-16 at 12 51 50 PM](https://github.com/amplitude/Amplitude-TypeScript/assets/20634289/ee6e6dfe-bcc9-4e05-af5a-9a0ff1e69a7e)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
