### PR TITLE
ci: update aws-actions/configure-aws-credentials

### DIFF
--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -81,7 +81,7 @@ jobs:
           npm whoami
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
           aws-region: us-west-2

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -80,7 +80,7 @@ jobs:
           npm whoami
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
           aws-region: us-west-2


### PR DESCRIPTION
### Summary

* aws-actions/configure-aws-credentials from v1 to v2
* According to aws-actions/configure-aws-credentials v2 [changelog](https://github.com/aws-actions/configure-aws-credentials/blob/main/CHANGELOG.md?plain=1#L16-L19), the change only uses node 16 by default which we are already using, so nothing else needs to be changed from our end

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
