### PR TITLE
fix: config values should take precedence over nativemodule in Context plugin

### DIFF
--- a/packages/analytics-react-native/src/plugins/context.ts
+++ b/packages/analytics-react-native/src/plugins/context.ts
@@ -65,7 +65,7 @@ export class Context implements BeforePlugin {
   async execute(context: Event): Promise<Event> {
     const time = new Date().getTime();
     const nativeContext = await this.nativeModule?.getApplicationContext(this.config.trackingOptions);
-    const appVersion = nativeContext?.version || this.config.appVersion;
+    const appVersion = this.config.appVersion || nativeContext?.version;
     const platform = nativeContext?.platform || BROWSER_PLATFORM;
     const osName = nativeContext?.osName || this.uaResult.browser.name;
     const osVersion = nativeContext?.osVersion || this.uaResult.browser.version;


### PR DESCRIPTION
### Summary

Config values should take precedence over nativemodule in Context plugin.
I can't find other issues except `appVersion`.

> [bgiori](https://github.com/bgiori) [on Jul 27](https://github.com/amplitude/Amplitude-TypeScript/pull/507#discussion_r1275464705)
> FWIW analytics-browser does the same, we use uaresult values not the config values

I can't find the config values related to uaresult. I believe, uaresult values are specific for a user/device and shouldn't be configured globally.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
