### PR TITLE
fix(plugins): change timing of record upon initialization for session replay plugin

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -50,7 +50,7 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
       ...event.event_properties,
       [DEFAULT_SESSION_REPLAY_PROPERTY]: true,
     };
-    if (event.event_type === DEFAULT_SESSION_START_EVENT) {
+    if (event.event_type === DEFAULT_SESSION_START_EVENT && !this.stopRecordingEvents) {
       this.recordEvents();
     } else if (event.event_type === DEFAULT_SESSION_END_EVENT) {
       if (event.session_id) {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -84,8 +84,8 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
       const currentSessionStoredEvents = this.config.sessionId && storedReplaySessions[this.config.sessionId];
       this.currentSequenceId = currentSessionStoredEvents ? currentSessionStoredEvents.sequenceId + 1 : 0;
       void this.storeEventsForSession([], this.currentSequenceId);
-      this.recordEvents();
     }
+    this.recordEvents();
   }
 
   recordEvents() {


### PR DESCRIPTION
### Summary

This PR modifies the timing of initializing the recording of events for the session replay plugin, so that events are always recorded upon plugin initialization.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
