### PR TITLE
fix: ignore non-string form.name values for form interaction tracking

### DIFF
--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -17,6 +17,7 @@ interface EventListener {
 export const formInteractionTracking = (): EnrichmentPlugin => {
   let observer: MutationObserver | undefined;
   let eventListeners: EventListener[] = [];
+
   const addEventListener = (element: Element, type: 'change' | 'submit', handler: () => void) => {
     element.addEventListener(type, handler);
     eventListeners.push({
@@ -25,6 +26,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       handler,
     });
   };
+
   const removeClickListeners = () => {
     eventListeners.forEach(({ element, type, handler }) => {
       /* istanbul ignore next */
@@ -57,7 +59,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
             [FORM_ID]: form.id,
-            [FORM_NAME]: form.name,
+            [FORM_NAME]: stringOrUndefined(form.name),
             [FORM_DESTINATION]: form.action,
           });
         }
@@ -68,14 +70,14 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
             [FORM_ID]: form.id,
-            [FORM_NAME]: form.name,
+            [FORM_NAME]: stringOrUndefined(form.name),
             [FORM_DESTINATION]: form.action,
           });
         }
 
         amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
           [FORM_ID]: form.id,
-          [FORM_NAME]: form.name,
+          [FORM_NAME]: stringOrUndefined(form.name),
           [FORM_DESTINATION]: form.action,
         });
         hasFormChanged = false;
@@ -121,4 +123,16 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     execute,
     teardown,
   };
+};
+
+export const stringOrUndefined = (name: string) => {
+  /* istanbul ignore if */
+  if (typeof name !== 'string') {
+    // We found instances where the value of `name` is an Element and not a string.
+    // Elements may have circular references and would throw an error when passed to `JSON.stringify(...)`.
+    // If a non-string value is seen, assume there is no value.
+    return undefined;
+  }
+
+  return name;
 };

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -125,14 +125,14 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
   };
 };
 
-export const stringOrUndefined = (name: string) => {
+export const stringOrUndefined = <T>(name: T): T extends string ? string : undefined => {
   /* istanbul ignore if */
   if (typeof name !== 'string') {
     // We found instances where the value of `name` is an Element and not a string.
     // Elements may have circular references and would throw an error when passed to `JSON.stringify(...)`.
     // If a non-string value is seen, assume there is no value.
-    return undefined;
+    return undefined as T extends string ? string : undefined;
   }
 
-  return name;
+  return name as T extends string ? string : undefined;
 };

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -62,7 +62,7 @@ describe('formInteractionTracking', () => {
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
 
-    // add form elemen dynamically
+    // add form element dynamically
     const form = document.createElement('form');
     form.setAttribute('id', 'my-form-2-id');
     form.setAttribute('name', 'my-form-2-name');
@@ -135,7 +135,7 @@ describe('formInteractionTracking', () => {
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
 
-    // add form elemen dynamically
+    // add form element dynamically
     const form = document.createElement('form');
     form.setAttribute('id', 'my-form-2-id');
     form.setAttribute('name', 'my-form-2-name');


### PR DESCRIPTION
### Summary

ignore non-string `form.name` values for form interaction tracking

We've seen in a customer's production site where `form.name` can return a value of type Element. This yields an error when this value is included in the event payload as it eventually gets stringified and the element has circular references. The following error is thrown.

```
logger.ts:38 Amplitude Logger [Error]: Converting circular structure to JSON
    --> starting at object with constructor 'HTMLInputElement'
    |     property 'xxx' -> object with constructor 'x'
    --- property 'stateNode' closes the circle
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No