### PR TITLE
fix: skip parent element event when it is not target

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -200,13 +200,23 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     }
     const addListener = (el: Element) => {
       if (shouldTrackEvent('click', el)) {
-        addEventListener(el, 'click', () => {
+        addEventListener(el, 'click', (event: Event) => {
+          // Limit to only the element that was clicked, not the propagated event.
+          /* istanbul ignore next */
+          if (event?.target != event?.currentTarget) {
+            return;
+          }
           /* istanbul ignore next */
           amplitude?.track(constants.AMPLITUDE_ELEMENT_CLICKED_EVENT, getEventProperties('click', el));
         });
       }
       if (shouldTrackEvent('change', el)) {
-        addEventListener(el, 'change', () => {
+        addEventListener(el, 'change', (event: Event) => {
+          // Limit to only the element that was clicked, not the propagated event.
+          /* istanbul ignore next */
+          if (event?.target != event?.currentTarget) {
+            return;
+          }
           /* istanbul ignore next */
           amplitude?.track(constants.AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', el));
         });

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -8,6 +8,7 @@ import {
   removeEmptyProperties,
   getNearestLabel,
   querySelectUniqueElements,
+  getClosestElement,
 } from './helpers';
 import { finder } from './libs/finder';
 
@@ -201,9 +202,12 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     const addListener = (el: Element) => {
       if (shouldTrackEvent('click', el)) {
         addEventListener(el, 'click', (event: Event) => {
-          // Limit to only the element that was clicked, not the propagated event.
+          // Limit to only the innermost element that matches the selectors, avoiding all propagated event after matching.
           /* istanbul ignore next */
-          if (event?.target != event?.currentTarget) {
+          if (
+            event?.target != event?.currentTarget &&
+            getClosestElement(event?.target as HTMLElement, cssSelectorAllowlist) != event?.currentTarget
+          ) {
             return;
           }
           /* istanbul ignore next */
@@ -212,9 +216,12 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
       }
       if (shouldTrackEvent('change', el)) {
         addEventListener(el, 'change', (event: Event) => {
-          // Limit to only the element that was clicked, not the propagated event.
+          // Limit to only the innermost element that matches the selectors, avoiding all propagated event after matching.
           /* istanbul ignore next */
-          if (event?.target != event?.currentTarget) {
+          if (
+            event?.target != event?.currentTarget &&
+            getClosestElement(event?.target as HTMLElement, cssSelectorAllowlist) != event?.currentTarget
+          ) {
             return;
           }
           /* istanbul ignore next */

--- a/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
@@ -123,3 +123,16 @@ export const querySelectUniqueElements = (root: Element | Document, selectors: s
   }, new Set<Element>());
   return Array.from(elementSet);
 };
+
+// Similar as element.closest, but works with multiple selectors
+export const getClosestElement = (element: Element | null, selectors: string[]): Element | null => {
+  if (!element) {
+    return null;
+  }
+  /* istanbul ignore next */
+  if (selectors.some((selector) => element?.matches?.(selector))) {
+    return element;
+  }
+  /* istanbul ignore next */
+  return getClosestElement(element?.parentElement, selectors);
+};

--- a/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
@@ -598,6 +598,35 @@ describe('autoTrackingPlugin', () => {
       document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
       expect(track).toHaveBeenCalledTimes(0);
     });
+
+    test('should only fire event for the current target when container element also matches the allowlist', async () => {
+      const containerDiv = document.createElement('div');
+      containerDiv.setAttribute('id', 'container-div-id');
+      document.body.appendChild(containerDiv);
+
+      const innerDiv = document.createElement('div');
+      innerDiv.setAttribute('id', 'inner-div-id');
+      containerDiv.appendChild(innerDiv);
+
+      plugin = defaultEventTrackingAdvancedPlugin({ cssSelectorAllowlist: ['div'] });
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click inner div
+      document.getElementById('inner-div-id')?.dispatchEvent(new Event('click', { bubbles: true }));
+      expect(track).toHaveBeenCalledTimes(1);
+
+      // trigger click container div
+      document.getElementById('container-div-id')?.dispatchEvent(new Event('click', { bubbles: true }));
+      expect(track).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('teardown', () => {

--- a/packages/plugin-default-event-tracking-advanced-browser/test/helpers.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/helpers.test.ts
@@ -9,9 +9,15 @@ import {
   removeEmptyProperties,
   getNearestLabel,
   querySelectUniqueElements,
+  getClosestElement,
 } from '../src/helpers';
 
 describe('default-event-tracking-advanced-plugin helpers', () => {
+  afterEach(() => {
+    document.getElementsByTagName('body')[0].innerHTML = '';
+    jest.clearAllMocks();
+  });
+
   describe('isNonSensitiveString', () => {
     test('should return false when text is missing', () => {
       const text = null;
@@ -334,6 +340,57 @@ describe('default-event-tracking-advanced-plugin helpers', () => {
       // elements should be deduped
       result = querySelectUniqueElements(container, ['div', '.test-class']);
       expect(result).toEqual([div1, div2]);
+    });
+  });
+
+  describe('getClosestElement', () => {
+    test('should return null when element null', () => {
+      expect(getClosestElement(null, ['div'])).toEqual(null);
+    });
+
+    test('should return current element if it matches any selectors', () => {
+      document.getElementsByTagName('body')[0].innerHTML = `
+        <div id="container">
+          <div id="inner">
+            xxx
+          </div>
+        </div>
+      `;
+
+      const inner = document.getElementById('inner');
+      expect(getClosestElement(inner, ['span', 'div'])?.id).toEqual('inner');
+    });
+
+    test('should return closest element if it matches any selectors', () => {
+      document.getElementsByTagName('body')[0].innerHTML = `
+        <div id="parent2" data-target>
+          <div id="parent1-sibling" data-target>
+          </div>
+          <div id="parent1">
+            <div id="inner">
+              xxx
+            </div>
+          </div>
+        </div>
+      `;
+
+      const inner = document.getElementById('inner');
+      expect(getClosestElement(inner, ['span', '[data-target]'])?.id).toEqual('parent2');
+    });
+
+    test('should return null when no element matches', () => {
+      document.getElementsByTagName('body')[0].innerHTML = `
+        <div id="parent2">
+          <div id="parent1">
+            <div id="inner">
+              xxx
+            </div>
+          </div>
+        </div>
+      `;
+
+      const inner = document.getElementById('inner');
+      expect(getClosestElement(inner, ['div.some-class'])).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
### Summary
- fix: skip parent element event when it is not target
- feat: limit to only the innermost allowed element

In the following case, the plugin will fire 3 events, as the clicking event is propagated to the parent (and parent's parent):
```html
<div data-testid="details">
  <div data-testid="container">
    <button data-testid="button">Click Me</button>
  </div>
</div>

// configure
cssSelectorAllowlist: ["[data-testid]"]
```

To avoid this, we can check the `event?.target != event?.currentTarget`. However, this will potential introduce another issue:
```html
<button>
  <span>Click Me</span>
</button>

// configure
cssSelectorAllowlist: ["button"]
```
When clicking on `span`, it won't track as `span` is not in the allow list, and due to the change we check the target, it will not track the event for `button` as well.

To fix the above issue, we introduce another check `getClosestElement(event?.target, cssSelectorAllowlist) != event?.currentTarget`, so it will track the event for the innermost allowed element, e.g.:
```html
<div id="container2">
  <div id="container1">
    <div id="inner">
      click me
    </div>
  </div>
</div>

cssSelectorAllowlist: ['div']
expect: only track inner, as we should only track the innermost allowed element

<div id="container2">
  <div id="container1">
    <span id="inner">
      click me
    </span>
  </div>
</div>

cssSelectorAllowlist: ['div']
expect: only track container1, as we should only track the innermost allowed element
```

There is a case like below:
```html
<button id="container" data-track>
  <div id="inner" data-track>
    click me
  </div>
</button>

cssSelectorAllowlist: ['[data-track]']
expect: only track div click, as div is innermost element that matches allowlist
```
Note: we do not track the button click here, this is a rare case that the inner div is also allowed.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
