### PR TITLE
fix: cookie-storage SSR incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "version": "0.0.0",
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "version": "0.0.0",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/analytics-client-common/src/storage/cookie.ts
+++ b/packages/analytics-client-common/src/storage/cookie.ts
@@ -50,7 +50,7 @@ export class CookieStorage<T> implements Storage<T> {
 
   async getRaw(key: string): Promise<string | undefined> {
     const globalScope = getGlobalScope();
-    const cookie = globalScope?.document.cookie.split('; ') ?? [];
+    const cookie = globalScope?.document?.cookie.split('; ') ?? [];
     const match = cookie.find((c) => c.indexOf(key + '=') === 0);
     if (!match) {
       return undefined;

--- a/packages/analytics-client-common/test/storage/cookies.test.ts
+++ b/packages/analytics-client-common/test/storage/cookies.test.ts
@@ -43,6 +43,14 @@ describe('cookies', () => {
       expect(await cookies.get('hello')).toEqual(undefined);
       await cookies.remove('hello');
     });
+
+    test('should return undefined when global scope is defined but document is not', async () => {
+      const cookies = new CookieStorage<number[]>();
+      await cookies.set('hello', [1]);
+      jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValueOnce({} as typeof globalThis);
+      expect(await cookies.get('hello')).toEqual(undefined);
+      await cookies.remove('hello');
+    });
   });
 
   describe('set', () => {


### PR DESCRIPTION
### Summary

Fixes #444 - SSR (tested with nextjs) fails when using the cookie storage.

### Checklist

* [x] Does your PR title have the correct
* Does your PR have a breaking change?:  No
