### PR TITLE
feat: user agent plugin

### DIFF
--- a/packages/plugin-user-agent-enrichment-browser/README.md
+++ b/packages/plugin-user-agent-enrichment-browser/README.md
@@ -1,0 +1,6 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>

--- a/packages/plugin-user-agent-enrichment-browser/README.md
+++ b/packages/plugin-user-agent-enrichment-browser/README.md
@@ -23,7 +23,8 @@ yarn add @amplitude/plugin-user-agent-enrichment-browser@^1.0.0
 
 ## Usage
 
-This plugin works on top of the Amplitude Browser SDK. It's used for enriching your user agent information using the @amplitude/ua-parser-js npm package. The user agent identifies the application, operating system, vendor, and/or version of the requesting client. You can use this plugin to maintain the user agent information's consistency with earlier versions.
+This plugin works on top of the Amplitude Browser SDK. It's used for enriching events with user agent information using the @amplitude/ua-parser-js. The user agent identifies the application, operating system, vendor, and/or version of the requesting client.
+For Browser SDK v1.x, we use @amplitude/ua-parser-js internally to parse the user agent information. In Browser v2.x, we have removed this client-side user agent parser and have instead implemented server-side user agent parser. You can use this plugin to maintain consistency with the user agent information from earlier SDK versions.
 
 ### 1. Import Amplitude packages
 
@@ -37,7 +38,7 @@ import { userAgentEnrichmentPlugin } from '@amplitude/plugin-user-agent-enrichme
 
 ### 2. Instantiate user agent enrichment plugin
 
-The plugin accepet 1 optional parameter, which is an `Object` for disable/enable the corrosponding tracking options. Each options are enabled by default.
+The plugin accepts 1 optional parameter, which is an `Object` to disable/enable the corresponding tracking options. Each option is enabled by default.
 
 ```typescript
 const uaPlugin = userAgentEnrichmentPlugin({
@@ -52,11 +53,10 @@ const uaPlugin = userAgentEnrichmentPlugin({
 
 |Name|Type|Default|Description|
 |-|-|-|-|
-|
-|`osName`|`boolean`|`true`| Whether to track the `os_name` using this plugin. |
-|`osVersion`|`boolean`|`true`| Whether to track the `os_version` using this plugin. |
-|`deviceManufacturer`|`boolean`|`true`| Whether to track the ``device_manufacturer` using this plugin. |
-|`deviceModel`|`boolean`|`true`| Whether to track the `device_model` using this plugin. |
+|`osName`|`boolean`|`true`| Enables enrichment of `os_name` property. |
+|`osVersion`|`boolean`|`true`| Enables enrichment of `os_version` property. |
+|`deviceManufacturer`|`boolean`|`true`| Enables enrichment of `device_manufacturer` property. |
+|`deviceModel`|`boolean`|`true`| Enables enrichment of `device_model` property. |
 
 ### 3. Install plugin to Amplitude SDK
 
@@ -72,4 +72,4 @@ amplitude.init('API_KEY');
 
 ## Resulting page view event
 
-This plugin derieve the user agent information using @amplitude/ua-parser-js based on your configuration. It might finally effect the value or the format of `device_family`, `device_family`, `device_model`, `device_manufacturer`, `device_type`, `os`, `os_name`, `os_version` in the event property.
+This plugin parses user agent information using @amplitude/ua-parser-js and enriches events based on your configuration. This affects the value of the following properties: `device_family`, `device_model`, `device_manufacturer`, `device_type`, `os`, `os_name`, and `os_version`.

--- a/packages/plugin-user-agent-enrichment-browser/README.md
+++ b/packages/plugin-user-agent-enrichment-browser/README.md
@@ -40,7 +40,7 @@ import { userAgentEnrichmentPlugin } from '@amplitude/plugin-user-agent-enrichme
 The plugin accepet 1 optional parameter, which is an `Object` for disable/enable the corrosponding tracking options. Each options are enabled by default.
 
 ```typescript
-const userAgentEnrichmentPlugin = userAgentEnrichmentPlugin({
+const uaPlugin = userAgentEnrichmentPlugin({
   osName: true,
   osVersion: true,
   deviceManufacturer: false,
@@ -61,7 +61,7 @@ const userAgentEnrichmentPlugin = userAgentEnrichmentPlugin({
 ### 3. Install plugin to Amplitude SDK
 
 ```typescript
-amplitude.add(userAgentEnrichmentPlugin);
+amplitude.add(uaPlugin);
 ```
 
 ### 4. Initialize Amplitude SDK

--- a/packages/plugin-user-agent-enrichment-browser/README.md
+++ b/packages/plugin-user-agent-enrichment-browser/README.md
@@ -61,7 +61,7 @@ const userAgentEnrichmentPlugin = userAgentEnrichmentPlugin({
 ### 3. Install plugin to Amplitude SDK
 
 ```typescript
-amplitude.add(pageViewTracking);
+amplitude.add(userAgentEnrichmentPlugin);
 ```
 
 ### 4. Initialize Amplitude SDK

--- a/packages/plugin-user-agent-enrichment-browser/README.md
+++ b/packages/plugin-user-agent-enrichment-browser/README.md
@@ -4,3 +4,72 @@
   </a>
   <br />
 </p>
+
+# @amplitude/plugin-user-agent-enrichment-browser
+
+Official Browser SDK plugin for user agent enrichment.
+
+## Installation
+
+This package is published on NPM registry and is available to be installed using npm and yarn.
+
+```sh
+# npm
+npm install @amplitude/plugin-user-agent-enrichment-browser@^1.0.0
+
+# yarn
+yarn add @amplitude/plugin-user-agent-enrichment-browser@^1.0.0
+```
+
+## Usage
+
+This plugin works on top of the Amplitude Browser SDK. It's used for enriching your user agent information using the @amplitude/ua-parser-js npm package. The user agent identifies the application, operating system, vendor, and/or version of the requesting client. You can use this plugin to maintain the user agent information's consistency with earlier versions.
+
+### 1. Import Amplitude packages
+
+* `@amplitude/analytics-browser`
+* `@amplitude/plugin-user-agent-enrichment-browser`
+
+```typescript
+import * as amplitude from '@amplitude/analytics-browser';
+import { userAgentEnrichmentPlugin } from '@amplitude/plugin-user-agent-enrichment-browser';
+```
+
+### 2. Instantiate user agent enrichment plugin
+
+The plugin accepet 1 optional parameter, which is an `Object` for disable/enable the corrosponding tracking options. Each options are enabled by default.
+
+```typescript
+const userAgentEnrichmentPlugin = userAgentEnrichmentPlugin({
+  osName: true,
+  osVersion: true,
+  deviceManufacturer: false,
+  deviceModel: false,
+});
+```
+
+#### Options
+
+|Name|Type|Default|Description|
+|-|-|-|-|
+|
+|`osName`|`boolean`|`true`| Whether to track the `os_name` using this plugin. |
+|`osVersion`|`boolean`|`true`| Whether to track the `os_version` using this plugin. |
+|`deviceManufacturer`|`boolean`|`true`| Whether to track the ``device_manufacturer` using this plugin. |
+|`deviceModel`|`boolean`|`true`| Whether to track the `device_model` using this plugin. |
+
+### 3. Install plugin to Amplitude SDK
+
+```typescript
+amplitude.add(pageViewTracking);
+```
+
+### 4. Initialize Amplitude SDK
+
+```typescript
+amplitude.init('API_KEY');
+```
+
+## Resulting page view event
+
+This plugin derieve the user agent information using @amplitude/ua-parser-js based on your configuration. It might finally effect the value or the format of `device_family`, `device_family`, `device_model`, `device_manufacturer`, `device_type`, `os`, `os_name`, `os_version` in the event property.

--- a/packages/plugin-user-agent-enrichment-browser/jest.config.js
+++ b/packages/plugin-user-agent-enrichment-browser/jest.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require('../../jest.config.js');
+const package = require('./package');
+
+module.exports = {
+  ...baseConfig,
+  displayName: package.name,
+  rootDir: '.',
+  testEnvironment: 'jsdom',
+  coveragePathIgnorePatterns: ['index.ts'],
+};

--- a/packages/plugin-user-agent-enrichment-browser/package.json
+++ b/packages/plugin-user-agent-enrichment-browser/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@amplitude/plugin-user-agent-enrichment-browser",
+  "version": "0.0.0",
+  "description": "",
+  "author": "Amplitude Inc",
+  "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
+  "license": "MIT",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
+  },
+  "scripts": {
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
+    "bundle": "rollup --config rollup.config.js",
+    "build:es5": "tsc -p ./tsconfig.es5.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "clean": "rimraf node_modules lib coverage",
+    "fix": "yarn fix:eslint & yarn fix:prettier",
+    "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
+    "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
+    "lint": "yarn lint:eslint & yarn lint:prettier",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
+    "test": "jest",
+    "typecheck": "tsc -p ./tsconfig.json"
+  },
+  "bugs": {
+    "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
+  },
+  "dependencies": {
+    "@amplitude/analytics-client-common": "^2.0.4",
+    "@amplitude/analytics-types": "^2.1.1",
+    "@amplitude/ua-parser-js": "^0.7.33",
+    "tslib": "^2.4.1"
+  },
+  "devDependencies": {
+    "@amplitude/analytics-browser": "^2.1.2",
+    "@rollup/plugin-commonjs": "^23.0.4",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^10.0.1",
+    "rollup": "^2.79.1",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/packages/plugin-user-agent-enrichment-browser/rollup.config.js
+++ b/packages/plugin-user-agent-enrichment-browser/rollup.config.js
@@ -1,0 +1,6 @@
+import { iife, umd } from '../../scripts/build/rollup.config';
+
+iife.input = umd.input;
+iife.output.name = 'amplitudeUserAgentEnrichmentPlugin';
+
+export default [umd, iife];

--- a/packages/plugin-user-agent-enrichment-browser/src/index.ts
+++ b/packages/plugin-user-agent-enrichment-browser/src/index.ts
@@ -1,0 +1,2 @@
+export { userAgentEnrichmentPlugin } from './user-agent-enrichment-plugin';
+export { userAgentEnrichmentPlugin as plugin } from './user-agent-enrichment-plugin';

--- a/packages/plugin-user-agent-enrichment-browser/src/typings/ua-parser.d.ts
+++ b/packages/plugin-user-agent-enrichment-browser/src/typings/ua-parser.d.ts
@@ -1,0 +1,4 @@
+declare module '@amplitude/ua-parser-js' {
+  import UAParser from 'ua-parser-js';
+  export = UAParser;
+}

--- a/packages/plugin-user-agent-enrichment-browser/src/typings/user-agent-enrichment-plugin.ts
+++ b/packages/plugin-user-agent-enrichment-browser/src/typings/user-agent-enrichment-plugin.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import { EnrichmentPlugin } from '@amplitude/analytics-types';
+
+export interface Options {
+  osName?: boolean;
+  osVersion?: boolean;
+  deviceManufacturer?: boolean;
+  deviceModel?: boolean;
+}
+
+export interface CreateUserAgentEnrichmentPlugin {
+  (options?: Options): EnrichmentPlugin;
+}

--- a/packages/plugin-user-agent-enrichment-browser/src/user-agent-enrichment-plugin.ts
+++ b/packages/plugin-user-agent-enrichment-browser/src/user-agent-enrichment-plugin.ts
@@ -1,0 +1,43 @@
+import { BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-types';
+import { CreateUserAgentEnrichmentPlugin, Options } from './typings/user-agent-enrichment-plugin';
+import UAParser from '@amplitude/ua-parser-js';
+
+export const userAgentEnrichmentPlugin: CreateUserAgentEnrichmentPlugin = function (options: Options = {}) {
+  const { osName = true, osVersion = true, deviceManufacturer = true, deviceModel = true } = options;
+
+  let uaResult: UAParser.IResult;
+
+  const plugin: EnrichmentPlugin = {
+    name: '@amplitude/plugin-ua-parser',
+    type: 'enrichment',
+
+    setup: async function (config: BrowserConfig) {
+      let userAgent: string | undefined;
+      /* istanbul ignore else */
+      if (typeof navigator !== 'undefined') {
+        userAgent = navigator.userAgent;
+      }
+
+      uaResult = new UAParser(userAgent).getResult();
+
+      config.loggerProvider.log('Installing @amplitude/plugin-ua-parser.');
+    },
+
+    execute: async (event: Event) => {
+      const uaOsName = uaResult.browser.name;
+      const UaOsVersion = uaResult.browser.version;
+      const UaDeviceModel = uaResult.device.model || uaResult.os.name;
+      const UaDeviceVendor = uaResult.device.vendor;
+
+      return {
+        ...event,
+        ...(osName && { os_name: uaOsName }),
+        ...(osVersion && { os_version: UaOsVersion }),
+        ...(deviceManufacturer && { device_manufacturer: UaDeviceVendor }),
+        ...(deviceModel && { device_model: UaDeviceModel }),
+      };
+    },
+  };
+
+  return plugin;
+};

--- a/packages/plugin-user-agent-enrichment-browser/src/user-agent-enrichment-plugin.ts
+++ b/packages/plugin-user-agent-enrichment-browser/src/user-agent-enrichment-plugin.ts
@@ -8,7 +8,7 @@ export const userAgentEnrichmentPlugin: CreateUserAgentEnrichmentPlugin = functi
   let uaResult: UAParser.IResult;
 
   const plugin: EnrichmentPlugin = {
-    name: '@amplitude/plugin-ua-parser',
+    name: '@amplitude/plugin-user-agent-enrichment-browser',
     type: 'enrichment',
 
     setup: async function (config: BrowserConfig) {
@@ -20,7 +20,7 @@ export const userAgentEnrichmentPlugin: CreateUserAgentEnrichmentPlugin = functi
 
       uaResult = new UAParser(userAgent).getResult();
 
-      config.loggerProvider.log('Installing @amplitude/plugin-ua-parser.');
+      config.loggerProvider.log('Installing @amplitude/plugin-user-agent-enrichment-browser.');
     },
 
     execute: async (event: Event) => {

--- a/packages/plugin-user-agent-enrichment-browser/test/user-agent.test.ts
+++ b/packages/plugin-user-agent-enrichment-browser/test/user-agent.test.ts
@@ -1,0 +1,120 @@
+import { createInstance } from '@amplitude/analytics-browser';
+import { CookieStorage, FetchTransport } from '@amplitude/analytics-client-common';
+import { userAgentEnrichmentPlugin } from '../src/user-agent-enrichment-plugin';
+import { BaseEvent, BrowserConfig, LogLevel } from '@amplitude/analytics-types';
+import { Logger, UUID } from '@amplitude/analytics-core';
+
+describe('uaParserPlugin', () => {
+  let event: BaseEvent;
+
+  const mockConfig: BrowserConfig = {
+    apiKey: UUID(),
+    flushIntervalMillis: 0,
+    flushMaxRetries: 0,
+    flushQueueSize: 0,
+    logLevel: LogLevel.None,
+    loggerProvider: new Logger(),
+    optOut: false,
+    serverUrl: undefined,
+    transportProvider: new FetchTransport(),
+    useBatch: false,
+    cookieOptions: {
+      domain: '.amplitude.com',
+      expiration: 365,
+      sameSite: 'Lax',
+      secure: false,
+      upgrade: true,
+    },
+    cookieStorage: new CookieStorage(),
+    sessionTimeout: 30 * 60 * 1000,
+    trackingOptions: {
+      ipAddress: true,
+      language: true,
+      platform: true,
+    },
+  };
+
+  beforeEach(() => {
+    event = {
+      event_type: 'event_type',
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execute', () => {
+    test('should overwirte all devices info without option', async () => {
+      const amplitude = createInstance();
+
+      const plugin = userAgentEnrichmentPlugin();
+      const executeSpy = jest.spyOn(plugin, 'execute');
+
+      await plugin.setup?.(mockConfig, amplitude);
+      const enrichedEvent = await plugin.execute?.(event);
+
+      expect(executeSpy).toHaveBeenCalledWith(event);
+      expect(enrichedEvent).toHaveProperty('os_name');
+      expect(enrichedEvent).toHaveProperty('os_version');
+      expect(enrichedEvent).toHaveProperty('os_name');
+      expect(enrichedEvent).toHaveProperty('device_model');
+    });
+
+    test('should escape the optOut devices info with disabled options 1', async () => {
+      const amplitude = createInstance();
+
+      const plugin = userAgentEnrichmentPlugin({
+        osVersion: false,
+      });
+
+      await plugin.setup?.(mockConfig, amplitude);
+
+      const enrichedEvent = await plugin.execute?.(event);
+
+      expect(enrichedEvent).toHaveProperty('device_model');
+      expect(enrichedEvent).toHaveProperty('os_name');
+      expect(enrichedEvent).not.toHaveProperty('os_version');
+      expect(enrichedEvent).toHaveProperty('device_manufacturer');
+    });
+
+    test('should escape the optOut devices info with disabled options 2', async () => {
+      const amplitude = createInstance();
+
+      const plugin = userAgentEnrichmentPlugin({
+        osName: false,
+        deviceManufacturer: true,
+      });
+
+      await plugin.setup?.(mockConfig, amplitude);
+
+      const enrichedEvent = await plugin.execute?.(event);
+
+      expect(enrichedEvent).toHaveProperty('device_model');
+      expect(enrichedEvent).not.toHaveProperty('os_name');
+      expect(enrichedEvent).toHaveProperty('os_version');
+      expect(enrichedEvent).toHaveProperty('device_manufacturer');
+    });
+
+    test('should overwrite the opted in devices info', async () => {
+      const amplitude = createInstance();
+
+      const plugin = userAgentEnrichmentPlugin({
+        osName: true,
+        osVersion: true,
+        deviceManufacturer: false,
+        deviceModel: false,
+      });
+
+      await plugin.setup?.(mockConfig, amplitude);
+
+      const enrichedEvent = await plugin.execute?.(event);
+
+      expect(enrichedEvent).toHaveProperty('os_name');
+      expect(enrichedEvent).toHaveProperty('os_version');
+
+      expect(enrichedEvent).not.toHaveProperty('device_manufacturer');
+      expect(enrichedEvent).not.toHaveProperty('device_model');
+    });
+  });
+});

--- a/packages/plugin-user-agent-enrichment-browser/tsconfig.es5.json
+++ b/packages/plugin-user-agent-enrichment-browser/tsconfig.es5.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "lib/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/packages/plugin-user-agent-enrichment-browser/tsconfig.esm.json
+++ b/packages/plugin-user-agent-enrichment-browser/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "es6",
+    "noEmit": false,
+    "outDir": "lib/esm",
+    "rootDir": "./src"
+  }
+}

--- a/packages/plugin-user-agent-enrichment-browser/tsconfig.json
+++ b/packages/plugin-user-agent-enrichment-browser/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "noEmit": true,
+    "rootDir": ".",
+  }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This pr is the same as [this PR](https://github.com/amplitude/Amplitude-TypeScript/pull/497), but merge to v1.x branch since we made the decision to merge to which branch is based on the version in the package.json in[ this discussion](https://amplitude.atlassian.net/wiki/spaces/GOV/pages/2148827164/Process+to+maintain+the+typescript+repo.). 

Where to use this plugin:
This plugin will be used to avoid breaking changes for GTM Browser 2.0 template. 
The plugin will be added to [ the GTM SDK Wrapper ](https://github.com/amplitude/amplitude-js-gtm/blob/v3.x/src/amplitude-wrapper.js#L146-L154) by default.
Still investigating on if this can be configured based on customer input, if not, or if there is no quick solution at this time, we are going to force everyone to use this plugin for the user agent and investigate further.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
