### PR TITLE
feat(plugins): add masking controls to session replay and reorganize constants and helper fns

### DIFF
--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -60,3 +60,13 @@ const sessionReplayTracking = sessionReplayPlugin({
 ```typescript
 amplitude.add(sessionReplayTracking);
 ```
+
+## Privacy
+By default, the session recording will mask all inputs, meaning the text in inputs will appear in a session replay as asterisks: `***`. You may require more specific masking controls based on your use case, so we offer the following controls:
+
+#### 1. Unmask inputs
+In your application code, add the class `.amp-unmask` to any __input__ whose text you'd like to have unmasked in the recording. In the replay of a recorded session, it will be possible to read the exact text entered into an input with this class, the text will not be converted to asterisks.
+
+#### 2. Mask non-input elements
+In your application code, add the class `.amp-mask` to any __non-input element__ whose text you'd like to have masked from the recording. The text in the element, as well as it's children, will all be converted to asterisks.
+

--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@amplitude/analytics-types": ">=1 <3",
     "idb-keyval": "^6.2.1",
-    "rrweb": "^2.0.0-alpha.4",
+    "rrweb": "^2.0.0-alpha.9",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -1,5 +1,22 @@
+import { AMPLITUDE_PREFIX } from '@amplitude/analytics-core';
+import { IDBStoreSession } from './typings/session-replay';
+
 export const DEFAULT_EVENT_PROPERTY_PREFIX = '[Amplitude]';
 
 export const DEFAULT_SESSION_REPLAY_PROPERTY = `${DEFAULT_EVENT_PROPERTY_PREFIX} Session Recorded`;
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';
+
+export const MASK_TEXT_CLASS = 'amp-mask';
+export const UNMASK_TEXT_CLASS = 'amp-unmask';
+export const SESSION_REPLAY_SERVER_URL = 'https://api-secure.amplitude.com/sessions/track';
+export const STORAGE_PREFIX = `${AMPLITUDE_PREFIX}_replay_unsent`;
+const PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS = 500; // derived by JSON stringifying an example payload without events
+export const MAX_EVENT_LIST_SIZE_IN_BYTES = 10 * 1000000 - PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS;
+export const MIN_INTERVAL = 500; // 500 ms
+export const MAX_INTERVAL = 10 * 1000; // 10 seconds
+export const defaultSessionStore: IDBStoreSession = {
+  shouldRecord: true,
+  currentSequenceId: 0,
+  sessionSequences: {},
+};

--- a/packages/plugin-session-replay-browser/src/helpers.ts
+++ b/packages/plugin-session-replay-browser/src/helpers.ts
@@ -1,0 +1,8 @@
+import { UNMASK_TEXT_CLASS } from './constants';
+
+export const maskInputFn = (text: string, element: HTMLElement) => {
+  if (element.classList?.contains(UNMASK_TEXT_CLASS)) {
+    return text;
+  }
+  return '*'.repeat(text.length);
+};

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,7 +1,6 @@
 import { BrowserConfig, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { record } from 'rrweb';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SessionReplayOptions {
   sampleRate?: number;
 }

--- a/packages/plugin-session-replay-browser/test/helpers.test.ts
+++ b/packages/plugin-session-replay-browser/test/helpers.test.ts
@@ -1,0 +1,24 @@
+import { UNMASK_TEXT_CLASS } from '../src/constants';
+import { maskInputFn } from '../src/helpers';
+
+describe('SessionReplayPlugin helpers', () => {
+  describe('maskInputFn', () => {
+    test('should not mask an element whose class list has amp-unmask in it', () => {
+      const htmlElement = document.createElement('div');
+      htmlElement.classList.add(UNMASK_TEXT_CLASS);
+      const result = maskInputFn('some text', htmlElement);
+      expect(result).toEqual('some text');
+    });
+    test('should mask any other element', () => {
+      const htmlElement = document.createElement('div');
+      htmlElement.classList.add('another-class');
+      const result = maskInputFn('some text', htmlElement);
+      expect(result).toEqual('*********');
+    });
+    test('should handle an element without a class list', () => {
+      const htmlElement = {} as unknown as HTMLElement;
+      const result = maskInputFn('some text', htmlElement);
+      expect(result).toEqual('*********');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,74 @@
 # yarn lockfile v1
 
 
-"@amplitude/analytics-connector@^1.4.5":
+"@amplitude/analytics-browser@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.1.2.tgz#fadd74c56acfa163443db83b60ba2795294a6c31"
+  integrity sha512-1XoWJmLgGrszxupz61yCjen53bq7+kJN2gedu+kSrq/Ze9ow5R5QI0YfLyuzi1FHchzmSVWd2PheXOVYC4K/Cw==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.0.4"
+    "@amplitude/analytics-core" "^2.0.3"
+    "@amplitude/analytics-types" "^2.1.1"
+    "@amplitude/plugin-page-view-tracking-browser" "^2.0.4"
+    "@amplitude/plugin-web-attribution-browser" "^2.0.4"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-client-common@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.0.4.tgz#59c9a86c68bdd53cc925afe17d295ab47bd9d7b3"
+  integrity sha512-X0+zE8sODcQ2ioj9ZB98Gr/9FCRDiJuSixefaLrfng/4x5VwHK0if8biCqqBHXu6HlMpeMFrCyiABUTDT87QVA==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.4.8"
+    "@amplitude/analytics-core" "^2.0.3"
+    "@amplitude/analytics-types" "^2.1.1"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-connector@^1.4.5", "@amplitude/analytics-connector@^1.4.8":
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
   integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
+
+"@amplitude/analytics-core@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.0.3.tgz#491d29707765899abbe7da06d9d3a3677a8a9193"
+  integrity sha512-tpD1gCmPpzPNPumQT1ecOJtuan5OsQdKp9AX8YKc7t1/K3xHzGo3FH3JvdaAJVYYWeZV40bp/JL6wJiYIzyZjA==
+  dependencies:
+    "@amplitude/analytics-types" "^2.1.1"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-types@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.1.1.tgz#89ef85397c4e6bc3a6aeaae4f3d4354ebb7de297"
+  integrity sha512-H3vebPR9onRdp0WzAZmI/4qmAE903uLOd2ZfMeHsVc1zaFTTCk46SoCuV4IrlF+VILrDw9Fy6gC9yl5N2PZcJQ==
+
+"@amplitude/plugin-page-view-tracking-browser@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.4.tgz#294c050f66810619816caa9027cfe6c61567e9b6"
+  integrity sha512-XQlgydCmfUb+mkXjD8NoOU80eO/578m2AupRcV0dPKwk+VN5D7D1s+xXYM6Bg7l1HSJx2mt0Qwa5xsdSCFzF2g==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.0.4"
+    "@amplitude/analytics-types" "^2.1.1"
+    tslib "^2.4.1"
+
+"@amplitude/plugin-web-attribution-browser@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.4.tgz#30498aaff7c385cb14ebbb3976d6cc8df1794766"
+  integrity sha512-y/VQjDH7tnevRlKO9IWzELF9L87MwiR+y7WCRxR5/wRGKDxKS5Ol33vHYWe1RaOzkC/7wO0px7pZGRZkj/X+1Q==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.0.4"
+    "@amplitude/analytics-core" "^2.0.3"
+    "@amplitude/analytics-types" "^2.1.1"
+    tslib "^2.4.1"
 
 "@amplitude/ua-parser-js@^0.7.31":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.31.tgz#749bf7cb633cfcc7ff3c10805bad7c5f6fbdbc61"
   integrity sha512-+z8UGRaj13Pt5NDzOnkTBy49HE2CX64jeL0ArB86HAtilpnfkPB7oqkigN7Lf2LxscMg4QhFD7mmCfedh3rqTg==
+
+"@amplitude/ua-parser-js@^0.7.33":
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.33.tgz#26441a0fb2e956a64e4ede50fb80b848179bb5db"
+  integrity sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA==
 
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
@@ -3778,12 +3837,12 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rrweb/types@^2.0.0-alpha.4":
-  version "2.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@rrweb/types/-/types-2.0.0-alpha.8.tgz#29a6550dd833364a459af4be4ce3b233003fb78b"
-  integrity sha512-yAr6ZQrgmr7+qZU5DMGqYXnVsolC5epftmZtkOtgFD/bbvCWflNnl09M32hUjttlKCV1ohhmQGioXkCQ37IF7A==
+"@rrweb/types@^2.0.0-alpha.9":
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@rrweb/types/-/types-2.0.0-alpha.9.tgz#960cd224f7de7d0ba86852db0c04783320f92846"
+  integrity sha512-yS2KghLSmSSxo6H7tHrJ6u+nWJA9zCXaKFyc79rUSX8RHHSImRqocTqJ8jz794kCIWA90rvaQayRONdHO+vB0Q==
   dependencies:
-    rrweb-snapshot "^2.0.0-alpha.8"
+    rrweb-snapshot "^2.0.0-alpha.9"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -11017,31 +11076,31 @@ rollup@^2.79.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rrdom@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-0.1.7.tgz#f2f49bfd01b59291bb7b0d981371a5e02a18e2aa"
-  integrity sha512-ZLd8f14z9pUy2Hk9y636cNv5Y2BMnNEY99wxzW9tD2BLDfe1xFxtLjB4q/xCBYo6HRe0wofzKzjm4JojmpBfFw==
+rrdom@^2.0.0-alpha.9:
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-2.0.0-alpha.9.tgz#a326d4176cec7eb8c9374ed8bb7da784252f09ef"
+  integrity sha512-jfaZ8tHi098P4GpPEtkOwnkucyKA5eGanAVHGPklzCqAeEq1Yx+9/y8AeOtF3yiobqKKkW8lLvFH2KrBH1CZlQ==
   dependencies:
-    rrweb-snapshot "^2.0.0-alpha.4"
+    rrweb-snapshot "^2.0.0-alpha.9"
 
-rrweb-snapshot@^2.0.0-alpha.4, rrweb-snapshot@^2.0.0-alpha.8:
-  version "2.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.8.tgz#5f93f8ab7d78b3de26f6a64e993ff68edd54e0cf"
-  integrity sha512-3Rb7c+mnDEADQ8N9qn9SDH5PzCyHlZ1cwZC932qRyt9O8kJWLM11JLYqqEyQCa2FZVQbzH2iAaCgnyM7A32p7A==
+rrweb-snapshot@^2.0.0-alpha.9:
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.9.tgz#4f504a4f266f0cb075ecbfa35aaf687d00483ca5"
+  integrity sha512-mHg1uUE2iUf0MXLE//4r5cMynkbduwmaOEis4gC7EuqkUAC1pYoLpcYYVt9lD6dgYIF6BmK6dgLLzMpD/tTyyA==
 
-rrweb@^2.0.0-alpha.4:
-  version "2.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.4.tgz#3c7cf2f1bcf44f7a88dd3fad00ee8d6dd711f258"
-  integrity sha512-wEHUILbxDPcNwkM3m4qgPgXAiBJyqCbbOHyVoNEVBJzHszWEFYyTbrZqUdeb1EfmTRC2PsumCIkVcomJ/xcOzA==
+rrweb@^2.0.0-alpha.9:
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.9.tgz#bce02ae1024251ece9d981bc7ebfe6a2eb6bbf9e"
+  integrity sha512-8E2yiLY7IrFjDcVUZ7AcQtdBNFuTIsBrlCMpbyLua6X64dGRhOZ+IUDXLnAbNj5oymZgFtZu2UERG9rmV2VAng==
   dependencies:
-    "@rrweb/types" "^2.0.0-alpha.4"
+    "@rrweb/types" "^2.0.0-alpha.9"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
     fflate "^0.4.4"
     mitt "^3.0.0"
-    rrdom "^0.1.7"
-    rrweb-snapshot "^2.0.0-alpha.4"
+    rrdom "^2.0.0-alpha.9"
+    rrweb-snapshot "^2.0.0-alpha.9"
 
 run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
### Summary

This PR adds support for masking non-input elements, as well as unmasking some input elements. See the README update for further details.

I also split out the constants from the top of the session-replay.ts file into their own file, and added a helper file for smaller functions (like the maskInputFn added here)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
