### PR TITLE
fix(plugins): prevent any activity from occurring in session replay plugin if document does not have focus

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -75,8 +75,6 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
       };
     }
 
-    await this.initialize(true);
-
     const GlobalScope = getGlobalScope();
     if (GlobalScope && GlobalScope.window) {
       GlobalScope.window.addEventListener('blur', () => {
@@ -87,9 +85,18 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
         void this.initialize();
       });
     }
+
+    if (GlobalScope && GlobalScope.document && GlobalScope.document.hasFocus()) {
+      await this.initialize(true);
+    }
   }
 
   async execute(event: Event) {
+    const GlobalScope = getGlobalScope();
+    if (GlobalScope && GlobalScope.document && !GlobalScope.document.hasFocus()) {
+      return Promise.resolve(event);
+    }
+
     if (this.shouldRecord) {
       event.event_properties = {
         ...event.event_properties,

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -151,6 +151,16 @@ describe('SessionReplayPlugin', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(initialize.mock.calls[0]).toEqual([]);
     });
+    test('it should not call initialize if the document does not have focus', () => {
+      const sessionReplay = sessionReplayPlugin();
+      const initialize = jest.spyOn(sessionReplay, 'initialize').mockReturnValueOnce(Promise.resolve());
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+        document: {
+          hasFocus: () => false,
+        },
+      } as typeof globalThis);
+      expect(initialize).not.toHaveBeenCalled();
+    });
   });
 
   describe('initalize', () => {
@@ -410,6 +420,25 @@ describe('SessionReplayPlugin', () => {
   });
 
   describe('execute', () => {
+    test('it should return event if document does not have focus', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+        document: {
+          hasFocus: () => false,
+        },
+      } as typeof globalThis);
+      await sessionReplay.setup(mockConfig);
+      const event = {
+        event_type: 'event_type',
+        event_properties: {
+          property_a: true,
+          property_b: 123,
+        },
+      };
+
+      const executedEvent = await sessionReplay.execute(event);
+      expect(executedEvent).toEqual(event);
+    });
     test('should add event property for [Amplitude] Session Recorded', async () => {
       const sessionReplay = sessionReplayPlugin();
       await sessionReplay.setup(mockConfig);


### PR DESCRIPTION
### Summary

This fixes some confusing behavior observed when users open a new tab but do not have it in focus. We only want to record the tab that is in focus at any time.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
