### PR TITLE
fix: set user id and device id from ga events

### DIFF
--- a/packages/plugin-ga-events-forwarder-browser/src/constants.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/constants.ts
@@ -8,7 +8,6 @@ export const GA_PAYLOAD_VERSION_VALUE = '2';
 
 export const GA_PAYLOAD_TAG_ID_KEY = 'tid';
 export const GA_PAYLOAD_VERSION_KEY = 'v';
-export const GA_PAYLOAD_CLIENT_ID_KEY = 'cid';
 export const GA_PAYLOAD_USER_ID_KEY = 'uid';
 export const GA_PAYLOAD_EVENT_NAME_KEY = 'en';
 export const GA_PAYLOAD_TRACKING_ID_KEY = 'tid';

--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -123,6 +123,11 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
       return;
     }
 
+    if (event.device_id) {
+      amplitude.setDeviceId(event.device_id);
+    }
+    amplitude.setUserId(event.user_id);
+
     if (
       (trackFileDownloads && event.event_type === GA_AUTOMATIC_EVENT_FILE_DOWNLOAD) ||
       (trackFormInteractions && event.event_type === GA_AUTOMATIC_EVENT_FORM_START) ||

--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -139,7 +139,11 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
     const userId = event.user_id;
     // 1. Ignore user ID received from a Google Analytics event. This allows the Amplitude SDK to enrich the user ID field later.
     delete event.user_id;
-    // 2. If current event's user ID is different from the previous event's user ID, this means the user ID was updated mid-session.
+    // 2. If current event's user ID is different from the previous event's user ID
+    // The current event's user ID can be different from the previous event's user ID when a new user_id is set through Google Analytics, for example:
+    // gtag('config', 'TAG_ID', {
+    //   'user_id': 'USER_ID'
+    // });
     if (userId !== lastSeenGAUserId) {
       // 2a. Set current event's user ID as Amplitude SDK's current user ID.
       amplitude.setUserId(event.user_id);

--- a/packages/plugin-ga-events-forwarder-browser/src/helpers.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/helpers.ts
@@ -2,7 +2,6 @@ import { BaseEvent, BrowserConfig } from '@amplitude/analytics-types';
 import {
   AMPLITUDE_EVENT_LIBRARY,
   AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID,
-  GA_PAYLOAD_CLIENT_ID_KEY,
   GA_PAYLOAD_EVENT_NAME_KEY,
   GA_PAYLOAD_EVENT_PROPERTY_NUMBER_PREFIX,
   GA_PAYLOAD_EVENT_PROPERTY_STRING_PREFIX,
@@ -57,7 +56,6 @@ export const parseGA4Events = (url: URL, data?: BodyInit | null): GA4Event[] => 
 export const transformToAmplitudeEvents = (ga4Events: GA4Event[]): BaseEvent[] =>
   ga4Events.map<BaseEvent>((ga4Event) => ({
     event_type: String(ga4Event[GA_PAYLOAD_EVENT_NAME_KEY]),
-    device_id: String(ga4Event[GA_PAYLOAD_CLIENT_ID_KEY]),
     user_id: String(ga4Event[GA_PAYLOAD_USER_ID_KEY]),
     event_properties: {
       ...getProperties(ga4Event, GA_PAYLOAD_EVENT_PROPERTY_STRING_PREFIX, GA_PAYLOAD_EVENT_PROPERTY_NUMBER_PREFIX),

--- a/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
@@ -178,6 +178,8 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
+        setDeviceId: jest.fn(),
+        setUserId: jest.fn(),
       };
 
       // 1. Send event to Google Analytics
@@ -230,6 +232,8 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
+        setDeviceId: jest.fn(),
+        setUserId: jest.fn(),
       };
 
       // 1. Setup is called when Amplitude SDK is initialized
@@ -282,6 +286,8 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
+        setDeviceId: jest.fn(),
+        setUserId: jest.fn(),
       };
 
       // 1. Setup is called when Amplitude SDK is initialized
@@ -334,6 +340,8 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
+        setDeviceId: jest.fn(),
+        setUserId: jest.fn(),
       };
 
       // 1. Setup is called when Amplitude SDK is initialized

--- a/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
@@ -178,7 +178,6 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
-        setDeviceId: jest.fn(),
         setUserId: jest.fn(),
       };
 
@@ -189,20 +188,17 @@ describe('gaEventsForwarderPlugin', () => {
 
       expect(amplitude.track).toHaveBeenCalledTimes(2);
       expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
           '__Session ID__': 1691687380,
         },
         event_type: 'page_view',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {},
         extra: {
           library: AMPLITUDE_EVENT_LIBRARY,
         },
       });
       expect(amplitude.track).toHaveBeenNthCalledWith(2, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           '1': 1,
           a: 'a',
@@ -210,7 +206,6 @@ describe('gaEventsForwarderPlugin', () => {
           '__Session ID__': 1691687380,
         },
         event_type: 'custom_event',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {
           '2': 2,
           b: 'b',
@@ -232,7 +227,6 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
-        setDeviceId: jest.fn(),
         setUserId: jest.fn(),
       };
 
@@ -243,20 +237,17 @@ describe('gaEventsForwarderPlugin', () => {
 
       expect(amplitude.track).toHaveBeenCalledTimes(2);
       expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
           '__Session ID__': 1691687380,
         },
         event_type: 'page_view',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {},
         extra: {
           library: AMPLITUDE_EVENT_LIBRARY,
         },
       });
       expect(amplitude.track).toHaveBeenNthCalledWith(2, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           '1': 1,
           a: 'a',
@@ -264,7 +255,6 @@ describe('gaEventsForwarderPlugin', () => {
           '__Session ID__': 1691687380,
         },
         event_type: 'custom_event',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {
           '2': 2,
           b: 'b',
@@ -286,7 +276,6 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
-        setDeviceId: jest.fn(),
         setUserId: jest.fn(),
       };
 
@@ -297,20 +286,17 @@ describe('gaEventsForwarderPlugin', () => {
 
       expect(amplitude.track).toHaveBeenCalledTimes(2);
       expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
           '__Session ID__': 1691687380,
         },
         event_type: 'page_view',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {},
         extra: {
           library: AMPLITUDE_EVENT_LIBRARY,
         },
       });
       expect(amplitude.track).toHaveBeenNthCalledWith(2, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           '1': 1,
           a: 'a',
@@ -318,7 +304,6 @@ describe('gaEventsForwarderPlugin', () => {
           '__Session ID__': 1691687380,
         },
         event_type: 'custom_event',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {
           '2': 2,
           b: 'b',
@@ -340,7 +325,6 @@ describe('gaEventsForwarderPlugin', () => {
       };
       const amplitude: Partial<BrowserClient> = {
         track: jest.fn(),
-        setDeviceId: jest.fn(),
         setUserId: jest.fn(),
       };
 
@@ -351,7 +335,6 @@ describe('gaEventsForwarderPlugin', () => {
 
       expect(amplitude.track).toHaveBeenCalledTimes(1);
       expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        device_id: '1129698125.1691607592',
         event_properties: {
           '1': 1,
           a: 'a',
@@ -359,7 +342,6 @@ describe('gaEventsForwarderPlugin', () => {
           '__Session ID__': 1691687380,
         },
         event_type: 'custom_event',
-        user_id: 'kevinp@amplitude.com',
         user_properties: {
           '2': 2,
           b: 'b',

--- a/packages/plugin-ga-events-forwarder-browser/test/helpers.test.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/helpers.test.ts
@@ -70,7 +70,6 @@ describe('parseGA4Events', () => {
       expect(amplitudeEvent).toEqual([
         {
           event_type: 'custom_event',
-          device_id: MOCK_GA_EVENT.cid,
           user_id: MOCK_GA_EVENT.uid,
           event_properties: {
             a: 'a',


### PR DESCRIPTION
### Summary

* Set Amplitude SDK user ID when a new Google Analytics SDK user ID is processed
* Ignore Google Analytics SDK device ID completely

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
