### PR TITLE
feat(plugins): add option to block elements based on amp-block class in session replay

### DIFF
--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -70,3 +70,5 @@ In your application code, add the class `.amp-unmask` to any __input__ whose tex
 #### 2. Mask non-input elements
 In your application code, add the class `.amp-mask` to any __non-input element__ whose text you'd like to have masked from the recording. The text in the element, as well as it's children, will all be converted to asterisks.
 
+#### 3. Block non-text elements
+In your application code, add the class `.amp-block` to any element you would like to have blocked from the recording. The element will appear in the replay as a placeholder with the same dimensions.

--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SESSION_REPLAY_PROPERTY = `${DEFAULT_EVENT_PROPERTY_PREFIX}
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';
 
+export const BLOCK_CLASS = 'amp-block';
 export const MASK_TEXT_CLASS = 'amp-mask';
 export const UNMASK_TEXT_CLASS = 'amp-unmask';
 export const SESSION_REPLAY_SERVER_URL = 'https://api-secure.amplitude.com/sessions/track';

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -4,6 +4,7 @@ import { BrowserConfig, Event, Status } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import { pack, record } from 'rrweb';
 import {
+  BLOCK_CLASS,
   DEFAULT_SESSION_END_EVENT,
   DEFAULT_SESSION_REPLAY_PROPERTY,
   DEFAULT_SESSION_START_EVENT,
@@ -207,6 +208,7 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
       packFn: pack,
       maskAllInputs: true,
       maskTextClass: MASK_TEXT_CLASS,
+      blockClass: BLOCK_CLASS,
       maskInputFn,
     });
   }


### PR DESCRIPTION
### Summary

Adds the ability to block elements in the recording by using the class `amp-block` in the implementer's code.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
