### PR TITLE
fix(plugin): override lerna autocorrect packages

### DIFF
--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -31,19 +31,20 @@
     "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
-    "typecheck": "tsc -p ./tsconfig.json"
+    "typecheck": "tsc -p ./tsconfig.json",
+    "version": "yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\""
   },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-types": "^1.3.2",
+    "@amplitude/analytics-client-common": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
     "idb-keyval": "^6.2.1",
     "rrweb": "^2.0.0-alpha.9",
     "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "@amplitude/analytics-client-common": "^1.1.2",
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",


### PR DESCRIPTION
### Summary

Add an override so that Lerna doesn't autocorrect packages for session replay plugin

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
