### PR TITLE
fix: allow plugins to teardown to remove listeners

### DIFF
--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -8,7 +8,31 @@ import {
 } from '../constants';
 import { BrowserConfig } from '../config';
 
+interface EventListener {
+  element: Element;
+  type: 'change' | 'submit';
+  handler: () => void;
+}
+
 export const formInteractionTracking = (): EnrichmentPlugin => {
+  let observer: MutationObserver | undefined;
+  let eventListeners: EventListener[] = [];
+  const addEventListener = (element: Element, type: 'change' | 'submit', handler: () => void) => {
+    element.addEventListener(type, handler);
+    eventListeners.push({
+      element,
+      type,
+      handler,
+    });
+  };
+  const removeClickListeners = () => {
+    eventListeners.forEach(({ element, type, handler }) => {
+      /* istanbul ignore next */
+      element?.removeEventListener(type, handler);
+    });
+    eventListeners = [];
+  };
+
   const name = '@amplitude/plugin-form-interaction-tracking-browser';
   const type = PluginType.ENRICHMENT;
   const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
@@ -21,25 +45,26 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       return;
     }
 
+    /* istanbul ignore if */
+    if (typeof document === 'undefined') {
+      return;
+    }
+
     const addFormInteractionListener = (form: HTMLFormElement) => {
       let hasFormChanged = false;
 
-      form.addEventListener(
-        'change',
-        () => {
-          if (!hasFormChanged) {
-            amplitude.track(DEFAULT_FORM_START_EVENT, {
-              [FORM_ID]: form.id,
-              [FORM_NAME]: form.name,
-              [FORM_DESTINATION]: form.action,
-            });
-          }
-          hasFormChanged = true;
-        },
-        {},
-      );
+      addEventListener(form, 'change', () => {
+        if (!hasFormChanged) {
+          amplitude.track(DEFAULT_FORM_START_EVENT, {
+            [FORM_ID]: form.id,
+            [FORM_NAME]: form.name,
+            [FORM_DESTINATION]: form.action,
+          });
+        }
+        hasFormChanged = true;
+      });
 
-      form.addEventListener('submit', () => {
+      addEventListener(form, 'submit', () => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
             [FORM_ID]: form.id,
@@ -64,7 +89,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     // Adds listener to anchor tags added after initial load
     /* istanbul ignore else */
     if (typeof MutationObserver !== 'undefined') {
-      const observer = new MutationObserver((mutations) => {
+      observer = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeName === 'FORM') {
@@ -84,11 +109,16 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     }
   };
   const execute = async (event: Event) => event;
+  const teardown = async () => {
+    observer?.disconnect();
+    removeClickListeners();
+  };
 
   return {
     name,
     type,
     setup,
     execute,
+    teardown,
   };
 };

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -29,7 +29,7 @@ describe('fileDownloadTracking', () => {
     const plugin = fileDownloadTracking();
     await plugin.setup(config, amplitude);
 
-    // trigger change event
+    // trigger click event
     document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
 
     // assert file download event was tracked
@@ -41,6 +41,15 @@ describe('fileDownloadTracking', () => {
       [LINK_TEXT]: 'my-link-text',
       [LINK_URL]: 'https://analytics.amplitude.com/files/my-file.pdf',
     });
+
+    // stop observer and listeners
+    await plugin.teardown?.();
+
+    // trigger click event
+    document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+    // assert no additional event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
   test('should track file_download event for a dynamically added achor tag', async () => {
@@ -71,6 +80,25 @@ describe('fileDownloadTracking', () => {
       [LINK_TEXT]: 'my-link-2-text',
       [LINK_URL]: 'https://analytics.amplitude.com/files/my-file-2.pdf',
     });
+
+    // stop observer and listeners
+    await plugin.teardown?.();
+
+    // add anchor element dynamically
+    const link3 = document.createElement('a');
+    link3.setAttribute('id', 'my-link-3-id');
+    link3.setAttribute('class', 'my-link-3-class');
+    link3.setAttribute('href', 'https://analytics.amplitude.com/files/my-file-3.pdf');
+    link3.text = 'my-link-3-text';
+    document.body.appendChild(link3);
+
+    // allow mutation observer to execute and event listener to be attached
+    await new Promise((r) => r(undefined)); // basically, await next clock tick
+    // trigger change event
+    link.dispatchEvent(new Event('click'));
+
+    // assert no additional file download event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
   test('should track file_download event for a dynamically added nested achor tag', async () => {
@@ -129,5 +157,13 @@ describe('fileDownloadTracking', () => {
     const plugin = fileDownloadTracking();
     const result = await plugin.execute(input);
     expect(result).toEqual(input);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  test('should teardown plugin', async () => {
+    const plugin = fileDownloadTracking();
+    await plugin.teardown?.();
+    // no explicit assertion
+    // test asserts that no error is thrown
   });
 });

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -98,6 +98,35 @@ describe('formInteractionTracking', () => {
 
     // assert second event was not tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
+
+    // stop observer and listeners
+    await plugin.teardown?.();
+
+    // add form element dynamically
+    const form3 = document.createElement('form');
+    form3.setAttribute('id', 'my-form-3-id');
+    form3.setAttribute('name', 'my-form-3-name');
+    form3.setAttribute('action', '/submit');
+
+    const text3 = document.createElement('input');
+    text3.setAttribute('type', 'text');
+    text3.setAttribute('id', 'my-text-3-id');
+
+    const submit3 = document.createElement('input');
+    submit3.setAttribute('type', 'submit');
+    submit3.setAttribute('id', 'my-submit-3-id');
+
+    form3.appendChild(text3);
+    form3.appendChild(submit3);
+    document.body.appendChild(form3);
+
+    // allow mutation observer to execute and event listener to be attached
+    await new Promise((r) => r(undefined)); // basically, await next clock tick
+    // trigger change event
+    form3.dispatchEvent(new Event('change'));
+
+    // assert no additional event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
   test('should track form_start event for a dynamically added nested form tag', async () => {
@@ -154,29 +183,6 @@ describe('formInteractionTracking', () => {
     const plugin = formInteractionTracking();
     await plugin.setup(config, amplitude);
 
-    // trigger change event
-    document.getElementById('my-form-id')?.dispatchEvent(new Event('submit'));
-
-    // assert both events were tracked
-    expect(amplitude.track).toHaveBeenCalledTimes(2);
-    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
-      [FORM_ID]: 'my-form-id',
-      [FORM_NAME]: 'my-form-name',
-      [FORM_DESTINATION]: 'http://localhost/submit',
-    });
-    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submitted', {
-      [FORM_ID]: 'my-form-id',
-      [FORM_NAME]: 'my-form-name',
-      [FORM_DESTINATION]: 'http://localhost/submit',
-    });
-  });
-
-  test('should track form_start and form_submit events on submit only', async () => {
-    // setup
-    const config = createConfigurationMock();
-    const plugin = formInteractionTracking();
-    await plugin.setup(config, amplitude);
-
     // trigger change event again
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
 
@@ -200,6 +206,38 @@ describe('formInteractionTracking', () => {
     });
   });
 
+  test('should track form_start and form_submit events on submit only', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = formInteractionTracking();
+    await plugin.setup?.(config, amplitude);
+
+    // trigger change event
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('submit'));
+
+    // assert both events were tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(2);
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
+    });
+    expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Submitted', {
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/submit',
+    });
+
+    // stop observer and listeners
+    await plugin.teardown?.();
+
+    // trigger change event
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('submit'));
+
+    // assert no additional event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(2);
+  });
+
   test('should not enrich events', async () => {
     const input = {
       event_type: 'page_view',
@@ -207,5 +245,13 @@ describe('formInteractionTracking', () => {
     const plugin = formInteractionTracking();
     const result = await plugin.execute(input);
     expect(result).toEqual(input);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  test('should teardown plugin', async () => {
+    const plugin = formInteractionTracking();
+    await plugin.teardown?.();
+    // no explicit assertion
+    // test asserts that no error is thrown
   });
 });

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -27,16 +27,17 @@ export class Timeline {
     this.plugins.push(plugin);
   }
 
-  deregister(pluginName: string) {
-    this.plugins.splice(
-      this.plugins.findIndex((plugin) => plugin.name === pluginName),
-      1,
-    );
-    return Promise.resolve();
+  async deregister(pluginName: string) {
+    const index = this.plugins.findIndex((plugin) => plugin.name === pluginName);
+    const plugin = this.plugins[index];
+    this.plugins.splice(index, 1);
+    await plugin.teardown?.();
   }
 
   reset(client: CoreClient) {
     this.applying = false;
+    const plugins = this.plugins;
+    plugins.map((plugin) => plugin.teardown?.());
     this.plugins = [];
     this.client = client;
   }

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -3,21 +3,13 @@ import { Event, Plugin, PluginType } from '@amplitude/analytics-types';
 import { useDefaultConfig, promiseState } from './helpers/default';
 import { createTrackEvent } from '../src/utils/event-builder';
 import { AmplitudeCore } from '../src/core-client';
+import { UUID } from 'src';
 
 describe('timeline', () => {
   let timeline = new Timeline(new AmplitudeCore());
 
   beforeEach(() => {
     timeline = new Timeline(new AmplitudeCore());
-  });
-
-  describe('register', () => {
-    test('should accept empty plugin', async () => {
-      const config = useDefaultConfig();
-      await timeline.register({}, config);
-      expect(timeline.plugins[0].name).toBeDefined();
-      expect(timeline.plugins[0].type).toBe('enrichment');
-    });
   });
 
   describe('reset', () => {
@@ -34,7 +26,10 @@ describe('timeline', () => {
       const timeline = new Timeline(new AmplitudeCore());
       timeline.plugins = [
         {
+          name: UUID(),
+          type: PluginType.BEFORE,
           setup,
+          execute: async (e) => e,
         },
       ];
       timeline.reset(new AmplitudeCore());
@@ -48,6 +43,10 @@ describe('timeline', () => {
       const timeline = new Timeline(new AmplitudeCore());
       timeline.plugins = [
         {
+          name: UUID(),
+          type: PluginType.BEFORE,
+          setup: async () => undefined,
+          execute: async (e) => e,
           teardown,
         },
       ];

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -11,8 +11,56 @@ describe('timeline', () => {
     timeline = new Timeline(new AmplitudeCore());
   });
 
+  describe('register', () => {
+    test('should accept empty plugin', async () => {
+      const config = useDefaultConfig();
+      await timeline.register({}, config);
+      expect(timeline.plugins[0].name).toBeDefined();
+      expect(timeline.plugins[0].type).toBe('enrichment');
+    });
+  });
+
+  describe('reset', () => {
+    test('should reset timeline', () => {
+      const timeline = new Timeline(new AmplitudeCore());
+      timeline.plugins = [];
+      timeline.reset(new AmplitudeCore());
+      expect(timeline.applying).toEqual(false);
+      expect(timeline.plugins).toEqual([]);
+    });
+
+    test('should reset timeline without plugin.teardown', () => {
+      const setup = jest.fn();
+      const timeline = new Timeline(new AmplitudeCore());
+      timeline.plugins = [
+        {
+          setup,
+        },
+      ];
+      timeline.reset(new AmplitudeCore());
+      expect(setup).toHaveBeenCalledTimes(0);
+      expect(timeline.applying).toEqual(false);
+      expect(timeline.plugins).toEqual([]);
+    });
+
+    test('should reset timeline with plugin.teardown', () => {
+      const teardown = jest.fn();
+      const timeline = new Timeline(new AmplitudeCore());
+      timeline.plugins = [
+        {
+          teardown,
+        },
+      ];
+      timeline.reset(new AmplitudeCore());
+      expect(teardown).toHaveBeenCalledTimes(1);
+      expect(timeline.applying).toEqual(false);
+      expect(timeline.plugins).toEqual([]);
+    });
+  });
+
   test('should update event using before/enrichment plugin', async () => {
     const beforeSetup = jest.fn().mockReturnValue(Promise.resolve());
+    const beforeTeardown = jest.fn().mockReturnValue(Promise.resolve());
     const beforeExecute = jest.fn().mockImplementation((event: Event) =>
       Promise.resolve({
         ...event,
@@ -23,6 +71,7 @@ describe('timeline', () => {
       name: 'plugin:before',
       type: PluginType.BEFORE,
       setup: beforeSetup,
+      teardown: beforeTeardown,
       execute: beforeExecute,
     };
     const enrichmentSetup = jest.fn().mockReturnValue(Promise.resolve());

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -3,7 +3,7 @@ import { Event, Plugin, PluginType } from '@amplitude/analytics-types';
 import { useDefaultConfig, promiseState } from './helpers/default';
 import { createTrackEvent } from '../src/utils/event-builder';
 import { AmplitudeCore } from '../src/core-client';
-import { UUID } from 'src';
+import { UUID } from '../src/utils/uuid';
 
 describe('timeline', () => {
   let timeline = new Timeline(new AmplitudeCore());

--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -14,6 +14,7 @@ export interface BeforePlugin<T = CoreClient, U = Config> {
   type: PluginType.BEFORE;
   setup(config: U, client?: T): Promise<void>;
   execute(context: Event): Promise<Event | null>;
+  teardown?(): Promise<void>;
 }
 
 export interface EnrichmentPlugin<T = CoreClient, U = Config> {
@@ -21,6 +22,7 @@ export interface EnrichmentPlugin<T = CoreClient, U = Config> {
   type: PluginType.ENRICHMENT;
   setup(config: U, client?: T): Promise<void>;
   execute(context: Event): Promise<Event | null>;
+  teardown?(): Promise<void>;
 }
 
 export interface DestinationPlugin<T = CoreClient, U = Config> {
@@ -29,6 +31,7 @@ export interface DestinationPlugin<T = CoreClient, U = Config> {
   setup(config: U, client?: T): Promise<void>;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;
+  teardown?(): Promise<void>;
 }
 
 export type Plugin<T = CoreClient, U = Config> = BeforePlugin<T, U> | EnrichmentPlugin<T, U> | DestinationPlugin<T, U>;

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -498,7 +498,9 @@ describe('pageViewTrackingPlugin', () => {
       const config: Partial<Config> = {
         loggerProvider: loggerProvider as Logger,
       };
-      const plugin = pageViewTrackingPlugin();
+      const plugin = pageViewTrackingPlugin({
+        trackHistoryChanges: 'all',
+      });
       await plugin.setup(config as Config, amplitude);
       await plugin.teardown?.();
       expect(removeEventListener).toHaveBeenCalledTimes(1);
@@ -506,7 +508,9 @@ describe('pageViewTrackingPlugin', () => {
 
     test('should call remove listeners without proxy', async () => {
       const removeEventListener = jest.spyOn(window, 'removeEventListener');
-      const plugin = pageViewTrackingPlugin();
+      const plugin = pageViewTrackingPlugin({
+        trackHistoryChanges: 'all',
+      });
       await plugin.teardown?.();
       expect(removeEventListener).toHaveBeenCalledTimes(1);
     });

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -492,8 +492,14 @@ describe('pageViewTrackingPlugin', () => {
     test('should call remove listeners', async () => {
       const amplitude = createInstance();
       const removeEventListener = jest.spyOn(window, 'removeEventListener');
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+      };
+      const config: Partial<Config> = {
+        loggerProvider: loggerProvider as Logger,
+      };
       const plugin = pageViewTrackingPlugin();
-      await plugin.setup({} as Config, amplitude);
+      await plugin.setup(config as Config, amplitude);
       await plugin.teardown?.();
       expect(removeEventListener).toHaveBeenCalledTimes(1);
     });

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -488,6 +488,24 @@ describe('pageViewTrackingPlugin', () => {
     });
   });
 
+  describe('teardown', () => {
+    test('should call remove listeners', async () => {
+      const amplitude = createInstance();
+      const removeEventListener = jest.spyOn(window, 'removeEventListener');
+      const plugin = pageViewTrackingPlugin();
+      await plugin.setup({} as Config, amplitude);
+      await plugin.teardown?.();
+      expect(removeEventListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('should call remove listeners without proxy', async () => {
+      const removeEventListener = jest.spyOn(window, 'removeEventListener');
+      const plugin = pageViewTrackingPlugin();
+      await plugin.teardown?.();
+      expect(removeEventListener).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test('shouldTrackHistoryPageView pathOnly option', () => {
     const url1 = 'https://www.example.com/path/to/page';
     const url2 = 'https://www.example.com/path/to/page?query=1';


### PR DESCRIPTION
### Summary

Cherry picks https://github.com/amplitude/Amplitude-TypeScript/pull/460

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
