### PR TITLE
fix: log error trace in catch blocks

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -127,8 +127,8 @@ export class AmplitudeCore implements CoreClient {
 
       return result;
     } catch (e) {
+      this.config.loggerProvider.error(e);
       const message = String(e);
-      this.config.loggerProvider.error(message);
       const result = buildResult(event, 0, message);
 
       return result;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -166,8 +166,8 @@ export class Destination implements DestinationPlugin {
       }
       this.handleResponse(res, list);
     } catch (e) {
+      this.config.loggerProvider.error(e);
       const errorMessage = getErrorMessage(e);
-      this.config.loggerProvider.error(errorMessage);
       this.fulfillRequest(list, 0, errorMessage);
     }
   }

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -1022,7 +1022,7 @@ describe('destination', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(loggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(loggerProvider.error).toHaveBeenCalledWith(message);
+      expect(loggerProvider.error).toHaveBeenCalledWith(err instanceof Error ? new Error(message) : message);
     });
 
     test('should parse response without body', async () => {

--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -110,9 +110,9 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
         }
       }
       return true;
-    } catch (error) {
+    } catch (e) {
       /* istanbul ignore next */
-      logger?.error(String(error));
+      logger?.error(e);
       return false;
     }
   };


### PR DESCRIPTION
### Summary

Logs caught errors before stringifying
* Allows complete error trace to be logged using the logger provider

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No