### PR TITLE
fix: handle concurrent history push state calls

### DIFF
--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -44,13 +44,19 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
 
   const trackHistoryPageView = async (): Promise<void> => {
     const newURL = location.href;
+    const shouldTrackPageView =
+      shouldTrackHistoryPageView(options.trackHistoryChanges, newURL, previousURL || '') && shouldTrackOnPageLoad();
+    // Note: Update `previousURL` in the same clock tick as `shouldTrackHistoryPageView()`
+    // This was previously done after `amplitude?.track(await createPageViewEvent());` and
+    // causes a concurrency issue where app triggers `pushState` twice with the same URL target
+    // but `previousURL` is only updated after the second `pushState` producing two page viewed events
+    previousURL = newURL;
 
-    if (shouldTrackHistoryPageView(options.trackHistoryChanges, newURL, previousURL || '') && shouldTrackOnPageLoad()) {
+    if (shouldTrackPageView) {
       /* istanbul ignore next */
       loggerProvider?.log('Tracking page view event');
       amplitude?.track(await createPageViewEvent());
     }
-    previousURL = newURL;
   };
 
   /* istanbul ignore next */


### PR DESCRIPTION
### Summary

Handles concurrent history.pushState calls

#### Issue

`previousURL` is stale. Consider the following steps that lead to the error

0. current path is `/home`
1. First pushState()  to `/settings`
2. diffs previousURL with newURL
3. First track event (awaited)
4. Second pushState()  to `/settings`
5. diffs previousURL with newURL
    * Because step 3 is being awaited on, `previousURL` is still `/home`
6. Second track event (awaited)
7. Updates `previousURL` for first push state
8. Updates `previousURL` for second push state

#### Solution

Update `previousURL` on the same clock tick. Consider the following steps that lead to correct state

0. current path is `/home`
1. First pushState()  to `/settings`
2. diffs previousURL with newURL
3. Updates `previousURL` for first push state
4. First track event (awaited)
5. Second pushState()  to `/settings`
6. diffs previousURL with newURL
7. Updates `previousURL` for second push state
8. No second track event because previousURL and newURL are the same

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
