### PR TITLE
fix: remove event stopPropagation

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -186,17 +186,15 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     }
     const addListener = (el: Element) => {
       if (shouldTrackEvent('click', el)) {
-        addEventListener(el, 'click', (event: Event) => {
+        addEventListener(el, 'click', () => {
           /* istanbul ignore next */
           amplitude?.track(constants.AMPLITUDE_ELEMENT_CLICKED_EVENT, getEventProperties('click', el));
-          event.stopPropagation();
         });
       }
       if (shouldTrackEvent('change', el)) {
-        addEventListener(el, 'change', (event: Event) => {
+        addEventListener(el, 'change', () => {
           /* istanbul ignore next */
           amplitude?.track(constants.AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', el));
-          event.stopPropagation();
         });
       }
     };


### PR DESCRIPTION
### Summary
- fix: remove event stopPropagation

I was under the wrong impression that `stopPropagation` won't affect the parent clicking event when there are other `onclick` attached, this fix removes the `stopPropagation`.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
