### PR TITLE
fix: npm latest tags

### DIFF
--- a/packages/analytics-client-common/src/attribution/campaign-tracker.ts
+++ b/packages/analytics-client-common/src/attribution/campaign-tracker.ts
@@ -15,8 +15,8 @@ import { BASE_CAMPAIGN, EMPTY_VALUE, MKTG } from './constants';
 /**
  * @deprecated
  * Campaign tracker has mixed logic from built-in and plugin web attribution
- * features. Do not add more features here. The plan moving foward is to consolidate logic
- * in @amplitude/plugin-web-attribution-browser with backward compatibility.
+ * features. Do not add more features here. The plan moving foward is to consolidate
+ * logic in @amplitude/plugin-web-attribution-browser with backward compatibility.
  */
 export class CampaignTracker implements ICampaignTracker {
   storage: Storage<Campaign>;

--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -7,4 +7,4 @@
 
 # @amplitude/analytics-core
 
-> Internal Node package for Amplitude
+Internal Node package for Amplitude

--- a/packages/analytics-types/README.md
+++ b/packages/analytics-types/README.md
@@ -1,1 +1,3 @@
 # @amplitude/analytics-types
+
+Shared types used for Ampilitude Analytics Typescript packages


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR is to set the npm latest tag to the correct versions for 
- @amplitude/analytics-client-common
- @amplitude/analytics-core
- @amplitude/analytics-types

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
