### PR TITLE
feat(session replay): add getSessionReplayProperties method

### DIFF
--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -50,10 +50,10 @@ sessionReplay.init(API_KEY, {
 ### 3. Get session replay event properties
 Any event that occurs within the span of a session replay must be tagged with properties that signal to Amplitude to include it in the scope of the replay. The following shows an example of how to use the properties
 ```typescript
-const sessionRecordingProperties = sessionReplay.getSessionRecordingProperties();
+const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
 track(EVENT_NAME, {
   ...eventProperties,
-  ...sessionRecordingProperties
+  ...sessionReplayProperties
 })
 ```
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -91,7 +91,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.recordEvents();
   }
 
-  getSessionRecordingProperties() {
+  getSessionReplayProperties() {
     if (!this.config) {
       this.loggerProvider.error('Session replay init has not been called, cannot get session recording properties.');
       return {};
@@ -106,6 +106,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     return {};
   }
+
+  getSessionRecordingProperties = () => {
+    this.loggerProvider.warn('Please use getSessionReplayProperties instead of getSessionRecordingProperties.');
+
+    return this.getSessionReplayProperties();
+  };
 
   blurListener = () => {
     this.stopRecordingAndSendEvents();

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -186,6 +186,38 @@ describe('SessionReplayPlugin', () => {
     });
   });
 
+  describe('getSessionReplayProperties', () => {
+    test('should return an empty object if config not set', () => {
+      const sessionReplay = new SessionReplay();
+      sessionReplay.loggerProvider = mockLoggerProvider;
+
+      const result = sessionReplay.getSessionReplayProperties();
+      expect(result).toEqual({});
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.error).toHaveBeenCalled();
+    });
+
+    test('should return an empty object if shouldRecord is false', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.getShouldRecord = () => false;
+
+      const result = sessionReplay.getSessionReplayProperties();
+      expect(result).toEqual({});
+    });
+
+    test('should return the session recorded property if shouldRecord is true', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.getShouldRecord = () => true;
+
+      const result = sessionReplay.getSessionReplayProperties();
+      expect(result).toEqual({
+        '[Amplitude] Session Recorded': true,
+      });
+    });
+  });
+
   describe('getSessionRecordingProperties', () => {
     test('should return an empty object if config not set', () => {
       const sessionReplay = new SessionReplay();
@@ -1088,7 +1120,7 @@ describe('SessionReplayPlugin', () => {
         jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.2 }).promise;
-        const sessionRecordingProperties = sessionReplay.getSessionRecordingProperties();
+        const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
         expect(sessionRecordingProperties).toMatchObject({});
         expect(record).not.toHaveBeenCalled();
         expect(update).not.toHaveBeenCalled();
@@ -1104,7 +1136,7 @@ describe('SessionReplayPlugin', () => {
         });
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.8 }).promise;
-        const sessionRecordingProperties = sessionReplay.getSessionRecordingProperties();
+        const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
         expect(sessionRecordingProperties).toMatchObject({
           [DEFAULT_SESSION_REPLAY_PROPERTY]: true,
         });


### PR DESCRIPTION
### Summary

Expose a getSessionReplayProperties method, that does the same as the existing getSessionRecordingProperties. For now we are doing this in a backwards compatible manner, and maintaining getSessionRecordingProperties. We will remove getSessionRecordingProperties in a future breaking changes version.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
