### PR TITLE
feat: convert session replay plugin to be a destination plugin with flush support

### DIFF
--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -23,7 +23,7 @@ yarn add @amplitude/plugin-session-replay-browser
 
 ## Usage
 
-This plugin works on top of Amplitude Browser SDK and adds session replay features to built-in features. To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.0.0` or later.
+This plugin works on top of Amplitude Browser SDK and adds session replay features to built-in features. To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.9.1` or later.
 
 This plugin requires that default tracking for sessions is enabled. If default tracking for sessions is not enabled in the config, the plugin will automatically enable it.
 

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -45,7 +45,12 @@ export class SessionReplayPlugin implements DestinationPlugin {
     this.options = { ...options };
   }
 
-  async setup(config: BrowserConfig, client: BrowserClient) {
+  async setup(config: BrowserConfig, client?: BrowserClient) {
+    if (!client) {
+      config.loggerProvider.error('SessionReplayPlugin requires v1.9.1+ of the Amplitude SDK.');
+      return;
+    }
+
     config.loggerProvider.log('Installing @amplitude/plugin-session-replay.');
 
     this.config = config;

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,10 +1,40 @@
-import { BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-types';
+import {
+  BrowserClient,
+  BrowserConfig,
+  DestinationPlugin,
+  EnrichmentPlugin,
+  Event,
+  Result,
+} from '@amplitude/analytics-types';
 import * as sessionReplay from '@amplitude/session-replay-browser';
 import { DEFAULT_SESSION_START_EVENT } from './constants';
 import { SessionReplayOptions } from './typings/session-replay';
-export class SessionReplayPlugin implements EnrichmentPlugin {
-  name = '@amplitude/plugin-session-replay-browser';
+
+class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
+  name = '@amplitude/plugin-session-replay-browser-enrichment';
   type = 'enrichment' as const;
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async setup(_config: BrowserConfig, _client: BrowserClient) {}
+
+  async execute(event: Event) {
+    if (event.event_type === DEFAULT_SESSION_START_EVENT && event.session_id) {
+      sessionReplay.setSessionId(event.session_id);
+    }
+
+    const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+    event.event_properties = {
+      ...event.event_properties,
+      ...sessionRecordingProperties,
+    };
+
+    return Promise.resolve(event);
+  }
+}
+
+export class SessionReplayPlugin implements DestinationPlugin {
+  name = '@amplitude/plugin-session-replay-browser';
+  type = 'destination' as const;
   // this.config is defined in setup() which will always be called first
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -15,7 +45,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
     this.options = { ...options };
   }
 
-  async setup(config: BrowserConfig) {
+  async setup(config: BrowserConfig, client: BrowserClient) {
     config.loggerProvider.log('Installing @amplitude/plugin-session-replay.');
 
     this.config = config;
@@ -50,20 +80,21 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
         blockSelector: this.options.privacyConfig?.blockSelector,
       },
     }).promise;
+
+    // add enrichment plugin to add session replay properties to events
+    client.add(new SessionReplayEnrichmentPlugin());
   }
 
-  async execute(event: Event) {
-    if (event.event_type === DEFAULT_SESSION_START_EVENT && event.session_id) {
-      sessionReplay.setSessionId(event.session_id);
-    }
+  async execute(event: Event): Promise<Result> {
+    return Promise.resolve({
+      event,
+      code: 200,
+      message: 'success',
+    });
+  }
 
-    const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
-    event.event_properties = {
-      ...event.event_properties,
-      ...sessionRecordingProperties,
-    };
-
-    return Promise.resolve(event);
+  async flush(): Promise<void> {
+    await sessionReplay.flush(false);
   }
 
   async teardown(): Promise<void> {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -106,7 +106,7 @@ export class SessionReplayPlugin implements DestinationPlugin {
   }
 }
 
-export const sessionReplayPlugin: (options?: SessionReplayOptions) => EnrichmentPlugin = (
+export const sessionReplayPlugin: (options?: SessionReplayOptions) => DestinationPlugin = (
   options?: SessionReplayOptions,
 ) => {
   return new SessionReplayPlugin(options);

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -14,8 +14,9 @@ class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
   name = '@amplitude/plugin-session-replay-enrichment-browser';
   type = 'enrichment' as const;
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async setup(_config: BrowserConfig, _client: BrowserClient) {}
+  async setup(_config: BrowserConfig, _client: BrowserClient) {
+    // do nothing
+  }
 
   async execute(event: Event) {
     if (event.event_type === DEFAULT_SESSION_START_EVENT && event.session_id) {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -11,7 +11,7 @@ import { DEFAULT_SESSION_START_EVENT } from './constants';
 import { SessionReplayOptions } from './typings/session-replay';
 
 class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
-  name = '@amplitude/plugin-session-replay-browser-enrichment';
+  name = '@amplitude/plugin-session-replay-enrichment-browser';
   type = 'enrichment' as const;
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -68,7 +68,7 @@ describe('SessionReplayPlugin', () => {
       const sessionReplay = new SessionReplayPlugin();
       await sessionReplay.setup(mockConfig);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(sessionReplay.config.loggerProvider.error).toHaveBeenCalledTimes(1);
+      expect(mockLoggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalledWith(
         'SessionReplayPlugin requires v1.9.1+ of the Amplitude SDK.',

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -185,11 +185,6 @@ describe('SessionReplayPlugin', () => {
   });
 
   describe('execute', () => {
-    // beforeEach(() => {
-    //   // clear plugins
-    //   plugins.splice(0, plugins.length);
-    // });
-
     test('should not modify event and return success from DestinationPlugin', async () => {
       const sessionReplay = sessionReplayPlugin();
       await sessionReplay.setup(mockConfig, mockAmplitude);

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,2 +1,2 @@
 import sessionReplay from './session-replay-factory';
-export const { init, setSessionId, getSessionReplayProperties, shutdown } = sessionReplay;
+export const { init, setSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -27,6 +27,7 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       'getSessionReplayProperties',
       getLogConfig(sessionReplay),
     ),
+    flush: debugWrapper(sessionReplay.flush.bind(sessionReplay), 'flush', getLogConfig(sessionReplay)),
     shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'shutdown', getLogConfig(sessionReplay)),
   };
 };

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -27,7 +27,7 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       'getSessionReplayProperties',
       getLogConfig(sessionReplay),
     ),
-    shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'teardown', getLogConfig(sessionReplay)),
+    shutdown: debugWrapper(sessionReplay.shutdown.bind(sessionReplay), 'shutdown', getLogConfig(sessionReplay)),
   };
 };
 

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -53,5 +53,6 @@ export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
   setSessionId: (sessionId: number) => void;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
+  flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;
 }


### PR DESCRIPTION
### Summary
Alternative to #628 

* [AMP-89820](https://amplitude.atlassian.net/browse/AMP-89820) - update Browser SR plugin to allow explicit flushing
* [fix: binding of sessionReplay shutdown method](https://github.com/amplitude/Amplitude-TypeScript/pull/633/commits/65812f376aa5c0129eeb9759a0dd3297166271d5)

For Mobile session replay I am using the Browser SR plugin to convert the mobile layouts to `rrweb` events. This works well but I need a way to explicitly flush the SR events, which is not currently possible as the Browser SR plugin doesn't expose a flush method.

This PR converts the session replay plugin to a DestinationPlugin to add `flush()`. Since we also need to do enrichment the new DestinationPlugin adds a EnrichmentPlugin in `setup()`. This allows the change to be (mostly) backwards compatible.

"Breaking" Changes
1. SessionReplayPlugin now extends DestinationPlugin (vs EnrichmentPlugin). This should be transparent to users as long as they are using `sessionReply.plugin()` and `createSessionReplayPlugin()` and not manually extending the class.
2. SessionReplayPlugin now requires access to the Amplitude BrowserClient which is passed into `plugin.setup(config, client)`. The `client` parameter is only supported in `v1.9.1+`. A [majority of customers are using version](https://app.amplitude.com/analytics/amplitude/chart/new/iuc36ny3) `v1.9.1+`.

Customer comm updates
1. We should call out the SessionReplay will now require `v1.9.1+`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Kind of, but should be transparent to end users


[AMP-89820]: https://amplitude.atlassian.net/browse/AMP-89820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ