### PR TITLE
feat(plugins): Adding configuration options to session replay plugin

### DIFF
--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -51,7 +51,7 @@ const sessionReplayTracking = sessionReplayPlugin({
 
 |Name|Type|Default|Description|
 |-|-|-|-|
-|`sampleRate`|`number`|`undefined`|Use this option to control how many sessions will be selected for recording. <br></br>The number should be a decimal between 0 and 1, ie `0.4`, representing the fraction of sessions you would like to have randomly selected for recording. Over a large number of sessions, `0.4` would select `40%` of those sessions.|
+|`sampleRate`|`number`|`undefined`|Use this option to control how many sessions will be selected for recording. A selected session will be recorded, while sessions that are not selected will not be recorded.  <br></br>The number should be a decimal between 0 and 1, ie `0.4`, representing the fraction of sessions you would like to have randomly selected for recording. Over a large number of sessions, `0.4` would select `40%` of those sessions.|
 
 ### 3. Install plugin to Amplitude SDK
 

--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -35,12 +35,26 @@ import * as amplitude from '@amplitude/analytics-browser';
 import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 ```
 
-### 2. Instantiate session replay plugin and install plugin to Amplitude SDK
+### 2. Instantiate Session Replay plugin
 
-The plugin must be registered with the amplitude instance via the following code:
+The plugin must be registered with the amplitude instance via the following code. The plugin accepts an optional parameter which is an `Object` to configure the plugin based on your use case.
 
 ```typescript
 amplitude.init(API_KEY);
-const sessionReplayTracking = sessionReplayPlugin();
+const sessionReplayTracking = sessionReplayPlugin({
+  sampleRate: undefined
+});
+```
+
+
+#### Options
+
+|Name|Type|Default|Description|
+|-|-|-|-|
+|`sampleRate`|`number`|`undefined`|Use this option to control how many sessions will be selected for recording. <br></br>The number should be a decimal between 0 and 1, ie `0.4`, representing the fraction of sessions you would like to have randomly selected for recording. Over a large number of sessions, `0.4` would select `40%` of those sessions.|
+
+### 3. Install plugin to Amplitude SDK
+
+```typescript
 amplitude.add(sessionReplayTracking);
 ```

--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -25,6 +25,8 @@ yarn add @amplitude/plugin-session-replay-browser
 
 This plugin works on top of Amplitude Browser SDK and adds session replay features to built-in features. To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.0.0` or later.
 
+This plugin requires that default tracking for sessions is enabled. If default tracking for sessions is not enabled in the config, the plugin will automatically enable it.
+
 ### 1. Import Amplitude packages
 
 * `@amplitude/analytics-browser`

--- a/packages/plugin-session-replay-browser/src/messages.ts
+++ b/packages/plugin-session-replay-browser/src/messages.ts
@@ -1,4 +1,5 @@
-export const SUCCESS_MESSAGE = 'Session replay event batch tracked successfully';
+export const getSuccessMessage = (sessionId: number) =>
+  `Session replay event batch tracked successfully for session id ${sessionId}`;
 export const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred';
 export const MAX_RETRIES_EXCEEDED_MESSAGE = 'Session replay event batch rejected due to exceeded retry count';
 export const STORAGE_FAILURE = 'Failed to store session replay events in IndexedDB';

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -51,8 +51,12 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
 
   async setup(config: BrowserConfig) {
     config.loggerProvider.log('Installing @amplitude/plugin-session-replay.');
+    if (config.optOut) {
+      this.shouldRecordEvents = false;
+    }
+
     if (!this.shouldRecordEvents) {
-      config.loggerProvider.log('Opting session out of recording due to lack of inclusion in sample.');
+      config.loggerProvider.log('Opting session out of recording.');
       return;
     }
 

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -42,6 +42,22 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
   async setup(config: BrowserConfig) {
     config.loggerProvider.log('Installing @amplitude/plugin-session-replay.');
 
+    if (typeof config.defaultTracking === 'boolean') {
+      if (config.defaultTracking === false) {
+        config.defaultTracking = {
+          pageViews: false,
+          formInteractions: false,
+          fileDownloads: false,
+          sessions: true,
+        };
+      }
+    } else {
+      config.defaultTracking = {
+        ...config.defaultTracking,
+        sessions: true,
+      };
+    }
+
     this.config = config;
     this.storageKey = `${STORAGE_PREFIX}_${this.config.apiKey.substring(0, 10)}`;
     await this.initialize(true);

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -145,11 +145,12 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
   setShouldRecord(sessionStore?: IDBStoreSession) {
     if (sessionStore?.shouldRecord === false) {
       this.shouldRecord = false;
-    } else if (this.options && this.options.sampleRate) {
-      this.shouldRecord = Math.random() < this.options.sampleRate;
     } else if (this.config.optOut) {
       this.shouldRecord = false;
+    } else if (this.options && this.options.sampleRate) {
+      this.shouldRecord = Math.random() < this.options.sampleRate;
     }
+
     this.config.sessionId && void this.storeShouldRecordForSession(this.config.sessionId, this.shouldRecord);
     if (!this.shouldRecord && this.config.sessionId) {
       this.config.loggerProvider.log(`Opting session ${this.config.sessionId} out of recording.`);

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -32,6 +32,7 @@ export interface IDBStore {
   };
 }
 export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
+  setup: (config: BrowserConfig) => Promise<void>;
   config: BrowserConfig;
   storageKey: string;
   retryTimeout: number;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,8 +1,10 @@
-import { BrowserClient, BrowserConfig, EnrichmentPlugin } from '@amplitude/analytics-types';
+import { BrowserConfig, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { record } from 'rrweb';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Options {}
+export interface SessionReplayOptions {
+  sampleRate?: number;
+}
 
 export type Events = string[];
 
@@ -76,8 +78,5 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
 }
 
 export interface SessionReplayPlugin {
-  (client: BrowserClient, options?: Options): SessionReplayEnrichmentPlugin;
-  (options?: Options): SessionReplayEnrichmentPlugin;
+  (options?: SessionReplayOptions): SessionReplayEnrichmentPlugin;
 }
-
-export type SessionReplayPluginParameters = [BrowserClient, Options?] | [Options?];

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -27,11 +27,16 @@ export interface IDBStoreSequence {
   status: RecordingStatus;
 }
 
-export interface IDBStore {
-  [sessionId: number]: {
-    currentSequenceId: number;
-    sessionSequences: { [sequenceId: number]: IDBStoreSequence };
+export interface IDBStoreSession {
+  shouldRecord: boolean;
+  currentSequenceId: number;
+  sessionSequences: {
+    [sequenceId: number]: IDBStoreSequence;
   };
+}
+
+export interface IDBStore {
+  [sessionId: number]: IDBStoreSession;
 }
 export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   setup: (config: BrowserConfig) => Promise<void>;
@@ -41,11 +46,13 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   events: Events;
   currentSequenceId: number;
   interval: number;
+  shouldRecord: boolean;
   queue: SessionReplayContext[];
   timeAtLastSend: number | null;
   stopRecordingEvents: ReturnType<typeof record> | null;
   maxPersistedEventsSize: number;
   initialize: (shouldSendStoredEvents?: boolean) => Promise<void>;
+  setShouldRecord: (sessionStore?: IDBStoreSession) => void;
   recordEvents: () => void;
   shouldSplitEventsList: (nextEventString: string) => boolean;
   sendEventsList: ({
@@ -74,6 +81,7 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   }): void;
   getAllSessionEventsFromStore: () => Promise<IDBStore | undefined>;
   storeEventsForSession: (events: Events, sequenceId: number, sessionId: number) => Promise<void>;
+  storeShouldRecordForSession: (sessionId: number, shouldRecord: boolean) => Promise<void>;
   cleanUpSessionEventsStore: (sessionId: number, sequenceId: number) => Promise<void>;
 }
 

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -362,7 +362,6 @@ describe('SessionReplayPlugin', () => {
       expect(sessionReplay.shouldRecord).toBe(false);
     });
     test('should not set record as false if no options', () => {
-      jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
       const sessionReplay = sessionReplayPlugin();
       sessionReplay.config = mockConfig;
       sessionReplay.setShouldRecord();
@@ -378,8 +377,29 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.setShouldRecord();
       expect(sessionReplay.shouldRecord).toBe(false);
     });
+    test('should set record as true if session is included in sample rate', () => {
+      jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
+      const sessionReplay = sessionReplayPlugin({
+        sampleRate: 0.8,
+      });
+      sessionReplay.config = mockConfig;
+      sessionReplay.setShouldRecord();
+      expect(sessionReplay.shouldRecord).toBe(true);
+    });
     test('should set record as false if opt out in config', () => {
       const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = {
+        ...mockConfig,
+        optOut: true,
+      };
+      sessionReplay.setShouldRecord();
+      expect(sessionReplay.shouldRecord).toBe(false);
+    });
+    test('opt out in config should override the sample rate', () => {
+      jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
+      const sessionReplay = sessionReplayPlugin({
+        sampleRate: 0.8,
+      });
       sessionReplay.config = {
         ...mockConfig,
         optOut: true,

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -293,6 +293,42 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.initialize();
       expect(record).toHaveBeenCalledTimes(1);
     });
+    describe('defaultTracking', () => {
+      test('should not change defaultTracking if its set to true', async () => {
+        const sessionReplay = sessionReplayPlugin();
+        await sessionReplay.setup({
+          ...mockConfig,
+          defaultTracking: true,
+        });
+        expect(sessionReplay.config.defaultTracking).toBe(true);
+      });
+      test('should modify defaultTracking to enable sessions if its set to false', async () => {
+        const sessionReplay = sessionReplayPlugin();
+        await sessionReplay.setup({
+          ...mockConfig,
+          defaultTracking: false,
+        });
+        expect(sessionReplay.config.defaultTracking).toEqual({
+          pageViews: false,
+          formInteractions: false,
+          fileDownloads: false,
+          sessions: true,
+        });
+      });
+      test('should modify defaultTracking to enable sessions if it is an object', async () => {
+        const sessionReplay = sessionReplayPlugin();
+        await sessionReplay.setup({
+          ...mockConfig,
+          defaultTracking: {
+            pageViews: false,
+          },
+        });
+        expect(sessionReplay.config.defaultTracking).toEqual({
+          pageViews: false,
+          sessions: true,
+        });
+      });
+    });
   });
 
   describe('execute', () => {

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable jest/expect-expect */
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { CookieStorage, FetchTransport } from '@amplitude/analytics-client-common';
-import { BrowserConfig, LogLevel } from '@amplitude/analytics-types';
+import { BrowserConfig, LogLevel, Logger } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import * as RRWeb from 'rrweb';
-import { SUCCESS_MESSAGE, UNEXPECTED_ERROR_MESSAGE } from '../src/messages';
+import { UNEXPECTED_ERROR_MESSAGE, getSuccessMessage } from '../src/messages';
 import { sessionReplayPlugin } from '../src/session-replay';
 import { IDBStore, RecordingStatus } from '../src/typings/session-replay';
 
@@ -13,6 +13,8 @@ type MockedIDBKeyVal = jest.Mocked<typeof import('idb-keyval')>;
 
 jest.mock('rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('rrweb')>;
+
+type MockedLogger = jest.Mocked<Logger>;
 
 const mockEvent = {
   type: 4,
@@ -30,20 +32,11 @@ async function runScheduleTimers() {
   jest.runAllTimers();
 }
 
-const mockLoggerProvider = {
-  error: jest.fn(),
-  log: jest.fn(),
-  logLevel: 1,
-  disable: jest.fn(),
-  enable: jest.fn(),
-  warn: jest.fn(),
-  debug: jest.fn(),
-};
-
 describe('SessionReplayPlugin', () => {
   const { get, update } = IDBKeyVal as MockedIDBKeyVal;
   const { record } = RRWeb as MockedRRWeb;
   let originalFetch: typeof global.fetch;
+  let mockLoggerProvider: MockedLogger;
   let addEventListenerMock: jest.Mock<typeof window.addEventListener>;
   const mockConfig: BrowserConfig = {
     apiKey: 'static_key',
@@ -78,10 +71,8 @@ describe('SessionReplayPlugin', () => {
       platform: true,
     },
   };
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
   beforeEach(() => {
+    jest.useFakeTimers();
     originalFetch = global.fetch;
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -97,12 +88,19 @@ describe('SessionReplayPlugin', () => {
         hasFocus: () => true,
       },
     } as Window & typeof globalThis);
+    mockLoggerProvider = {
+      error: jest.fn(),
+      log: jest.fn(),
+      disable: jest.fn(),
+      enable: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
   });
   afterEach(() => {
     jest.resetAllMocks();
+    jest.spyOn(global.Math, 'random').mockRestore();
     global.fetch = originalFetch;
-  });
-  afterAll(() => {
     jest.useRealTimers();
   });
   describe('setup', () => {
@@ -165,6 +163,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = config;
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             3: {
@@ -174,6 +173,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -243,6 +243,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             3: {
@@ -262,6 +263,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             3: {
@@ -280,6 +282,21 @@ describe('SessionReplayPlugin', () => {
       const sessionReplay = sessionReplayPlugin();
       sessionReplay.config = mockConfig;
       const mockGetResolution = Promise.resolve({});
+      get.mockReturnValueOnce(mockGetResolution);
+      await sessionReplay.initialize();
+      expect(sessionReplay.currentSequenceId).toBe(0);
+      expect(sessionReplay.events).toEqual([]);
+    });
+    test('should handle no stored sequences for session', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = mockConfig;
+      const mockGetResolution = Promise.resolve({
+        123: {
+          shouldRecord: true,
+          currentSequenceId: 0,
+          sessionSequences: {},
+        },
+      });
       get.mockReturnValueOnce(mockGetResolution);
       await sessionReplay.initialize();
       expect(sessionReplay.currentSequenceId).toBe(0);
@@ -328,6 +345,47 @@ describe('SessionReplayPlugin', () => {
           sessions: true,
         });
       });
+    });
+  });
+
+  describe('setShouldRecord', () => {
+    test('should set record as false if false in session store', () => {
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = mockConfig;
+      const sessionStore = {
+        shouldRecord: false,
+        currentSequenceId: 0,
+        sessionSequences: {},
+      };
+      expect(sessionReplay.shouldRecord).toBe(true);
+      sessionReplay.setShouldRecord(sessionStore);
+      expect(sessionReplay.shouldRecord).toBe(false);
+    });
+    test('should not set record as false if no options', () => {
+      jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = mockConfig;
+      sessionReplay.setShouldRecord();
+      expect(sessionReplay.shouldRecord).toBe(true);
+    });
+    test('should set record as false if session not included in sample rate', () => {
+      jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
+      const sessionReplay = sessionReplayPlugin({
+        sampleRate: 0.2,
+      });
+      sessionReplay.config = mockConfig;
+      expect(sessionReplay.shouldRecord).toBe(true);
+      sessionReplay.setShouldRecord();
+      expect(sessionReplay.shouldRecord).toBe(false);
+    });
+    test('should set record as false if opt out in config', () => {
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = {
+        ...mockConfig,
+        optOut: true,
+      };
+      sessionReplay.setShouldRecord();
+      expect(sessionReplay.shouldRecord).toBe(false);
     });
   });
 
@@ -406,6 +464,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1]({})).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 0,
           sessionSequences: {
             0: {
@@ -420,16 +479,16 @@ describe('SessionReplayPlugin', () => {
     test('should split the events list at an increasing interval and send', () => {
       const sessionReplay = sessionReplayPlugin();
       sessionReplay.config = mockConfig;
+      sessionReplay.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
       sessionReplay.recordEvents();
-      sessionReplay.timeAtLastSend = 1;
-      const dateNowMock = jest.spyOn(Date, 'now').mockReturnValue(1);
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
       const sendEventsList = jest.spyOn(sessionReplay, 'sendEventsList');
       const recordArg = record.mock.calls[0][0];
       // Emit first event, which is not sent immediately
       recordArg?.emit && recordArg?.emit(mockEvent);
       expect(sendEventsList).toHaveBeenCalledTimes(0);
       // Emit second event and advance timers to interval
-      dateNowMock.mockReturnValue(1002);
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:31:00').getTime());
       recordArg?.emit && recordArg?.emit(mockEvent);
       expect(sendEventsList).toHaveBeenCalledTimes(1);
       expect(sendEventsList).toHaveBeenCalledWith({
@@ -439,7 +498,6 @@ describe('SessionReplayPlugin', () => {
       });
       expect(sessionReplay.events).toEqual([mockEventString]);
       expect(sessionReplay.currentSequenceId).toEqual(1);
-      dateNowMock.mockClear();
     });
 
     test('should split the events list at max size and send', () => {
@@ -467,6 +525,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1]({})).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -755,18 +814,92 @@ describe('SessionReplayPlugin', () => {
           sampleRate: 0.2,
         });
         await sessionReplay.setup(mockConfig);
+        expect(update).toHaveBeenCalled();
+        expect(update.mock.calls[0][1]({})).toEqual({
+          123: {
+            shouldRecord: false,
+            currentSequenceId: 0,
+            sessionSequences: {},
+          },
+        });
+        update.mockClear();
         await sessionReplay.execute({
-          event_type: 'session_start',
-          session_id: 456,
+          event_type: 'my_event',
+          session_id: 123,
         });
         expect(record).not.toHaveBeenCalled();
         expect(update).not.toHaveBeenCalled();
         await sessionReplay.execute({
           event_type: 'session_end',
-          session_id: 456,
+          session_id: 123,
         });
         await runScheduleTimers();
         expect(fetch).not.toHaveBeenCalled();
+      });
+      test('should recalculate whether to exclude session due to sample rate when start session fires', async () => {
+        jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.1);
+        const sessionReplay = sessionReplayPlugin({
+          sampleRate: 0.2,
+        });
+        await sessionReplay.setup(mockConfig);
+        expect(update).toHaveBeenCalled();
+        expect(update.mock.calls[0][1]({})).toEqual({
+          123: {
+            shouldRecord: true,
+            currentSequenceId: 0,
+            sessionSequences: {},
+          },
+        });
+        update.mockClear();
+        // Record is called in setup, but we're not interested in that now
+        record.mockClear();
+        // This will exclude session from sample rate
+        jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
+        await sessionReplay.execute({
+          event_type: 'session_start',
+          session_id: 123,
+        });
+        expect(record).not.toHaveBeenCalled();
+        expect(update).toHaveBeenCalled();
+        expect(update.mock.calls[0][1]({})).toEqual({
+          123: {
+            shouldRecord: false,
+            currentSequenceId: 0,
+            sessionSequences: {},
+          },
+        });
+        await sessionReplay.execute({
+          event_type: 'session_end',
+          session_id: 123,
+        });
+        await runScheduleTimers();
+        expect(fetch).not.toHaveBeenCalled();
+      });
+      test('should fetch whether to record session from IDB', async () => {
+        const sessionReplay = sessionReplayPlugin();
+        const mockIDBStore = {
+          123: {
+            shouldRecord: false,
+            currentSequenceId: 0,
+            sessionSequences: {},
+          },
+        };
+        get.mockImplementationOnce(() => Promise.resolve(mockIDBStore));
+        await sessionReplay.setup(mockConfig);
+        expect(record).not.toHaveBeenCalled();
+        expect(update).toHaveBeenCalled();
+        expect(update.mock.calls[0][1]({})).toEqual({
+          123: {
+            shouldRecord: false,
+            currentSequenceId: 0,
+            sessionSequences: {},
+          },
+        });
+        await sessionReplay.execute({
+          event_type: 'session_start',
+          session_id: 123,
+        });
+        expect(record).not.toHaveBeenCalled();
       });
       test('should record session if included due to sampling', async () => {
         (fetch as jest.Mock).mockImplementationOnce(() => {
@@ -783,25 +916,25 @@ describe('SessionReplayPlugin', () => {
           loggerProvider: mockLoggerProvider,
         };
         await sessionReplay.setup(config);
-        // Log is called from setup, but that's not what we're testing here
-        mockLoggerProvider.log.mockClear();
         await sessionReplay.execute({
           event_type: 'session_start',
           session_id: 456,
         });
+        // Log is called from setup, but that's not what we're testing here
+        mockLoggerProvider.log.mockClear();
         expect(record).toHaveBeenCalled();
         const recordArg = record.mock.calls[0][0];
         recordArg?.emit && recordArg?.emit(mockEvent);
-        expect(update).toHaveBeenCalledTimes(1);
         await sessionReplay.execute({
           event_type: 'session_end',
           session_id: 456,
         });
         await runScheduleTimers();
         expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual(SUCCESS_MESSAGE);
+        expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual(getSuccessMessage(456));
       });
     });
 
@@ -817,7 +950,6 @@ describe('SessionReplayPlugin', () => {
           session_id: 456,
         });
         expect(record).not.toHaveBeenCalled();
-        expect(update).not.toHaveBeenCalled();
         await sessionReplay.execute({
           event_type: 'session_end',
           session_id: 456,
@@ -834,12 +966,14 @@ describe('SessionReplayPlugin', () => {
       };
       (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
       await sessionReplay.setup(config);
+      sessionReplay.events = [mockEventString];
       await sessionReplay.execute({
         event_type: 'session_end',
         session_id: 456,
       });
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(mockLoggerProvider.error.mock.calls[0][0]).toEqual('API Failure');
@@ -866,16 +1000,19 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.setup(config);
       // Log is called from setup, but that's not what we're testing here
       mockLoggerProvider.log.mockClear();
+      sessionReplay.events = [mockEventString];
       await sessionReplay.execute({
         event_type: 'session_end',
         session_id: 456,
       });
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledTimes(0);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual(SUCCESS_MESSAGE);
+      expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual(getSuccessMessage(456));
     });
     test('should handle retry for 413 error with flushQueueSize of 1', async () => {
       (fetch as jest.Mock)
@@ -895,6 +1032,7 @@ describe('SessionReplayPlugin', () => {
         flushMaxRetries: 2,
       };
       await sessionReplay.setup(config);
+      sessionReplay.events = [mockEventString];
       const event = {
         event_type: 'session_end',
         session_id: 456,
@@ -921,6 +1059,7 @@ describe('SessionReplayPlugin', () => {
         flushMaxRetries: 2,
       };
       await sessionReplay.setup(config);
+      sessionReplay.events = [mockEventString];
       const event = {
         event_type: 'session_end',
         session_id: 456,
@@ -947,6 +1086,7 @@ describe('SessionReplayPlugin', () => {
         flushMaxRetries: 2,
       };
       await sessionReplay.setup(config);
+      sessionReplay.events = [mockEventString];
       const event = {
         event_type: 'session_end',
         session_id: 456,
@@ -966,6 +1106,7 @@ describe('SessionReplayPlugin', () => {
         loggerProvider: mockLoggerProvider,
       };
       await sessionReplay.setup(config);
+      sessionReplay.events = [mockEventString];
       const event = {
         event_type: 'session_end',
         session_id: 456,
@@ -973,6 +1114,7 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.execute(event);
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(mockLoggerProvider.error.mock.calls[0][0]).toEqual(UNEXPECTED_ERROR_MESSAGE);
@@ -989,11 +1131,81 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = config;
       get.mockImplementationOnce(() => Promise.reject('error'));
       await sessionReplay.getAllSessionEventsFromStore();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(mockLoggerProvider.error.mock.calls[0][0]).toEqual(
         'Failed to store session replay events in IndexedDB: error',
       );
+    });
+  });
+  describe('storeShouldRecordForSession', () => {
+    test('should store if should record session', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = mockConfig;
+      const mockIDBStore: IDBStore = {
+        123: {
+          shouldRecord: true,
+          currentSequenceId: 3,
+          sessionSequences: {
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          shouldRecord: true,
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await sessionReplay.storeShouldRecordForSession(456, false);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        ...mockIDBStore,
+        456: {
+          ...mockIDBStore[456],
+          shouldRecord: false,
+        },
+      });
+    });
+    test('should catch errors', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      const config = {
+        ...mockConfig,
+        loggerProvider: mockLoggerProvider,
+      };
+      sessionReplay.config = config;
+      update.mockImplementationOnce(() => Promise.reject('error'));
+      await sessionReplay.storeShouldRecordForSession(123, true);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.error.mock.calls[0][0]).toEqual(
+        'Failed to store session replay events in IndexedDB: error',
+      );
+    });
+    test('should handle an undefined store', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      const config = {
+        ...mockConfig,
+        loggerProvider: mockLoggerProvider,
+      };
+      sessionReplay.config = config;
+      update.mockImplementationOnce(() => Promise.resolve());
+      await sessionReplay.storeShouldRecordForSession(123, true);
+      expect(update.mock.calls[0][1](undefined)).toEqual({
+        123: {
+          shouldRecord: true,
+          currentSequenceId: 0,
+          sessionSequences: {},
+        },
+      });
     });
   });
 
@@ -1003,6 +1215,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockIDBStore: IDBStore = {
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             2: {
@@ -1016,6 +1229,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1030,6 +1244,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             2: {
@@ -1043,6 +1258,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1059,6 +1275,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockIDBStore: IDBStore = {
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             2: {
@@ -1072,6 +1289,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1086,6 +1304,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 3,
           sessionSequences: {
             3: {
@@ -1095,6 +1314,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1114,6 +1334,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = config;
       update.mockImplementationOnce(() => Promise.reject('error'));
       await sessionReplay.cleanUpSessionEventsStore(123, 1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(mockLoggerProvider.error.mock.calls[0][0]).toEqual(
@@ -1139,6 +1360,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockIDBStore: IDBStore = {
         123: {
+          shouldRecord: true,
           currentSequenceId: 2,
           sessionSequences: {
             2: {
@@ -1148,6 +1370,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1162,6 +1385,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 2,
           sessionSequences: {
             2: {
@@ -1171,6 +1395,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1186,6 +1411,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockIDBStore: IDBStore = {
         123: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1195,6 +1421,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1209,6 +1436,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 2,
           sessionSequences: {
             1: {
@@ -1222,6 +1450,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 1,
           sessionSequences: {
             1: {
@@ -1237,6 +1466,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = mockConfig;
       const mockIDBStore: IDBStore = {
         123: {
+          shouldRecord: true,
           currentSequenceId: 2,
           sessionSequences: {
             2: {
@@ -1251,6 +1481,7 @@ describe('SessionReplayPlugin', () => {
       expect(update).toHaveBeenCalledTimes(1);
       expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
         123: {
+          shouldRecord: true,
           currentSequenceId: 2,
           sessionSequences: {
             2: {
@@ -1260,6 +1491,7 @@ describe('SessionReplayPlugin', () => {
           },
         },
         456: {
+          shouldRecord: true,
           currentSequenceId: 0,
           sessionSequences: {
             0: {
@@ -1279,6 +1511,8 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.config = config;
       update.mockImplementationOnce(() => Promise.reject('error'));
       await sessionReplay.storeEventsForSession([mockEventString], 0, config.sessionId as number);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(mockLoggerProvider.error.mock.calls[0][0]).toEqual(
@@ -1296,6 +1530,7 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.storeEventsForSession([mockEventString], 0, 456);
       expect(update.mock.calls[0][1](undefined)).toEqual({
         456: {
+          shouldRecord: true,
           currentSequenceId: 0,
           sessionSequences: {
             0: {
@@ -1338,17 +1573,17 @@ describe('SessionReplayPlugin', () => {
       });
       test('should return false if it has not been long enough since last send', () => {
         const sessionReplay = sessionReplayPlugin();
-        sessionReplay.timeAtLastSend = 1;
-        jest.spyOn(Date, 'now').mockReturnValue(2);
+        sessionReplay.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
+        jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
         const nextEvent = 'a';
         const result = sessionReplay.shouldSplitEventsList(nextEvent);
         expect(result).toBe(false);
       });
       test('should return true if it has been long enough since last send and events have been emitted', () => {
         const sessionReplay = sessionReplayPlugin();
-        sessionReplay.timeAtLastSend = 1;
         sessionReplay.events = [mockEventString];
-        jest.spyOn(Date, 'now').mockReturnValue(100002);
+        sessionReplay.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
+        jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:33:00').getTime());
         const nextEvent = 'a';
         const result = sessionReplay.shouldSplitEventsList(nextEvent);
         expect(result).toBe(true);


### PR DESCRIPTION
### Summary

This PR contains three changes:
1. Add default tracking of sessions upon setup of session replay plugin. Its required for the session replay plugin to work to have sessions tracked, this allows us to enforce that requirement
2. Add a configuration option for the sampling rate. This allows users to specify what percent of the sessions they would like to have recorded
3. Abide by the global configuration for opting out of tracking in the session recording - ie don't record if opt out is true

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
