### PR TITLE
refactor(plugin-auto-tracking-browser): remove ingestion metadata option

### DIFF
--- a/packages/plugin-auto-tracking-browser/README.md
+++ b/packages/plugin-auto-tracking-browser/README.md
@@ -5,9 +5,10 @@
   <br />
 </p>
 
-# @amplitude/plugin-auto-tracking-browser
+# @amplitude/plugin-auto-tracking-browser (alpha)
+**This plugin is in alpha stage, naming and interface might change in the future.**
 
-Official Browser SDK plugin for auto-tracking.
+Browser SDK plugin for auto-tracking.
 
 ## Installation
 

--- a/packages/plugin-auto-tracking-browser/README.md
+++ b/packages/plugin-auto-tracking-browser/README.md
@@ -54,8 +54,6 @@ Examples:
     - `<a class="amp-auto-tracking">Link</a>`
 - The above `tagAllowlist` will only allow `button` and `a` tags to be tracked.
 
-Note `ingestionMetadata` is for internal use only, you don't need to provide it.
-
 #### Options
 
 |Name|Type|Default|Description|

--- a/packages/plugin-auto-tracking-browser/src/auto-tracking-plugin.ts
+++ b/packages/plugin-auto-tracking-browser/src/auto-tracking-plugin.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-globals */
-import { BrowserClient, BrowserConfig, EnrichmentPlugin, IngestionMetadata } from '@amplitude/analytics-types';
+import { BrowserClient, BrowserConfig, EnrichmentPlugin } from '@amplitude/analytics-types';
 import * as constants from './constants';
 import { getText } from './helpers';
 
@@ -17,11 +17,10 @@ interface EventListener {
 interface Options {
   cssSelectorAllowlist?: string[];
   tagAllowlist?: string[];
-  ingestionMetadata?: IngestionMetadata; // Should avoid overriding this if unplanned to do so, this is not available in the charts.
 }
 
 export const autoTrackingPlugin = (options: Options = {}): BrowserEnrichmentPlugin => {
-  const { tagAllowlist = DEFAULT_TAG_ALLOWLIST, cssSelectorAllowlist, ingestionMetadata } = options;
+  const { tagAllowlist = DEFAULT_TAG_ALLOWLIST, cssSelectorAllowlist } = options;
   const name = constants.PLUGIN_NAME;
   const type = 'enrichment';
 
@@ -164,13 +163,6 @@ export const autoTrackingPlugin = (options: Options = {}): BrowserEnrichmentPlug
   };
 
   const execute: BrowserEnrichmentPlugin['execute'] = async (event) => {
-    const { sourceName, sourceVersion } = ingestionMetadata || {};
-    if (sourceName && sourceVersion) {
-      event.ingestion_metadata = {
-        source_name: `${constants.INGESTION_METADATA_SOURCE_NAME_PREFIX}${sourceName}`, // Make sure the source name is prefixed with the correct context.
-        source_version: sourceVersion,
-      };
-    }
     return event;
   };
 

--- a/packages/plugin-auto-tracking-browser/src/constants.ts
+++ b/packages/plugin-auto-tracking-browser/src/constants.ts
@@ -14,5 +14,3 @@ export const AMPLITUDE_EVENT_PROP_PAGE_URL = '[Amplitude] Page URL';
 export const AMPLITUDE_EVENT_PROP_PAGE_TITLE = '[Amplitude] Page Title';
 export const AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT = '[Amplitude] Viewport Height';
 export const AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH = '[Amplitude] Viewport Width';
-
-export const INGESTION_METADATA_SOURCE_NAME_PREFIX = 'browser-typescript-';

--- a/packages/plugin-auto-tracking-browser/test/auto-tracking-plugin.test.ts
+++ b/packages/plugin-auto-tracking-browser/test/auto-tracking-plugin.test.ts
@@ -97,53 +97,6 @@ describe('autoTrackingPlugin', () => {
         event_type: 'custom_event',
       });
     });
-
-    test('should enrich ingestion_metadata field', async () => {
-      plugin = autoTrackingPlugin({
-        ingestionMetadata: {
-          sourceName: 'unit-test',
-          sourceVersion: '1.0.0',
-        },
-      });
-      const event = await plugin?.execute({
-        event_type: 'custom_event',
-      });
-      expect(event).toEqual({
-        event_type: 'custom_event',
-        ingestion_metadata: {
-          source_name: 'browser-typescript-unit-test',
-          source_version: '1.0.0',
-        },
-      });
-    });
-
-    test('should not enrich ingestion_metadata field if source_name is missing', async () => {
-      plugin = autoTrackingPlugin({
-        ingestionMetadata: {
-          sourceVersion: '1.0.0',
-        },
-      });
-      const event = await plugin?.execute({
-        event_type: 'custom_event',
-      });
-      expect(event).toEqual({
-        event_type: 'custom_event',
-      });
-    });
-
-    test('should not enrich ingestion_metadata field if source_version is missing', async () => {
-      plugin = autoTrackingPlugin({
-        ingestionMetadata: {
-          sourceName: 'unit-test',
-        },
-      });
-      const event = await plugin?.execute({
-        event_type: 'custom_event',
-      });
-      expect(event).toEqual({
-        event_type: 'custom_event',
-      });
-    });
   });
 
   describe('auto-tracking events', () => {


### PR DESCRIPTION
### Summary
- refactor(plugin-auto-tracking-browser): remove ingestion metadata option

We can use the `ingestionMetadata` configured in the global config.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
