### PR TITLE
feat: integrate with selector

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
@@ -18,3 +18,7 @@ export const AMPLITUDE_EVENT_PROP_PAGE_URL = '[Amplitude] Page URL';
 export const AMPLITUDE_EVENT_PROP_PAGE_TITLE = '[Amplitude] Page Title';
 export const AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT = '[Amplitude] Viewport Height';
 export const AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH = '[Amplitude] Viewport Width';
+
+export const AMPLITUDE_ORIGIN = 'https://app.amplitude.com';
+export const AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL =
+  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.0.0.js.gz';

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -11,6 +11,7 @@ import {
   getClosestElement,
 } from './helpers';
 import { finder } from './libs/finder';
+import { IMessenger, WindowMessenger } from './libs/messenger';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 type ActionType = 'click' | 'change';
@@ -63,6 +64,11 @@ interface Options {
    * Default is 'data-amp-auto-track-'.
    */
   dataAttributePrefix?: string;
+
+  visualTaggingOptions?: {
+    enabled?: boolean;
+    messenger?: IMessenger;
+  };
 }
 
 export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): BrowserEnrichmentPlugin => {
@@ -71,6 +77,10 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     pageUrlAllowlist,
     shouldTrackEventResolver,
     dataAttributePrefix = DEFAULT_DATA_ATTRIBUTE_PREFIX,
+    visualTaggingOptions = {
+      enabled: true,
+      messenger: new WindowMessenger(),
+    },
   } = options;
   const name = constants.PLUGIN_NAME;
   const type = 'enrichment';
@@ -249,6 +259,12 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     }
     /* istanbul ignore next */
     config?.loggerProvider?.log(`${name} has been successfully added.`);
+
+    // Setup visual tagging selector
+    if (window.opener && visualTaggingOptions.enabled) {
+      /* istanbul ignore next */
+      visualTaggingOptions.messenger?.setup();
+    }
   };
 
   const execute: BrowserEnrichmentPlugin['execute'] = async (event) => {

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -11,7 +11,7 @@ import {
   getClosestElement,
 } from './helpers';
 import { finder } from './libs/finder';
-import { IMessenger, WindowMessenger } from './libs/messenger';
+import { Messenger, WindowMessenger } from './libs/messenger';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 type ActionType = 'click' | 'change';
@@ -67,7 +67,7 @@ interface Options {
 
   visualTaggingOptions?: {
     enabled?: boolean;
-    messenger?: IMessenger;
+    messenger?: Messenger;
   };
 }
 

--- a/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
@@ -140,21 +140,25 @@ export const getClosestElement = (element: Element | null, selectors: string[]):
 export const asyncLoadScript = (url: string) => {
   return new Promise((resolve, reject) => {
     try {
-      const scriptEle = document.createElement('script');
-      scriptEle.type = 'text/javascript';
-      scriptEle.async = true;
-      scriptEle.src = url;
-      scriptEle.addEventListener('load', () => {
-        resolve({ status: true });
-      });
-      scriptEle.addEventListener('error', () => {
+      const scriptElement = document.createElement('script');
+      scriptElement.type = 'text/javascript';
+      scriptElement.async = true;
+      scriptElement.src = url;
+      scriptElement.addEventListener(
+        'load',
+        () => {
+          resolve({ status: true });
+        },
+        { once: true },
+      );
+      scriptElement.addEventListener('error', () => {
         reject({
           status: false,
           message: `Failed to load the script ${url}`,
         });
       });
       /* istanbul ignore next */
-      document.head?.appendChild(scriptEle);
+      document.head?.appendChild(scriptElement);
     } catch (error) {
       /* istanbul ignore next */
       reject(error);

--- a/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
@@ -136,3 +136,28 @@ export const getClosestElement = (element: Element | null, selectors: string[]):
   /* istanbul ignore next */
   return getClosestElement(element?.parentElement, selectors);
 };
+
+export const asyncLoadScript = (url: string) => {
+  return new Promise((resolve, reject) => {
+    try {
+      const scriptEle = document.createElement('script');
+      scriptEle.type = 'text/javascript';
+      scriptEle.async = true;
+      scriptEle.src = url;
+      scriptEle.addEventListener('load', () => {
+        resolve({ status: true });
+      });
+      scriptEle.addEventListener('error', () => {
+        reject({
+          status: false,
+          message: `Failed to load the script ${url}`,
+        });
+      });
+      /* istanbul ignore next */
+      document.head?.appendChild(scriptEle);
+    } catch (error) {
+      /* istanbul ignore next */
+      reject(error);
+    }
+  });
+};

--- a/packages/plugin-default-event-tracking-advanced-browser/src/libs/messenger.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/libs/messenger.ts
@@ -1,0 +1,71 @@
+/* istanbul ignore file */
+/* eslint-disable no-restricted-globals */
+import { AMPLITUDE_ORIGIN, AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL } from '../constants';
+import { asyncLoadScript } from '../helpers';
+import { Logger } from '@amplitude/analytics-types';
+
+export interface IMessenger {
+  logger?: Logger;
+  setup: () => void;
+}
+
+interface Data {
+  [key: string]: any;
+}
+
+interface Message {
+  action: string;
+  data?: Data;
+}
+
+export class WindowMessenger implements IMessenger {
+  endpoint = AMPLITUDE_ORIGIN;
+  logger?: Logger;
+
+  constructor({ logger }: { logger?: Logger } = {}) {
+    this.logger = logger;
+  }
+
+  private notify(message: Message) {
+    this.logger?.debug('Message sent: ', message);
+    (window.opener as WindowProxy)?.postMessage?.(message, this.endpoint);
+  }
+
+  setup() {
+    this.notify({ action: 'page-loaded' });
+    let amplitudeVisualTaggingSelectorInstance: any = null;
+    window.addEventListener('message', (event) => {
+      this.logger?.debug('Message received: ', event);
+      if (this.endpoint !== event.origin) {
+        return;
+      }
+      const eventData = event?.data as Message;
+      const action = eventData?.action;
+      if (!action) {
+        return;
+      }
+      if (action === 'ping') {
+        this.notify({ action: 'pong' });
+      } else if (action === 'initialize-visual-tagging-selector') {
+        asyncLoadScript(AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL)
+          .then(() => {
+            // eslint-disable-next-line
+            amplitudeVisualTaggingSelectorInstance = (window as any)?.amplitudeVisualTaggingSelector?.({
+              onSelect: this.onSelect,
+            });
+            this.notify({ action: 'selector-loaded' });
+          })
+          .catch(() => {
+            this.logger?.warn('Failed to initialize visual tagging selector');
+          });
+      } else if (action === 'close-visual-tagging-selector') {
+        // eslint-disable-next-line
+        amplitudeVisualTaggingSelectorInstance?.close?.();
+      }
+    });
+  }
+
+  private onSelect = (data: Data) => {
+    this.notify({ action: 'element-selected', data });
+  };
+}

--- a/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
@@ -87,6 +87,30 @@ describe('autoTrackingPlugin', () => {
         } plugin requires a later version of @amplitude/analytics-browser. Events are not tracked.`,
       );
     });
+
+    test('should setup visual tagging selector', async () => {
+      window.opener = true;
+      const messengerMock = {
+        setup: jest.fn(),
+      };
+      plugin = defaultEventTrackingAdvancedPlugin({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        visualTaggingOptions: { enabled: true, messenger: messengerMock as any },
+      });
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      const amplitude: Partial<BrowserClient> = {};
+      await plugin?.setup?.(config as BrowserConfig, amplitude as BrowserClient);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect((messengerMock as any).setup).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('execute', () => {

--- a/packages/plugin-default-event-tracking-advanced-browser/test/helpers.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   getNearestLabel,
   querySelectUniqueElements,
   getClosestElement,
+  asyncLoadScript,
 } from '../src/helpers';
 
 describe('default-event-tracking-advanced-plugin helpers', () => {
@@ -391,6 +392,36 @@ describe('default-event-tracking-advanced-plugin helpers', () => {
 
       const inner = document.getElementById('inner');
       expect(getClosestElement(inner, ['div.some-class'])).toEqual(null);
+    });
+  });
+
+  describe('asyncLoadScript', () => {
+    test('should append the script to document and resolve with status true', () => {
+      void asyncLoadScript('https://test-url.amplitude/').then((result) => {
+        expect(result).toEqual({ status: true });
+      });
+      const script = document.getElementsByTagName('script')[0];
+      expect(document.getElementsByTagName('script')[0].src).toEqual('https://test-url.amplitude/');
+
+      script.dispatchEvent(new Event('load'));
+    });
+
+    test('should reject with status false when error', () => {
+      void asyncLoadScript('https://test-url.amplitude/').then(
+        () => {
+          expect('should not be called').toEqual(true);
+        },
+        (result) => {
+          expect(result).toEqual({
+            status: false,
+            message: 'Failed to load the script https://test-url.amplitude/',
+          });
+        },
+      );
+      const script = document.getElementsByTagName('script')[0];
+      expect(document.getElementsByTagName('script')[0].src).toEqual('https://test-url.amplitude/');
+
+      script.dispatchEvent(new Event('error'));
     });
   });
 });


### PR DESCRIPTION
### Summary
feat: integrate with selector

- Add the lazy loading of visual tagging selector UI when enabled
- Implement a messenger to sync to the opener, treating the selector UI as a tool to only get the selected element

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
