### PR TITLE
fix(plugins): update timing of sending batches of session replay events

### DIFF
--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -37,14 +37,13 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^1.1.1",
-    "@amplitude/analytics-types": "^1.3.1",
+    "@amplitude/analytics-types": ">=1 <3",
     "idb-keyval": "^6.2.1",
     "rrweb": "^2.0.0-alpha.4",
     "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "@amplitude/analytics-browser": "^1.12.1",
+    "@amplitude/analytics-client-common": ">=1 <3",
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",

--- a/packages/plugin-session-replay-browser/src/helpers.ts
+++ b/packages/plugin-session-replay-browser/src/helpers.ts
@@ -1,8 +1,0 @@
-export const shouldSplitEventsList = (eventsList: string[], nextEventString: string, maxListSize: number): boolean => {
-  const sizeOfNextEvent = new Blob([nextEventString]).size;
-  const sizeOfEventsList = new Blob(eventsList).size;
-  if (sizeOfEventsList + sizeOfNextEvent >= maxListSize) {
-    return true;
-  }
-  return false;
-};

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -92,13 +92,14 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
     this.stopRecordingEvents = record({
       emit: (event) => {
         const eventString = JSON.stringify(event);
-        // Send the first recorded event immediately
-        if (!this.events.length && this.currentSequenceId === 0) {
+        // Send the first two recorded events immediately
+        if (this.events.length === 1 && this.currentSequenceId === 0) {
           this.sendEventsList({
-            events: [eventString],
+            events: this.events.concat(eventString),
             sequenceId: this.currentSequenceId,
             sessionId: this.config.sessionId as number,
           });
+          this.events = [];
           this.currentSequenceId++;
           return;
         }

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -91,7 +91,6 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
   recordEvents() {
     this.stopRecordingEvents = record({
       emit: (event) => {
-        console.log('this.events', this.events);
         const eventString = JSON.stringify(event);
         // Send the first recorded event immediately
         if (!this.events.length && this.currentSequenceId === 0) {

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -28,7 +28,7 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   currentSequenceId: number;
   interval: number;
   queue: SessionReplayContext[];
-  timeSinceLastSend: number | null;
+  timeAtLastSend: number | null;
   stopRecordingEvents: ReturnType<typeof record> | null;
   maxPersistedEventsSize: number;
   emptyStoreAndReset: () => Promise<void>;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -26,11 +26,14 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   retryTimeout: number;
   events: Events;
   currentSequenceId: number;
+  interval: number;
   queue: SessionReplayContext[];
+  timeSinceLastSend: number | null;
   stopRecordingEvents: ReturnType<typeof record> | null;
   maxPersistedEventsSize: number;
   emptyStoreAndReset: () => Promise<void>;
   recordEvents: () => void;
+  shouldSplitEventsList: (nextEventString: string) => boolean;
   sendEventsList: ({
     events,
     sequenceId,


### PR DESCRIPTION
### Summary
This PR updates the timing of when batches of session replay events as the following:
- As soon as the first two events in a session sequence are recorded they are sent to the API
- Then batches are sent every 1000, 2000, 3000....up to 10000 max milliseconds.
- There is also a size limit kept on the event batch of 20MB, if the next event would cause the batch of events to go over 20MB the list will be sent.

This PR also adds a default of masking all inputs to the recorder, this will be updated to be configurable in future revisions.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
