### PR TITLE
fix: get trackingOptions from config

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -213,10 +213,9 @@ export const useBrowserConfig = async (
   amplitudeInstance.previousSessionUserId = previousCookies?.userId ?? legacyCookies.userId;
 
   const trackingOptions = {
-    ...options.trackingOptions,
-    ipAddress: true,
-    language: true,
-    platform: true,
+    ipAddress: options.trackingOptions?.ipAddress === undefined ? true : options.trackingOptions.ipAddress,
+    language: options.trackingOptions?.language === undefined ? true : options.trackingOptions.language,
+    platform: options.trackingOptions?.platform === undefined ? true : options.trackingOptions.platform,
   };
 
   return new BrowserConfig(

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -213,9 +213,10 @@ export const useBrowserConfig = async (
   amplitudeInstance.previousSessionUserId = previousCookies?.userId ?? legacyCookies.userId;
 
   const trackingOptions = {
-    ipAddress: options.trackingOptions?.ipAddress === undefined ? true : options.trackingOptions.ipAddress,
-    language: options.trackingOptions?.language === undefined ? true : options.trackingOptions.language,
-    platform: options.trackingOptions?.platform === undefined ? true : options.trackingOptions.platform,
+    ipAddress: true,
+    language: true,
+    platform: true,
+    ...options.trackingOptions,
   };
 
   return new BrowserConfig(

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -242,21 +242,25 @@ describe('config', () => {
       expect(config.cookieOptions?.domain).toEqual('amplitude.com');
     });
 
-    test('should use trackingOptions', async () => {
+    test.each([
+      [true, true]
+      [undefined, true]
+      [false, false]
+    ])('should use trackingOptions', async (input, expected) => {
       const config = await Config.useBrowserConfig(
         apiKey,
         {
           trackingOptions: {
-            ipAddress: false,
-            language: false,
-            platform: false,
+            ipAddress: input,
+            language: input,
+            platform: input,
           },
         },
         new AmplitudeBrowser(),
       );
-      expect(config.trackingOptions.ipAddress).toEqual(false);
-      expect(config.trackingOptions.language).toEqual(false);
-      expect(config.trackingOptions.platform).toEqual(false);
+      expect(config.trackingOptions.ipAddress).toEqual(expected);
+      expect(config.trackingOptions.language).toEqual(expected);
+      expect(config.trackingOptions.platform).toEqual(expected);
     });
   });
 

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -241,6 +241,23 @@ describe('config', () => {
       );
       expect(config.cookieOptions?.domain).toEqual('amplitude.com');
     });
+
+    test('should use trackingOptions', async () => {
+      const config = await Config.useBrowserConfig(
+        apiKey,
+        {
+          trackingOptions: {
+            ipAddress: false,
+            language: false,
+            platform: false,
+          },
+        },
+        new AmplitudeBrowser(),
+      );
+      expect(config.trackingOptions.ipAddress).toEqual(false);
+      expect(config.trackingOptions.language).toEqual(false);
+      expect(config.trackingOptions.platform).toEqual(false);
+    });
   });
 
   describe('createCookieStorage', () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix https://github.com/amplitude/Amplitude-TypeScript/issues/492 where ipAddress is set to be false but is still tracked in the event payload.

The original code uses a spread operator (...) to spread out the properties of the options.trackingOptions object into the new trackingOptions object being created. It creates a shallow copy of the options.trackingOptions object. And then ipAddress, language, and platform properties are added to the trackingOptions object setting true which overrides the value in options.trackingOptions

To fix it, check if each property is undefined. If so, default it to be true. Otherwise use the property value of trackingOptions.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
