### PR TITLE
fix: Fix React Native 0.72 deprecation warning

### DIFF
--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -19,6 +19,8 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace "com.amplitude.reactnative"
+
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {

--- a/packages/analytics-react-native/android/src/main/AndroidManifest.xml
+++ b/packages/analytics-react-native/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.amplitude.reactnative">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>


### PR DESCRIPTION
### Summary

React Native 0.72 has update gradle things and has the following warning

```
> Task :amplitude_analytics-react-native:processDebugManifest
package="com.amplitude.reactnative" found in source AndroidManifest.xml: /home/johnf/work/gladly/mobile/node_modules/@amplitude/analytics-react-native/android/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```
This PR updates to the newer format.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: I don't think so, from the docs it sounds like this has been in the works for a while but maybe it would break for someone using a very old gradle?
