### PR TITLE
fix(session replay): opt out should take effect immediately

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -177,7 +177,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       identityStoreOptOut = identityStore.getIdentity().optOut;
     }
 
-    return identityStoreOptOut || this.config?.optOut;
+    return identityStoreOptOut !== undefined ? identityStoreOptOut : this.config?.optOut;
   }
 
   getShouldRecord() {
@@ -241,7 +241,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.stopRecordingEvents = record({
       emit: (event) => {
         const globalScope = getGlobalScope();
-        if (globalScope && globalScope.document && !globalScope.document.hasFocus()) {
+        if ((globalScope && globalScope.document && !globalScope.document.hasFocus()) || !this.getShouldRecord()) {
           this.stopRecordingAndSendEvents();
           return;
         }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -524,6 +524,20 @@ describe('SessionReplayPlugin', () => {
       await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
       expect(sessionReplay.shouldOptOut()).toEqual(true);
     });
+    test('should return opt out from identity store even if set to false', async () => {
+      jest.spyOn(AnalyticsClientCommon, 'getAnalyticsConnector').mockReturnValue({
+        identityStore: {
+          getIdentity: () => {
+            return {
+              optOut: false,
+            };
+          },
+        },
+      } as unknown as ReturnType<typeof AnalyticsClientCommon.getAnalyticsConnector>);
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance', optOut: true }).promise;
+      expect(sessionReplay.shouldOptOut()).toEqual(false);
+    });
     test('should return config device id if set', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance', optOut: true }).promise;
@@ -652,6 +666,15 @@ describe('SessionReplayPlugin', () => {
       expect(record).not.toHaveBeenCalled();
       expect(sessionReplay.events).toEqual([]);
     });
+
+    test('should return early if user opts out', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, optOut: true }).promise;
+      sessionReplay.recordEvents();
+      expect(record).not.toHaveBeenCalled();
+      expect(sessionReplay.events).toEqual([]);
+    });
+
     test('should store events in class and in IDB', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, mockOptions).promise;
@@ -750,6 +773,30 @@ describe('SessionReplayPlugin', () => {
       } as typeof globalThis);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const sendEventsListMock = jest.spyOn(sessionReplay, 'sendEventsList').mockImplementationOnce(() => {});
+      const recordArg = record.mock.calls[0][0];
+      recordArg?.emit && recordArg?.emit(mockEvent);
+      expect(sendEventsListMock).toHaveBeenCalledTimes(1);
+      expect(sendEventsListMock).toHaveBeenCalledWith({
+        events: [mockEventString],
+        sequenceId: 0,
+        sessionId: 123,
+      });
+      expect(stopRecordingMock).toHaveBeenCalled();
+      expect(sessionReplay.stopRecordingEvents).toEqual(null);
+      expect(sessionReplay.events).toEqual([mockEventString]); // events should not change, emmitted event should be ignored
+    });
+
+    test('should stop recording and send events if user opts out during recording', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.recordEvents();
+      const stopRecordingMock = jest.fn();
+      sessionReplay.stopRecordingEvents = stopRecordingMock;
+      expect(sessionReplay.events).toEqual([]);
+      sessionReplay.events = [mockEventString]; // Add one event to list to trigger sending in stopRecordingAndSendEvents
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const sendEventsListMock = jest.spyOn(sessionReplay, 'sendEventsList').mockImplementationOnce(() => {});
+      sessionReplay.shouldOptOut = () => true;
       const recordArg = record.mock.calls[0][0];
       recordArg?.emit && recordArg?.emit(mockEvent);
       expect(sendEventsListMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Summary

Fix issue with session replay opt out not applying immediately. This change will immediately stop recordings and opt the user out of session replay. 

Also fixed issue where identityStoreOptOut would default to this.config.optOut when identityStoreOptOut was false. This misses the case where optOut should be false and not defaulted to this.config.optOut which could be the previous optOut state.


* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  
