### PR TITLE
fix: add allowed hostname for ga events forwarder

### DIFF
--- a/packages/plugin-ga-events-forwarder-browser/src/constants.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/constants.ts
@@ -1,5 +1,4 @@
-export const GA_PAYLOAD_HOSTNAME_VALUE_1 = 'analytics.google.com';
-export const GA_PAYLOAD_HOSTNAME_VALUE_2 = 'www.google-analytics.com';
+export const GA_PAYLOAD_HOSTNAME_VALUES = ['analytics.google.com', 'www.google-analytics.com'];
 export const GA_PAYLOAD_PATHNAME_VALUE = '/g/collect';
 export const GA_PAYLOAD_VERSION_VALUE = '2';
 

--- a/packages/plugin-ga-events-forwarder-browser/src/constants.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/constants.ts
@@ -1,4 +1,5 @@
-export const GA_PAYLOAD_HOSTNAME_VALUE = 'www.google-analytics.com';
+export const GA_PAYLOAD_HOSTNAME_VALUE_1 = 'analytics.google.com';
+export const GA_PAYLOAD_HOSTNAME_VALUE_2 = 'www.google-analytics.com';
 export const GA_PAYLOAD_PATHNAME_VALUE = '/g/collect';
 export const GA_PAYLOAD_VERSION_VALUE = '2';
 

--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import { BaseEvent, BrowserClient, BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
-import { GA_PAYLOAD_HOSTNAME_VALUE, GA_PAYLOAD_PATHNAME_VALUE } from './constants';
+import { GA_PAYLOAD_HOSTNAME_VALUE_1, GA_PAYLOAD_HOSTNAME_VALUE_2, GA_PAYLOAD_PATHNAME_VALUE } from './constants';
 import { isTrackingIdAllowed, isVersionSupported, parseGA4Events, transformToAmplitudeEvents } from './helpers';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
@@ -71,7 +71,7 @@ export const gaEventsForwarderPlugin = ({ trackingIds = [] }: Options = {}): Bro
     try {
       const url = new URL(requestUrl);
       if (
-        url.hostname === GA_PAYLOAD_HOSTNAME_VALUE &&
+        (url.hostname === GA_PAYLOAD_HOSTNAME_VALUE_1 || url.hostname === GA_PAYLOAD_HOSTNAME_VALUE_2) &&
         url.pathname === GA_PAYLOAD_PATHNAME_VALUE &&
         isTrackingIdAllowed(url, trackingIdList) &&
         isVersionSupported(url)

--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import { BaseEvent, BrowserClient, BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
-import { GA_PAYLOAD_HOSTNAME_VALUE_1, GA_PAYLOAD_HOSTNAME_VALUE_2, GA_PAYLOAD_PATHNAME_VALUE } from './constants';
+import { GA_PAYLOAD_HOSTNAME_VALUES, GA_PAYLOAD_PATHNAME_VALUE } from './constants';
 import { isTrackingIdAllowed, isVersionSupported, parseGA4Events, transformToAmplitudeEvents } from './helpers';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
@@ -71,7 +71,7 @@ export const gaEventsForwarderPlugin = ({ trackingIds = [] }: Options = {}): Bro
     try {
       const url = new URL(requestUrl);
       if (
-        (url.hostname === GA_PAYLOAD_HOSTNAME_VALUE_1 || url.hostname === GA_PAYLOAD_HOSTNAME_VALUE_2) &&
+        GA_PAYLOAD_HOSTNAME_VALUES.includes(url.hostname) &&
         url.pathname === GA_PAYLOAD_PATHNAME_VALUE &&
         isTrackingIdAllowed(url, trackingIdList) &&
         isVersionSupported(url)

--- a/packages/plugin-ga-events-forwarder-browser/src/helpers.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/helpers.ts
@@ -40,7 +40,7 @@ export const parseGA4Events = (url: URL, data?: BodyInit): GA4Event[] => {
         ...sharedProperties,
         ...event.split('&').reduce<GA4Event>((acc, props) => {
           const [key, value] = props.split('=');
-          acc[key] = value;
+          acc[decodeURIComponent(key)] = decodeURIComponent(value);
           return acc;
         }, {}),
       };


### PR DESCRIPTION
### Summary

* Include `analytics.google.com` in tracked endpoints
* Decode payload when parsing

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
