### PR TITLE
ci: prerelease feature branch

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -1,0 +1,105 @@
+name: Prerelease feature branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      featureBranch:
+        type: string
+        description: Feature branch name
+        required: true
+      dryRun:
+        type: boolean
+        description: Dry run without actual release
+        required: true
+        default: true
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.actor }} permission check to do a release
+        uses: 'lannonbr/repo-permission-check-action@2.0.2'
+        with:
+          permission: 'write'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [authorize]
+    permissions:
+      id-token: write
+      contents: write
+    env:
+      FEATURE_BRANCH: ${{ github.event.inputs.featureBranch }}
+      DRY_RUN: ${{ github.event.inputs.dryRun }}
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.FEATURE_BRANCH }}
+          fetch-depth: 0
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install project dependencies
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: Build all packages
+        run: |
+          yarn build
+
+      - name: Test all packages
+        run: |
+          yarn test
+
+      - name: Lint all packages
+        run: |
+          yarn lint
+
+      - name: Configure Git User
+        run: |
+          git config --global user.name amplitude-sdk-bot
+          git config --global user.email amplitude-sdk-bot@users.noreply.github.com
+
+      - name: Configure NPM User
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > ~/.npmrc
+          npm whoami
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
+          aws-region: us-west-2
+
+      # converted to all lowercase and stripped of non-letter characters
+      - name: Transform feature branch name
+        run: |
+          echo "BRANCH_NAME=$(echo '${{ env.FEATURE_BRANCH }}' | tr -cd '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Dry run pre-release version
+        if: ${{ env.DRY_RUN == true}}
+        run: |
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --no-push --preid ${{ env.BRANCH_NAME}}
+
+      - name: Pre-release version
+        if: ${{ env.DRY_RUN == false }}
+        run: |
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --preid ${{ env.BRANCH_NAME}}

--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ env.DRY_RUN == true}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --no-push --preid ${{ env.BRANCH_NAME}}
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --no-push --preid ${{ env.BRANCH_NAME}} --allow-branch ${{ env.FEATURE_BRANCH}}} --no-changelog
 
       - name: Pre-release version
         if: ${{ env.DRY_RUN == false }}

--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -98,12 +98,12 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ env.DRY_RUN == true}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --no-push --preid ${{ env.BRANCH_NAME}} --allow-branch ${{ env.FEATURE_BRANCH}}} --no-changelog
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --no-push --preid ${{ env.BRANCH_NAME}} --allow-branch ${{ env.FEATURE_BRANCH}}} --no-changelog
 
       - name: Pre-release version
         if: ${{ env.DRY_RUN == false }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --preid ${{ env.BRANCH_NAME}} --create-release github
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --preid ${{ env.BRANCH_NAME}} --create-release github
     
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM

--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -89,11 +89,12 @@ jobs:
           role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
           aws-region: us-west-2
 
-      # converted to all lowercase and stripped of non-letter characters
+      # Converted to all lowercase and stripped of non-letter characters
       - name: Transform feature branch name
         run: |
           echo "BRANCH_NAME=$(echo '${{ env.FEATURE_BRANCH }}' | tr -cd '[:lower:]')" >> $GITHUB_ENV
 
+     # Use --no-push to prevent pushing to remote
       - name: Dry run pre-release version
         if: ${{ env.DRY_RUN == true}}
         run: |
@@ -103,3 +104,11 @@ jobs:
         if: ${{ env.DRY_RUN == false }}
         run: |
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --preid ${{ env.BRANCH_NAME}}
+    
+      # Use 'from git' option if `lerna version` has already been run
+      - name: Publish Release to NPM
+        if: ${{ env.DRY_RUN == false }}
+        run: |
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y
+        env:
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           echo "PREID=$(echo '${{ steps.branch-name.outputs.current_branch }}' | tr -cd '[:lower:]')" >> $GITHUB_ENV
 
-     # Use --no-push to prevent pushing to remote
+      # Use --no-push to prevent pushing to remote
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.dryRun == true}}
         run: |
@@ -101,7 +101,7 @@ jobs:
         if: ${{ github.event.inputs.dryRun == false }}
         run: |
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.branch-name.outputs.current_branch }} --create-release github
-    
+
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM
         if: ${{ github.event.inputs.dryRun == false }}

--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -3,13 +3,9 @@ name: Prerelease feature branch
 on:
   workflow_dispatch:
     inputs:
-      featureBranch:
-        type: string
-        description: Feature branch name
-        required: true
       dryRun:
         type: boolean
-        description: Dry run without actual release
+        description: Select true to dry run without actual release
         required: true
         default: true
 
@@ -32,18 +28,19 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      FEATURE_BRANCH: ${{ github.event.inputs.featureBranch }}
-      DRY_RUN: ${{ github.event.inputs.dryRun }}
     strategy:
       matrix:
         node-version: [16.x]
 
     steps:
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-name@v7
+
       - name: Check out git repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.FEATURE_BRANCH }}
+          ref: ${{ steps.branch-name.outputs.ref_branch }}
           fetch-depth: 0
 
       - name: Cache dependencies
@@ -92,22 +89,22 @@ jobs:
       # Converted to all lowercase and stripped of non-letter characters
       - name: Transform feature branch name
         run: |
-          echo "BRANCH_NAME=$(echo '${{ env.FEATURE_BRANCH }}' | tr -cd '[:lower:]')" >> $GITHUB_ENV
+          echo "PREID=$(echo '${{ steps.branch-name.outputs.current_branch }}' | tr -cd '[:lower:]')" >> $GITHUB_ENV
 
      # Use --no-push to prevent pushing to remote
       - name: Dry run pre-release version
-        if: ${{ env.DRY_RUN == true}}
+        if: ${{ github.event.inputs.dryRun == true}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --no-push --preid ${{ env.BRANCH_NAME}} --allow-branch ${{ env.FEATURE_BRANCH}}} --no-changelog
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.branch-name.outputs.current_branch }} --no-changelog --no-push
 
       - name: Pre-release version
-        if: ${{ env.DRY_RUN == false }}
+        if: ${{ github.event.inputs.dryRun == false }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --preid ${{ env.BRANCH_NAME}} --create-release github
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.branch-name.outputs.current_branch }} --create-release github
     
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM
-        if: ${{ env.DRY_RUN == false }}
+        if: ${{ github.event.inputs.dryRun == false }}
         run: |
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y
         env:

--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Pre-release version
         if: ${{ env.DRY_RUN == false }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --preid ${{ env.BRANCH_NAME}}
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prereleas --preid ${{ env.BRANCH_NAME}} --create-release github
     
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM

--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -93,21 +93,21 @@ jobs:
       - name: Create pre-release version
         if: ${{ env.RELEASE_TYPE == 'prerelease'}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --conventional-prerelease
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --conventional-prerelease --create-release github
 
       # https://www.npmjs.com/package/@lerna/version#--conventional-graduate
       # 1.0.0-alpha.0 -> 1.0.1
       - name: Create graduate version
         if: ${{ env.RELEASE_TYPE == 'graduate'}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --conventional-graduate
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --conventional-graduate --create-release github
 
       # Use 'release' for the usual deployment
       # NOTE: You probably want this
       - name: Create release version
         if: ${{ env.RELEASE_TYPE == 'release'}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --create-release github
 
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -92,21 +92,21 @@ jobs:
       - name: Create pre-release version
         if: ${{ env.RELEASE_TYPE == 'prerelease'}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-prerelease --create-release github
 
       # https://www.npmjs.com/package/@lerna/version#--conventional-graduate
       # 1.0.0-alpha.0 -> 1.0.1
       - name: Create graduate version
         if: ${{ env.RELEASE_TYPE == 'graduate'}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-graduate
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --conventional-graduate --create-release github
 
       # Use 'release' for the usual deployment
       # NOTE: You probably want this
       - name: Create release version
         if: ${{ env.RELEASE_TYPE == 'release'}}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --create-release github
 
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Release to NPM

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,6 @@
   "useWorkspaces": true,
   "command": {
     "version": {
-      "allowBranch": "main",
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): publish",

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,6 @@
     "version": {
       "allowBranch": "main",
       "conventionalCommits": true,
-      "createRelease": "github",
       "message": "chore(release): publish",
       "preid": "beta"
     }

--- a/lerna.json
+++ b/lerna.json
@@ -7,6 +7,7 @@
   "useWorkspaces": true,
   "command": {
     "version": {
+      "allowBranch": "main",
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): publish",


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/browse/AMP-88911
Add a Github actions workflow to prerelease from a feature branch
- Can run a dry run without pushing to remote repo 
- Must input the branch name. It is then used when checkout and used as the preid

Example:
If current version is `@amplitude/analytics-browser: 2.2.1`, the feature branch is `feat-sdk-diagnostics`, it will prerelease to ` 2.3.0-featsdkdiagnostics.0`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
