### PR TITLE
fix(session replay): expose getSessionReplayProperties externally

### DIFF
--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,2 +1,3 @@
 import sessionReplay from './session-replay-factory';
-export const { init, setSessionId, getSessionRecordingProperties, shutdown } = sessionReplay;
+export const { init, setSessionId, getSessionRecordingProperties, getSessionReplayProperties, shutdown } =
+  sessionReplay;

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -27,6 +27,11 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       'getSessionRecordingProperties',
       getLogConfig(sessionReplay),
     ),
+    getSessionReplayProperties: debugWrapper(
+      sessionReplay.getSessionReplayProperties.bind(sessionReplay),
+      'getSessionReplayProperties',
+      getLogConfig(sessionReplay),
+    ),
     shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'teardown', getLogConfig(sessionReplay)),
   };
 };

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -47,5 +47,6 @@ export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
   setSessionId: (sessionId: number) => void;
   getSessionRecordingProperties: () => { [key: string]: boolean };
+  getSessionReplayProperties: () => { [key: string]: boolean };
   shutdown: () => void;
 }


### PR DESCRIPTION
### Summary

In my last PR, I forgot to actually expose the getSessionReplayProperties method

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
