### PR TITLE
fix: limit local storage size

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -248,7 +248,7 @@ export const createEventsStorage = async (overrides?: BrowserOptions): Promise<S
   // Otherwise storageProvider is overriden
   const loggerProvider = overrides && overrides.loggerProvider;
   if (!hasStorageProviderProperty || overrides.storageProvider) {
-    for (const storage of [overrides?.storageProvider, new LocalStorage<Event[]>({ loggerProvider: loggerProvider })]) {
+    for (const storage of [overrides?.storageProvider, new LocalStorage<Event[]>({ loggerProvider })]) {
       if (storage && (await storage.isEnabled())) {
         return storage;
       }

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -247,7 +247,12 @@ export const createEventsStorage = async (overrides?: BrowserOptions): Promise<S
   // then storageProvider is LocalStorage
   // Otherwise storageProvider is overriden
   if (!hasStorageProviderProperty || overrides.storageProvider) {
-    for (const storage of [overrides?.storageProvider, new LocalStorage<Event[]>()]) {
+    for (const storage of [
+      overrides?.storageProvider,
+      overrides?.loggerProvider
+        ? new LocalStorage<Event[]>({ loggerProvider: overrides?.loggerProvider })
+        : new LocalStorage<Event[]>(),
+    ]) {
       if (storage && (await storage.isEnabled())) {
         return storage;
       }

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -246,13 +246,9 @@ export const createEventsStorage = async (overrides?: BrowserOptions): Promise<S
   // If storageProvider is implicitly undefined `{ }`
   // then storageProvider is LocalStorage
   // Otherwise storageProvider is overriden
+  const loggerProvider = overrides && overrides.loggerProvider;
   if (!hasStorageProviderProperty || overrides.storageProvider) {
-    for (const storage of [
-      overrides?.storageProvider,
-      overrides?.loggerProvider
-        ? new LocalStorage<Event[]>({ loggerProvider: overrides?.loggerProvider })
-        : new LocalStorage<Event[]>(),
-    ]) {
+    for (const storage of [overrides?.storageProvider, new LocalStorage<Event[]>({ loggerProvider: loggerProvider })]) {
       if (storage && (await storage.isEnabled())) {
         return storage;
       }

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -1,7 +1,7 @@
 import * as Config from '../src/config';
 import * as LocalStorageModule from '../src/storage/local-storage';
 import * as core from '@amplitude/analytics-core';
-import { LogLevel, Storage, TransportType, UserSession } from '@amplitude/analytics-types';
+import { Event, LogLevel, Storage, TransportType, UserSession } from '@amplitude/analytics-types';
 import * as BrowserUtils from '@amplitude/analytics-client-common';
 import { getCookieName, FetchTransport } from '@amplitude/analytics-client-common';
 import { XHRTransport } from '../src/transports/xhr';
@@ -268,9 +268,10 @@ describe('config', () => {
       expect(storage).toBe(storageProvider);
     });
 
-    test('should use return storage', async () => {
+    test('should use return storage with no logger', async () => {
       const storage = await Config.createEventsStorage();
       expect(storage).toBeInstanceOf(LocalStorageModule.LocalStorage);
+      expect((storage as LocalStorageModule.LocalStorage<[Event]>).loggerProvider).toBeUndefined();
     });
 
     test('should return undefined storage', async () => {
@@ -278,6 +279,21 @@ describe('config', () => {
         storageProvider: undefined,
       });
       expect(storage).toBe(undefined);
+    });
+
+    test('should return storage with no logger', async () => {
+      const storage = await Config.createEventsStorage({});
+      expect(storage).toBeInstanceOf(LocalStorageModule.LocalStorage);
+      expect((storage as LocalStorageModule.LocalStorage<[Event]>).loggerProvider).toBeUndefined();
+    });
+
+    test('should return storage with logger', async () => {
+      const loggerProvider = new core.Logger();
+      const storage = await Config.createEventsStorage({
+        loggerProvider: loggerProvider,
+      });
+      expect(storage).toBeInstanceOf(LocalStorageModule.LocalStorage);
+      expect((storage as LocalStorageModule.LocalStorage<[Event]>).loggerProvider).toBe(loggerProvider);
     });
   });
 

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -268,7 +268,7 @@ describe('config', () => {
       expect(storage).toBe(storageProvider);
     });
 
-    test('should use return storage with no logger', async () => {
+    test('should return storage with no logger', async () => {
       const storage = await Config.createEventsStorage();
       expect(storage).toBeInstanceOf(LocalStorageModule.LocalStorage);
       expect((storage as LocalStorageModule.LocalStorage<[Event]>).loggerProvider).toBeUndefined();
@@ -279,12 +279,6 @@ describe('config', () => {
         storageProvider: undefined,
       });
       expect(storage).toBe(undefined);
-    });
-
-    test('should return storage with no logger', async () => {
-      const storage = await Config.createEventsStorage({});
-      expect(storage).toBeInstanceOf(LocalStorageModule.LocalStorage);
-      expect((storage as LocalStorageModule.LocalStorage<[Event]>).loggerProvider).toBeUndefined();
     });
 
     test('should return storage with logger', async () => {

--- a/packages/analytics-browser/test/storage/local-storage.test.ts
+++ b/packages/analytics-browser/test/storage/local-storage.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@amplitude/analytics-core';
 import { LocalStorage } from '../../src/storage/local-storage';
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 
@@ -33,6 +34,28 @@ describe('local-storage', () => {
       const localStorage = new LocalStorage();
       await localStorage.set('1', 'a');
       expect(await localStorage.get('1')).toBe('a');
+    });
+
+    test('should drop events when set more than 1000 events without logging', async () => {
+      const localStorage = new LocalStorage<number[]>();
+
+      await localStorage.set('storage-key', new Array<number>(1001).fill(1));
+      const value = await localStorage.get('storage-key');
+
+      expect(value?.length).toBe(1000);
+    });
+
+    test('should drop events when set more than 1000 events and use custom logger', async () => {
+      const loggerProvider = new Logger();
+      const localStorage = new LocalStorage<number[]>({ loggerProvider });
+      const errorMock = jest.spyOn(loggerProvider, 'error');
+
+      await localStorage.set('storage-key', new Array<number>(1001).fill(1));
+      const value = await localStorage.get('storage-key');
+
+      expect(value?.length).toBe(1000);
+      expect(errorMock).toHaveBeenCalledTimes(1);
+      expect(errorMock).toHaveBeenCalledWith('Failed to save 1 events because the queue length exceeded 1000.');
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

To fix https://amplitude.atlassian.net/browse/AMP-82144
Equivalent for v2.0 https://github.com/amplitude/Amplitude-TypeScript/pull/528
Limit local storage size to 1000 events if it stores an array of events

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
