### PR TITLE
fix: allow literal values for plugin type

### DIFF
--- a/packages/analytics-types/src/plugin.ts
+++ b/packages/analytics-types/src/plugin.ts
@@ -11,7 +11,7 @@ export enum PluginType {
 
 export interface BeforePlugin<T = CoreClient, U = Config> {
   name: string;
-  type: PluginType.BEFORE;
+  type: PluginType.BEFORE | 'before';
   setup(config: U, client?: T): Promise<void>;
   execute(context: Event): Promise<Event | null>;
   teardown?(): Promise<void>;
@@ -19,7 +19,7 @@ export interface BeforePlugin<T = CoreClient, U = Config> {
 
 export interface EnrichmentPlugin<T = CoreClient, U = Config> {
   name: string;
-  type: PluginType.ENRICHMENT;
+  type: PluginType.ENRICHMENT | 'enrichment';
   setup(config: U, client?: T): Promise<void>;
   execute(context: Event): Promise<Event | null>;
   teardown?(): Promise<void>;
@@ -27,7 +27,7 @@ export interface EnrichmentPlugin<T = CoreClient, U = Config> {
 
 export interface DestinationPlugin<T = CoreClient, U = Config> {
   name: string;
-  type: PluginType.DESTINATION;
+  type: PluginType.DESTINATION | 'destination';
   setup(config: U, client?: T): Promise<void>;
   execute(context: Event): Promise<Result>;
   flush?(): Promise<void>;

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,5 +1,5 @@
 import { AMPLITUDE_PREFIX, BaseTransport } from '@amplitude/analytics-core';
-import { BrowserConfig, Event, PluginType, Status } from '@amplitude/analytics-types';
+import { BrowserConfig, Event, Status } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import { pack, record } from 'rrweb';
 import { DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_REPLAY_PROPERTY, DEFAULT_SESSION_START_EVENT } from './constants';
@@ -20,7 +20,7 @@ const MAX_EVENT_LIST_SIZE_IN_BYTES = 20 * 1000000 - PAYLOAD_ESTIMATED_SIZE_IN_BY
 
 class SessionReplay implements SessionReplayEnrichmentPlugin {
   name = '@amplitude/plugin-session-replay-browser';
-  type = PluginType.ENRICHMENT as const;
+  type = 'enrichment' as const;
   // this.config is defined in setup() which will always be called first
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore


### PR DESCRIPTION
### Summary

Extends plugin interface to allow literal values for `type`. This effectively fixes compatibility issue of `plugin-session-replay-browser` with Browser SDK 2.0.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No