### PR TITLE
feat: make auto-tracking solely use css selector allowlist

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/README.md
+++ b/packages/plugin-default-event-tracking-advanced-browser/README.md
@@ -65,7 +65,7 @@ Examples:
 
 |Name|Type|Default|Description|
 |-|-|-|-|
-|`cssSelectorAllowlist`|`string[]`|`['a', 'button', 'input', 'select', 'textarea', 'label']`| When provided, only allow elements matching any selector to be tracked. |
+|`cssSelectorAllowlist`|`string[]`|`['a', 'button', 'input', 'select', 'textarea', 'label', '.amp-default-track']`| When provided, only allow elements matching any selector to be tracked. |
 |`pageUrlAllowlist`|`(string\|RegExp)[]`|`undefined`| When provided, only allow elements matching URLs to be tracked. |
 |`shouldTrackEventResolver`|`(actionType: ActionType, element: Element) => boolean`|`undefined`| When provided, overwrite the default filter behavior. |
 |`dataAttributePrefix`|`string`|`'data-amp-track-'`| Allow data attributes to be collected in event property. |

--- a/packages/plugin-default-event-tracking-advanced-browser/README.md
+++ b/packages/plugin-default-event-tracking-advanced-browser/README.md
@@ -65,7 +65,7 @@ Examples:
 
 |Name|Type|Default|Description|
 |-|-|-|-|
-|`cssSelectorAllowlist`|`string[]`|`undefined`| When provided, only allow elements matching any selector to be tracked. |
+|`cssSelectorAllowlist`|`string[]`|`['a', 'button', 'input', 'select', 'textarea', 'label']`| When provided, only allow elements matching any selector to be tracked. |
 |`pageUrlAllowlist`|`(string\|RegExp)[]`|`undefined`| When provided, only allow elements matching URLs to be tracked. |
 |`shouldTrackEventResolver`|`(actionType: ActionType, element: Element) => boolean`|`undefined`| When provided, overwrite the default filter behavior. |
 |`dataAttributePrefix`|`string`|`'data-amp-track-'`| Allow data attributes to be collected in event property. |

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -14,7 +14,15 @@ import { finder } from './libs/finder';
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 type ActionType = 'click' | 'change';
 
-export const DEFAULT_CSS_SELECTOR_ALLOWLIST = ['a', 'button', 'input', 'select', 'textarea', 'label'];
+export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
+  'a',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'label',
+  '.amp-default-track',
+];
 export const DEFAULT_DATA_ATTRIBUTE_PREFIX = 'data-amp-track-';
 
 interface EventListener {

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -1,19 +1,26 @@
 /* eslint-disable no-restricted-globals */
 import { BrowserClient, BrowserConfig, EnrichmentPlugin } from '@amplitude/analytics-types';
 import * as constants from './constants';
-import { getText, isPageUrlAllowed, getAttributesWithPrefix, removeEmptyProperties, getNearestLabel } from './helpers';
+import {
+  getText,
+  isPageUrlAllowed,
+  getAttributesWithPrefix,
+  removeEmptyProperties,
+  getNearestLabel,
+  querySelectUniqueElements,
+} from './helpers';
 import { finder } from './libs/finder';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 type ActionType = 'click' | 'change';
 
-const DEFAULT_TAG_ALLOWLIST = ['a', 'button', 'input', 'select', 'textarea', 'label'];
-const DEFAULT_DATA_ATTRIBUTE_PREFIX = 'data-amp-track-';
+export const DEFAULT_CSS_SELECTOR_ALLOWLIST = ['a', 'button', 'input', 'select', 'textarea', 'label'];
+export const DEFAULT_DATA_ATTRIBUTE_PREFIX = 'data-amp-track-';
 
 interface EventListener {
   element: Element;
   type: ActionType;
-  handler: () => void;
+  handler: (event: Event) => void;
 }
 
 interface Options {
@@ -50,7 +57,7 @@ interface Options {
 
 export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): BrowserEnrichmentPlugin => {
   const {
-    cssSelectorAllowlist,
+    cssSelectorAllowlist = DEFAULT_CSS_SELECTOR_ALLOWLIST,
     pageUrlAllowlist,
     shouldTrackEventResolver,
     dataAttributePrefix = DEFAULT_DATA_ATTRIBUTE_PREFIX,
@@ -61,7 +68,7 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
   let observer: MutationObserver | undefined;
   let eventListeners: EventListener[] = [];
 
-  const addEventListener = (element: Element, type: ActionType, handler: () => void) => {
+  const addEventListener = (element: Element, type: ActionType, handler: (event: Event) => void) => {
     element.addEventListener(type, handler);
     eventListeners.push({
       element: element,
@@ -108,19 +115,6 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     /* istanbul ignore next */
     const tag = element?.tagName?.toLowerCase?.();
 
-    // We only track these limited tags, as general text tag is not interactive and might contain sensitive information.
-    /* istanbul ignore if */
-    if (!DEFAULT_TAG_ALLOWLIST.includes(tag)) {
-      return false;
-    }
-
-    /* istanbul ignore if */
-    if (cssSelectorAllowlist) {
-      const hasMatchAnyAllowedSelector = cssSelectorAllowlist.some((selector) => element.matches(selector));
-      if (!hasMatchAnyAllowedSelector) {
-        return false;
-      }
-    }
     switch (tag) {
       case 'input':
       case 'select':
@@ -184,19 +178,21 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     }
     const addListener = (el: Element) => {
       if (shouldTrackEvent('click', el)) {
-        addEventListener(el, 'click', () => {
+        addEventListener(el, 'click', (event: Event) => {
           /* istanbul ignore next */
           amplitude?.track(constants.AMPLITUDE_ELEMENT_CLICKED_EVENT, getEventProperties('click', el));
+          event.stopPropagation();
         });
       }
       if (shouldTrackEvent('change', el)) {
-        addEventListener(el, 'change', () => {
+        addEventListener(el, 'change', (event: Event) => {
           /* istanbul ignore next */
           amplitude?.track(constants.AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', el));
+          event.stopPropagation();
         });
       }
     };
-    const allElements = Array.from(document.body.querySelectorAll(DEFAULT_TAG_ALLOWLIST.join(',')));
+    const allElements = querySelectUniqueElements(document.body, cssSelectorAllowlist);
     allElements.forEach(addListener);
     if (typeof MutationObserver !== 'undefined') {
       observer = new MutationObserver((mutations) => {
@@ -204,7 +200,7 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
           mutation.addedNodes.forEach((node: Node) => {
             addListener(node as Element);
             if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
-              Array.from(node.querySelectorAll(DEFAULT_TAG_ALLOWLIST.join(',')) as HTMLElement[]).map(addListener);
+              querySelectUniqueElements(node as Element, cssSelectorAllowlist).map(addListener);
             }
           });
         });

--- a/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
@@ -23,7 +23,8 @@ export const isTextNode = (node: Node) => {
 };
 
 export const isNonSensitiveElement = (element: Element) => {
-  const tag = element.tagName.toLowerCase();
+  /* istanbul ignore next */
+  const tag = element?.tagName?.toLowerCase?.();
   return !SENTITIVE_TAGS.includes(tag);
 };
 
@@ -108,4 +109,17 @@ export const getNearestLabel = (element: Element): string => {
     return isNonSensitiveString(labelText) ? labelText : '';
   }
   return getNearestLabel(parent);
+};
+
+export const querySelectUniqueElements = (root: Element | Document, selectors: string[]): Element[] => {
+  const elementSet = selectors.reduce((elements: Set<Element>, selector) => {
+    if (selector) {
+      const selectedElements = Array.from(root.querySelectorAll(selector));
+      selectedElements.forEach((element) => {
+        elements.add(element);
+      });
+    }
+    return elements;
+  }, new Set<Element>());
+  return Array.from(elementSet);
 };

--- a/packages/plugin-default-event-tracking-advanced-browser/src/index.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/index.ts
@@ -1,4 +1,6 @@
 export {
   defaultEventTrackingAdvancedPlugin as plugin,
   defaultEventTrackingAdvancedPlugin,
+  DEFAULT_CSS_SELECTOR_ALLOWLIST,
+  DEFAULT_DATA_ATTRIBUTE_PREFIX,
 } from './default-event-tracking-advanced-plugin';

--- a/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
@@ -36,6 +36,7 @@ describe('autoTrackingPlugin', () => {
 
   afterEach(() => {
     void plugin?.teardown?.();
+    document.getElementsByTagName('body')[0].innerHTML = '';
     jest.clearAllMocks();
   });
 
@@ -306,6 +307,38 @@ describe('autoTrackingPlugin', () => {
         // trigger click div
         document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
         expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('should respect default cssSelectorAllowlist', async () => {
+        const div = document.createElement('div');
+        div.textContent = 'my-div-text';
+        div.setAttribute('id', 'my-div-id');
+        div.className = 'amp-default-track'; // default css class to enable tracking
+        document.body.appendChild(div);
+
+        const button = document.createElement('button');
+        button.textContent = 'my-button-text';
+        button.setAttribute('id', 'my-button-id');
+        document.body.appendChild(button);
+
+        plugin = defaultEventTrackingAdvancedPlugin();
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          warn: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        await plugin?.setup(config as BrowserConfig, instance);
+
+        // trigger click button
+        document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
+        expect(track).toHaveBeenCalledTimes(1);
+
+        // trigger click div
+        document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
+        expect(track).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
@@ -248,32 +248,65 @@ describe('autoTrackingPlugin', () => {
       expect(track).toHaveBeenCalledTimes(1);
     });
 
-    test('should follow cssSelectorAllowlist configuration', async () => {
-      const button = document.createElement('button');
-      const buttonText = document.createTextNode('submit');
-      button.setAttribute('id', 'my-button-id');
-      button.setAttribute('class', 'my-button-class');
-      button.appendChild(buttonText);
-      document.body.appendChild(button);
+    describe('cssSelectorAllowlist configuration', () => {
+      test('should only track selector class', async () => {
+        const button = document.createElement('button');
+        const buttonText = document.createTextNode('submit');
+        button.setAttribute('id', 'my-button-id');
+        button.setAttribute('class', 'my-button-class');
+        button.appendChild(buttonText);
+        document.body.appendChild(button);
 
-      plugin = defaultEventTrackingAdvancedPlugin({ cssSelectorAllowlist: ['.my-button-class'] });
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        warn: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      await plugin?.setup(config as BrowserConfig, instance);
+        plugin = defaultEventTrackingAdvancedPlugin({ cssSelectorAllowlist: ['.my-button-class'] });
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          warn: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        await plugin?.setup(config as BrowserConfig, instance);
 
-      // trigger click link
-      document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
-      expect(track).toHaveBeenCalledTimes(0);
+        // trigger click link
+        document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+        expect(track).toHaveBeenCalledTimes(0);
 
-      // trigger click button
-      document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
-      expect(track).toHaveBeenCalledTimes(1);
+        // trigger click button
+        document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
+        expect(track).toHaveBeenCalledTimes(1);
+      });
+
+      test('should be able to track non-default tags by overwriting default cssSelectorAllowlist', async () => {
+        const div = document.createElement('div');
+        div.textContent = 'my-div-text';
+        div.setAttribute('id', 'my-div-id');
+        document.body.appendChild(div);
+
+        const button = document.createElement('button');
+        button.textContent = 'my-button-text';
+        button.setAttribute('id', 'my-button-id');
+        document.body.appendChild(button);
+
+        plugin = defaultEventTrackingAdvancedPlugin({ cssSelectorAllowlist: ['div'] });
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          warn: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        await plugin?.setup(config as BrowserConfig, instance);
+
+        // trigger click button
+        document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
+        expect(track).toHaveBeenCalledTimes(0);
+
+        // trigger click div
+        document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
+        expect(track).toHaveBeenCalledTimes(1);
+      });
     });
 
     test('should follow pageUrlAllowlist configuration', async () => {

--- a/packages/plugin-default-event-tracking-advanced-browser/test/helpers.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/helpers.test.ts
@@ -8,6 +8,7 @@ import {
   isEmpty,
   removeEmptyProperties,
   getNearestLabel,
+  querySelectUniqueElements,
 } from '../src/helpers';
 
 describe('default-event-tracking-advanced-plugin helpers', () => {
@@ -314,6 +315,25 @@ describe('default-event-tracking-advanced-plugin helpers', () => {
 
       const result = getNearestLabel(input);
       expect(result).toEqual('');
+    });
+  });
+
+  describe('querySelectUniqueElements', () => {
+    test('should return unique elements with selector under root', () => {
+      const container = document.createElement('div');
+
+      const div1 = document.createElement('div');
+      div1.className = 'test-class';
+      container.appendChild(div1);
+      const div2 = document.createElement('div');
+      container.appendChild(div2);
+
+      let result = querySelectUniqueElements(container, ['div']);
+      expect(result).toEqual([div1, div2]);
+
+      // elements should be deduped
+      result = querySelectUniqueElements(container, ['div', '.test-class']);
+      expect(result).toEqual([div1, div2]);
     });
   });
 });


### PR DESCRIPTION
### Summary
feat: make auto-tracking solely use css selector allowlist

This change make `cssSelectorAllowlist` the single source of truth for the selector configuration, which allows us to track clicking of elements not in the default tag list: `['a', 'button', 'input', 'select', 'textarea', 'label']`. Reason is some button might be built with `div`, not with the `button`.

Add `event.stopPropagation();` specifically, as nested element clicking may cause unexpected events flood.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
