### PR TITLE
fix: handle concurrent cookie testing

### DIFF
--- a/packages/analytics-client-common/src/storage/cookie.ts
+++ b/packages/analytics-client-common/src/storage/cookie.ts
@@ -3,6 +3,7 @@ import { getGlobalScope } from '../global-scope';
 
 export class CookieStorage<T> implements Storage<T> {
   options: CookieStorageOptions;
+  private static testValue: undefined | string;
 
   constructor(options?: CookieStorageOptions) {
     this.options = { ...options };
@@ -14,13 +15,13 @@ export class CookieStorage<T> implements Storage<T> {
       return false;
     }
 
-    const random = String(Date.now());
+    CookieStorage.testValue = String(Date.now());
     const testStrorage = new CookieStorage<string>(this.options);
     const testKey = 'AMP_TEST';
     try {
-      await testStrorage.set(testKey, random);
+      await testStrorage.set(testKey, CookieStorage.testValue);
       const value = await testStrorage.get(testKey);
-      return value === random;
+      return value === CookieStorage.testValue;
     } catch {
       /* istanbul ignore next */
       return false;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Handles concurrent cookie testing

#### Problem

Concurrent cookie testing causes isEnabled to return `false`. This is mainly because the cookie key for the cookie tester is the same and is shared by all instances. Below are the specific steps that lead to the issue:

1. Cookie test 1 starts
2. Cookie test 1 sets AMP_TEST to random value 1
3. Cookie test 2 starts
4. Cookie test 2 sets AMP_TEST to random value 2
5. Cookie test 1 reads AMP_TEST but gets random value 2
6. Cookie test 1 fails
7. Cookie test 2 reads AMP_TEST and gets random value 2
8. Cookie test 1 succeeds

#### Solution

Keep static property of latest random value generated and always test against latest random value

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
