### PR TITLE
feat: update browser sr plugin to allow explicit flushing

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,5 +1,6 @@
 import { BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-types';
 import * as sessionReplay from '@amplitude/session-replay-browser';
+import { AmplitudeSessionReplay } from '@amplitude/session-replay-browser';
 import { DEFAULT_SESSION_START_EVENT } from './constants';
 import { SessionReplayOptions } from './typings/session-replay';
 export class SessionReplayPlugin implements EnrichmentPlugin {
@@ -13,6 +14,11 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
 
   constructor(options?: SessionReplayOptions) {
     this.options = { ...options };
+  }
+
+  get sessionReplay(): AmplitudeSessionReplay {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return sessionReplay as AmplitudeSessionReplay;
   }
 
   async setup(config: BrowserConfig) {

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -64,6 +64,15 @@ describe('SessionReplayPlugin', () => {
       expect(sessionReplay.config.flushIntervalMillis).toBe(0);
     });
 
+    test('should expose underlying sessionReplay object', async () => {
+      const sessionReplay = new SessionReplayPlugin();
+      await sessionReplay.setup(mockConfig);
+      expect(sessionReplay.sessionReplay.getSessionReplayProperties).toBeDefined();
+      expect(sessionReplay.sessionReplay.setSessionId).toBeDefined();
+      expect(sessionReplay.sessionReplay.shutdown).toBeDefined();
+      expect(sessionReplay.sessionReplay.flush).toBeDefined();
+    });
+
     describe('defaultTracking', () => {
       test('should not change defaultTracking if its set to true', async () => {
         const sessionReplay = new SessionReplayPlugin();

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -67,6 +67,7 @@ describe('SessionReplayPlugin', () => {
     test('should expose underlying sessionReplay object', async () => {
       const sessionReplay = new SessionReplayPlugin();
       await sessionReplay.setup(mockConfig);
+      expect(sessionReplay.sessionReplay.init).toBeDefined();
       expect(sessionReplay.sessionReplay.getSessionReplayProperties).toBeDefined();
       expect(sessionReplay.sessionReplay.setSessionId).toBeDefined();
       expect(sessionReplay.sessionReplay.shutdown).toBeDefined();

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,2 +1,3 @@
 import sessionReplay from './session-replay-factory';
-export const { init, setSessionId, getSessionReplayProperties, shutdown } = sessionReplay;
+export const { init, setSessionId, getSessionReplayProperties, shutdown, flush } = sessionReplay;
+export { AmplitudeSessionReplay } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -27,7 +27,7 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       'getSessionReplayProperties',
       getLogConfig(sessionReplay),
     ),
-    shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'teardown', getLogConfig(sessionReplay)),
+    shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'shutdown', getLogConfig(sessionReplay)),
   };
 };
 

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -28,6 +28,7 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       getLogConfig(sessionReplay),
     ),
     shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'shutdown', getLogConfig(sessionReplay)),
+    flush: debugWrapper(sessionReplay.flush.bind(sessionReplay), 'flush', getLogConfig(sessionReplay)),
   };
 };
 

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -49,4 +49,5 @@ export interface AmplitudeSessionReplay {
   setSessionId: (sessionId: number) => void;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   shutdown: () => void;
+  flush: (useRetry: boolean) => Promise<void>;
 }


### PR DESCRIPTION
⚠️ This is replaced by #633  ⚠️ 

### Summary

* [AMP-89820](https://amplitude.atlassian.net/browse/AMP-89820) - update Browser SR plugin to allow explicit flushing
* [fix: binding of sessionReplay shutdown method](https://github.com/amplitude/Amplitude-TypeScript/pull/628/commits/9883c22a62b1c565fccb2fc56b89a3ada30c4752)

For Mobile session replay I am using the Browser SR plugin to convert the mobile layouts to `rrweb` events. This works well but I need a way to explicitly flush the SR events, which is not currently possible as the Browser SR plugin doesn't expose a flush method.

As discussed, we don't want to add a `flush()` method to the Browser SR plugin, as that will cause the SR events to be flushed more that desired.

This approach is just to expose the underlying `session-replay-browser` object to allow calling `sessionReplayPlugin.sessionReplay.flush()`



### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-89820]: https://amplitude.atlassian.net/browse/AMP-89820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ