### PR TITLE
feat(session replay eu): route traffic to eu based on config

### DIFF
--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -11,6 +11,7 @@ export const BLOCK_CLASS = 'amp-block';
 export const MASK_TEXT_CLASS = 'amp-mask';
 export const UNMASK_TEXT_CLASS = 'amp-unmask';
 export const SESSION_REPLAY_SERVER_URL = 'https://api-secure.amplitude.com/sessions/track';
+export const SESSION_REPLAY_EU_URL = 'https://api.eu.amplitude.com/sessions/track';
 export const STORAGE_PREFIX = `${AMPLITUDE_PREFIX}_replay_unsent`;
 const PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS = 500; // derived by JSON stringifying an example payload without events
 export const MAX_EVENT_LIST_SIZE_IN_BYTES = 10 * 1000000 - PAYLOAD_ESTIMATED_SIZE_IN_BYTES_WITHOUT_EVENTS;

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import { BaseTransport } from '@amplitude/analytics-core';
-import { BrowserConfig, Event, Status } from '@amplitude/analytics-types';
+import { BrowserConfig, Event, ServerZone, Status } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import { pack, record } from 'rrweb';
 import {
@@ -15,6 +15,7 @@ import {
   SESSION_REPLAY_SERVER_URL,
   STORAGE_PREFIX,
   defaultSessionStore,
+  SESSION_REPLAY_EU_URL as SESSION_REPLAY_EU_SERVER_URL,
 } from './constants';
 import { maskInputFn } from './helpers';
 import { MAX_RETRIES_EXCEEDED_MESSAGE, STORAGE_FAILURE, UNEXPECTED_ERROR_MESSAGE, getSuccessMessage } from './messages';
@@ -301,6 +302,13 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
     await Promise.all(list.map((context) => this.send(context, useRetry)));
   }
 
+  getServerUrl() {
+    if (this.config.serverZone === ServerZone.EU) {
+      return SESSION_REPLAY_EU_SERVER_URL;
+    }
+    return SESSION_REPLAY_SERVER_URL;
+  }
+
   async send(context: SessionReplayContext, useRetry = true) {
     const payload = {
       api_key: this.config.apiKey,
@@ -322,7 +330,8 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
         body: JSON.stringify(payload),
         method: 'POST',
       };
-      const res = await fetch(SESSION_REPLAY_SERVER_URL, options);
+      const server_url = this.getServerUrl();
+      const res = await fetch(server_url, options);
       if (res === null) {
         this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE, removeEvents: false });
         return;

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { CookieStorage, FetchTransport } from '@amplitude/analytics-client-common';
-import { BrowserConfig, LogLevel, Logger } from '@amplitude/analytics-types';
+import { BrowserConfig, LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import * as RRWeb from 'rrweb';
 import { UNEXPECTED_ERROR_MESSAGE, getSuccessMessage } from '../src/messages';
@@ -754,6 +754,34 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.send(context);
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith('https://api-secure.amplitude.com/sessions/track', {
+        body: JSON.stringify({
+          api_key: 'static_key',
+          session_id: 123,
+          start_timestamp: 123,
+          events_batch: { version: 1, events: [mockEventString], seq_number: 1 },
+        }),
+        headers: { Accept: '*/*', 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+    });
+    test('should make a request to eu', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = {
+        ...mockConfig,
+        serverZone: ServerZone.EU,
+      };
+
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        attempts: 0,
+        timeout: 0,
+      };
+
+      await sessionReplay.send(context);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('https://api.eu.amplitude.com/sessions/track', {
         body: JSON.stringify({
           api_key: 'static_key',
           session_id: 123,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
Uses the right server endpoint based on the config from the SDK. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
