### PR TITLE
build: expose window.amplitudeGTM for gtm template

### DIFF
--- a/packages/analytics-browser/generated/amplitude-gtm-snippet.js
+++ b/packages/analytics-browser/generated/amplitude-gtm-snippet.js
@@ -1,0 +1,96 @@
+"use strict";
+
+/**
+ * Imported in client browser via <script> tag
+ * Async capabilities: Interally creates stubbed window.amplitudeGTM object until real SDK loaded
+ * Stubbed functions keep track of funciton calls and their arguments
+ * These are sent once real SDK loaded through another <script> tag
+ */
+!function (window, document) {
+  var amplitude = window.amplitudeGTM || {
+    _q: [],
+    _iq: {}
+  };
+  if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');else {
+    var proxy = function proxy(obj, fn) {
+      obj.prototype[fn] = function () {
+        this._q.push({
+          name: fn,
+          args: Array.prototype.slice.call(arguments, 0)
+        });
+        return this;
+      };
+    };
+    var getPromiseResult = function getPromiseResult(instance, fn, args) {
+      return function (resolve) {
+        instance._q.push({
+          name: fn,
+          args: Array.prototype.slice.call(args, 0),
+          resolve: resolve
+        });
+      };
+    };
+    var proxyMain = function proxyMain(instance, fn, isPromise) {
+      var args = arguments;
+      instance[fn] = function () {
+        if (isPromise) return {
+          promise: new Promise(getPromiseResult(instance, fn, Array.prototype.slice.call(arguments)))
+        };
+      };
+    };
+    var setUpProxy = function setUpProxy(instance) {
+      for (var k = 0; k < funcs.length; k++) {
+        proxyMain(instance, funcs[k], false);
+      }
+      for (var l = 0; l < funcsWithPromise.length; l++) {
+        proxyMain(instance, funcsWithPromise[l], true);
+      }
+    };
+    amplitude.invoked = true;
+    var as = document.createElement('script');
+    as.type = 'text/javascript';
+    as.integrity = 'sha384-slx5+gMeTDnjn4NnEcw9OwBVFUI6M4Od3bVcWwMw6owXGvsJOla40Vg5gNCXxNvq';
+    as.crossOrigin = 'anonymous';
+    as.async = true;
+    as.src = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-2.1.2-min.js.gz';
+    as.onload = function () {
+      if (!window.amplitudeGTM.runQueuedFunctions) {
+        console.log('[Amplitude] Error: could not load SDK');
+      }
+    };
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(as, s);
+    var Identify = function Identify() {
+      this._q = [];
+      return this;
+    };
+    var identifyFuncs = ['add', 'append', 'clearAll', 'prepend', 'set', 'setOnce', 'unset', 'preInsert', 'postInsert', 'remove', 'getUserProperties'];
+    for (var i = 0; i < identifyFuncs.length; i++) {
+      proxy(Identify, identifyFuncs[i]);
+    }
+    amplitude.Identify = Identify;
+    var Revenue = function Revenue() {
+      this._q = [];
+      return this;
+    };
+    var revenueFuncs = ['getEventProperties', 'setProductId', 'setQuantity', 'setPrice', 'setRevenue', 'setRevenueType', 'setEventProperties'];
+    for (var j = 0; j < revenueFuncs.length; j++) {
+      proxy(Revenue, revenueFuncs[j]);
+    }
+    amplitude.Revenue = Revenue;
+    var funcs = ['getDeviceId', 'setDeviceId', 'getSessionId', 'setSessionId', 'getUserId', 'setUserId', 'setOptOut', 'setTransport', 'reset', 'extendSession'];
+    var funcsWithPromise = ['init', 'add', 'remove', 'track', 'logEvent', 'identify', 'groupIdentify', 'setGroup', 'revenue', 'flush'];
+    setUpProxy(amplitude);
+    amplitude.createInstance = function (instanceName) {
+      amplitude._iq[instanceName] = {
+        _q: []
+      };
+      setUpProxy(amplitude._iq[instanceName]);
+      return amplitude._iq[instanceName];
+    };
+    window.amplitudeGTM = amplitude;
+    if (!window.amplitude) {
+      window.amplitude = window.amplitudeGTM;
+    }
+  }
+}(window, document);

--- a/packages/analytics-browser/rollup.config.js
+++ b/packages/analytics-browser/rollup.config.js
@@ -1,3 +1,3 @@
-import { umd, iife, snippet } from '../../scripts/build/rollup.config';
+import { umd, iife, snippet, iifeGTM, snippetGTM } from '../../scripts/build/rollup.config';
 
-export default [umd, iife, snippet];
+export default [umd, iife, snippet, iifeGTM, snippetGTM];

--- a/packages/analytics-browser/src/gtm-snippet-index.ts
+++ b/packages/analytics-browser/src/gtm-snippet-index.ts
@@ -1,0 +1,44 @@
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+import * as amplitudeGTM from './index';
+import { createInstance } from './browser-client-factory';
+import { runQueuedFunctions } from './utils/snippet-helper';
+
+// https://developer.mozilla.org/en-US/docs/Glossary/IIFE
+(function () {
+  const GlobalScope = getGlobalScope();
+
+  if (!GlobalScope) {
+    console.error('[Amplitude] Error: GlobalScope is not defined');
+    return;
+  }
+
+  const createNamedInstance = (instanceName?: string) => {
+    const instance = createInstance();
+    const GlobalScope = getGlobalScope();
+    if (GlobalScope && GlobalScope.amplitudeGTM && GlobalScope.amplitudeGTM._iq && instanceName) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      GlobalScope.amplitudeGTM._iq[instanceName] = instance;
+    }
+    return instance;
+  };
+
+  GlobalScope.amplitudeGTM = Object.assign(GlobalScope.amplitudeGTM || {}, amplitudeGTM, {
+    createInstance: createNamedInstance,
+  });
+
+  if (GlobalScope.amplitudeGTM.invoked) {
+    const queue = GlobalScope.amplitudeGTM._q;
+    GlobalScope.amplitudeGTM._q = [];
+    runQueuedFunctions(amplitudeGTM, queue);
+
+    const instanceNames = Object.keys(GlobalScope.amplitudeGTM._iq) || [];
+    for (let i = 0; i < instanceNames.length; i++) {
+      const instanceName = instanceNames[i];
+      const instance = Object.assign(GlobalScope.amplitudeGTM._iq[instanceName], createNamedInstance(instanceName));
+      const queue = instance._q;
+      instance._q = [];
+      runQueuedFunctions(instance, queue);
+    }
+  }
+})();

--- a/packages/analytics-browser/src/typings/browser-snippet.d.ts
+++ b/packages/analytics-browser/src/typings/browser-snippet.d.ts
@@ -4,4 +4,7 @@ declare global {
   // globalThis only includes `var` declarations
   // eslint-disable-next-line no-var
   var amplitude: InstanceProxy & { invoked: boolean };
+
+  // eslint-disable-next-line no-var
+  var amplitudeGTM: InstanceProxy & { invoked: boolean };
 }

--- a/scripts/publish/upload-to-s3.js
+++ b/scripts/publish/upload-to-s3.js
@@ -5,7 +5,7 @@ const { getName, getVersion } = require('../utils');
 
 const bucket = process.env.S3_BUCKET_NAME;
 const location = path.join(process.cwd(), 'lib', 'scripts');
-const gtmTemplate = location.includes('marketing-analytics-browser') ? `amplitude-gtm-min.js.gz` : ``;
+const gtmTemplate = location.includes('analytics-browser') ? `amplitude-gtm-min.js.gz` : ``;
 const files = ['amplitude-min.js.gz', 'amplitude-min.umd.js.gz'];
 if (gtmTemplate) files.push(gtmTemplate);
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Exposing the window.amplitudeGTM for gtm template. 
This is for avoiding the issue caused by multiple window.amplitude compatibility issues which brought up by Unity at the beginning. We have those changes in marketing-analytics-browser before. Duplicate the work here, since we want to upgrade the GTM template to wrap Browser 2.0.

The PRs we have made in marketing-analytics-browser:
[build: fix the issue in marketing analytics browser GTM template by yuhao900914 · Pull Request #365 · amplitude/Amplitude-TypeScript](https://github.com/amplitude/Amplitude-TypeScript/pull/365/files) 

[build: fix the CDN for marketing analytics browser GTM by yuhao900914 · Pull Request #363 · amplitude/Amplitude-TypeScript](https://github.com/amplitude/Amplitude-TypeScript/pull/363/files) 

[build: expose amplitudeGTM for GTM template by yuhao900914 · Pull Request #353 · amplitude/Amplitude-TypeScript](https://github.com/amplitude/Amplitude-TypeScript/pull/353/files)


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
