### PR TITLE
fix(core): allow no destination plugins on instance

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -1,24 +1,24 @@
 import {
-  CoreClient,
-  Config,
-  Event,
   BaseEvent,
+  Config,
+  CoreClient,
+  Event,
   EventOptions,
   Identify,
   Plugin,
-  Revenue,
   Result,
+  Revenue,
 } from '@amplitude/analytics-types';
+import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from './messages';
+import { Timeline } from './timeline';
 import {
+  createGroupEvent,
   createGroupIdentifyEvent,
   createIdentifyEvent,
-  createTrackEvent,
   createRevenueEvent,
-  createGroupEvent,
+  createTrackEvent,
 } from './utils/event-builder';
-import { Timeline } from './timeline';
 import { buildResult } from './utils/result-builder';
-import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from './messages';
 import { returnWrapper } from './utils/return-wrapper';
 
 export class AmplitudeCore implements CoreClient {
@@ -123,6 +123,8 @@ export class AmplitudeCore implements CoreClient {
 
       result.code === 200
         ? this.config.loggerProvider.log(result.message)
+        : result.code === 100
+        ? this.config.loggerProvider.warn(result.message)
         : this.config.loggerProvider.error(result.message);
 
       return result;

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -120,7 +120,9 @@ export class Timeline {
     });
 
     void Promise.all(executeDestinations).then(([result]) => {
-      resolve(result);
+      const resolveResult =
+        result || buildResult(event, 100, 'Event not tracked, no destination plugins on the instance');
+      resolve(resolveResult);
     });
 
     return;

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -2,12 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, Plugin, Status } from '@amplitude/analytics-types';
 import { AmplitudeCore, Identify, Revenue } from '../src/index';
-import { useDefaultConfig } from './helpers/default';
 import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from '../src/messages';
+import { useDefaultConfig } from './helpers/default';
 
 describe('core-client', () => {
   const success = { event: { event_type: 'sample' }, code: 200, message: Status.Success };
   const badRequest = { event: { event_type: 'sample' }, code: 400, message: Status.Invalid };
+  const continueRequest = { event: { event_type: 'sample' }, code: 100, message: Status.Unknown };
   const client = new AmplitudeCore();
 
   describe('init', () => {
@@ -162,6 +163,17 @@ describe('core-client', () => {
 
       const result = await client.dispatch(event);
       expect(result).toBe(badRequest);
+      expect(push).toHaveBeenCalledTimes(1);
+    });
+
+    test('should handle warning', async () => {
+      const push = jest.spyOn(client.timeline, 'push').mockReturnValueOnce(Promise.resolve(continueRequest));
+      const event: Event = {
+        event_type: 'event_type',
+      };
+
+      const result = await client.dispatch(event);
+      expect(result).toBe(continueRequest);
       expect(push).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
### Summary

We have some use cases where customers will need to remove the 'amplitude' destination plugin, for example if they need to use a shell Browser SDK for session management only. When testing these use cases, I noticed that there is an implicit expectation that at least one destination plugin is on the instance. This PR removes that expectation, logging a warning to the console if an event is tracked without any destination plugins. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
