### PR TITLE
feat: add session replay ID generic identifier to init/turnover

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -51,7 +51,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
 
   async execute(event: Event) {
     if (event.event_type === DEFAULT_SESSION_START_EVENT && event.session_id) {
-      sessionReplay.setSessionId(event.session_id);
+      sessionReplay.setSessionId({ sessionId: event.session_id });
     }
 
     const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -51,7 +51,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
 
   async execute(event: Event) {
     if (event.event_type === DEFAULT_SESSION_START_EVENT && event.session_id) {
-      sessionReplay.setSessionId({ sessionId: event.session_id });
+      sessionReplay.setSessionId(event.session_id);
     }
 
     const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
@@ -65,6 +65,10 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
 
   async teardown(): Promise<void> {
     sessionReplay.shutdown();
+  }
+
+  getSessionReplayProperties() {
+    return sessionReplay.getSessionReplayProperties();
   }
 }
 

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -167,4 +167,20 @@ describe('SessionReplayPlugin', () => {
       expect(shutdown).toHaveBeenCalled();
     });
   });
+
+  describe('getSessionReplayProperties', () => {
+    test('should return session replay properties', async () => {
+      const sessionReplay = sessionReplayPlugin() as SessionReplayPlugin;
+      await sessionReplay.setup(mockConfig);
+      getSessionReplayProperties.mockReturnValueOnce({
+        '[Amplitude] Session Recorded': true,
+        '[Amplitude] Session Replay ID': '123/456',
+      });
+      const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
+      expect(sessionReplayProperties).toEqual({
+        '[Amplitude] Session Recorded': true,
+        '[Amplitude] Session Replay ID': '123/456',
+      });
+    });
+  });
 });

--- a/packages/session-replay-browser/src/config.ts
+++ b/packages/session-replay-browser/src/config.ts
@@ -3,6 +3,7 @@ import { Config, Logger } from '@amplitude/analytics-core';
 import { LogLevel } from '@amplitude/analytics-types';
 import { SessionReplayConfig as ISessionReplayConfig, SessionReplayOptions } from './typings/session-replay';
 import { DEFAULT_SAMPLE_RATE } from './constants';
+import { generateSessionReplayId } from './helpers';
 
 export const getDefaultConfig = () => ({
   flushMaxRetries: 2,
@@ -16,6 +17,7 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
   sampleRate: number;
   deviceId?: string | undefined;
   sessionId?: number | undefined;
+  sessionReplayId?: string | undefined | null;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -32,7 +34,12 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
     this.apiKey = apiKey;
     this.sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
 
-    this.deviceId = options.deviceId;
-    this.sessionId = options.sessionId;
+    if (options.sessionReplayId) {
+      this.sessionReplayId = options.sessionReplayId;
+    } else if (options.sessionId && options.deviceId) {
+      this.deviceId = options.deviceId;
+      this.sessionId = options.sessionId;
+      this.sessionReplayId = generateSessionReplayId(options.sessionId, options.deviceId);
+    }
   }
 }

--- a/packages/session-replay-browser/src/config.ts
+++ b/packages/session-replay-browser/src/config.ts
@@ -17,7 +17,7 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
   sampleRate: number;
   deviceId?: string | undefined;
   sessionId?: number | undefined;
-  sessionReplayId?: string | undefined | null;
+  sessionReplayId?: string | undefined;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();

--- a/packages/session-replay-browser/src/config.ts
+++ b/packages/session-replay-browser/src/config.ts
@@ -33,11 +33,13 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
 
     this.apiKey = apiKey;
     this.sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
+    this.deviceId = options.deviceId;
+    this.sessionId = options.sessionId;
 
     if (options.sessionId && options.deviceId) {
-      this.deviceId = options.deviceId;
-      this.sessionId = options.sessionId;
       this.sessionReplayId = generateSessionReplayId(options.sessionId, options.deviceId);
+    } else {
+      this.loggerProvider.error('Please provide both sessionId and deviceId.');
     }
   }
 }

--- a/packages/session-replay-browser/src/config.ts
+++ b/packages/session-replay-browser/src/config.ts
@@ -34,9 +34,7 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
     this.apiKey = apiKey;
     this.sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
 
-    if (options.sessionReplayId) {
-      this.sessionReplayId = options.sessionReplayId;
-    } else if (options.sessionId && options.deviceId) {
+    if (options.sessionId && options.deviceId) {
       this.deviceId = options.deviceId;
       this.sessionId = options.sessionId;
       this.sessionReplayId = generateSessionReplayId(options.sessionId, options.deviceId);

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -3,6 +3,7 @@ import { IDBStoreSession } from './typings/session-replay';
 
 export const DEFAULT_EVENT_PROPERTY_PREFIX = '[Amplitude]';
 
+export const NEW_SESSION_REPLAY_PROPERTY = `${DEFAULT_EVENT_PROPERTY_PREFIX} Session Replay ID`;
 export const DEFAULT_SESSION_REPLAY_PROPERTY = `${DEFAULT_EVENT_PROPERTY_PREFIX} Session Recorded`;
 export const DEFAULT_SESSION_START_EVENT = 'session_start';
 export const DEFAULT_SESSION_END_EVENT = 'session_end';

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -35,19 +35,3 @@ export const getCurrentUrl = () => {
 export const generateSessionReplayId = (sessionId: number, deviceId: string): string => {
   return `${deviceId}/${sessionId}`;
 };
-
-export const parseSessionReplayId = (
-  sessionReplayId: string | undefined,
-): { deviceId?: string; sessionId?: string } => {
-  if (!sessionReplayId) {
-    return {};
-  }
-
-  const parts = sessionReplayId.split('/');
-  if (parts.length === 2) {
-    const [deviceId, sessionId] = sessionReplayId.split('/');
-    return { deviceId, sessionId };
-  }
-
-  return {};
-};

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -31,3 +31,7 @@ export const getCurrentUrl = () => {
   const globalScope = getGlobalScope();
   return globalScope?.location ? globalScope.location.href : '';
 };
+
+export const generateSessionReplayId = (sessionId: number, deviceId: string): string => {
+  return `${sessionId}/${deviceId}`;
+};

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -33,5 +33,21 @@ export const getCurrentUrl = () => {
 };
 
 export const generateSessionReplayId = (sessionId: number, deviceId: string): string => {
-  return `${sessionId}/${deviceId}`;
+  return `${deviceId}/${sessionId}`;
+};
+
+export const parseSessionReplayId = (
+  sessionReplayId: string | undefined,
+): { deviceId?: string; sessionId?: string } => {
+  if (!sessionReplayId) {
+    return {};
+  }
+
+  const parts = sessionReplayId.split('/');
+  if (parts.length === 2) {
+    const [deviceId, sessionId] = sessionReplayId.split('/');
+    return { deviceId, sessionId };
+  }
+
+  return {};
 };

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -151,7 +151,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.loggerProvider.warn(`Error occurred while stopping recording: ${typedError.toString()}`);
     }
 
-    const parseSessionId = parseSessionReplayId(sessionReplayId)?.sessionId;
+    const parseSessionId = parseSessionReplayId(sessionReplayId).sessionId;
     const sessionIdToSend = parseSessionId ? +parseSessionId : this.config?.sessionId;
     if (this.events.length && sessionIdToSend) {
       this.sendEventsList({

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -46,7 +46,7 @@ export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
-  setSessionId: ({ sessionId, sessionReplayId }: { sessionId?: number; sessionReplayId?: string }) => void;
+  setSessionId: (sessionId: number) => void;
   getSessionRecordingProperties: () => { [key: string]: boolean | string | null };
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   shutdown: () => void;

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -39,14 +39,14 @@ export interface SessionReplayConfig extends Config {
   logLevel: LogLevel;
   flushMaxRetries: number;
   sampleRate: number;
-  sessionReplayId?: string | null;
+  sessionReplayId?: string;
 }
 
 export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
-  setSessionId: (sessionId?: number, sessionReplayId?: string) => void;
+  setSessionId: ({ sessionId, sessionReplayId }: { sessionId?: number; sessionReplayId?: string }) => void;
   getSessionRecordingProperties: () => { [key: string]: boolean | string | null };
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   shutdown: () => void;

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -39,14 +39,15 @@ export interface SessionReplayConfig extends Config {
   logLevel: LogLevel;
   flushMaxRetries: number;
   sampleRate: number;
+  sessionReplayId?: string | null;
 }
 
 export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
-  setSessionId: (sessionId: number) => void;
-  getSessionRecordingProperties: () => { [key: string]: boolean };
-  getSessionReplayProperties: () => { [key: string]: boolean };
+  setSessionId: (sessionId?: number, sessionReplayId?: string) => void;
+  getSessionRecordingProperties: () => { [key: string]: boolean | string | null };
+  getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   shutdown: () => void;
 }

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -1,5 +1,5 @@
 import { UNMASK_TEXT_CLASS } from '../src/constants';
-import { generateHashCode, isSessionInSample, maskInputFn } from '../src/helpers';
+import { generateHashCode, isSessionInSample, maskInputFn, parseSessionReplayId } from '../src/helpers';
 
 describe('SessionReplayPlugin helpers', () => {
   describe('maskInputFn', () => {
@@ -45,6 +45,20 @@ describe('SessionReplayPlugin helpers', () => {
     test('should deterministically return false if calculation puts session id above sample rate', () => {
       const result = isSessionInSample(1691092416403, 0.5);
       expect(result).toEqual(false);
+    });
+  });
+
+  describe('parseSessionReplayId', () => {
+    test('should return empty object if sessionReplayId is not the correct format', () => {
+      const sessionReplayId = '123/234/345';
+      const result = parseSessionReplayId(sessionReplayId);
+      expect(result).toEqual({});
+    });
+
+    test('should return empty object if sessionReplayId is undefined', () => {
+      const sessionReplayId = undefined;
+      const result = parseSessionReplayId(sessionReplayId);
+      expect(result).toEqual({});
     });
   });
 });

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -1,5 +1,5 @@
 import { UNMASK_TEXT_CLASS } from '../src/constants';
-import { generateHashCode, isSessionInSample, maskInputFn, parseSessionReplayId } from '../src/helpers';
+import { generateHashCode, isSessionInSample, maskInputFn } from '../src/helpers';
 
 describe('SessionReplayPlugin helpers', () => {
   describe('maskInputFn', () => {
@@ -45,20 +45,6 @@ describe('SessionReplayPlugin helpers', () => {
     test('should deterministically return false if calculation puts session id above sample rate', () => {
       const result = isSessionInSample(1691092416403, 0.5);
       expect(result).toEqual(false);
-    });
-  });
-
-  describe('parseSessionReplayId', () => {
-    test('should return empty object if sessionReplayId is not the correct format', () => {
-      const sessionReplayId = '123/234/345';
-      const result = parseSessionReplayId(sessionReplayId);
-      expect(result).toEqual({});
-    });
-
-    test('should return empty object if sessionReplayId is undefined', () => {
-      const sessionReplayId = undefined;
-      const result = parseSessionReplayId(sessionReplayId);
-      expect(result).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Adding in generic session replay ID to initialization and session turnover:

### Browser SDK
```
// Your existing initialization logic with Browser SDK
amplitude.init(API_KEY);

// Create and Install Session Replay Plugin
const sessionReplayTracking = sessionReplayPlugin();
amplitude.add(sessionReplayTracking);

amplitude.getSessionReplay
```

### Standalone SDK
```
// Can include generic sessionReplayId 
await sessionReplay.init(AMPLITUDE_API_KEY, {
  deviceId: <string>,
  sessionId: <number>,
  // sessionReplayId: <string>,
  optOut: <boolean>,
  sampleRate: <number>
}).promise;

// This would generate from sessionId/deviceId
sessionReplay.setSessionId({sessionId:123});

// This would use passed in generic
//sessionReplay.setSessionId({sessionReplayId:"123/456"});

// This will include [NEW_SESSION_REPLAY_PROPERTY]: sessionReplayId / "device_id/session_id" / null
const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
```

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
