### PR TITLE
test(plugins): add test for sending events that are not current sessions current sequence

### DIFF
--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -17,7 +17,6 @@ export interface SessionReplayContext {
 
 export enum RecordingStatus {
   RECORDING = 'recording',
-  SENDING = 'sending',
   SENT = 'sent',
 }
 
@@ -49,6 +48,7 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   stopRecordingEvents: ReturnType<typeof record> | null;
   maxPersistedEventsSize: number;
   initialize: (shouldSendStoredEvents?: boolean) => Promise<void>;
+  sendStoredEvents: (storedReplaySessions: IDBStore) => void;
   getShouldRecord: () => boolean;
   recordEvents: () => void;
   shouldSplitEventsList: (nextEventString: string) => boolean;


### PR DESCRIPTION

### Summary

Add a test for robustness of sending events that are not recording for current session and current sequence

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
