### PR TITLE
feat: Amp 86005 add session tracking bookmarklet

### DIFF
--- a/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
+++ b/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
@@ -5,7 +5,6 @@
  * Script will fail to load if the website has a Content Security Policy (CSP) that blocks third-party inline scripts.
  */
 !function (window, document) {
-  var AMPLITUDE_API_KEY = 'YOUR_API_KEY';
   var amplitude = window.amplitude || {
     _q: [],
     _iq: {}
@@ -55,7 +54,7 @@
       if (!window.amplitude.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.amplitude.init(AMPLITUDE_API_KEY, 'YOUR_USER_ID', {
+      window.amplitude.init('YOUR_API_KEY', 'YOUR_USER_ID', {
         serverZone: 'YOUR_SERVER_ZONE'
       });
       var autoTracking = function autoTracking() {

--- a/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
+++ b/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Create a bookmark with this code snippet in the browser, update the apiKey and userId (optional), and click the bookmark on any website to run.
+ * Create a bookmark with this code snippet in the browser, update the apiKey, userId, and serverZone, and click the bookmark on any website to run.
  * Script will fail to load if the website has a Content Security Policy (CSP) that blocks third-party inline scripts.
  */
 !function (window, document) {
@@ -55,7 +55,9 @@
       if (!window.amplitude.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.amplitude.init(AMPLITUDE_API_KEY, 'test-user');
+      window.amplitude.init(AMPLITUDE_API_KEY, 'YOUR_USER_ID', {
+        serverZone: 'YOUR_SERVER_ZONE'
+      });
       var autoTracking = function autoTracking() {
         var name = '@amplitude/plugin-auto-tracking-browser';
         var type = 'enrichment';

--- a/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
+++ b/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
@@ -148,12 +148,18 @@
         };
         var getEventProperties = function getEventProperties(event, element) {
           var tag = element.tagName.toLowerCase();
+          var rect = typeof element.getBoundingClientRect === 'function' ? element.getBoundingClientRect() : {};
           var properties = {
             '[Amplitude] Element ID': element.id,
             '[Amplitude] Element Class': element.className,
             '[Amplitude] Element Tag': tag,
             '[Amplitude] Element Text': getText(element),
-            '[Amplitude] Page URL': window.location.href.split('?')[0]
+            '[Amplitude] Element Position Left': rect.left == null ? null : Math.round(rect.left),
+            '[Amplitude] Element Position Top': rect.top == null ? null : Math.round(rect.top),
+            '[Amplitude] Page URL': window.location.href.split('?')[0],
+            '[Amplitude] Page Title': typeof document !== 'undefined' && document.title || '',
+            '[Amplitude] Viewport Height': window.innerHeight,
+            '[Amplitude] Viewport Width': window.innerWidth
           };
           if (tag === 'a' && event === 'click') {
             properties['[Amplitude] Element Href'] = element.href;

--- a/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
+++ b/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
@@ -5,6 +5,7 @@
  * Script will fail to load if the website has a Content Security Policy (CSP) that blocks third-party inline scripts.
  */
 !function (window, document) {
+  var AMPLITUDE_API_KEY = 'YOUR_API_KEY';
   var amplitude = window.amplitude || {
     _q: [],
     _iq: {}
@@ -54,7 +55,7 @@
       if (!window.amplitude.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.amplitude.init('YOUR_API_KEY', 'test-user');
+      window.amplitude.init(AMPLITUDE_API_KEY, 'test-user');
       var autoTracking = function autoTracking() {
         var name = '@amplitude/plugin-auto-tracking-browser';
         var type = 'enrichment';
@@ -116,6 +117,9 @@
             }
           }
           var tag = element.tagName.toLowerCase();
+          if (!tagList.includes(tag)) {
+            return false;
+          }
           switch (tag) {
             case 'input':
             case 'select':

--- a/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
+++ b/packages/analytics-browser/generated/amplitude-bookmarklet-snippet.js
@@ -1,0 +1,248 @@
+"use strict";
+
+/**
+ * Create a bookmark with this code snippet in the browser, update the apiKey and userId (optional), and click the bookmark on any website to run.
+ * Script will fail to load if the website has a Content Security Policy (CSP) that blocks third-party inline scripts.
+ */
+!function (window, document) {
+  var amplitude = window.amplitude || {
+    _q: [],
+    _iq: {}
+  };
+  if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');else {
+    var proxy = function proxy(obj, fn) {
+      obj.prototype[fn] = function () {
+        this._q.push({
+          name: fn,
+          args: Array.prototype.slice.call(arguments, 0)
+        });
+        return this;
+      };
+    };
+    var getPromiseResult = function getPromiseResult(instance, fn, args) {
+      return function (resolve) {
+        instance._q.push({
+          name: fn,
+          args: Array.prototype.slice.call(args, 0),
+          resolve: resolve
+        });
+      };
+    };
+    var proxyMain = function proxyMain(instance, fn, isPromise) {
+      instance[fn] = function () {
+        if (isPromise) return {
+          promise: new Promise(getPromiseResult(instance, fn, Array.prototype.slice.call(arguments)))
+        };
+      };
+    };
+    var setUpProxy = function setUpProxy(instance) {
+      for (var k = 0; k < funcs.length; k++) {
+        proxyMain(instance, funcs[k], false);
+      }
+      for (var l = 0; l < funcsWithPromise.length; l++) {
+        proxyMain(instance, funcsWithPromise[l], true);
+      }
+    };
+    amplitude.invoked = true;
+    var as = document.createElement('script');
+    as.type = 'text/javascript';
+    as.integrity = 'sha384-lI19/rkWkq7akQskdqbaYBssAwNImFV9Iwejq7dylnP0Yx8TyWYX1PwAoaA5xrUp';
+    as.crossOrigin = 'anonymous';
+    as.async = true;
+    as.src = 'https://cdn.amplitude.com/libs/analytics-browser-2.1.3-min.js.gz';
+    as.onload = function () {
+      if (!window.amplitude.runQueuedFunctions) {
+        console.log('[Amplitude] Error: could not load SDK');
+      }
+      window.amplitude.init('YOUR_API_KEY', 'test-user');
+      var autoTracking = function autoTracking() {
+        var name = '@amplitude/plugin-auto-tracking-browser';
+        var type = 'enrichment';
+        var tagList = ['a', 'button', 'input', 'select', 'textarea', 'label'];
+        var observer = void 0;
+        var eventListeners = [];
+        var addEventListener = function addEventListener(element, type, handler) {
+          element.addEventListener(type, handler);
+          eventListeners.push({
+            element: element,
+            type: type,
+            handler: handler
+          });
+        };
+        var removeEventListeners = function removeEventListeners() {
+          eventListeners.forEach(function (_ref) {
+            var element = _ref.element,
+              type = _ref.type,
+              handler = _ref.handler;
+            element?.removeEventListener(type, handler);
+          });
+          eventListeners = [];
+        };
+        var isTextNode = function isTextNode(node) {
+          return !!node && node.nodeType === 3;
+        };
+        var isNonSensitiveString = function isNonSensitiveString(text) {
+          if (text == null) {
+            return false;
+          }
+          if (typeof value === 'string') {
+            var ccRegex = /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/;
+            if (ccRegex.test((value || '').replace(/[- ]/g, ''))) {
+              return false;
+            }
+            var ssnRegex = /(^\d{3}-?\d{2}-?\d{4}$)/;
+            if (ssnRegex.test(value)) {
+              return false;
+            }
+          }
+          return true;
+        };
+        var isNonSensitiveElement = function isNonSensitiveElement(element) {
+          var tag = element.tagName.toLowerCase();
+          var sentitiveTags = ['input', 'select', 'textarea'];
+          return !sentitiveTags.includes(tag);
+        };
+        var shouldTrackEvent = function shouldTrackEvent(event, element) {
+          if (!element) {
+            return false;
+          }
+          var type = element.type || '';
+          if (typeof type === 'string') {
+            switch (type.toLowerCase()) {
+              case 'hidden':
+                return false;
+              case 'password':
+                return false;
+            }
+          }
+          var tag = element.tagName.toLowerCase();
+          switch (tag) {
+            case 'input':
+            case 'select':
+            case 'textarea':
+              return event === 'change' || event === 'click';
+            default:
+              var computedStyle = window.getComputedStyle(element);
+              if (computedStyle && computedStyle.getPropertyValue('cursor') === 'pointer' && event === 'click') {
+                return true;
+              }
+              return event === 'click';
+          }
+        };
+        var getText = function getText(element) {
+          var text = '';
+          if (isNonSensitiveElement(element) && element.childNodes && element.childNodes.length) {
+            element.childNodes.forEach(function (child) {
+              if (isTextNode(child) && child.textContent) {
+                text += child.textContent.split(/(\s+)/).filter(isNonSensitiveString).join('').replace(/[\r\n]/g, ' ').replace(/[ ]+/g, ' ').substring(0, 255);
+              }
+            });
+          }
+          return text;
+        };
+        var getEventProperties = function getEventProperties(event, element) {
+          var tag = element.tagName.toLowerCase();
+          var properties = {
+            '[Amplitude] Element ID': element.id,
+            '[Amplitude] Element Class': element.className,
+            '[Amplitude] Element Tag': tag,
+            '[Amplitude] Element Text': getText(element),
+            '[Amplitude] Page URL': window.location.href.split('?')[0]
+          };
+          if (tag === 'a' && event === 'click') {
+            properties['[Amplitude] Element Href'] = element.href;
+          }
+          return properties;
+        };
+        var setup = function setup(_, amplitude) {
+          if (!amplitude) {
+            console.warn('Auto-tracking requires a later version of @amplitude/analytics-browser. Events are not tracked.');
+            return;
+          }
+          if (typeof document === 'undefined') {
+            return;
+          }
+          var addListener = function addListener(el) {
+            if (shouldTrackEvent('click', el)) {
+              addEventListener(el, 'click', function () {
+                amplitude.track('[Amplitude] Element Clicked', getEventProperties('click', el));
+              });
+            }
+            if (shouldTrackEvent('change', el)) {
+              addEventListener(el, 'change', function () {
+                amplitude.track('[Amplitude] Element Changed', getEventProperties('change', el));
+              });
+            }
+          };
+          var allElements = Array.from(document.body.querySelectorAll(tagList.join(',')));
+          allElements.forEach(addListener);
+          if (typeof MutationObserver !== 'undefined') {
+            var _observer = new MutationObserver(function (mutations) {
+              mutations.forEach(function (mutation) {
+                mutation.addedNodes.forEach(function (node) {
+                  addListener(node);
+                  if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+                    Array.from(node.querySelectorAll(tagList.join(','))).map(addListener);
+                  }
+                });
+              });
+            });
+            _observer.observe(document.body, {
+              subtree: true,
+              childList: true
+            });
+          }
+        };
+        var execute = function execute(event) {
+          return event;
+        };
+        var teardown = function teardown() {
+          if (observer) {
+            observer.disconnect();
+          }
+          removeEventListeners();
+        };
+        return {
+          name: name,
+          type: type,
+          setup: setup,
+          execute: execute,
+          teardown: teardown
+        };
+      };
+      window.amplitude.add(autoTracking());
+      alert('Amplitude is now tracking events!');
+    };
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(as, s);
+    var Identify = function Identify() {
+      this._q = [];
+      return this;
+    };
+    var identifyFuncs = ['add', 'append', 'clearAll', 'prepend', 'set', 'setOnce', 'unset', 'preInsert', 'postInsert', 'remove', 'getUserProperties'];
+    for (var i = 0; i < identifyFuncs.length; i++) {
+      proxy(Identify, identifyFuncs[i]);
+    }
+    amplitude.Identify = Identify;
+    var Revenue = function Revenue() {
+      this._q = [];
+      return this;
+    };
+    var revenueFuncs = ['getEventProperties', 'setProductId', 'setQuantity', 'setPrice', 'setRevenue', 'setRevenueType', 'setEventProperties'];
+    for (var j = 0; j < revenueFuncs.length; j++) {
+      proxy(Revenue, revenueFuncs[j]);
+    }
+    amplitude.Revenue = Revenue;
+    var funcs = ['getDeviceId', 'setDeviceId', 'getSessionId', 'setSessionId', 'getUserId', 'setUserId', 'setOptOut', 'setTransport', 'reset', 'extendSession'];
+    var funcsWithPromise = ['init', 'add', 'remove', 'track', 'logEvent', 'identify', 'groupIdentify', 'setGroup', 'revenue', 'flush'];
+    setUpProxy(amplitude);
+    amplitude.createInstance = function (instanceName) {
+      amplitude._iq[instanceName] = {
+        _q: []
+      };
+      setUpProxy(amplitude._iq[instanceName]);
+      return amplitude._iq[instanceName];
+    };
+    window.amplitude = amplitude;
+  }
+}(window, document);

--- a/packages/analytics-browser/rollup.config.js
+++ b/packages/analytics-browser/rollup.config.js
@@ -1,3 +1,3 @@
-import { umd, iife, snippet, iifeGTM, snippetGTM } from '../../scripts/build/rollup.config';
+import { umd, iife, snippet, iifeGTM, snippetGTM, bookmarklet } from '../../scripts/build/rollup.config';
 
-export default [umd, iife, snippet, iifeGTM, snippetGTM];
+export default [umd, iife, snippet, iifeGTM, snippetGTM, bookmarklet];

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -90,7 +90,9 @@ export const snippet = {
   plugins: [
     createSnippet(),
     terser(),
-    execute(`node ${base}/scripts/version/create-snippet-instructions.js && node ${base}/scripts/version/update-readme.js`),
+    execute(
+      `node ${base}/scripts/version/create-snippet-instructions.js && node ${base}/scripts/version/update-readme.js`,
+    ),
   ],
 };
 
@@ -101,12 +103,15 @@ const createGTMSnippet = () => {
       return new Promise((resolve) => {
         opt.input = 'generated/amplitude-gtm-snippet.js';
         if (process.env.GENERATE_SNIPPET !== 'true') return resolve(opt);
-        exec(`node ${base}/scripts/version/create-snippet.js --inputFile=amplitude-gtm-min.js --outputFile=amplitude-gtm-snippet.js --globalVar=amplitudeGTM --nameSuffix=-gtm`, (err) => {
-          if (err) {
-            throw err;
-          }
-          resolve(opt);
-        });
+        exec(
+          `node ${base}/scripts/version/create-snippet.js --inputFile=amplitude-gtm-min.js --outputFile=amplitude-gtm-snippet.js --globalVar=amplitudeGTM --nameSuffix=-gtm`,
+          (err) => {
+            if (err) {
+              throw err;
+            }
+            resolve(opt);
+          },
+        );
       });
     },
   };
@@ -145,8 +150,37 @@ export const snippetGTM = {
     file: 'lib/scripts/amplitude-gtm-snippet-min.js',
     format: 'iife',
   },
-  plugins: [
-    createGTMSnippet(),
-    terser(),
-  ],
+  plugins: [createGTMSnippet(), terser()],
 };
+
+// Input: bookmarklet js template + amplitude js
+// Output: bookmarklet js snippet
+const createBookmarkletSnippet = () => {
+  return {
+    name: 'amplitude-bookmarklet-snippet',
+    options: (opt) => {
+      return new Promise((resolve) => {
+        opt.input = 'generated/amplitude-bookmarklet-snippet.js';
+        if (process.env.GENERATE_SNIPPET !== 'true') return resolve(opt);
+        exec(`node ${base}/scripts/version/create-bookmarklet-snippet.js`, (err) => {
+          if (err) {
+            throw err;
+          }
+          resolve(opt);
+        });
+      });
+    },
+  };
+};
+
+// Input: bookmarklet js snippet
+// Output: bookmarklet prefix + bookmarklet js snippet (url encoded)
+export const bookmarklet = {
+  output: {
+    name: 'amplitude',
+    file: 'lib/scripts/amplitude-bookmarklet-snippet-min.js',
+    format: 'iife',
+  },
+  plugins: [createBookmarkletSnippet(), terser(), execute(`node ${base}/scripts/version/create-bookmarklet.js`)],
+};
+

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -183,4 +183,3 @@ export const bookmarklet = {
   },
   plugins: [createBookmarkletSnippet(), terser(), execute(`node ${base}/scripts/version/create-bookmarklet.js`)],
 };
-

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -1,0 +1,293 @@
+const snippet = (name, integrity, version, globalVar, apiKey, userId) => `
+!(function (window, document) {
+  var amplitude = window.${globalVar} || { _q: [], _iq: {} };
+  if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');
+  else {
+    amplitude.invoked = true;
+    var as = document.createElement('script');
+    as.type = 'text/javascript';
+    as.integrity = '${integrity}';
+    as.crossOrigin = 'anonymous';
+    as.async = true;
+    as.src = 'https://cdn.amplitude.com/libs/${name}-${version}-min.js.gz';
+    as.onload = function () {
+      if (!window.${globalVar}.runQueuedFunctions) {
+        console.log('[Amplitude] Error: could not load SDK');
+      }
+      window.${globalVar}.init('${apiKey}', '${userId}');
+      const autoTracking = () => {
+        const name = '@amplitude/plugin-auto-tracking-browser';
+        const type = 'enrichment';
+        const tagList = ['a', 'button', 'input', 'select', 'textarea', 'label'];
+        let observer;
+        let eventListeners = [];
+        const addEventListener = (element, type, handler) => {
+          element.addEventListener(type, handler);
+          eventListeners.push({
+            element,
+            type,
+            handler,
+          });
+        };
+        const removeEventListeners = () => {
+          eventListeners.forEach(({ element, type, handler }) => {
+            element?.removeEventListener(type, handler);
+          });
+          eventListeners = [];
+        };
+        const isTextNode = (node) => !!node && node.nodeType === 3;
+        const isNonSensitiveString = (text) => {
+          if (text == null) {
+            return false;
+          }
+          if (typeof value === 'string') {
+            const ccRegex =
+              /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/;
+            if (ccRegex.test((value || '').replace(/[- ]/g, ''))) {
+              return false;
+            }
+            const ssnRegex = /(^\\d{3}-?\\d{2}-?\\d{4}$)/;
+            if (ssnRegex.test(value)) {
+              return false;
+            }
+          }
+          return true;
+        };
+        const isNonSensitiveElement = (element) => {
+          const tag = element.tagName.toLowerCase();
+          const sentitiveTags = ['input', 'select', 'textarea'];
+          return !sentitiveTags.includes(tag);
+        };
+        const shouldTrackEvent = (event, element) => {
+          if (!element) {
+            return false;
+          }
+          const type = element.type || '';
+          if (typeof type === 'string') {
+            switch (type.toLowerCase()) {
+              case 'hidden':
+                return false;
+              case 'password':
+                return false;
+            }
+          }
+          const tag = element.tagName.toLowerCase();
+          switch (tag) {
+            case 'input':
+            case 'select':
+            case 'textarea':
+              return event === 'change' || event === 'click';
+            default:
+              const computedStyle = window.getComputedStyle(element);
+              if (computedStyle && computedStyle.getPropertyValue('cursor') === 'pointer' && event === 'click') {
+                return true;
+              }
+              return event === 'click';
+          }
+        };
+        const getText = (element) => {
+          let text = '';
+          if (isNonSensitiveElement(element) && element.childNodes && element.childNodes.length) {
+            element.childNodes.forEach(function (child) {
+              if (isTextNode(child) && child.textContent) {
+                text += child.textContent
+                  .split(/(\\s+)/)
+                  .filter(isNonSensitiveString)
+                  .join('')
+                  .replace(/[\\r\\n]/g, ' ')
+                  .replace(/[ ]+/g, ' ')
+                  .substring(0, 255);
+              }
+            });
+          }
+          return text;
+        };
+        const getEventProperties = (event, element) => {
+          const tag = element.tagName.toLowerCase();
+          const properties = {
+            '[Amplitude] Element ID': element.id,
+            '[Amplitude] Element Class': element.className,
+            '[Amplitude] Element Tag': tag,
+            '[Amplitude] Element Text': getText(element),
+            '[Amplitude] Page URL': window.location.href.split('?')[0],
+          };
+          if (tag === 'a' && event === 'click') {
+            properties['[Amplitude] Element Href'] = element.href;
+          }
+          return properties;
+        };
+        const setup = (_, amplitude) => {
+          if (!amplitude) {
+            console.warn(
+              'Auto-tracking requires a later version of @amplitude/analytics-browser. Events are not tracked.',
+            );
+            return;
+          }
+          if (typeof document === 'undefined') {
+            return;
+          }
+          const addListener = (el) => {
+            if (shouldTrackEvent('click', el)) {
+              addEventListener(el, 'click', () => {
+                amplitude.track('[Amplitude] Element Clicked', getEventProperties('click', el));
+              });
+            }
+            if (shouldTrackEvent('change', el)) {
+              addEventListener(el, 'change', () => {
+                amplitude.track('[Amplitude] Element Changed', getEventProperties('change', el));
+              });
+            }
+          };
+          const allElements = Array.from(document.body.querySelectorAll(tagList.join(',')));
+          allElements.forEach(addListener);
+          if (typeof MutationObserver !== 'undefined') {
+            const observer = new MutationObserver((mutations) => {
+              mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                  addListener(node);
+                  if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+                    Array.from(node.querySelectorAll(tagList.join(','))).map(addListener);
+                  }
+                });
+              });
+            });
+            observer.observe(document.body, {
+              subtree: true,
+              childList: true,
+            });
+          }
+        };
+        const execute = (event) => event;
+        const teardown = () => {
+          if (observer) {
+            observer.disconnect();
+          }
+          removeEventListeners();
+        };
+        return {
+          name,
+          type,
+          setup,
+          execute,
+          teardown,
+        };
+      };
+      window.${globalVar}.add(autoTracking());
+      alert('Amplitude is now tracking events!');
+    };
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(as, s);
+    function proxy(obj, fn) {
+      obj.prototype[fn] = function () {
+        this._q.push({
+          name: fn,
+          args: Array.prototype.slice.call(arguments, 0),
+        });
+        return this;
+      };
+    }
+    var Identify = function () {
+      this._q = [];
+      return this;
+    };
+    var identifyFuncs = [
+      'add',
+      'append',
+      'clearAll',
+      'prepend',
+      'set',
+      'setOnce',
+      'unset',
+      'preInsert',
+      'postInsert',
+      'remove',
+      'getUserProperties',
+    ];
+    for (var i = 0; i < identifyFuncs.length; i++) {
+      proxy(Identify, identifyFuncs[i]);
+    }
+    amplitude.Identify = Identify;
+    var Revenue = function () {
+      this._q = [];
+      return this;
+    };
+    var revenueFuncs = [
+      'getEventProperties',
+      'setProductId',
+      'setQuantity',
+      'setPrice',
+      'setRevenue',
+      'setRevenueType',
+      'setEventProperties',
+    ];
+    for (var j = 0; j < revenueFuncs.length; j++) {
+      proxy(Revenue, revenueFuncs[j]);
+    }
+    amplitude.Revenue = Revenue;
+    var funcs = [
+      'getDeviceId',
+      'setDeviceId',
+      'getSessionId',
+      'setSessionId',
+      'getUserId',
+      'setUserId',
+      'setOptOut',
+      'setTransport',
+      'reset',
+      'extendSession',
+    ];
+    var funcsWithPromise = [
+      'init',
+      'add',
+      'remove',
+      'track',
+      'logEvent',
+      'identify',
+      'groupIdentify',
+      'setGroup',
+      'revenue',
+      'flush',
+    ];
+    function getPromiseResult(instance, fn, args) {
+      return function (resolve) {
+        instance._q.push({
+          name: fn,
+          args: Array.prototype.slice.call(args, 0),
+          resolve: resolve,
+        });
+      };
+    }
+    function proxyMain(instance, fn, isPromise) {
+      instance[fn] = function () {
+        if (isPromise) return {
+          promise: new Promise(getPromiseResult(instance, fn, Array.prototype.slice.call(arguments))),
+        };
+      };
+    }
+    function setUpProxy(instance) {
+      for (var k = 0; k < funcs.length; k++) {
+        proxyMain(instance, funcs[k], false);
+      }
+      for (var l = 0; l < funcsWithPromise.length; l++) {
+        proxyMain(instance, funcsWithPromise[l], true);
+      }
+    }
+    setUpProxy(amplitude);
+    amplitude.createInstance = function (instanceName) {
+      amplitude._iq[instanceName] = { _q: [] };
+      setUpProxy(amplitude._iq[instanceName]);
+      return amplitude._iq[instanceName];
+    };
+    window.${globalVar} = amplitude;
+    ${
+      globalVar !== 'amplitude'
+        ? `if (!window.amplitude) {
+      window.amplitude = window.${globalVar};
+    }`
+        : ``
+    }
+  }
+})(window, document);
+`;
+
+exports.snippet = snippet;

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -1,6 +1,5 @@
 const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone) => `
 !(function (window, document) {
-  const AMPLITUDE_API_KEY = '${apiKey}';
   var amplitude = window.${globalVar} || { _q: [], _iq: {} };
   if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');
   else {
@@ -15,7 +14,7 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone
       if (!window.${globalVar}.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.${globalVar}.init(AMPLITUDE_API_KEY, '${userId}', { serverZone: '${serverZone}' });
+      window.${globalVar}.init('${apiKey}', '${userId}', { serverZone: '${serverZone}' });
       const autoTracking = () => {
         const name = '@amplitude/plugin-auto-tracking-browser';
         const type = 'enrichment';

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -1,4 +1,4 @@
-const snippet = (name, integrity, version, globalVar, apiKey, userId) => `
+const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone) => `
 !(function (window, document) {
   const AMPLITUDE_API_KEY = '${apiKey}';
   var amplitude = window.${globalVar} || { _q: [], _iq: {} };
@@ -15,7 +15,7 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId) => `
       if (!window.${globalVar}.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.${globalVar}.init(AMPLITUDE_API_KEY, '${userId}');
+      window.${globalVar}.init(AMPLITUDE_API_KEY, '${userId}', { serverZone: '${serverZone}' });
       const autoTracking = () => {
         const name = '@amplitude/plugin-auto-tracking-browser';
         const type = 'enrichment';

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -1,5 +1,6 @@
 const snippet = (name, integrity, version, globalVar, apiKey, userId) => `
 !(function (window, document) {
+  const AMPLITUDE_API_KEY = '${apiKey}';
   var amplitude = window.${globalVar} || { _q: [], _iq: {} };
   if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');
   else {
@@ -14,7 +15,7 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId) => `
       if (!window.${globalVar}.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.${globalVar}.init('${apiKey}', '${userId}');
+      window.${globalVar}.init(AMPLITUDE_API_KEY, '${userId}');
       const autoTracking = () => {
         const name = '@amplitude/plugin-auto-tracking-browser';
         const type = 'enrichment';
@@ -72,6 +73,9 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId) => `
             }
           }
           const tag = element.tagName.toLowerCase();
+          if (!tagList.includes(tag)) {
+            return false;
+          }
           switch (tag) {
             case 'input':
             case 'select':

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -4,17 +4,26 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone
   if (amplitude.invoked) window.console && console.error && console.error('Amplitude snippet has been loaded.');
   else {
     amplitude.invoked = true;
+    var s = document.getElementsByTagName('script')[0];
+    var sessionReplayPluginScript = document.createElement('script');
+    sessionReplayPluginScript.src = 'https://cdn.amplitude.com/libs/plugin-session-replay-browser-0.6.13-min.js.gz';
+    sessionReplayPluginScript.async = false;
+    s.parentNode.insertBefore(sessionReplayPluginScript, s);
     var as = document.createElement('script');
     as.type = 'text/javascript';
     as.integrity = '${integrity}';
     as.crossOrigin = 'anonymous';
-    as.async = true;
+    as.async = false;
     as.src = 'https://cdn.amplitude.com/libs/${name}-${version}-min.js.gz';
     as.onload = function () {
       if (!window.${globalVar}.runQueuedFunctions) {
         console.log('[Amplitude] Error: could not load SDK');
       }
-      window.${globalVar}.init('${apiKey}', '${userId}', { serverZone: '${serverZone}' });
+      window.${globalVar}.init('${apiKey}', '${userId}', {
+        instanceName: 'amplitude-bookmarklet',
+        serverZone: '${serverZone}',
+        optOut: false
+      });
       const autoTracking = () => {
         const name = '@amplitude/plugin-auto-tracking-browser';
         const type = 'enrichment';
@@ -176,6 +185,10 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone
         };
       };
       window.${globalVar}.add(autoTracking());
+      if (window.sessionReplay && window.sessionReplay.plugin && typeof window.sessionReplay.plugin === 'function') {
+        console.log('Adding Session Replay plugin to Amplitude');
+        window.amplitude.add(window.sessionReplay.plugin());
+      }
       alert('Amplitude is now tracking events!');
     };
     var s = document.getElementsByTagName('script')[0];

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -108,12 +108,18 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone
         };
         const getEventProperties = (event, element) => {
           const tag = element.tagName.toLowerCase();
+          const rect = typeof element.getBoundingClientRect === 'function' ? element.getBoundingClientRect() : {};
           const properties = {
             '[Amplitude] Element ID': element.id,
             '[Amplitude] Element Class': element.className,
             '[Amplitude] Element Tag': tag,
             '[Amplitude] Element Text': getText(element),
+            '[Amplitude] Element Position Left': rect.left == null ? null : Math.round(rect.left),
+            '[Amplitude] Element Position Top': rect.top == null ? null : Math.round(rect.top),
             '[Amplitude] Page URL': window.location.href.split('?')[0],
+            '[Amplitude] Page Title': (typeof document !== 'undefined' && document.title) || '',
+            '[Amplitude] Viewport Height': window.innerHeight,
+            '[Amplitude] Viewport Width': window.innerWidth,
           };
           if (tag === 'a' && event === 'click') {
             properties['[Amplitude] Element Href'] = element.href;

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -91,17 +91,7 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone
         const getText = (element) => {
           let text = '';
           if (isNonSensitiveElement(element) && element.childNodes && element.childNodes.length) {
-            element.childNodes.forEach(function (child) {
-              if (isTextNode(child) && child.textContent) {
-                text += child.textContent
-                  .split(/(\\s+)/)
-                  .filter(isNonSensitiveString)
-                  .join('')
-                  .replace(/[\\r\\n]/g, ' ')
-                  .replace(/[ ]+/g, ' ')
-                  .substring(0, 255);
-              }
-            });
+            text = element.innerText.replace(/\\n/g, ' ');
           }
           return text;
         };
@@ -119,9 +109,13 @@ const snippet = (name, integrity, version, globalVar, apiKey, userId, serverZone
             '[Amplitude] Page Title': (typeof document !== 'undefined' && document.title) || '',
             '[Amplitude] Viewport Height': window.innerHeight,
             '[Amplitude] Viewport Width': window.innerWidth,
+            '[Amplitude] Element Aria Label': element.getAttribute('aria-label') || '',
           };
           if (tag === 'a' && event === 'click') {
             properties['[Amplitude] Element Href'] = element.href;
+          }
+          if (element.dataset && Object.keys(element.dataset).length > 0) {
+            properties['[Amplitude] Element Attributes'] = element.dataset;
           }
           return properties;
         };

--- a/scripts/templates/browser-snippet.template.js
+++ b/scripts/templates/browser-snippet.template.js
@@ -98,7 +98,6 @@ const snippet = (name, integrity, version, globalVar) => `
       };
     }
     function proxyMain(instance, fn, isPromise) {
-      var args = arguments;
       instance[fn] = function () {
         if (isPromise) return {
           promise: new Promise(getPromiseResult(instance, fn, Array.prototype.slice.call(arguments))),

--- a/scripts/version/create-bookmarklet-snippet.js
+++ b/scripts/version/create-bookmarklet-snippet.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const { snippet } = require('../templates/browser-snippet.template');
+const { snippet } = require('../templates/browser-bookmarklet.template');
 const { getName, getVersion } = require('../utils');
 const babel = require('@babel/core');
 const yargs = require('yargs/yargs');
@@ -15,25 +15,26 @@ const inputPath = path.join(process.cwd(), inputDir, inputFile);
 
 // Setup output
 const outputDir = 'generated/';
-const outputFile = argv.outputFile ?? 'amplitude-snippet.js';
+const outputFile = argv.outputFile ?? 'amplitude-bookmarklet-snippet.js';
 const outputPath = path.join(process.cwd(), outputDir, outputFile);
 
 const globalVar = argv.globalVar ?? 'amplitude';
 const nameSuffix = argv.nameSuffix ?? '';
 
+const apiKey = argv.apiKey ?? 'YOUR_API_KEY';
+const userId = argv.userId ?? 'test-user';
+
 // Generate output contents
 const header = `/**
- * Imported in client browser via <script> tag
- * Async capabilities: Interally creates stubbed window.${globalVar} object until real SDK loaded
- * Stubbed functions keep track of funciton calls and their arguments
- * These are sent once real SDK loaded through another <script> tag
+ * Create a bookmark with this code snippet in the browser, update the apiKey and userId (optional), and click the bookmark on any website to run.
+ * Script will fail to load if the website has a Content Security Policy (CSP) that blocks third-party inline scripts.
  */`;
 const algorithm = 'sha384';
 const encoding = 'base64';
 const inputText = fs.readFileSync(inputPath, 'utf-8');
 const integrity = algorithm + '-' + crypto.createHash(algorithm).update(inputText).digest(encoding);
 const version = getVersion() || '';
-const outputText = header + snippet(getName() + nameSuffix, integrity, version, globalVar);
+const outputText = header + snippet(getName() + nameSuffix, integrity, version, globalVar, apiKey, userId);
 const { code: transpiledOutputText } = babel.transformSync(outputText, {
   presets: ['env'],
 });

--- a/scripts/version/create-bookmarklet-snippet.js
+++ b/scripts/version/create-bookmarklet-snippet.js
@@ -21,9 +21,9 @@ const outputPath = path.join(process.cwd(), outputDir, outputFile);
 const globalVar = argv.globalVar ?? 'amplitude';
 const nameSuffix = argv.nameSuffix ?? '';
 
-const apiKey = argv.apiKey ?? 'YOUR_API_KEY';
-const userId = argv.userId ?? 'YOUR_USER_ID';
-const serverZone = argv.serverZone ?? 'YOUR_SERVER_ZONE';
+const apiKey = argv.apiKey ?? process.env.AMP_API_KEY ?? 'YOUR_API_KEY';
+const userId = argv.userId ?? process.env.AMP_USER_ID ?? 'YOUR_USER_ID';
+const serverZone = argv.serverZone ?? process.env.AMP_SERVER_ZONE ?? 'YOUR_SERVER_ZONE';
 
 // Generate output contents
 const header = `/**

--- a/scripts/version/create-bookmarklet-snippet.js
+++ b/scripts/version/create-bookmarklet-snippet.js
@@ -22,11 +22,12 @@ const globalVar = argv.globalVar ?? 'amplitude';
 const nameSuffix = argv.nameSuffix ?? '';
 
 const apiKey = argv.apiKey ?? 'YOUR_API_KEY';
-const userId = argv.userId ?? 'test-user';
+const userId = argv.userId ?? 'YOUR_USER_ID';
+const serverZone = argv.serverZone ?? 'YOUR_SERVER_ZONE';
 
 // Generate output contents
 const header = `/**
- * Create a bookmark with this code snippet in the browser, update the apiKey and userId (optional), and click the bookmark on any website to run.
+ * Create a bookmark with this code snippet in the browser, update the apiKey, userId, and serverZone, and click the bookmark on any website to run.
  * Script will fail to load if the website has a Content Security Policy (CSP) that blocks third-party inline scripts.
  */`;
 const algorithm = 'sha384';
@@ -34,7 +35,7 @@ const encoding = 'base64';
 const inputText = fs.readFileSync(inputPath, 'utf-8');
 const integrity = algorithm + '-' + crypto.createHash(algorithm).update(inputText).digest(encoding);
 const version = getVersion() || '';
-const outputText = header + snippet(getName() + nameSuffix, integrity, version, globalVar, apiKey, userId);
+const outputText = header + snippet(getName() + nameSuffix, integrity, version, globalVar, apiKey, userId, serverZone);
 const { code: transpiledOutputText } = babel.transformSync(outputText, {
   presets: ['env'],
 });

--- a/scripts/version/create-bookmarklet.js
+++ b/scripts/version/create-bookmarklet.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const cwd = process.cwd();
+
+// Setup input
+const inputDir = 'lib/scripts';
+const inputFile = 'amplitude-bookmarklet-snippet-min.js';
+const inputPath = path.join(cwd, inputDir, inputFile);
+
+// Setup output
+const outputDir = 'lib/scripts';
+const outputFile = 'amplitude-bookmarklet.html';
+const outputPath = path.join(cwd, outputDir, outputFile);
+
+// Generate output contents
+const inputText = fs.readFileSync(inputPath, 'utf-8');
+const outputText = `javascript:${encodeURIComponent(inputText)}`;
+
+// Write to disk
+fs.writeFileSync(outputPath, outputText);
+
+console.log(`Generated ${outputFile}`);


### PR DESCRIPTION
### Summary

* Add session tracking to autotrack bookmarklet for test data capture
* [Example session here](https://app.amplitude.com/analytics/amplitude/project/511400/search/amplitude_id%3D735640964307) 
* Need to capture more test sessions - WIP 

### Usage

1. Generate the snippet.
`GENERATE_SNIPPET=true AMP_API_KEY=YOUR_API_KEY AMP_USER_ID=YOUR_USER_ID AMP_SERVER_ZONE=us yarn build`
2. Copy the bookmarklet code to clipboard.
`cat packages/analytics-browser/lib/scripts/amplitude-bookmarklet.html | pbcopy`
3. Create a new bookmark to the bookmarks bar in the browser. Paste the contents of step 2 for the url.
4. Go to a site you want to record data for
    a. Click the bookmark, it will install autotracking & session recording on 
    b. Click buttons, links, etc
    c. Whenever you load a new page you need to do step 4a again to reinstall autotracking.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
