### PR TITLE
feat: add auto-tracking plugin

### DIFF
--- a/packages/plugin-auto-tracking-browser/CHANGELOG.md
+++ b/packages/plugin-auto-tracking-browser/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/plugin-auto-tracking-browser/README.md
+++ b/packages/plugin-auto-tracking-browser/README.md
@@ -1,0 +1,76 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>
+
+# @amplitude/plugin-auto-tracking-browser
+
+Official Browser SDK plugin for auto-tracking.
+
+## Installation
+
+This package is published on NPM registry and is available to be installed using npm and yarn.
+
+```sh
+# npm
+npm install @amplitude/plugin-auto-tracking-browser
+
+# yarn
+yarn add @amplitude/plugin-auto-tracking-browser
+```
+
+## Usage
+
+This plugin works on top of the Amplitude Browser SDK, generating auto-tracked events and sending to Amplitude.
+
+To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.9.1` or later.
+
+### 1. Import Amplitude packages
+
+* `@amplitude/analytics-browser`
+* `@amplitude/plugin-auto-tracking-browser`
+
+```typescript
+import * as amplitude from '@amplitude/analytics-browser';
+import { autoTrackingPlugin } from '@amplitude/plugin-auto-tracking-browser';
+```
+
+### 2. Instantiate the plugin
+
+The plugin accepts 1 optional parameter, which is an `Object` to configure the allowed tracking options.
+
+```typescript
+const plugin = autoTrackingPlugin({
+  cssSelectorAllowlist: ['.amp-auto-tracking', '[amp-auto-tracking]'],
+  tagAllowlist: ['button', 'a'],
+});
+```
+
+Examples:
+- The above `cssSelectorAllowlist` will only allow tracking elements like:
+    - `<button amp-auto-tracking>Click</button>`
+    - `<a class="amp-auto-tracking">Link</a>`
+- The above `tagAllowlist` will only allow `button` and `a` tags to be tracked.
+
+Note `ingestionMetadata` is for internal use only, you don't need to provide it.
+
+#### Options
+
+|Name|Type|Default|Description|
+|-|-|-|-|
+|`cssSelectorAllowlist`|`string[]`|`undefined`| When provided, only allow elements matching any selector to be tracked. |
+|`tagAllowlist`|`string[]`|`['a', 'button', 'input', 'select', 'textarea', 'label']`| Only allow elements with tag in this list to be tracked. |
+
+### 3. Install plugin to Amplitude SDK
+
+```typescript
+amplitude.add(plugin);
+```
+
+### 4. Initialize Amplitude SDK
+
+```typescript
+amplitude.init('API_KEY');
+```

--- a/packages/plugin-auto-tracking-browser/jest.config.js
+++ b/packages/plugin-auto-tracking-browser/jest.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require('../../jest.config.js');
+const package = require('./package');
+
+module.exports = {
+  ...baseConfig,
+  displayName: package.name,
+  rootDir: '.',
+  testEnvironment: 'jsdom',
+  coveragePathIgnorePatterns: ['index.ts'],
+};

--- a/packages/plugin-auto-tracking-browser/package.json
+++ b/packages/plugin-auto-tracking-browser/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@amplitude/plugin-auto-tracking-browser",
+  "version": "0.0.1",
+  "description": "",
+  "author": "Amplitude Inc",
+  "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
+  "license": "MIT",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
+  },
+  "scripts": {
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
+    "bundle": "rollup --config rollup.config.js",
+    "build:es5": "tsc -p ./tsconfig.es5.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "clean": "rimraf node_modules lib coverage",
+    "fix": "yarn fix:eslint & yarn fix:prettier",
+    "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
+    "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
+    "lint": "yarn lint:eslint & yarn lint:prettier",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
+    "publish": "node ../../scripts/publish/upload-to-s3.js",
+    "test": "jest",
+    "typecheck": "tsc -p ./tsconfig.json"
+  },
+  "bugs": {
+    "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
+  },
+  "dependencies": {
+    "@amplitude/analytics-client-common": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
+    "tslib": "^2.4.1"
+  },
+  "devDependencies": {
+    "@amplitude/analytics-browser": "^2.1.2",
+    "@rollup/plugin-commonjs": "^23.0.4",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^10.0.1",
+    "rollup": "^2.79.1",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/packages/plugin-auto-tracking-browser/package.json
+++ b/packages/plugin-auto-tracking-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/plugin-auto-tracking-browser",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "",
   "author": "Amplitude Inc",
   "homepage": "https://github.com/amplitude/Amplitude-TypeScript",

--- a/packages/plugin-auto-tracking-browser/rollup.config.js
+++ b/packages/plugin-auto-tracking-browser/rollup.config.js
@@ -1,0 +1,6 @@
+import { iife, umd } from '../../scripts/build/rollup.config';
+
+iife.input = umd.input;
+iife.output.name = 'amplitudeAutoTrackingPlugin';
+
+export default [umd, iife];

--- a/packages/plugin-auto-tracking-browser/src/auto-tracking-plugin.ts
+++ b/packages/plugin-auto-tracking-browser/src/auto-tracking-plugin.ts
@@ -1,0 +1,191 @@
+/* eslint-disable no-restricted-globals */
+import { BrowserClient, BrowserConfig, EnrichmentPlugin, IngestionMetadata } from '@amplitude/analytics-types';
+import * as constants from './constants';
+import { getText } from './helpers';
+
+type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
+type ActionType = 'click' | 'change';
+
+const DEFAULT_TAG_ALLOWLIST = ['a', 'button', 'input', 'select', 'textarea', 'label'];
+
+interface EventListener {
+  element: Element;
+  type: ActionType;
+  handler: () => void;
+}
+
+interface Options {
+  cssSelectorAllowlist?: string[];
+  tagAllowlist?: string[];
+  ingestionMetadata?: IngestionMetadata; // Should avoid overriding this if unplanned to do so, this is not available in the charts.
+}
+
+export const autoTrackingPlugin = (options: Options = {}): BrowserEnrichmentPlugin => {
+  const { tagAllowlist = DEFAULT_TAG_ALLOWLIST, cssSelectorAllowlist, ingestionMetadata } = options;
+  const name = constants.PLUGIN_NAME;
+  const type = 'enrichment';
+
+  let observer: MutationObserver | undefined;
+  let eventListeners: EventListener[] = [];
+
+  const addEventListener = (element: Element, type: ActionType, handler: () => void) => {
+    element.addEventListener(type, handler);
+    eventListeners.push({
+      element: element,
+      type: type,
+      handler: handler,
+    });
+  };
+
+  const removeEventListeners = () => {
+    eventListeners.forEach((_ref) => {
+      const element = _ref.element,
+        type = _ref.type,
+        handler = _ref.handler;
+      /* istanbul ignore next */
+      element?.removeEventListener(type, handler);
+    });
+    eventListeners = [];
+  };
+
+  const shouldTrackEvent = (actionType: ActionType, element: Element) => {
+    /* istanbul ignore if */
+    if (!element) {
+      return false;
+    }
+    /* istanbul ignore next */
+    const elementType = (element as HTMLInputElement)?.type || '';
+    if (typeof elementType === 'string') {
+      switch (elementType.toLowerCase()) {
+        case 'hidden':
+          return false;
+        case 'password':
+          return false;
+      }
+    }
+    const tag = element.tagName.toLowerCase();
+    /* istanbul ignore if */
+    if (!tagAllowlist.includes(tag)) {
+      return false;
+    }
+    if (cssSelectorAllowlist) {
+      const hasMatchAnyAllowedSelector = cssSelectorAllowlist.some((selector) => element.matches(selector));
+      if (!hasMatchAnyAllowedSelector) {
+        return false;
+      }
+    }
+    switch (tag) {
+      case 'input':
+      case 'select':
+      case 'textarea':
+        return actionType === 'change' || actionType === 'click';
+      default: {
+        /* istanbul ignore next */
+        const computedStyle = window?.getComputedStyle?.(element);
+        /* istanbul ignore next */
+        if (computedStyle && computedStyle.getPropertyValue('cursor') === 'pointer' && actionType === 'click') {
+          return true;
+        }
+        return actionType === 'click';
+      }
+    }
+  };
+
+  const getEventProperties = (actionType: ActionType, element: Element) => {
+    const tag = element.tagName.toLowerCase();
+    /* istanbul ignore next */
+    const rect =
+      typeof element.getBoundingClientRect === 'function' ? element.getBoundingClientRect() : { left: null, top: null };
+    /* istanbul ignore next */
+    const properties: Record<string, any> = {
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ID]: element.id,
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_CLASS]: element.className,
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: getText(element),
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_LEFT]: rect.left == null ? null : Math.round(rect.left),
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_TOP]: rect.top == null ? null : Math.round(rect.top),
+      [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: window.location.href.split('?')[0],
+      [constants.AMPLITUDE_EVENT_PROP_PAGE_TITLE]: (typeof document !== 'undefined' && document.title) || '',
+      [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT]: window.innerHeight,
+      [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH]: window.innerWidth,
+    };
+    if (tag === 'a' && actionType === 'click' && element instanceof HTMLAnchorElement) {
+      properties[constants.AMPLITUDE_EVENT_PROP_ELEMENT_HREF] = element.href;
+    }
+    return properties;
+  };
+
+  const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
+    if (!amplitude) {
+      /* istanbul ignore next */
+      config?.loggerProvider?.warn(
+        `${name} plugin requires a later version of @amplitude/analytics-browser. Events are not tracked.`,
+      );
+      return;
+    }
+    /* istanbul ignore if */
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const addListener = (el: Element) => {
+      if (shouldTrackEvent('click', el)) {
+        addEventListener(el, 'click', () => {
+          /* istanbul ignore next */
+          amplitude?.track(constants.AMPLITUDE_ELEMENT_CLICKED_EVENT, getEventProperties('click', el));
+        });
+      }
+      if (shouldTrackEvent('change', el)) {
+        addEventListener(el, 'change', () => {
+          /* istanbul ignore next */
+          amplitude?.track(constants.AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', el));
+        });
+      }
+    };
+    const allElements = Array.from(document.body.querySelectorAll(tagAllowlist.join(',')));
+    allElements.forEach(addListener);
+    if (typeof MutationObserver !== 'undefined') {
+      observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node: Node) => {
+            addListener(node as Element);
+            if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+              Array.from(node.querySelectorAll(tagAllowlist.join(',')) as HTMLElement[]).map(addListener);
+            }
+          });
+        });
+      });
+      observer.observe(document.body, {
+        subtree: true,
+        childList: true,
+      });
+    }
+    /* istanbul ignore next */
+    config?.loggerProvider?.log(`${name} has been successfully added.`);
+  };
+
+  const execute: BrowserEnrichmentPlugin['execute'] = async (event) => {
+    const { sourceName, sourceVersion } = ingestionMetadata || {};
+    if (sourceName && sourceVersion) {
+      event.ingestion_metadata = {
+        source_name: `${constants.INGESTION_METADATA_SOURCE_NAME_PREFIX}${sourceName}`, // Make sure the source name is prefixed with the correct context.
+        source_version: sourceVersion,
+      };
+    }
+    return event;
+  };
+
+  const teardown = async () => {
+    if (observer) {
+      observer.disconnect();
+    }
+    removeEventListeners();
+  };
+
+  return {
+    name,
+    type,
+    setup,
+    execute,
+    teardown,
+  };
+};

--- a/packages/plugin-auto-tracking-browser/src/constants.ts
+++ b/packages/plugin-auto-tracking-browser/src/constants.ts
@@ -1,0 +1,18 @@
+export const PLUGIN_NAME = '@amplitude/plugin-auto-tracking-browser';
+
+export const AMPLITUDE_ELEMENT_CLICKED_EVENT = '[Amplitude] Element Clicked';
+export const AMPLITUDE_ELEMENT_CHANGED_EVENT = '[Amplitude] Element Changed';
+
+export const AMPLITUDE_EVENT_PROP_ELEMENT_ID = '[Amplitude] Element ID';
+export const AMPLITUDE_EVENT_PROP_ELEMENT_CLASS = '[Amplitude] Element Class';
+export const AMPLITUDE_EVENT_PROP_ELEMENT_TAG = '[Amplitude] Element Tag';
+export const AMPLITUDE_EVENT_PROP_ELEMENT_TEXT = '[Amplitude] Element Text';
+export const AMPLITUDE_EVENT_PROP_ELEMENT_HREF = '[Amplitude] Element Href';
+export const AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_LEFT = '[Amplitude] Element Position Left';
+export const AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_TOP = '[Amplitude] Element Position Top';
+export const AMPLITUDE_EVENT_PROP_PAGE_URL = '[Amplitude] Page URL';
+export const AMPLITUDE_EVENT_PROP_PAGE_TITLE = '[Amplitude] Page Title';
+export const AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT = '[Amplitude] Viewport Height';
+export const AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH = '[Amplitude] Viewport Width';
+
+export const INGESTION_METADATA_SOURCE_NAME_PREFIX = 'browser-typescript-';

--- a/packages/plugin-auto-tracking-browser/src/helpers.ts
+++ b/packages/plugin-auto-tracking-browser/src/helpers.ts
@@ -1,0 +1,53 @@
+const SENTITIVE_TAGS = ['input', 'select', 'textarea'];
+
+export const isNonSensitiveString = (text: string | null) => {
+  if (text == null) {
+    return false;
+  }
+  if (typeof text === 'string') {
+    const ccRegex =
+      /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/;
+    if (ccRegex.test((text || '').replace(/[- ]/g, ''))) {
+      return false;
+    }
+    const ssnRegex = /(^\d{3}-?\d{2}-?\d{4}$)/;
+    if (ssnRegex.test(text)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const isTextNode = (node: Node) => {
+  return !!node && node.nodeType === 3;
+};
+
+export const isNonSensitiveElement = (element: Element) => {
+  const tag = element.tagName.toLowerCase();
+  return !SENTITIVE_TAGS.includes(tag);
+};
+
+// Maybe this can be simplified with element.innerText, keep and manual concatenating for now, more research needed.
+export const getText = (element: Element): string => {
+  let text = '';
+  if (isNonSensitiveElement(element) && element.childNodes && element.childNodes.length) {
+    element.childNodes.forEach((child) => {
+      let childText = '';
+      if (isTextNode(child)) {
+        if (child.textContent) {
+          childText = child.textContent;
+        }
+      } else {
+        childText = getText(child as Element);
+      }
+      text += childText
+        .split(/(\s+)/)
+        .filter(isNonSensitiveString)
+        .join('')
+        .replace(/[\r\n]/g, ' ')
+        .replace(/[ ]+/g, ' ')
+        .substring(0, 255);
+    });
+  }
+  return text;
+};

--- a/packages/plugin-auto-tracking-browser/src/index.ts
+++ b/packages/plugin-auto-tracking-browser/src/index.ts
@@ -1,0 +1,1 @@
+export { autoTrackingPlugin as plugin, autoTrackingPlugin } from './auto-tracking-plugin';

--- a/packages/plugin-auto-tracking-browser/test/auto-tracking-plugin.test.ts
+++ b/packages/plugin-auto-tracking-browser/test/auto-tracking-plugin.test.ts
@@ -1,0 +1,418 @@
+import { autoTrackingPlugin } from '../src/auto-tracking-plugin';
+import { BrowserClient, BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
+import { createInstance } from '@amplitude/analytics-browser';
+
+const mockWindowLocationFromURL = (url: URL) => {
+  window.location.href = url.toString();
+  window.location.search = url.search;
+  window.location.hostname = url.hostname;
+  window.location.pathname = url.pathname;
+};
+
+describe('autoTrackingPlugin', () => {
+  let plugin: EnrichmentPlugin | undefined;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '',
+        href: '',
+        pathname: '',
+        search: '',
+      },
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    (window.location as any) = {
+      hostname: '',
+      href: '',
+      pathname: '',
+      search: '',
+    };
+    plugin = autoTrackingPlugin();
+  });
+
+  afterEach(() => {
+    void plugin?.teardown?.();
+    jest.clearAllMocks();
+  });
+
+  describe('name', () => {
+    test('should return the plugin name', () => {
+      expect(plugin?.name).toBe('@amplitude/plugin-auto-tracking-browser');
+    });
+  });
+
+  describe('type', () => {
+    test('should return the plugin type', () => {
+      expect(plugin?.type).toBe('enrichment');
+    });
+  });
+
+  describe('setup', () => {
+    test('should setup successfully', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      const amplitude: Partial<BrowserClient> = {};
+      await plugin?.setup?.(config as BrowserConfig, amplitude as BrowserClient);
+      expect(loggerProvider.warn).toHaveBeenCalledTimes(0);
+      expect(loggerProvider.log).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.log).toHaveBeenNthCalledWith(1, `${plugin?.name as string} has been successfully added.`);
+    });
+
+    test('should handle incompatible Amplitude SDK version', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup?.(config as BrowserConfig);
+      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.warn).toHaveBeenNthCalledWith(
+        1,
+        `${
+          plugin?.name as string
+        } plugin requires a later version of @amplitude/analytics-browser. Events are not tracked.`,
+      );
+    });
+  });
+
+  describe('execute', () => {
+    test('should return the same event type', async () => {
+      const event = await plugin?.execute({
+        event_type: 'custom_event',
+      });
+      expect(event).toEqual({
+        event_type: 'custom_event',
+      });
+    });
+
+    test('should enrich ingestion_metadata field', async () => {
+      plugin = autoTrackingPlugin({
+        ingestionMetadata: {
+          sourceName: 'unit-test',
+          sourceVersion: '1.0.0',
+        },
+      });
+      const event = await plugin?.execute({
+        event_type: 'custom_event',
+      });
+      expect(event).toEqual({
+        event_type: 'custom_event',
+        ingestion_metadata: {
+          source_name: 'browser-typescript-unit-test',
+          source_version: '1.0.0',
+        },
+      });
+    });
+
+    test('should not enrich ingestion_metadata field if source_name is missing', async () => {
+      plugin = autoTrackingPlugin({
+        ingestionMetadata: {
+          sourceVersion: '1.0.0',
+        },
+      });
+      const event = await plugin?.execute({
+        event_type: 'custom_event',
+      });
+      expect(event).toEqual({
+        event_type: 'custom_event',
+      });
+    });
+
+    test('should not enrich ingestion_metadata field if source_version is missing', async () => {
+      plugin = autoTrackingPlugin({
+        ingestionMetadata: {
+          sourceName: 'unit-test',
+        },
+      });
+      const event = await plugin?.execute({
+        event_type: 'custom_event',
+      });
+      expect(event).toEqual({
+        event_type: 'custom_event',
+      });
+    });
+  });
+
+  describe('auto-tracking events', () => {
+    const API_KEY = 'API_KEY';
+    const USER_ID = 'USER_ID';
+
+    let instance = createInstance();
+    let track: jest.SpyInstance;
+
+    beforeEach(async () => {
+      plugin = autoTrackingPlugin();
+      instance = createInstance();
+      await instance.init(API_KEY, USER_ID).promise;
+      track = jest.spyOn(instance, 'track');
+
+      const link = document.createElement('a');
+      link.setAttribute('id', 'my-link-id');
+      link.setAttribute('class', 'my-link-class');
+      link.href = 'https://www.amplitude.com/click-link';
+      link.text = 'my-link-text';
+      document.body.appendChild(link);
+
+      mockWindowLocationFromURL(new URL('https://www.amplitude.com/unit-test?query=param'));
+    });
+
+    afterEach(() => {
+      document.querySelector('a#my-link-id')?.remove();
+      document.querySelector('button#my-button-id')?.remove();
+      document.querySelector('input#my-input-id')?.remove();
+    });
+
+    test('should monitor element clicked event', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click event
+      document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-link-class',
+        '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
+        '[Amplitude] Element ID': 'my-link-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'a',
+        '[Amplitude] Element Text': 'my-link-text',
+        '[Amplitude] Page Title': '',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
+
+      // stop observer and listeners
+      await plugin?.teardown?.();
+
+      // trigger click event
+      document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+      // assert no additional event was tracked
+      expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    test('should monitor element clicked event when dynamically rendered', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click event
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.setAttribute('id', 'my-button-id');
+      button.setAttribute('class', 'my-button-class');
+      button.appendChild(buttonText);
+      document.body.appendChild(button);
+      // allow mutation observer to execute and event listener to be attached
+      await new Promise((r) => r(undefined)); // basically, await next clock tick
+      document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
+
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-button-class',
+        '[Amplitude] Element ID': 'my-button-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'button',
+        '[Amplitude] Element Text': 'submit',
+        '[Amplitude] Page Title': '',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
+
+      // stop observer and listeners
+      await plugin?.teardown?.();
+
+      // trigger click event
+      document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+      // assert no additional event was tracked
+      expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    test('should follow tagAllowlist configuration', async () => {
+      plugin = autoTrackingPlugin({ tagAllowlist: ['button'] });
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click event
+      document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+      expect(track).toHaveBeenCalledTimes(0);
+    });
+
+    test('should follow cssSelectorAllowlist configuration', async () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.setAttribute('id', 'my-button-id');
+      button.setAttribute('class', 'my-button-class');
+      button.appendChild(buttonText);
+      document.body.appendChild(button);
+
+      plugin = autoTrackingPlugin({ cssSelectorAllowlist: ['.my-button-class'] });
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click link
+      document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(0);
+
+      // trigger click button
+      document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    test('should track change event', async () => {
+      const input = document.createElement('input');
+      input.setAttribute('id', 'my-input-id');
+      input.setAttribute('class', 'my-input-class');
+      document.body.appendChild(input);
+
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(1);
+
+      // trigger change input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('change'));
+      expect(track).toHaveBeenCalledTimes(2);
+    });
+
+    test('should not track when element type is hidden', async () => {
+      const input = document.createElement('input');
+      input.setAttribute('id', 'my-input-id');
+      input.setAttribute('class', 'my-input-class');
+      input.type = 'hidden';
+      document.body.appendChild(input);
+
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(0);
+
+      // trigger change input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('change'));
+      expect(track).toHaveBeenCalledTimes(0);
+    });
+
+    test('should not track when element type is password', async () => {
+      const input = document.createElement('input');
+      input.setAttribute('id', 'my-input-id');
+      input.setAttribute('class', 'my-input-class');
+      input.type = 'password';
+      document.body.appendChild(input);
+
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(0);
+
+      // trigger change input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('change'));
+      expect(track).toHaveBeenCalledTimes(0);
+    });
+
+    test('should not track for div tags', async () => {
+      const div = document.createElement('div');
+      div.setAttribute('id', 'my-div-id');
+      div.setAttribute('class', 'my-div-class');
+      document.body.appendChild(div);
+
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click input
+      document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(0);
+
+      // trigger change input
+      document.getElementById('my-div-id')?.dispatchEvent(new Event('change'));
+      expect(track).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('teardown', () => {
+    // eslint-disable-next-line jest/expect-expect
+    test('should teardown plugin', () => {
+      void plugin?.teardown?.();
+    });
+  });
+});

--- a/packages/plugin-auto-tracking-browser/test/helpers.test.ts
+++ b/packages/plugin-auto-tracking-browser/test/helpers.test.ts
@@ -1,0 +1,126 @@
+import { isNonSensitiveString, isTextNode, isNonSensitiveElement, getText } from '../src/helpers';
+
+describe('autoTrackingPlugin helpers', () => {
+  describe('isNonSensitiveString', () => {
+    test('should return false when text is missing', () => {
+      const text = null;
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return true when text is not sensitive', () => {
+      const text = 'test-string';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(true);
+    });
+
+    test('should return false when text is credit card format', () => {
+      const text = '4916024123820164';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when text is social security number format', () => {
+      const text = '269-28-9315';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return true when text is not a string', () => {
+      const text = 123;
+      const result = isNonSensitiveString(text as unknown as string);
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('isTextNode', () => {
+    test('should return false when node is not a text node', () => {
+      const node = document.createElement('a');
+      const result = isTextNode(node);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when node is missing', () => {
+      const node = null;
+      const result = isTextNode(node as unknown as Node);
+      expect(result).toEqual(false);
+    });
+
+    test('should return true when node is a text node', () => {
+      const node = document.createTextNode('text');
+      const result = isTextNode(node);
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('isNonSensitiveElement', () => {
+    test('should return false when element is not a sensitive tag', () => {
+      const element = document.createElement('textarea');
+      const result = isNonSensitiveElement(element);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when element is a sensitive tag', () => {
+      const element = document.createElement('a');
+      const result = isNonSensitiveElement(element);
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('getText', () => {
+    test('should return empty string when element is sensitive', () => {
+      const element = document.createElement('input');
+      element.value = 'test';
+      const result = getText(element);
+      expect(result).toEqual('');
+    });
+
+    test('should return text when element has text attribute', () => {
+      const element = document.createElement('a');
+      element.text = 'test';
+      const result = getText(element);
+      expect(result).toEqual('test');
+    });
+
+    test('should return text when element has text node', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const result = getText(button);
+      expect(result).toEqual('submit');
+    });
+
+    test('should return concatenated text when element has child text nodes', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const div = document.createElement('div');
+      div.textContent = ' and pay';
+      button.appendChild(div);
+      const result = getText(button);
+      expect(result).toEqual('submit and pay');
+    });
+
+    test('should return concatenated text with sensitive text filtered', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const div = document.createElement('div');
+      div.textContent = '269-28-9315';
+      button.appendChild(div);
+      const result = getText(button);
+      expect(result).toEqual('submit');
+    });
+
+    test('should return concatenated text with extra space removed', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const div = document.createElement('div');
+      div.textContent = ' and   \n pay';
+      button.appendChild(div);
+      const result = getText(button);
+      expect(result).toEqual('submit and pay');
+    });
+  });
+});

--- a/packages/plugin-auto-tracking-browser/tsconfig.es5.json
+++ b/packages/plugin-auto-tracking-browser/tsconfig.es5.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "lib/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/packages/plugin-auto-tracking-browser/tsconfig.esm.json
+++ b/packages/plugin-auto-tracking-browser/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "es6",
+    "noEmit": false,
+    "outDir": "lib/esm",
+    "rootDir": "./src"
+  }
+}

--- a/packages/plugin-auto-tracking-browser/tsconfig.json
+++ b/packages/plugin-auto-tracking-browser/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "noEmit": true,
+    "rootDir": "."
+  }
+}

--- a/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
@@ -114,7 +114,7 @@ describe('gaEventsForwarderPlugin', () => {
   });
 
   describe('execute', () => {
-    test('should return the return the same event type', async () => {
+    test('should return the same event type', async () => {
       const event = await plugin?.execute({
         event_type: 'custom_event',
       });


### PR DESCRIPTION
### Summary
Extract the auto-tracking logic from https://github.com/amplitude/Amplitude-TypeScript/pull/529 to a new package.

- feat: add auto-tracking plugin

#### Instantiate the plugin

The plugin accepts 1 optional parameter, which is an `Object` to configure the allowed tracking options.

```typescript
const plugin = autoTrackingPlugin({
  cssSelectorAllowlist: ['.amp-auto-tracking', '[amp-auto-tracking]'],
  tagAllowlist: ['button', 'a'],
});
```

Examples:
- The above `cssSelectorAllowlist` will only allow tracking elements like:
    - `<button amp-auto-tracking>Click</button>`
    - `<a class="amp-auto-tracking">Link</a>`
- The above `tagAllowlist` will only allow `button` and `a` tags to be tracked.

Note `ingestionMetadata` is for internal use only, you don't need to provide it.

#### Options

|Name|Type|Default|Description|
|-|-|-|-|
|`cssSelectorAllowlist`|`string[]`|`undefined`| When provided, only allow elements matching any selector to be tracked. |
|`tagAllowlist`|`string[]`|`['a', 'button', 'input', 'select', 'textarea', 'label']`| Only allow elements with tag in this list to be tracked. |

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
