### PR TITLE
feat(deta): use same method for element properties

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
@@ -19,6 +19,10 @@ export const AMPLITUDE_EVENT_PROP_PAGE_TITLE = '[Amplitude] Page Title';
 export const AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT = '[Amplitude] Viewport Height';
 export const AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH = '[Amplitude] Viewport Width';
 
+// Visual Tagging related constants
 export const AMPLITUDE_ORIGIN = 'https://app.amplitude.com';
 export const AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL =
-  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.0.0.js.gz';
+  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.0.1.js.gz';
+// This is the class name used by the visual tagging selector to highlight the selected element.
+// Should not use this class in the selector.
+export const AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS = 'amp-visual-tagging-selector-highlight';

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -166,7 +166,8 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
   };
 
   const getEventProperties = (actionType: ActionType, element: Element) => {
-    const tag = element.tagName.toLowerCase();
+    /* istanbul ignore next */
+    const tag = element?.tagName?.toLowerCase?.();
     /* istanbul ignore next */
     const rect =
       typeof element.getBoundingClientRect === 'function' ? element.getBoundingClientRect() : { left: null, top: null };
@@ -263,7 +264,7 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
     // Setup visual tagging selector
     if (window.opener && visualTaggingOptions.enabled) {
       /* istanbul ignore next */
-      visualTaggingOptions.messenger?.setup();
+      visualTaggingOptions.messenger?.setup({ logger: config?.loggerProvider });
     }
   };
 

--- a/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/helpers.ts
@@ -1,3 +1,7 @@
+/* eslint-disable no-restricted-globals */
+import { finder } from './libs/finder';
+import * as constants from './constants';
+
 const SENTITIVE_TAGS = ['input', 'select', 'textarea'];
 
 export const isNonSensitiveString = (text: string | null) => {
@@ -135,6 +139,24 @@ export const getClosestElement = (element: Element | null, selectors: string[]):
   }
   /* istanbul ignore next */
   return getClosestElement(element?.parentElement, selectors);
+};
+
+export const getEventTagProps = (element: Element) => {
+  if (!element) {
+    return {};
+  }
+  /* istanbul ignore next */
+  const tag = element?.tagName?.toLowerCase?.();
+  const selector = finder(element, {
+    className: (name: string) => name !== constants.AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
+  });
+  const properties: Record<string, string> = {
+    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
+    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: getText(element),
+    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_SELECTOR]: selector,
+    [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: window.location.href.split('?')[0],
+  };
+  return removeEmptyProperties(properties);
 };
 
 export const asyncLoadScript = (url: string) => {

--- a/packages/plugin-default-event-tracking-advanced-browser/src/index.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/index.ts
@@ -4,3 +4,4 @@ export {
   DEFAULT_CSS_SELECTOR_ALLOWLIST,
   DEFAULT_DATA_ATTRIBUTE_PREFIX,
 } from './default-event-tracking-advanced-plugin';
+export { Messenger, WindowMessenger } from './libs/messenger';

--- a/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/default-event-tracking-advanced.test.ts
@@ -1,13 +1,7 @@
 import { defaultEventTrackingAdvancedPlugin } from '../src/default-event-tracking-advanced-plugin';
 import { BrowserClient, BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
 import { createInstance } from '@amplitude/analytics-browser';
-
-const mockWindowLocationFromURL = (url: URL) => {
-  window.location.href = url.toString();
-  window.location.search = url.search;
-  window.location.hostname = url.hostname;
-  window.location.pathname = url.pathname;
-};
+import { mockWindowLocationFromURL } from './utils';
 
 describe('autoTrackingPlugin', () => {
   let plugin: EnrichmentPlugin | undefined;

--- a/packages/plugin-default-event-tracking-advanced-browser/test/utils.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/test/utils.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-restricted-globals */
+export const mockWindowLocationFromURL = (url: URL) => {
+  window.location.href = url.toString();
+  window.location.search = url.search;
+  window.location.hostname = url.hostname;
+  window.location.pathname = url.pathname;
+};


### PR DESCRIPTION
### Summary
feat(deta): use same method for element properties

Related to: https://github.com/amplitude/visual-tagging-selector/pull/7.

Expose the `origin` to be configurable so it can be used for testing in local/staging envs like:

```js
amplitude.add(amplitudeDefaultEventTrackingAdvancedPlugin.defaultEventTrackingAdvancedPlugin({
  visualTaggingOptions: {
    enabled: true,
    messenger: new amplitudeDefaultEventTrackingAdvancedPlugin.WindowMessenger({origin: 'http://localhost:3007'}),
  },
}));
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
