### PR TITLE
chore: remove extra comma in issue workflow

### DIFF
--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -62,7 +62,7 @@ jobs:
             "customfield_12028": ["${{ inputs.subcomponent }}"],
             "labels": ["${{ steps.string.outputs.lowercase }}"],
             "customfield_11481": {"value": "Governance"},
-            "customfield_11200": {"value": "Developer Experience"},
+            "customfield_11200": {"value": "Developer Experience"}
           }' # Source, Component, Subcomponents, Labels, Pillar, Pod
 
       - name: Log created issue


### PR DESCRIPTION
### Summary

* fix issue worflow by removing unnecessary comma

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
