### PR TITLE
fix(plugins): add error handling to session replay and bump rrweb version

### DIFF
--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -42,7 +42,7 @@
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-types": ">=1 <3",
     "idb-keyval": "^6.2.1",
-    "rrweb": "^2.0.0-alpha.9",
+    "rrweb": "^2.0.0-alpha.11",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -95,8 +95,13 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
   };
 
   stopRecordingAndSendEvents(sessionId?: number) {
-    this.stopRecordingEvents && this.stopRecordingEvents();
-    this.stopRecordingEvents = null;
+    try {
+      this.stopRecordingEvents && this.stopRecordingEvents();
+      this.stopRecordingEvents = null;
+    } catch (error) {
+      const typedError = error as Error;
+      this.config.loggerProvider.error(`Error occurred while stopping recording: ${typedError.toString()}`);
+    }
     const sessionIdToSend = sessionId || this.config.sessionId;
     if (this.events.length && sessionIdToSend) {
       this.sendEventsList({
@@ -121,6 +126,7 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
     }
 
     const shouldRecord = this.getShouldRecord();
+
     if (shouldRecord) {
       event.event_properties = {
         ...event.event_properties,
@@ -227,6 +233,13 @@ class SessionReplay implements SessionReplayEnrichmentPlugin {
       maskTextClass: MASK_TEXT_CLASS,
       blockClass: BLOCK_CLASS,
       maskInputFn,
+      recordCanvas: false,
+      errorHandler: (error) => {
+        const typedError = error as Error;
+        this.config.loggerProvider.error('Error while recording: ', typedError.toString());
+
+        return true;
+      },
     });
   }
 

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -46,6 +46,7 @@ export interface SessionReplayEnrichmentPlugin extends EnrichmentPlugin {
   queue: SessionReplayContext[];
   timeAtLastSend: number | null;
   stopRecordingEvents: ReturnType<typeof record> | null;
+  stopRecordingAndSendEvents: (sessionId?: number) => void;
   maxPersistedEventsSize: number;
   initialize: (shouldSendStoredEvents?: boolean) => Promise<void>;
   sendStoredEvents: (storedReplaySessions: IDBStore) => void;

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -503,6 +503,24 @@ describe('SessionReplayPlugin', () => {
     });
   });
 
+  describe('stopRecordingAndSendEvents', () => {
+    test('it should catch errors', () => {
+      const sessionReplay = sessionReplayPlugin();
+      const config = {
+        ...mockConfig,
+        loggerProvider: mockLoggerProvider,
+      };
+      sessionReplay.config = config;
+      const mockStopRecordingEvents = jest.fn().mockImplementation(() => {
+        throw new Error('test error');
+      });
+      sessionReplay.stopRecordingEvents = mockStopRecordingEvents;
+      sessionReplay.stopRecordingAndSendEvents();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.error).toHaveBeenCalled();
+    });
+  });
+
   describe('execute', () => {
     test('it should return event if document does not have focus', async () => {
       const sessionReplay = sessionReplayPlugin();
@@ -695,6 +713,21 @@ describe('SessionReplayPlugin', () => {
       expect(stopRecordingMock).toHaveBeenCalled();
       expect(sessionReplay.stopRecordingEvents).toEqual(null);
       expect(sessionReplay.events).toEqual([mockEventString]); // events should not change, emmitted event should be ignored
+    });
+
+    test('should add an error handler', () => {
+      const sessionReplay = sessionReplayPlugin();
+      const config = {
+        ...mockConfig,
+        loggerProvider: mockLoggerProvider,
+      };
+      sessionReplay.config = config;
+      sessionReplay.recordEvents();
+      const recordArg = record.mock.calls[0][0];
+      const errorHandlerReturn = recordArg?.errorHandler && recordArg?.errorHandler(new Error('test error'));
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.error).toHaveBeenCalled();
+      expect(errorHandlerReturn).toBe(true);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,12 +3837,12 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rrweb/types@^2.0.0-alpha.9":
-  version "2.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@rrweb/types/-/types-2.0.0-alpha.9.tgz#960cd224f7de7d0ba86852db0c04783320f92846"
-  integrity sha512-yS2KghLSmSSxo6H7tHrJ6u+nWJA9zCXaKFyc79rUSX8RHHSImRqocTqJ8jz794kCIWA90rvaQayRONdHO+vB0Q==
+"@rrweb/types@^2.0.0-alpha.11":
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@rrweb/types/-/types-2.0.0-alpha.11.tgz#30730ac4b619a698d910f391992be8682286b8c8"
+  integrity sha512-8ccocIkT5J/bfNRQY85qR/g6p5YQFpgFO2cMt4+Ex7w31Lq0yqZBRaoYEsawQKpLrn5KOHkdn2UTUrna7WMQuA==
   dependencies:
-    rrweb-snapshot "^2.0.0-alpha.9"
+    rrweb-snapshot "^2.0.0-alpha.11"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -11076,31 +11076,31 @@ rollup@^2.79.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rrdom@^2.0.0-alpha.9:
-  version "2.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-2.0.0-alpha.9.tgz#a326d4176cec7eb8c9374ed8bb7da784252f09ef"
-  integrity sha512-jfaZ8tHi098P4GpPEtkOwnkucyKA5eGanAVHGPklzCqAeEq1Yx+9/y8AeOtF3yiobqKKkW8lLvFH2KrBH1CZlQ==
+rrdom@^2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-2.0.0-alpha.11.tgz#4f0ca9ecbf22afd317e759762a354350cd4d9986"
+  integrity sha512-U37m0t4jTz63wnVRcOQ5qFzSTrI5RdNgeXnHAha2Fmh9+1K+XuCx421a8D1wZk3WcDc2sFz/04FVdM0OD2caHg==
   dependencies:
-    rrweb-snapshot "^2.0.0-alpha.9"
+    rrweb-snapshot "^2.0.0-alpha.11"
 
-rrweb-snapshot@^2.0.0-alpha.9:
-  version "2.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.9.tgz#4f504a4f266f0cb075ecbfa35aaf687d00483ca5"
-  integrity sha512-mHg1uUE2iUf0MXLE//4r5cMynkbduwmaOEis4gC7EuqkUAC1pYoLpcYYVt9lD6dgYIF6BmK6dgLLzMpD/tTyyA==
+rrweb-snapshot@^2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.11.tgz#5ce031181ac1ac182ce6706369f77824e2bea17a"
+  integrity sha512-N0dzeJA2VhrlSOadkKwCVmV/DuNOwBH+Lhx89hAf9PQK4lCS8AP4AaylhqUdZOYHqwVjqsYel/uZ4hN79vuLhw==
 
-rrweb@^2.0.0-alpha.9:
-  version "2.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.9.tgz#bce02ae1024251ece9d981bc7ebfe6a2eb6bbf9e"
-  integrity sha512-8E2yiLY7IrFjDcVUZ7AcQtdBNFuTIsBrlCMpbyLua6X64dGRhOZ+IUDXLnAbNj5oymZgFtZu2UERG9rmV2VAng==
+rrweb@^2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.11.tgz#1f8a1944e20fd5f3ddc11634a25df2f3832914d7"
+  integrity sha512-vJ2gNvF+pUG9C2aaau7iSNqhWBSc4BwtUO4FpegOtDObuH4PIaxNJOlgHz82+WxKr9XPm93ER0LqmNpy0KYdKg==
   dependencies:
-    "@rrweb/types" "^2.0.0-alpha.9"
+    "@rrweb/types" "^2.0.0-alpha.11"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
     fflate "^0.4.4"
     mitt "^3.0.0"
-    rrdom "^2.0.0-alpha.9"
-    rrweb-snapshot "^2.0.0-alpha.9"
+    rrdom "^2.0.0-alpha.11"
+    rrweb-snapshot "^2.0.0-alpha.11"
 
 run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION

### Summary

Capture errors from rrweb and swallow them, logging to the console instead. Also bumped rrweb version to the latest

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
