### PR TITLE
Making async storage not required.

### DIFF
--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -62,7 +62,6 @@
     "@amplitude/analytics-core": "^2.0.0-beta.0",
     "@amplitude/analytics-types": "^2.0.0-beta.0",
     "@amplitude/ua-parser-js": "^0.7.31",
-    "@react-native-async-storage/async-storage": "^1.17.11",
     "tslib": "^2.4.1"
   },
   "devDependencies": {
@@ -75,7 +74,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@react-native-async-storage/async-storage": "^1.17.11"
   },
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
Currently there is no way to avoid downloading async storage. Even when we supply our own alternative storage provider. This is causing errors.