### PR TITLE
fix(plugins): stop recording when document.hasFocus is false

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -16,8 +16,8 @@ import {
 
 const SESSION_REPLAY_SERVER_URL = 'https://api-secure.amplitude.com/sessions/track';
 const STORAGE_PREFIX = `${AMPLITUDE_PREFIX}_replay_unsent`;
-const PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS = 200; // derived by JSON stringifying an example payload without events
-const MAX_EVENT_LIST_SIZE_IN_BYTES = 20 * 1000000 - PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS;
+const PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS = 500; // derived by JSON stringifying an example payload without events
+const MAX_EVENT_LIST_SIZE_IN_BYTES = 10 * 1000000 - PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS;
 const MIN_INTERVAL = 500; // 500 ms
 const MAX_INTERVAL = 10 * 1000; // 10 seconds
 
@@ -132,6 +132,11 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
   recordEvents() {
     this.stopRecordingEvents = record({
       emit: (event) => {
+        const GlobalScope = getGlobalScope();
+        if (GlobalScope && GlobalScope.document && !GlobalScope.document.hasFocus()) {
+          this.stopRecordingEvents && this.stopRecordingEvents();
+          return;
+        }
         const eventString = JSON.stringify(event);
 
         const shouldSplit = this.shouldSplitEventsList(eventString);


### PR DESCRIPTION
### Summary

This PR adds logic to stop recording for session replay when document.hasFocus is false. I have noticed that there is some flakiness and timing issues in the window.blur event so the stop recording functionality does not always occur at the right time. This should add extra protection against recording when the tab is not active.

I also updated the max persisted event size to be 10 MB due to changes in the backend.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
