### PR TITLE
chore: Amp 78457 update GitHub issues workflows to amp project

### DIFF
--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -54,9 +54,10 @@ jobs:
             ${{ github.event.issue.html_url }}
           fields: '{
             "customfield_11416": {"value": "GitHub"},
+            "component": ["SDK"],
             "customfield_12028": ["${{ inputs.subcomponent }}"],
             "labels": ["${{ steps.string.outputs.lowercase }}"]
-          }' # Source, Subcomponents, labels
+          }' # Source, Component, Subcomponents, Labels
 
       - name: Log created issue
         run: echo "Issue AMP-${{ steps.create.outputs.issue }} was created"

--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -53,9 +53,10 @@ jobs:
           description: |
             ${{ github.event.issue.html_url }}
           fields: '{
-            "customfield_11794": {"value": "Github"},
+            "customfield_11416": {"value": "GitHub"},
+            "customfield_12028": ["${{ inputs.subcomponent }}"],
             "labels": ["${{ steps.string.outputs.lowercase }}"]
-          }' # origin, labels
+          }' # Source, Subcomponents, labels
 
       - name: Log created issue
         run: echo "Issue AMP-${{ steps.create.outputs.issue }} was created"

--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -56,8 +56,10 @@ jobs:
             "customfield_11416": {"value": "GitHub"},
             "component": ["SDK"],
             "customfield_12028": ["${{ inputs.subcomponent }}"],
-            "labels": ["${{ steps.string.outputs.lowercase }}"]
-          }' # Source, Component, Subcomponents, Labels
+            "labels": ["${{ steps.string.outputs.lowercase }}"],
+            "customfield_11481": {"value": "Governance"},
+            "customfield_11200": {"value": "Developer Experience"},
+          }' # Source, Component, Subcomponents, Labels, Pillar, Pod
 
       - name: Log created issue
         run: echo "Issue AMP-${{ steps.create.outputs.issue }} was created"

--- a/.github/workflows/ts-jira-issue-create.yml
+++ b/.github/workflows/ts-jira-issue-create.yml
@@ -14,6 +14,7 @@ jobs:
     uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@main
     with:
       label: "TS"
+      subcomponent: "dx_typescript_browser_sdk"
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}


### PR DESCRIPTION
### Summary

* Switch Github issues to create tickets in the AMP project (vs DXOC)
* Set AMP project fields - Source, Components, Subcomponents, Labels, Pillar, Pod

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
