### PR TITLE
fix: handle text node throw error issue

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -102,6 +102,13 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
       return false;
     }
 
+    /* istanbul ignore next */
+    const tag = element?.tagName?.toLowerCase?.();
+    // Text nodes have no tag
+    if (!tag) {
+      return false;
+    }
+
     if (shouldTrackEventResolver) {
       return shouldTrackEventResolver(actionType, element);
     }
@@ -120,12 +127,10 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
           return false;
       }
     }
-    /* istanbul ignore next */
-    const tag = element?.tagName?.toLowerCase?.();
 
     /* istanbul ignore if */
     if (cssSelectorAllowlist) {
-      const hasMatchAnyAllowedSelector = cssSelectorAllowlist.some((selector) => element.matches(selector));
+      const hasMatchAnyAllowedSelector = cssSelectorAllowlist.some((selector) => !!element?.matches?.(selector));
       if (!hasMatchAnyAllowedSelector) {
         return false;
       }

--- a/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
@@ -561,6 +561,33 @@ describe('autoTrackingPlugin', () => {
       document.getElementById('my-div-id')?.dispatchEvent(new Event('change'));
       expect(track).toHaveBeenCalledTimes(0);
     });
+
+    test('should not throw error when there is text node added to the page', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      const textNode = document.createTextNode('Some text node');
+      document.body.appendChild(textNode);
+
+      const div = document.createElement('div');
+      div.setAttribute('id', 'my-div-id');
+      div.setAttribute('class', 'my-div-class');
+      document.body.appendChild(div);
+
+      // allow mutation observer to execute and event listener to be attached
+      await new Promise((r) => r(undefined)); // basically, await next clock tick
+
+      // trigger click input
+      document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
+      expect(track).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('teardown', () => {


### PR DESCRIPTION
### Summary
- fix: handle text node throw error issue

This is an edge case, React Components debugging tool is injecting nodes onto the page, including Text Node. The text node doesn't have tag and matches method, which will throw error on the page.

Previously, as we have the tag list filter, so this issue was not triggered.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
