### PR TITLE
fix(plugins): fix edge case when opening tab in background

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -130,6 +130,12 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
       return;
     }
     const storedReplaySessions = await this.getAllSessionEventsFromStore();
+    // This resolves a timing issue when focus is fired multiple times in short succession,
+    // we only want the rest of this function to run once. We can be sure that initialize has
+    // already been called if this.stopRecordingEvents is defined
+    if (this.stopRecordingEvents) {
+      return;
+    }
     const storedSequencesForSession = storedReplaySessions && storedReplaySessions[this.config.sessionId];
     if (storedReplaySessions && storedSequencesForSession && storedSequencesForSession.sessionSequences) {
       const storedSeqId = storedSequencesForSession.currentSequenceId;
@@ -147,9 +153,8 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
     if (shouldSendStoredEvents && storedReplaySessions) {
       this.sendStoredEvents(storedReplaySessions);
     }
-    if (!this.stopRecordingEvents) {
-      this.recordEvents();
-    }
+
+    this.recordEvents();
   }
 
   setShouldRecord(sessionStore?: IDBStoreSession) {

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -248,6 +248,31 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.initialize();
       expect(getAllSessionEventsFromStore).not.toHaveBeenCalled();
     });
+    test('should return early if stopRecordingEvents is already defined, signaling that recording is already in progress', async () => {
+      const sessionReplay = sessionReplayPlugin();
+      sessionReplay.config = mockConfig;
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      sessionReplay.stopRecordingEvents = () => {};
+      const getAllSessionEventsFromStore = jest
+        .spyOn(sessionReplay, 'getAllSessionEventsFromStore')
+        .mockReturnValueOnce(
+          Promise.resolve({
+            123: {
+              shouldRecord: true,
+              currentSequenceId: 3,
+              sessionSequences: {
+                3: {
+                  events: [mockEventString],
+                  status: RecordingStatus.RECORDING,
+                },
+              },
+            },
+          }),
+        );
+      await sessionReplay.initialize();
+      expect(getAllSessionEventsFromStore).toHaveBeenCalled();
+      expect(sessionReplay.events).toEqual([]); // events should not be updated to match what is in the store
+    });
     test('should configure current sequence id and events correctly if last sequence was sending', async () => {
       const sessionReplay = sessionReplayPlugin();
       sessionReplay.config = mockConfig;


### PR DESCRIPTION
### Summary

This PR resolves the issue described in https://amplitude.atlassian.net/browse/AMP-81323, where some events were being dropped when a tab was opened in a background tab.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
