### PR TITLE
fix: update attribution plugin to apply utm params to the `session_start` event

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -89,7 +89,7 @@ describe('integration', () => {
         void client.track('Event Before Init').promise.then((response) => {
           expect(response.event).toEqual({
             device_id: deviceId, // NOTE: Device ID was set before init
-            event_id: 0,
+            event_id: 1,
             event_type: 'Event Before Init',
             insert_id: uuid,
             ip: '$remote',
@@ -212,7 +212,7 @@ describe('integration', () => {
                 wbraid: '-',
               },
             },
-            event_id: 0,
+            event_id: 1,
             library: library,
           },
           {
@@ -225,7 +225,7 @@ describe('integration', () => {
             ip: '$remote',
             insert_id: uuid,
             event_type: 'Event Before Init',
-            event_id: 1,
+            event_id: 2,
             library: library,
             user_agent: userAgent,
           },
@@ -257,7 +257,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event',
-        event_id: 0,
+        event_id: 1,
         event_properties: {
           mode: 'test',
         },
@@ -289,7 +289,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -320,7 +320,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -357,7 +357,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event',
-        event_id: 0,
+        event_id: 1,
         library: library,
         ingestion_metadata: {
           source_name: sourceName,
@@ -401,7 +401,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event',
-        event_id: 0,
+        event_id: 1,
         library: library,
         groups: {
           org: '15',
@@ -446,7 +446,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 1',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -463,7 +463,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 2',
-        event_id: 1,
+        event_id: 2,
         library: library,
         user_agent: userAgent,
       });
@@ -497,7 +497,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 1',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -514,7 +514,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 2',
-        event_id: 1,
+        event_id: 2,
         library: library,
         user_agent: userAgent,
       });
@@ -557,7 +557,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 1',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -574,7 +574,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 2',
-        event_id: 1,
+        event_id: 2,
         library: library,
         user_agent: userAgent,
       });
@@ -606,7 +606,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 1',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -623,7 +623,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event 2',
-        event_id: 1,
+        event_id: 2,
         library: library,
         user_agent: userAgent,
       });
@@ -655,7 +655,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: 'test event',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
       });
@@ -715,7 +715,7 @@ describe('integration', () => {
         insert_id: uuid,
         partner_id: undefined,
         event_type: '$identify',
-        event_id: 0,
+        event_id: 1,
         library: library,
         user_agent: userAgent,
         user_properties: {
@@ -767,7 +767,7 @@ describe('integration', () => {
       const response = await client.revenue(rev).promise;
       expect(response.event).toEqual({
         device_id: uuid,
-        event_id: 0,
+        event_id: 1,
         event_properties: {
           $price: 100,
           $productId: '1',
@@ -803,7 +803,7 @@ describe('integration', () => {
       const response = await client.setGroup('org', 'engineering').promise;
       expect(response.event).toEqual({
         device_id: uuid,
-        event_id: 0,
+        event_id: 1,
         event_type: '$identify',
         groups: {
           org: 'engineering',
@@ -907,22 +907,6 @@ describe('integration', () => {
                 device_id: uuid,
                 event_id: 101,
                 event_type: 'session_start',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: 'user1@amplitude.com',
-              },
-              {
-                device_id: uuid,
-                event_id: 102,
-                event_type: '$identify',
                 insert_id: uuid,
                 ip: '$remote',
                 language: 'en-US',
@@ -1095,42 +1079,23 @@ describe('integration', () => {
             payload.events[2].device_id,
             payload.events[3].device_id,
             payload.events[4].device_id,
-            payload.events[5].device_id,
           ].forEach((deviceId) => {
             expect(deviceId).toEqual(deviceId0);
           });
           const sessionId0 = payload.events[0].session_id;
-          [payload.events[1].session_id, payload.events[2].session_id, payload.events[3].session_id].forEach(
-            (sessionId) => {
-              expect(sessionId).toEqual(sessionId0);
-            },
-          );
-          expect(sessionId0).not.toEqual(payload.events[4].session_id);
-          expect(payload.events[4].session_id).toEqual(payload.events[5].session_id);
+          [payload.events[1].session_id, payload.events[2].session_id].forEach((sessionId) => {
+            expect(sessionId).toEqual(sessionId0);
+          });
+          expect(sessionId0).not.toEqual(payload.events[3].session_id);
+          expect(payload.events[3].session_id).toEqual(payload.events[4].session_id);
           expect(payload).toEqual({
             api_key: apiKey,
             client_upload_time: event_upload_time,
             events: [
               {
                 device_id: uuid,
-                event_id: 0,
-                event_type: 'session_start',
-                insert_id: uuid,
-                ip: '$remote',
-                language: 'en-US',
-                library,
-                partner_id: undefined,
-                plan: undefined,
-                platform: 'Web',
-                session_id: number,
-                time: number,
-                user_agent: userAgent,
-                user_id: 'user1@amplitude.com',
-              },
-              {
-                device_id: uuid,
                 event_id: 1,
-                event_type: '$identify',
+                event_type: 'session_start',
                 insert_id: uuid,
                 ip: '$remote',
                 language: 'en-US',
@@ -1189,7 +1154,7 @@ describe('integration', () => {
               },
               {
                 device_id: uuid,
-                event_id: 2,
+                event_id: 3,
                 event_type: 'Event in first session',
                 insert_id: uuid,
                 ip: '$remote',
@@ -1205,7 +1170,7 @@ describe('integration', () => {
               },
               {
                 device_id: uuid,
-                event_id: 3,
+                event_id: 4,
                 event_type: 'session_end',
                 insert_id: uuid,
                 ip: '$remote',
@@ -1221,7 +1186,7 @@ describe('integration', () => {
               },
               {
                 device_id: uuid,
-                event_id: 4,
+                event_id: 5,
                 event_type: 'session_start',
                 insert_id: uuid,
                 ip: '$remote',
@@ -1237,7 +1202,7 @@ describe('integration', () => {
               },
               {
                 device_id: uuid,
-                event_id: 5,
+                event_id: 6,
                 event_type: 'Event in next session',
                 insert_id: uuid,
                 ip: '$remote',
@@ -1485,7 +1450,7 @@ describe('integration', () => {
             events: [
               {
                 device_id: uuid,
-                event_id: 0,
+                event_id: 1,
                 event_properties: {
                   '[Amplitude] Page Domain': '',
                   '[Amplitude] Page Location': '',
@@ -1584,7 +1549,7 @@ describe('integration', () => {
             events: [
               {
                 device_id: uuid,
-                event_id: 0,
+                event_id: 1,
                 event_properties: {
                   '[Amplitude] Page Domain': '',
                   '[Amplitude] Page Location': '',
@@ -1727,7 +1692,7 @@ describe('integration', () => {
           insert_id: uuid,
           partner_id: undefined,
           event_type: 'test event',
-          event_id: 0,
+          event_id: 1,
           library: library,
           user_agent: userAgent,
         });
@@ -1767,7 +1732,7 @@ describe('integration', () => {
           insert_id: uuid,
           partner_id: undefined,
           event_type: 'test event',
-          event_id: 0,
+          event_id: 1,
           library: library,
           user_agent: userAgent,
         });

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -10,7 +10,7 @@ import {
   isFormInteractionTrackingEnabled,
   setConnectorDeviceId,
   setConnectorUserId,
-  isNewSession,
+  isSessionExpired,
 } from '@amplitude/analytics-client-common';
 import {
   BrowserClient,
@@ -104,7 +104,16 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     // Add web attribution plugin
     if (isAttributionTrackingEnabled(this.config.defaultTracking)) {
       const attributionTrackingOptions = getAttributionTrackingConfig(this.config);
-      const webAttribution = webAttributionPlugin(attributionTrackingOptions);
+      const resetSessionOnNewCampaign =
+        !this.config.lastEventTime || isSessionExpired(this.config.sessionTimeout, this.config.lastEventTime)
+          ? // A new session just started OR will start soon organically, no need to trigger another restart
+            false
+          : // Previous session is still valid, allow reset if configured
+            attributionTrackingOptions.resetSessionOnNewCampaign;
+      const webAttribution = webAttributionPlugin({
+        ...attributionTrackingOptions,
+        resetSessionOnNewCampaign,
+      });
       await this.add(webAttribution).promise;
     }
 
@@ -172,7 +181,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     const previousSessionId = this.getSessionId();
     const lastEventTime = this.config.lastEventTime;
-    let lastEventId = this.config.lastEventId ?? -1;
+    this.config.lastEventId = this.config.lastEventId ?? 0;
 
     this.config.sessionId = sessionId;
     this.config.lastEventTime = undefined;
@@ -181,7 +190,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       if (previousSessionId && lastEventTime) {
         this.track(DEFAULT_SESSION_END_EVENT, undefined, {
           device_id: this.previousSessionDeviceId,
-          event_id: ++lastEventId,
+          event_id: ++this.config.lastEventId,
           session_id: previousSessionId,
           time: lastEventTime + 1,
           user_id: this.previousSessionUserId,
@@ -190,7 +199,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
       this.config.lastEventTime = this.config.sessionId;
       this.track(DEFAULT_SESSION_START_EVENT, undefined, {
-        event_id: ++lastEventId,
+        event_id: ++this.config.lastEventId,
         session_id: this.config.sessionId,
         time: this.config.lastEventTime,
       });
@@ -251,13 +260,13 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
   async process(event: Event) {
     const currentTime = Date.now();
-    const isEventInNewSession = isNewSession(this.config.sessionTimeout, this.config.lastEventTime);
+    const isMostRecentSessionExpired = isSessionExpired(this.config.sessionTimeout, this.config.lastEventTime);
 
     if (
       event.event_type !== DEFAULT_SESSION_START_EVENT &&
       event.event_type !== DEFAULT_SESSION_END_EVENT &&
       (!event.session_id || event.session_id === this.getSessionId()) &&
-      isEventInNewSession
+      isMostRecentSessionExpired
     ) {
       this.setSessionId(currentTime);
     }

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -38,6 +38,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   config: BrowserConfig;
   previousSessionDeviceId: string | undefined;
   previousSessionUserId: string | undefined;
+  sessionStartEventTime: number | undefined;
 
   init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {
     let userId: string | undefined;
@@ -180,7 +181,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     }
 
     const previousSessionId = this.getSessionId();
-    const lastEventTime = this.config.lastEventTime;
+    const lastEventTime = this.config.lastEventTime ?? this.sessionStartEventTime;
     this.config.lastEventId = this.config.lastEventId ?? 0;
 
     this.config.sessionId = sessionId;
@@ -195,14 +196,19 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
           time: lastEventTime + 1,
           user_id: this.previousSessionUserId,
         });
+        this.sessionStartEventTime = undefined;
       }
 
-      this.config.lastEventTime = this.config.sessionId;
       this.track(DEFAULT_SESSION_START_EVENT, undefined, {
         event_id: ++this.config.lastEventId,
         session_id: this.config.sessionId,
-        time: this.config.lastEventTime,
+        time: this.config.sessionId,
       });
+      // `this.lastSessionStartEventTime` is used to handle extreme edge case where session
+      // is restarted before session start event is processed by context plugin to set
+      // the globally used this.config.lastEventTime. `this.config.lastEventTime` should
+      // only be modified by config builder and context plugin to limit tampering.
+      this.sessionStartEventTime = this.config.sessionId;
     }
 
     this.previousSessionDeviceId = this.config.deviceId;

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -40,7 +40,7 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
     }
 
     /* istanbul ignore if */
-    if (typeof document === 'undefined') {
+    if (typeof document === 'undefined' || !document.body) {
       return;
     }
 

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -48,7 +48,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     }
 
     /* istanbul ignore if */
-    if (typeof document === 'undefined') {
+    if (typeof document === 'undefined' || !document.body) {
       return;
     }
 

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -284,9 +284,7 @@ describe('browser-client', () => {
         ...BASE_CAMPAIGN,
         utm_source: 'amp-test',
       });
-      // const destinationExecute = jest.spyOn(Destination.prototype, 'execute');
       const setSessionId = jest.spyOn(client, 'setSessionId');
-      // client.remove('amplitude');
       const testDestination: DestinationPlugin = {
         name: 'test-destination',
         type: 'destination',

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -314,7 +314,7 @@ describe('browser-client', () => {
 
       expect(webAttributionPluginPlugin).toHaveBeenCalledTimes(1);
       expect(setSessionId).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenCalledTimes(2);
       expect(track.mock.calls[0][0]).toBe('session_start');
 
       await client.flush().promise;

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -278,15 +278,6 @@ describe('browser-client', () => {
         lastEventTime: Date.now() - 1000,
       });
       const webAttributionPluginPlugin = jest.spyOn(webAttributionPlugin, 'webAttributionPlugin');
-      jest.spyOn(client, 'dispatch').mockReturnValueOnce(
-        Promise.resolve({
-          code: 200,
-          message: '',
-          event: {
-            event_type: 'event_type',
-          },
-        }),
-      );
       const track = jest.spyOn(client, 'track');
       jest.spyOn(helpers, 'isNewCampaign').mockReturnValue(true);
       jest.spyOn(CampaignParser.prototype, 'parse').mockResolvedValueOnce({
@@ -300,7 +291,6 @@ describe('browser-client', () => {
         name: 'test-destination',
         type: 'destination',
         execute(event: Event): Promise<Result> {
-          console.log(`EVENT`, event); // eslint-disable-line no-console
           return Promise.resolve({
             code: 200,
             message: '',
@@ -326,20 +316,16 @@ describe('browser-client', () => {
 
       expect(webAttributionPluginPlugin).toHaveBeenCalledTimes(1);
       expect(setSessionId).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledTimes(2);
-      // expect(track.mock.calls[0][0]).toBe('session_end');
+      expect(track).toHaveBeenCalledTimes(1);
       expect(track.mock.calls[0][0]).toBe('session_start');
-      expect(track.mock.calls[1][0]).toEqual(campaignEventWithUtmSource);
+
       await client.flush().promise;
 
       expect(testDestinationExecute).toHaveBeenCalledTimes(1);
-
-      expect(testDestinationExecute.mock.calls[0][0]).toEqual({
-        ...campaignEventWithUtmSource,
-        // TODO: Fix this, we should only get one `session_start` event
-        // event_type: 'session_start',
-      });
-      // expect(destinationExecute.mock.calls[0][0]).toEqual(campaignEventWithUtmSource);
+      expect(testDestinationExecute.mock.calls[0][0].event_type).toEqual('session_start');
+      expect(testDestinationExecute.mock.calls[0][0].user_properties).toEqual(
+        campaignEventWithUtmSource.user_properties,
+      );
     });
   });
 

--- a/packages/analytics-client-common/src/attribution/campaign-helper.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-helper.ts
@@ -1,0 +1,13 @@
+import { Event, IdentifyOperation, IdentifyUserProperties } from '@amplitude/analytics-types';
+import { BASE_CAMPAIGN } from './constants';
+
+export const isCampaignEvent = (event: Event) => {
+  if (event.user_properties) {
+    const properties = event.user_properties as IdentifyUserProperties;
+    const $set = properties[IdentifyOperation.SET] || {};
+    const $unset = properties[IdentifyOperation.UNSET] || {};
+    const userProperties = [...Object.keys($set), ...Object.keys($unset)];
+    return Object.keys(BASE_CAMPAIGN).every((value) => userProperties.includes(value));
+  }
+  return false;
+};

--- a/packages/analytics-client-common/src/index.ts
+++ b/packages/analytics-client-common/src/index.ts
@@ -1,7 +1,7 @@
 export { CampaignParser } from './attribution/campaign-parser';
 export { CampaignTracker } from './attribution/campaign-tracker';
 export { getQueryParams } from './query-params';
-export { isNewSession } from './session';
+export { isNewSession, isSessionExpired } from './session';
 export { getCookieName, getOldCookieName } from './cookie-name';
 export { CookieStorage } from './storage/cookie';
 export { FetchTransport } from './transports/fetch';
@@ -19,3 +19,4 @@ export {
   isPageViewTrackingEnabled,
   isSessionTrackingEnabled,
 } from './default-tracking';
+export { isCampaignEvent } from './attribution/campaign-helper';

--- a/packages/analytics-client-common/src/session.ts
+++ b/packages/analytics-client-common/src/session.ts
@@ -1,4 +1,10 @@
-export const isNewSession = (sessionTimeout: number, lastEventTime: number = Date.now()): boolean => {
+/**
+ * @deprecated Function name is misleading. Use `isSessionExpired`.
+ */
+export const isNewSession = (sessionTimeout: number, lastEventTime: number = Date.now()): boolean =>
+  isSessionExpired(sessionTimeout, lastEventTime);
+
+export const isSessionExpired = (sessionTimeout: number, lastEventTime: number = Date.now()): boolean => {
   const currentTime = Date.now();
   const timeSinceLastEvent = currentTime - lastEventTime;
 

--- a/packages/analytics-client-common/test/attribution/campaign-helper.test.ts
+++ b/packages/analytics-client-common/test/attribution/campaign-helper.test.ts
@@ -1,0 +1,38 @@
+import { Identify } from '@amplitude/analytics-core';
+import { isCampaignEvent } from '../../src/attribution/campaign-helper';
+import { BASE_CAMPAIGN } from '../../src/attribution/constants';
+
+describe('isCampaignEvent', () => {
+  test('should return false with undefined user props', () => {
+    expect(
+      isCampaignEvent({
+        event_type: 'event_type',
+      }),
+    ).toBe(false);
+  });
+
+  test('should return false with empty user props', () => {
+    expect(
+      isCampaignEvent({
+        event_type: 'event_type',
+        user_properties: {},
+      }),
+    ).toBe(false);
+  });
+
+  test('should return true', () => {
+    const identifyEvent = Object.entries(BASE_CAMPAIGN).reduce((identify, [key, value]) => {
+      if (value) {
+        return identify.set(key, value);
+      }
+      return identify.unset(key);
+    }, new Identify());
+
+    expect(
+      isCampaignEvent({
+        event_type: 'event_type',
+        user_properties: identifyEvent.getUserProperties(),
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/analytics-client-common/test/session.test.ts
+++ b/packages/analytics-client-common/test/session.test.ts
@@ -1,8 +1,8 @@
-import { isNewSession } from '../src/session';
+import { isNewSession, isSessionExpired } from '../src/session';
+
+const sessionTimeout: number = 30 * 60 * 1000;
 
 describe('session', () => {
-  const sessionTimeout: number = 30 * 60 * 1000;
-
   test('should be in a same session for undefined lastEventTime', () => {
     const isEventInNewSession = isNewSession(sessionTimeout, undefined);
 
@@ -22,4 +22,24 @@ describe('session', () => {
 
     expect(isEventInNewSession).toBe(false);
   });
+});
+
+test('should be in a same session for undefined lastEventTime', () => {
+  const isEventInNewSession = isSessionExpired(sessionTimeout, undefined);
+
+  expect(isEventInNewSession).toBe(false);
+});
+
+test('should be a new session', () => {
+  const lastEventTime = Date.now() - sessionTimeout * 2;
+  const isEventInNewSession = isSessionExpired(sessionTimeout, lastEventTime);
+
+  expect(isEventInNewSession).toBe(true);
+});
+
+test('should be in a same session', () => {
+  const lastEventTime = Date.now();
+  const isEventInNewSession = isSessionExpired(sessionTimeout, lastEventTime);
+
+  expect(isEventInNewSession).toBe(false);
 });

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -84,7 +84,7 @@ export class Timeline {
       }
       const e = await plugin.execute({ ...event });
       if (e === null) {
-        resolve({ event, code: 0, message: '' });
+        resolve({ event, code: 100, message: `Event was dropped by a plugin` });
         return;
       } else {
         event = e;
@@ -103,7 +103,7 @@ export class Timeline {
       }
       const e = await plugin.execute({ ...event });
       if (e === null) {
-        resolve({ event, code: 0, message: '' });
+        resolve({ event, code: 100, message: `Event was dropped by a plugin` });
         return;
       } else {
         event = e;

--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -1,14 +1,5 @@
-import { CampaignParser, getGlobalScope } from '@amplitude/analytics-client-common';
-import {
-  BrowserClient,
-  BrowserConfig,
-  EnrichmentPlugin,
-  Event,
-  IdentifyOperation,
-  IdentifyUserProperties,
-  Logger,
-} from '@amplitude/analytics-types';
-import { BASE_CAMPAIGN } from '@amplitude/analytics-client-common';
+import { CampaignParser, getGlobalScope, isCampaignEvent } from '@amplitude/analytics-client-common';
+import { BrowserClient, BrowserConfig, EnrichmentPlugin, Event, Logger } from '@amplitude/analytics-types';
 import { CreatePageViewTrackingPlugin, Options } from './typings/page-view-tracking';
 import { omitUndefined } from './utils';
 
@@ -103,14 +94,22 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
 
     execute: async (event: Event) => {
       if (options.trackOn === 'attribution' && isCampaignEvent(event)) {
-        /* istanbul ignore next */ // loggerProvider should be defined by the time execute is invoked
-        loggerProvider?.log('Enriching campaign event to page view event with campaign parameters');
         const pageViewEvent = await createPageViewEvent();
-        event.event_type = pageViewEvent.event_type;
-        event.event_properties = {
-          ...event.event_properties,
-          ...pageViewEvent.event_properties,
-        };
+
+        if (event.event_type === '$identify') {
+          /* istanbul ignore next */ // loggerProvider should be defined by the time execute is invoked
+          loggerProvider?.log('Enriching campaign event to page view event with campaign parameters');
+          event.event_type = pageViewEvent.event_type;
+          event.event_properties = {
+            ...event.event_properties,
+            ...pageViewEvent.event_properties,
+          };
+        } else {
+          /* istanbul ignore else */
+          if (amplitude) {
+            amplitude.track(pageViewEvent);
+          }
+        }
       }
       return event;
     },
@@ -128,17 +127,6 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
 };
 
 const getCampaignParams = async () => omitUndefined(await new CampaignParser().parse());
-
-const isCampaignEvent = (event: Event) => {
-  if (event.event_type === '$identify' && event.user_properties) {
-    const properties = event.user_properties as IdentifyUserProperties;
-    const $set = properties[IdentifyOperation.SET] || {};
-    const $unset = properties[IdentifyOperation.UNSET] || {};
-    const userProperties = [...Object.keys($set), ...Object.keys($unset)];
-    return Object.keys(BASE_CAMPAIGN).every((value) => userProperties.includes(value));
-  }
-  return false;
-};
 
 export const shouldTrackHistoryPageView = (
   trackingOption: Options['trackHistoryChanges'],

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -256,6 +256,16 @@ describe('pageViewTrackingPlugin', () => {
       });
       expect(event?.event_type).toBe('session_start');
       expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenNthCalledWith(1, {
+        event_type: '[Amplitude] Page Viewed',
+        event_properties: {
+          '[Amplitude] Page Domain': '',
+          '[Amplitude] Page Location': '',
+          '[Amplitude] Page Path': '',
+          '[Amplitude] Page Title': '',
+          '[Amplitude] Page URL': '',
+        },
+      });
     });
 
     test('should enrich page view track on attribution user props', async () => {

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -197,7 +197,68 @@ describe('pageViewTrackingPlugin', () => {
   });
 
   describe('execute', () => {
-    test('should track page view on attribution', async () => {
+    test('should track a separate page view event on attribution', async () => {
+      const plugin = pageViewTrackingPlugin({
+        trackOn: 'attribution',
+      });
+      const amplitude = createInstance();
+      const track = jest.spyOn(amplitude, 'track');
+      await plugin.setup?.(mockConfig, amplitude);
+
+      const event = await plugin.execute?.({
+        event_type: 'session_start',
+        user_properties: {
+          $set: {
+            utm_source: 'amp-test',
+          },
+          $setOnce: {
+            initial_dclid: 'EMPTY',
+            initial_fbclid: 'EMPTY',
+            initial_gbraid: 'EMPTY',
+            initial_gclid: 'EMPTY',
+            initial_ko_click_id: 'EMPTY',
+            initial_li_fat_id: 'EMPTY',
+            initial_msclkid: 'EMPTY',
+            initial_wbraid: 'EMPTY',
+            initial_referrer: 'EMPTY',
+            initial_referring_domain: 'EMPTY',
+            initial_rtd_cid: 'EMPTY',
+            initial_ttclid: 'EMPTY',
+            initial_twclid: 'EMPTY',
+            initial_utm_campaign: 'EMPTY',
+            initial_utm_content: 'EMPTY',
+            initial_utm_id: 'EMPTY',
+            initial_utm_medium: 'EMPTY',
+            initial_utm_source: 'amp-test',
+            initial_utm_term: 'EMPTY',
+          },
+          $unset: {
+            dclid: '-',
+            fbclid: '-',
+            gbraid: '-',
+            gclid: '-',
+            ko_click_id: '-',
+            li_fat_id: '-',
+            msclkid: '-',
+            wbraid: '-',
+            referrer: '-',
+            referring_domain: '-',
+            rtd_cid: '-',
+            ttclid: '-',
+            twclid: '-',
+            utm_campaign: '-',
+            utm_content: '-',
+            utm_id: '-',
+            utm_medium: '-',
+            utm_term: '-',
+          },
+        },
+      });
+      expect(event?.event_type).toBe('session_start');
+      expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    test('should enrich page view track on attribution user props', async () => {
       const plugin = pageViewTrackingPlugin({
         trackOn: 'attribution',
       });

--- a/packages/plugin-web-attribution-browser/src/typings/web-attribution.ts
+++ b/packages/plugin-web-attribution-browser/src/typings/web-attribution.ts
@@ -1,5 +1,7 @@
 import { BeforePlugin } from '@amplitude/analytics-types';
 
+export const DEFAULT_SESSION_START_EVENT = 'session_start';
+
 export interface Options {
   excludeReferrers?: (string | RegExp)[];
   initialEmptyValue?: string;

--- a/packages/plugin-web-attribution-browser/src/typings/web-attribution.ts
+++ b/packages/plugin-web-attribution-browser/src/typings/web-attribution.ts
@@ -1,7 +1,5 @@
 import { BeforePlugin } from '@amplitude/analytics-types';
 
-export const DEFAULT_SESSION_START_EVENT = 'session_start';
-
 export interface Options {
   excludeReferrers?: (string | RegExp)[];
   initialEmptyValue?: string;

--- a/packages/plugin-web-attribution-browser/src/web-attribution.ts
+++ b/packages/plugin-web-attribution-browser/src/web-attribution.ts
@@ -63,6 +63,7 @@ export const webAttributionPlugin: CreateWebAttributionPlugin = function (option
     },
 
     execute: async (event: Event) => {
+      /* istanbul ignore next */
       if (isSessionStartEvent(event) && event?.session_id) {
         const campaignEvent = campaignPerSession[event.session_id];
         if (campaignEvent) {

--- a/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
+++ b/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
@@ -91,15 +91,6 @@ describe('webAttributionPlugin', () => {
       test('when a campaign changes', async () => {
         const amplitude = createInstance();
         const setSessionId = jest.spyOn(amplitude, 'setSessionId');
-        // const track = jest.spyOn(amplitude, 'track').mockReturnValueOnce({
-        //   promise: Promise.resolve({
-        //     code: 200,
-        //     message: '',
-        //     event: {
-        //       event_type: '$identify',
-        //     },
-        //   }),
-        // });
         jest.spyOn(helpers, 'isNewCampaign').mockReturnValue(true);
         jest.spyOn(CampaignParser.prototype, 'parse').mockResolvedValueOnce({
           ...BASE_CAMPAIGN,

--- a/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
+++ b/packages/plugin-web-attribution-browser/test/web-attribution.test.ts
@@ -186,7 +186,7 @@ describe('webAttributionPlugin', () => {
         await plugin.setup?.(overrideMockConfig, amplitude);
 
         expect(setSessionId).toHaveBeenCalledTimes(1);
-        expect(track).toHaveBeenCalledTimes(0);
+        expect(track).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -266,7 +266,7 @@ describe('webAttributionPlugin', () => {
       expect(result).toBe(event);
     });
 
-    test('should hydrate session_start event', async () => {
+    test('should enrich session_start event', async () => {
       const amplitude = createInstance();
       jest.spyOn(Date, 'now').mockReturnValue(Date.now());
       const sessionId = Date.now();
@@ -295,9 +295,16 @@ describe('webAttributionPlugin', () => {
       expect(result).toBe(event);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(result?.user_properties?.['$set']?.['utm_source']).toBe('amp-test');
+
+      const duplicateCampaignEvent = {
+        ...helpers.createCampaignEvent(BASE_CAMPAIGN, {}),
+        session_id: sessionId,
+      };
+      const duplicateResult = await plugin.execute?.(duplicateCampaignEvent);
+      expect(duplicateResult).toBe(null);
     });
 
-    test('should not hydrate session_start event if session_id is not present', async () => {
+    test('should not enrich session_start event if session_id is not present', async () => {
       const amplitude = createInstance();
       jest.spyOn(Date, 'now').mockReturnValue(Date.now());
       const sessionId = Date.now();


### PR DESCRIPTION
[AMP-85242](https://amplitude.atlassian.net/browse/AMP-85242)

### Summary
* update attribution plugin to apply utm params to the `session_start` event

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


[AMP-85242]: https://amplitude.atlassian.net/browse/AMP-85242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ