### PR TITLE
feat: add transform option to global user property

### DIFF
--- a/packages/plugin-global-user-properties/src/global-user-properties.ts
+++ b/packages/plugin-global-user-properties/src/global-user-properties.ts
@@ -10,12 +10,12 @@ export const globalUserPropertiesPlugin: GlobalUserPropertiesPlugin = function (
     /* Note: The promise is because of the interface, not because this has any asynchronous behavior */
     execute: async (event: Event): Promise<Event> => {
       if (!isTrackEvent(event) && !isAmplitudeIdentifyEvent(event)) {
-        return event
+        return event;
       }
 
       let globalUserProperties = event.user_properties;
       if (options.propertyTransform && globalUserProperties) {
-        globalUserProperties = options.propertyTransform(globalUserProperties)
+        globalUserProperties = options.propertyTransform(globalUserProperties);
       }
 
       if (!globalUserProperties) {

--- a/packages/plugin-global-user-properties/src/global-user-properties.ts
+++ b/packages/plugin-global-user-properties/src/global-user-properties.ts
@@ -9,12 +9,23 @@ export const globalUserPropertiesPlugin: GlobalUserPropertiesPlugin = function (
 
     /* Note: The promise is because of the interface, not because this has any asynchronous behavior */
     execute: async (event: Event): Promise<Event> => {
-      if (isTrackEvent(event) || isAmplitudeIdentifyEvent(event)) {
-        event.global_user_properties = event.user_properties;
+      if (!isTrackEvent(event) && !isAmplitudeIdentifyEvent(event)) {
+        return event
+      }
 
-        if (!options.shouldKeepOriginalUserProperties) {
-          delete event.user_properties;
-        }
+      let globalUserProperties = event.user_properties;
+      if (options.propertyTransform && globalUserProperties) {
+        globalUserProperties = options.propertyTransform(globalUserProperties)
+      }
+
+      if (!globalUserProperties) {
+        return event;
+      }
+
+      event.global_user_properties = globalUserProperties;
+
+      if (!options.shouldKeepOriginalUserProperties) {
+        delete event.user_properties;
       }
 
       return event;

--- a/packages/plugin-global-user-properties/src/typings/global-user-properties.ts
+++ b/packages/plugin-global-user-properties/src/typings/global-user-properties.ts
@@ -2,9 +2,17 @@ import { EnrichmentPlugin } from '@amplitude/analytics-types';
 
 export interface Options {
   /**
+   * A configuration to modify the user properties before they are attached as global user properties
+   * 
+   * @param properties The original user properties on the event
+   * @returns The modified global user properties. Returning no properties is possible
+   */
+  propertyTransform?: (properties: { [key: string]: any }) => { [key: string]: any } | undefined ;
+  /**
    * Whether or not the orignal user_properties field should be kept on the event
    */
   shouldKeepOriginalUserProperties?: boolean;
+
 }
 
 export interface GlobalUserPropertiesPlugin {

--- a/packages/plugin-global-user-properties/src/typings/global-user-properties.ts
+++ b/packages/plugin-global-user-properties/src/typings/global-user-properties.ts
@@ -3,16 +3,15 @@ import { EnrichmentPlugin } from '@amplitude/analytics-types';
 export interface Options {
   /**
    * A configuration to modify the user properties before they are attached as global user properties
-   * 
+   *
    * @param properties The original user properties on the event
    * @returns The modified global user properties. Returning no properties is possible
    */
-  propertyTransform?: (properties: { [key: string]: any }) => { [key: string]: any } | undefined ;
+  propertyTransform?: (properties: { [key: string]: any }) => { [key: string]: any } | undefined;
   /**
    * Whether or not the orignal user_properties field should be kept on the event
    */
   shouldKeepOriginalUserProperties?: boolean;
-
 }
 
 export interface GlobalUserPropertiesPlugin {

--- a/packages/plugin-global-user-properties/test/global-user-properties.test.ts
+++ b/packages/plugin-global-user-properties/test/global-user-properties.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { globalUserPropertiesPlugin } from '../src/global-user-properties';
 import { TrackEvent, IdentifyEvent, RevenueEvent, SpecialEventType } from '@amplitude/analytics-types';
 
@@ -51,7 +52,7 @@ describe('globalUserPropertiesPlugin', () => {
 
     const newEvent: any = await plugin.execute?.({ ...event });
     expect(newEvent?.global_user_properties).toStrictEqual(undefined);
-  })
+  });
 
   test('does not add global properties on revenue events', async () => {
     const plugin = globalUserPropertiesPlugin();
@@ -83,7 +84,7 @@ describe('globalUserPropertiesPlugin', () => {
   });
 
   test('transforms properties when the property transform option is passed', async () => {
-    const plugin = globalUserPropertiesPlugin({propertyTransform: () => TEST_USER_IDENTIFY_PROPERTIES});
+    const plugin = globalUserPropertiesPlugin({ propertyTransform: () => TEST_USER_IDENTIFY_PROPERTIES });
 
     const event: TrackEvent = {
       event_type: 'NOT A REAL EVENT TYPE',
@@ -92,5 +93,5 @@ describe('globalUserPropertiesPlugin', () => {
 
     const newEvent: any = await plugin.execute?.({ ...event });
     expect(newEvent?.global_user_properties).toStrictEqual(TEST_USER_IDENTIFY_PROPERTIES);
-  })
+  });
 });

--- a/packages/plugin-global-user-properties/test/global-user-properties.test.ts
+++ b/packages/plugin-global-user-properties/test/global-user-properties.test.ts
@@ -42,6 +42,17 @@ describe('globalUserPropertiesPlugin', () => {
     expect(newEvent?.user_properties).toStrictEqual(undefined);
   });
 
+  test('does not add global properties when user properties are not present', async () => {
+    const plugin = globalUserPropertiesPlugin();
+
+    const event: TrackEvent = {
+      event_type: 'NOT A REAL EVENT TYPE',
+    };
+
+    const newEvent: any = await plugin.execute?.({ ...event });
+    expect(newEvent?.global_user_properties).toStrictEqual(undefined);
+  })
+
   test('does not add global properties on revenue events', async () => {
     const plugin = globalUserPropertiesPlugin();
 
@@ -70,4 +81,16 @@ describe('globalUserPropertiesPlugin', () => {
     expect(newEvent?.global_user_properties).toStrictEqual(TEST_USER_IDENTIFY_PROPERTIES);
     expect(newEvent?.user_properties).toStrictEqual(TEST_USER_IDENTIFY_PROPERTIES);
   });
+
+  test('transforms properties when the property transform option is passed', async () => {
+    const plugin = globalUserPropertiesPlugin({propertyTransform: () => TEST_USER_IDENTIFY_PROPERTIES});
+
+    const event: TrackEvent = {
+      event_type: 'NOT A REAL EVENT TYPE',
+      user_properties: TEST_USER_PROPERTIES,
+    };
+
+    const newEvent: any = await plugin.execute?.({ ...event });
+    expect(newEvent?.global_user_properties).toStrictEqual(TEST_USER_IDENTIFY_PROPERTIES);
+  })
 });


### PR DESCRIPTION

### Summary

Adds a property transform option to the global user properties plugin. My own use case is to be able to filter the properties down to a list of allowed ones, and i thought this would be the most flexible way to accomplish that.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
