### PR TITLE
fix: ignore non-string form.id for form interaction tracking

### DIFF
--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -58,7 +58,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       addEventListener(form, 'change', () => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
-            [FORM_ID]: form.id,
+            [FORM_ID]: stringOrUndefined(form.id),
             [FORM_NAME]: stringOrUndefined(form.name),
             [FORM_DESTINATION]: form.action,
           });
@@ -69,14 +69,14 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       addEventListener(form, 'submit', () => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
-            [FORM_ID]: form.id,
+            [FORM_ID]: stringOrUndefined(form.id),
             [FORM_NAME]: stringOrUndefined(form.name),
             [FORM_DESTINATION]: form.action,
           });
         }
 
         amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
-          [FORM_ID]: form.id,
+          [FORM_ID]: stringOrUndefined(form.id),
           [FORM_NAME]: stringOrUndefined(form.name),
           [FORM_DESTINATION]: form.action,
         });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Ignore non-string form.id values for form interaction tracking. [AMP-89625](https://amplitude.atlassian.net/browse/)

If the `form.id` is not string, event property value is flatten and appends to property name "Form Id". For example:

```
"event_properties":{
   "Form ID": {A: B}
}
```
The backend will extract property name to be `Form ID.A` and property value to be `B`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-89625]: https://amplitude.atlassian.net/browse/AMP-89625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ