### PR TITLE
feat(browser): set optOut config in analytics connector

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -1,16 +1,17 @@
-import { AmplitudeCore, Destination, Identify, returnWrapper, Revenue, UUID } from '@amplitude/analytics-core';
 import {
   getAnalyticsConnector,
+  getCookieName,
   getPageViewTrackingConfig,
+  getQueryParams,
   IdentityEventSender,
-  isSessionTrackingEnabled,
   isFileDownloadTrackingEnabled,
   isFormInteractionTrackingEnabled,
-  getCookieName,
-  getQueryParams,
+  isSessionTrackingEnabled,
   setConnectorDeviceId,
+  setConnectorOptOut,
   setConnectorUserId,
 } from '@amplitude/analytics-client-common';
+import { AmplitudeCore, Destination, Identify, returnWrapper, Revenue, UUID } from '@amplitude/analytics-core';
 import {
   BrowserClient,
   BrowserConfig,
@@ -22,16 +23,16 @@ import {
   TransportType,
   UserSession,
 } from '@amplitude/analytics-types';
-import { convertProxyObjectToRealObject, isInstanceProxy } from './utils/snippet-helper';
-import { Context } from './plugins/context';
-import { useBrowserConfig, createTransport, getTopLevelDomain, createCookieStorage } from './config';
-import { parseLegacyCookies } from './cookie-migration';
-import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
 import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
-import { formInteractionTracking } from './plugins/form-interaction-tracking';
-import { fileDownloadTracking } from './plugins/file-download-tracking';
+import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
+import { createCookieStorage, createTransport, getTopLevelDomain, useBrowserConfig } from './config';
 import { DEFAULT_PAGE_VIEW_EVENT, DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from './constants';
+import { parseLegacyCookies } from './cookie-migration';
+import { Context } from './plugins/context';
 import { defaultPageViewEventEnrichment } from './plugins/default-page-view-event-enrichment';
+import { fileDownloadTracking } from './plugins/file-download-tracking';
+import { formInteractionTracking } from './plugins/form-interaction-tracking';
+import { convertProxyObjectToRealObject, isInstanceProxy } from './utils/snippet-helper';
 
 export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -179,6 +180,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     }
     this.config.deviceId = deviceId;
     setConnectorDeviceId(deviceId, this.config.instanceName);
+  }
+
+  setOptOut(optOut: boolean): void {
+    setConnectorOptOut(optOut, this.config.instanceName);
+    super.setOptOut(optOut);
   }
 
   reset() {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1,14 +1,14 @@
-import { AmplitudeBrowser } from '../src/browser-client';
+import { FetchTransport, getAnalyticsConnector, getCookieName } from '@amplitude/analytics-client-common';
 import * as core from '@amplitude/analytics-core';
+import { Status, TransportType, UserSession } from '@amplitude/analytics-types';
+import * as pageViewTrackingPlugin from '@amplitude/plugin-page-view-tracking-browser';
+import * as webAttributionPlugin from '@amplitude/plugin-web-attribution-browser';
+import { AmplitudeBrowser } from '../src/browser-client';
 import * as Config from '../src/config';
 import * as CookieMigration from '../src/cookie-migration';
-import { Status, TransportType, UserSession } from '@amplitude/analytics-types';
-import { FetchTransport, getAnalyticsConnector, getCookieName } from '@amplitude/analytics-client-common';
-import * as SnippetHelper from '../src/utils/snippet-helper';
 import * as fileDownloadTracking from '../src/plugins/file-download-tracking';
 import * as formInteractionTracking from '../src/plugins/form-interaction-tracking';
-import * as webAttributionPlugin from '@amplitude/plugin-web-attribution-browser';
-import * as pageViewTrackingPlugin from '@amplitude/plugin-page-view-tracking-browser';
+import * as SnippetHelper from '../src/utils/snippet-helper';
 
 describe('browser-client', () => {
   const API_KEY = 'API_KEY';
@@ -450,6 +450,18 @@ describe('browser-client', () => {
           });
         client.setDeviceId('asdfg');
       });
+    });
+  });
+
+  describe('setOptOut', () => {
+    test('should set opt out config', async () => {
+      const client = new AmplitudeBrowser();
+      await client.init(API_KEY, undefined, {
+        ...attributionConfig,
+      }).promise;
+      expect(client.config.optOut).toBe(false);
+      client.setOptOut(true);
+      expect(client.config.optOut).toBe(true);
     });
   });
 

--- a/packages/analytics-client-common/package.json
+++ b/packages/analytics-client-common/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-connector": "^1.4.5",
+    "@amplitude/analytics-connector": "^1.5.0",
     "@amplitude/analytics-core": "^1.2.3",
     "@amplitude/analytics-types": "^1.3.3",
     "tslib": "^2.4.1"

--- a/packages/analytics-client-common/src/analytics-connector.ts
+++ b/packages/analytics-client-common/src/analytics-connector.ts
@@ -13,3 +13,7 @@ export const setConnectorUserId = (userId: string | undefined, instanceName?: st
 export const setConnectorDeviceId = (deviceId: string, instanceName?: string): void => {
   getAnalyticsConnector(instanceName).identityStore.editIdentity().setDeviceId(deviceId).commit();
 };
+
+export const setConnectorOptOut = (optOut: boolean, instanceName?: string): void => {
+  getAnalyticsConnector(instanceName).identityStore.editIdentity().setOptOut(optOut).commit();
+};

--- a/packages/analytics-client-common/src/index.ts
+++ b/packages/analytics-client-common/src/index.ts
@@ -1,14 +1,13 @@
+export {
+  getAnalyticsConnector,
+  setConnectorDeviceId,
+  setConnectorOptOut,
+  setConnectorUserId,
+} from './analytics-connector';
 export { CampaignParser } from './attribution/campaign-parser';
 export { CampaignTracker } from './attribution/campaign-tracker';
-export { getQueryParams } from './query-params';
-export { getCookieName, getOldCookieName } from './cookie-name';
-export { CookieStorage } from './storage/cookie';
-export { FetchTransport } from './transports/fetch';
-export { getAnalyticsConnector, setConnectorDeviceId, setConnectorUserId } from './analytics-connector';
-export { IdentityEventSender } from './plugins/identity';
-export { getLanguage } from './language';
 export { BASE_CAMPAIGN } from './attribution/constants';
-export { getGlobalScope } from './global-scope';
+export { getCookieName, getOldCookieName } from './cookie-name';
 export {
   getPageViewTrackingConfig,
   isFileDownloadTrackingEnabled,
@@ -16,3 +15,9 @@ export {
   isPageViewTrackingEnabled,
   isSessionTrackingEnabled,
 } from './default-tracking';
+export { getGlobalScope } from './global-scope';
+export { getLanguage } from './language';
+export { IdentityEventSender } from './plugins/identity';
+export { getQueryParams } from './query-params';
+export { CookieStorage } from './storage/cookie';
+export { FetchTransport } from './transports/fetch';

--- a/packages/analytics-client-common/test/analytics-connector.test.ts
+++ b/packages/analytics-client-common/test/analytics-connector.test.ts
@@ -1,5 +1,10 @@
 import { AnalyticsConnector } from '@amplitude/analytics-connector';
-import { getAnalyticsConnector, setConnectorDeviceId, setConnectorUserId } from '../src/analytics-connector';
+import {
+  getAnalyticsConnector,
+  setConnectorDeviceId,
+  setConnectorOptOut,
+  setConnectorUserId,
+} from '../src/analytics-connector';
 
 describe('analytics-connector', () => {
   describe('getAnalyticsConnector', () => {
@@ -25,6 +30,9 @@ describe('analytics-connector', () => {
           return this;
         },
         updateUserProperties: function () {
+          return this;
+        },
+        setOptOut: function () {
           return this;
         },
         commit,
@@ -54,12 +62,45 @@ describe('analytics-connector', () => {
         updateUserProperties: function () {
           return this;
         },
+        setOptOut: function () {
+          return this;
+        },
         commit,
       };
       const instance = new AnalyticsConnector();
       jest.spyOn(instance.identityStore, 'editIdentity').mockReturnValueOnce(identityEditor);
       const getInstance = jest.spyOn(AnalyticsConnector, 'getInstance').mockReturnValueOnce(instance);
       expect(setConnectorDeviceId('123')).toBe(undefined);
+      expect(getInstance).toHaveBeenCalledTimes(1);
+      expect(commit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setConnectorOptOut', () => {
+    test('should commit opt out to connector instance', () => {
+      const commit = jest.fn();
+      const identityEditor = {
+        setUserId: function () {
+          return this;
+        },
+        setDeviceId: function () {
+          return this;
+        },
+        setUserProperties: function () {
+          return this;
+        },
+        updateUserProperties: function () {
+          return this;
+        },
+        setOptOut: function () {
+          return this;
+        },
+        commit,
+      };
+      const instance = new AnalyticsConnector();
+      jest.spyOn(instance.identityStore, 'editIdentity').mockReturnValueOnce(identityEditor);
+      const getInstance = jest.spyOn(AnalyticsConnector, 'getInstance').mockReturnValueOnce(instance);
+      expect(setConnectorOptOut(true)).toBe(undefined);
       expect(getInstance).toHaveBeenCalledTimes(1);
       expect(commit).toHaveBeenCalledTimes(1);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,12 +24,7 @@
     "@amplitude/analytics-types" "^2.1.1"
     tslib "^2.4.1"
 
-"@amplitude/analytics-connector@^1.4.8":
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
-  integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
-
-"@amplitude/analytics-connector@^1.5.0":
+"@amplitude/analytics-connector@^1.4.8", "@amplitude/analytics-connector@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz#89a78b8c6463abe4de1d621db4af6c62f0d62b0a"
   integrity sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g==
@@ -66,12 +61,7 @@
     "@amplitude/analytics-types" "^2.1.1"
     tslib "^2.4.1"
 
-"@amplitude/ua-parser-js@^0.7.31":
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.31.tgz#749bf7cb633cfcc7ff3c10805bad7c5f6fbdbc61"
-  integrity sha512-+z8UGRaj13Pt5NDzOnkTBy49HE2CX64jeL0ArB86HAtilpnfkPB7oqkigN7Lf2LxscMg4QhFD7mmCfedh3rqTg==
-
-"@amplitude/ua-parser-js@^0.7.33":
+"@amplitude/ua-parser-js@^0.7.31", "@amplitude/ua-parser-js@^0.7.33":
   version "0.7.33"
   resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.33.tgz#26441a0fb2e956a64e4ede50fb80b848179bb5db"
   integrity sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,15 @@
     "@amplitude/analytics-types" "^2.1.1"
     tslib "^2.4.1"
 
-"@amplitude/analytics-connector@^1.4.5", "@amplitude/analytics-connector@^1.4.8":
+"@amplitude/analytics-connector@^1.4.8":
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
   integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
+
+"@amplitude/analytics-connector@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz#89a78b8c6463abe4de1d621db4af6c62f0d62b0a"
+  integrity sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g==
 
 "@amplitude/analytics-core@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
### Summary

This PR updates the v1 version of browser sdk to allow amplitude.setOptOut to set the opt out config in the analytics connector. The session replay SDK will need to be able to fetch the most up to date value for opt out at run time, which this allows. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
