### PR TITLE
fix(plugins): use hash to calculate is session is included in sample

### DIFF
--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -18,7 +18,6 @@ export const MAX_EVENT_LIST_SIZE_IN_BYTES = 10 * 1000000 - PAYLOAD_ESTIMATED_SIZ
 export const MIN_INTERVAL = 500; // 500 ms
 export const MAX_INTERVAL = 10 * 1000; // 10 seconds
 export const defaultSessionStore: IDBStoreSession = {
-  shouldRecord: true,
   currentSequenceId: 0,
   sessionSequences: {},
 };

--- a/packages/plugin-session-replay-browser/src/helpers.ts
+++ b/packages/plugin-session-replay-browser/src/helpers.ts
@@ -6,3 +6,22 @@ export const maskInputFn = (text: string, element: HTMLElement) => {
   }
   return '*'.repeat(text.length);
 };
+
+export const generateHashCode = function (str: string) {
+  let hash = 0;
+  if (str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const chr = str.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
+  }
+  return hash;
+};
+
+export const isSessionInSample = function (sessionId: number, sampleRate: number) {
+  const hashNumber = generateHashCode(sessionId.toString());
+  const absHash = Math.abs(hashNumber);
+  const absHashMultiply = absHash * 31;
+  const mod = absHashMultiply % 100;
+  return mod / 100 < sampleRate;
+};

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -27,7 +27,6 @@ export interface IDBStoreSequence {
 }
 
 export interface IDBStoreSession {
-  shouldRecord: boolean;
   currentSequenceId: number;
   sessionSequences: {
     [sequenceId: number]: IDBStoreSequence;
@@ -45,13 +44,12 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   events: Events;
   currentSequenceId: number;
   interval: number;
-  shouldRecord: boolean;
   queue: SessionReplayContext[];
   timeAtLastSend: number | null;
   stopRecordingEvents: ReturnType<typeof record> | null;
   maxPersistedEventsSize: number;
   initialize: (shouldSendStoredEvents?: boolean) => Promise<void>;
-  setShouldRecord: (sessionStore?: IDBStoreSession) => void;
+  getShouldRecord: () => boolean;
   recordEvents: () => void;
   shouldSplitEventsList: (nextEventString: string) => boolean;
   sendEventsList: ({
@@ -80,7 +78,6 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   }): void;
   getAllSessionEventsFromStore: () => Promise<IDBStore | undefined>;
   storeEventsForSession: (events: Events, sequenceId: number, sessionId: number) => Promise<void>;
-  storeShouldRecordForSession: (sessionId: number, shouldRecord: boolean) => Promise<void>;
   cleanUpSessionEventsStore: (sessionId: number, sequenceId: number) => Promise<void>;
 }
 

--- a/packages/plugin-session-replay-browser/test/helpers.test.ts
+++ b/packages/plugin-session-replay-browser/test/helpers.test.ts
@@ -1,5 +1,5 @@
 import { UNMASK_TEXT_CLASS } from '../src/constants';
-import { maskInputFn } from '../src/helpers';
+import { generateHashCode, isSessionInSample, maskInputFn } from '../src/helpers';
 
 describe('SessionReplayPlugin helpers', () => {
   describe('maskInputFn', () => {
@@ -19,6 +19,32 @@ describe('SessionReplayPlugin helpers', () => {
       const htmlElement = {} as unknown as HTMLElement;
       const result = maskInputFn('some text', htmlElement);
       expect(result).toEqual('*********');
+    });
+  });
+
+  describe('generateHashCode', () => {
+    test('should return 0 if string length is 0', () => {
+      const hashCode = generateHashCode('');
+      expect(hashCode).toEqual(0);
+    });
+    test('should return hash for numeric string', () => {
+      const hashCode = generateHashCode('1691093770366');
+      expect(hashCode).toEqual(139812688);
+    });
+    test('should return hash for alphabetic string', () => {
+      const hashCode = generateHashCode('my_session_identifier');
+      expect(hashCode).toEqual(989939557);
+    });
+  });
+
+  describe('isSessionInSample', () => {
+    test('should deterministically return true if calculation puts session id below sample rate', () => {
+      const result = isSessionInSample(1691092433788, 0.5);
+      expect(result).toEqual(true);
+    });
+    test('should deterministically return false if calculation puts session id above sample rate', () => {
+      const result = isSessionInSample(1691092416403, 0.5);
+      expect(result).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
### Summary

This PR reduces our dependence on IndexedDB (and the timing issues related to using it) by using a hash function to deterministically calculate whether a session id is included in the sample or not. @jackson-amplitude and I ran a series of automated tests using 10,000 generated session ids to ensure that this calculation would allow for accurate sampling.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
