### PR TITLE
fix: missing core dependency for web attribution

### DIFF
--- a/packages/plugin-web-attribution-browser/package.json
+++ b/packages/plugin-web-attribution-browser/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-client-common": "^1.1.0",
+    "@amplitude/analytics-core": "^1.2.0",
     "@amplitude/analytics-types": "^1.3.0",
     "tslib": "^2.4.1"
   },


### PR DESCRIPTION
### Summary

Fixes: #459 for v1.x

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
