### PR TITLE
fix(session replay): remove beta tag from package.json to update public facing version

### DIFF
--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -10,8 +10,7 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public",
-    "tag": "beta"
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -10,8 +10,7 @@
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
   "publishConfig": {
-    "access": "public",
-    "tag": "beta"
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
The Beta tag in package.json was preventing the published version from incrementing, so `npm install @amplitude/plugin-session-replay-browser@latest` was installing 0.1.0 for customers. Removing this tag for the plugin and standalone to allow the latest version to be the actual latest

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
