### PR TITLE
fix(session replay plugin): update plugin to use the sessionReplayProperties fn

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -54,7 +54,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
       sessionReplay.setSessionId(event.session_id);
     }
 
-    const sessionRecordingProperties = sessionReplay.getSessionRecordingProperties();
+    const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
     event.event_properties = {
       ...event.event_properties,
       ...sessionRecordingProperties,

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -8,7 +8,7 @@ type MockedSessionReplayBrowser = jest.Mocked<typeof import('@amplitude/session-
 type MockedLogger = jest.Mocked<Logger>;
 
 describe('SessionReplayPlugin', () => {
-  const { init, setSessionId, getSessionRecordingProperties, shutdown } =
+  const { init, setSessionId, getSessionReplayProperties, shutdown } =
     sessionReplayBrowser as MockedSessionReplayBrowser;
   const mockLoggerProvider: MockedLogger = {
     error: jest.fn(),
@@ -127,7 +127,7 @@ describe('SessionReplayPlugin', () => {
     test('should add event property for [Amplitude] Session Recorded', async () => {
       const sessionReplay = sessionReplayPlugin();
       await sessionReplay.setup(mockConfig);
-      getSessionRecordingProperties.mockReturnValueOnce({
+      getSessionReplayProperties.mockReturnValueOnce({
         '[Amplitude] Session Recorded': true,
       });
       const event = {


### PR DESCRIPTION

### Summary

We want to update all places we mention 'record' to mention 'replay' instead, so we will eventually deprecate `getSessionRecordingProperties`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
