### PR TITLE
fix: fix attribution to capture UTMs even if there is no referral info

### DIFF
--- a/packages/plugin-web-attribution-browser/src/helpers.ts
+++ b/packages/plugin-web-attribution-browser/src/helpers.ts
@@ -17,13 +17,15 @@ const domainWithoutSubdomain = (domain: string) => {
   return parts.slice(parts.length - 2, parts.length).join('.');
 };
 
+//Direct traffic mean no external referral, no UTMs, no click-ids, and no other customer identified marketing campaign url params.
 const isDirectTraffic = (current: Campaign) => {
   const { referrer, referring_domain, ...currentCampaign } = current;
-  Object.keys(currentCampaign).forEach(
-    (key) => (currentCampaign[key] === undefined || currentCampaign[key] === '') && delete currentCampaign[key],
+  const currentCampaignWithValue = Object.keys(currentCampaign).filter(
+    (key) => currentCampaign[key] !== undefined && currentCampaign[key] !== '',
   );
+  const noCampaign = Object.keys(currentCampaignWithValue).length === 0;
 
-  return !referrer && Object.keys(currentCampaign).length === 0;
+  return !referrer && noCampaign;
 };
 
 export const isNewCampaign = (
@@ -40,7 +42,6 @@ export const isNewCampaign = (
   }
 
   //In the same session, direct traffic should not override or unset any persisting query params
-  //Direct traffic mean no external referral, no UTMs, no click-ids, and no other customer identified marketing campaign url params.
   if (!isNewSession && isDirectTraffic(current) && previous) {
     return false;
   }

--- a/packages/plugin-web-attribution-browser/src/helpers.ts
+++ b/packages/plugin-web-attribution-browser/src/helpers.ts
@@ -19,13 +19,7 @@ const domainWithoutSubdomain = (domain: string) => {
 
 //Direct traffic mean no external referral, no UTMs, no click-ids, and no other customer identified marketing campaign url params.
 const isDirectTraffic = (current: Campaign) => {
-  const { referrer, referring_domain, ...currentCampaign } = current;
-  const currentCampaignWithValue = Object.keys(currentCampaign).filter(
-    (key) => currentCampaign[key] !== undefined && currentCampaign[key] !== '',
-  );
-  const noCampaign = Object.keys(currentCampaignWithValue).length === 0;
-
-  return !referrer && noCampaign;
+  return Object.values(current).every((value) => !value);
 };
 
 export const isNewCampaign = (

--- a/packages/plugin-web-attribution-browser/src/helpers.ts
+++ b/packages/plugin-web-attribution-browser/src/helpers.ts
@@ -17,6 +17,15 @@ const domainWithoutSubdomain = (domain: string) => {
   return parts.slice(parts.length - 2, parts.length).join('.');
 };
 
+const isDirectTraffic = (current: Campaign) => {
+  const { referrer, referring_domain, ...currentCampaign } = current;
+  Object.keys(currentCampaign).forEach(
+    (key) => (currentCampaign[key] === undefined || currentCampaign[key] === '') && delete currentCampaign[key],
+  );
+
+  return !referrer && Object.keys(currentCampaign).length === 0;
+};
+
 export const isNewCampaign = (
   current: Campaign,
   previous: Campaign | undefined,
@@ -30,8 +39,9 @@ export const isNewCampaign = (
     return false;
   }
 
-  //In the same session, no referrer should not override or unset any persisting query params
-  if (!isNewSession && !referrer && previous) {
+  //In the same session, direct traffic should not override or unset any persisting query params
+  //Direct traffic mean no external referral, no UTMs, no click-ids, and no other customer identified marketing campaign url params.
+  if (!isNewSession && isDirectTraffic(current) && previous) {
     return false;
   }
 

--- a/packages/plugin-web-attribution-browser/test/helpers.test.ts
+++ b/packages/plugin-web-attribution-browser/test/helpers.test.ts
@@ -113,7 +113,7 @@ describe('isNewCampaign', () => {
     ).toBe(false);
   });
 
-  test('should return false for no referrer in the same session', () => {
+  test('should return false for no extra referrer with direct traffic in the same session', () => {
     const previousCampaign = {
       ...BASE_CAMPAIGN,
       utm_campaign: 'utm_campaign',
@@ -124,6 +124,20 @@ describe('isNewCampaign', () => {
     };
 
     expect(isNewCampaign(currentCampaign, previousCampaign, {}, false)).toBe(false);
+  });
+
+  test('should return true for no referrer with any new campaign in the same session', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_campaign: 'utm_campaign',
+      referring_domain: 'a.b.c.d',
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_source: 'utm_source',
+    };
+
+    expect(isNewCampaign(currentCampaign, previousCampaign, {}, false)).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix the issue at [Jira](https://amplitude.atlassian.net/browse/AMP-84339?filter=18277), based on the comment 

> Direct = No external referral, no UTMs, no click-ids, and no other customer-identified marketing campaign url params.
> 
> Therefore we should always capture UTMs even if there is no referral info.  Stripping referral info is common with redirects.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
