### PR TITLE
fix: Amp 90349 plugins not receiving session id

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -80,21 +80,23 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       cookieStorage,
     });
 
-    await super._init(browserOptions);
-
     // Step 3: Set session ID
     let isNewSession = false;
     if (
       // user has never sent an event
-      !this.config.lastEventTime ||
+      !browserOptions.lastEventTime ||
       // user has no previous session ID
-      !this.config.sessionId ||
+      !browserOptions.sessionId ||
       // has sent an event and has previous session but expired
-      (this.config.lastEventTime && Date.now() - this.config.lastEventTime > this.config.sessionTimeout)
+      (browserOptions.lastEventTime && Date.now() - browserOptions.lastEventTime > browserOptions.sessionTimeout)
     ) {
-      this.setSessionId(options.sessionId ?? this.config.sessionId ?? Date.now());
+      // we need to set the session ID before plugins run
+      // add it to the front of the queue
+      this.q.unshift(this.setSessionId.bind(this, options.sessionId ?? browserOptions.sessionId ?? Date.now()));
       isNewSession = true;
     }
+
+    await super._init(browserOptions);
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1,6 +1,14 @@
 import { FetchTransport, getAnalyticsConnector, getCookieName } from '@amplitude/analytics-client-common';
 import * as core from '@amplitude/analytics-core';
-import { Status, TransportType, UserSession } from '@amplitude/analytics-types';
+import {
+  EnrichmentPlugin,
+  Status,
+  TransportType,
+  UserSession,
+  Event,
+  BrowserConfig,
+  BrowserClient,
+} from '@amplitude/analytics-types';
 import * as pageViewTrackingPlugin from '@amplitude/plugin-page-view-tracking-browser';
 import * as webAttributionPlugin from '@amplitude/plugin-web-attribution-browser';
 import { AmplitudeBrowser } from '../src/browser-client';
@@ -281,6 +289,27 @@ describe('browser-client', () => {
         },
       }).promise;
       expect(webAttributionPluginPlugin).toHaveBeenCalledTimes(1);
+    });
+
+    test('should pass config.sessionId to plugin.setup', async () => {
+      const client = new AmplitudeBrowser();
+      const testPlugin: EnrichmentPlugin<BrowserClient, BrowserConfig> = {
+        name: 'testPlugin',
+        type: 'enrichment',
+        setup: (config) => {
+          expect(config.sessionId).toBe(42);
+          return Promise.resolve();
+        },
+        execute(e: Event): Promise<Event | null> {
+          return Promise.resolve(e);
+        },
+      };
+      const setupSpy = jest.spyOn(testPlugin, 'setup');
+      client.add(testPlugin);
+      await client.init(API_KEY, USER_ID, {
+        sessionId: 42,
+      }).promise;
+      expect(setupSpy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
### Summary

* Plugins were not receiving the config.sessionId
* Made it so browser config is finalized before calling plugin.setup


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
