### PR TITLE
build: bump visual tagger version to 0.1.0

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
@@ -22,7 +22,7 @@ export const AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH = '[Amplitude] Viewport Width';
 // Visual Tagging related constants
 export const AMPLITUDE_ORIGIN = 'https://app.amplitude.com';
 export const AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL =
-  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.0.2.js.gz';
+  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.1.0.js.gz';
 // This is the class name used by the visual tagging selector to highlight the selected element.
 // Should not use this class in the selector.
 export const AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS = 'amp-visual-tagging-selector-highlight';


### PR DESCRIPTION
### Summary
Bump version to 0.1.0, related to https://github.com/amplitude/visual-tagging-selector/pull/9.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
