### PR TITLE
fix(plugins): correctly fetch shouldRecord from store and clean up old store entries

### DIFF
--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -21,3 +21,4 @@ export const defaultSessionStore: IDBStoreSession = {
   currentSequenceId: 0,
   sessionSequences: {},
 };
+export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 3; // 3 days


### PR DESCRIPTION

### Summary

This PR includes two changes:
1. Correctly fetch shouldRecord from the store - previously we were only using the value if it was set to false, we need to know if a previous decision has been made that the session should be recorded as well.
2. Clean up the IDB store upon sending events, getting rid of session data that is older than 3 days. Average session durations are usually in the minutes-range, so a buffer of days should ensure that we are not evicting still relevant data for most sessions. But this cleanup will help ensure that the IDB storage doesn't unnecessarily bloat for customer's sites, which could potentially cause issues if they (or other services they use) also want to make use of IDB. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
