### PR TITLE
feat: session seplay debug mode

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -91,6 +91,7 @@ export class SessionReplayPlugin implements DestinationPlugin {
       privacyConfig: {
         blockSelector: this.options.privacyConfig?.blockSelector,
       },
+      debugMode: this.options.debugMode,
     }).promise;
 
     // add enrichment plugin to add session replay properties to events

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -4,4 +4,5 @@ export interface SessionReplayPrivacyConfig {
 export interface SessionReplayOptions {
   sampleRate?: number;
   privacyConfig?: SessionReplayPrivacyConfig;
+  debugMode?: boolean;
 }

--- a/packages/session-replay-browser/src/config.ts
+++ b/packages/session-replay-browser/src/config.ts
@@ -23,6 +23,7 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
   sessionId?: number | undefined;
   sessionReplayId?: string | undefined;
   privacyConfig?: SessionReplayPrivacyConfig;
+  debugMode?: boolean;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -50,6 +51,10 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
 
     if (options.privacyConfig) {
       this.privacyConfig = options.privacyConfig;
+    }
+
+    if (options.debugMode) {
+      this.debugMode = options.debugMode;
     }
   }
 }

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -10,6 +10,8 @@ export const DEFAULT_SESSION_END_EVENT = 'session_end';
 export const DEFAULT_SAMPLE_RATE = 0;
 export const DEFAULT_SERVER_ZONE = ServerZone.US;
 
+export const SESSION_REPLAY_DEBUG_PROPERTY = `${DEFAULT_EVENT_PROPERTY_PREFIX} Session Replay Debug`;
+
 export const BLOCK_CLASS = 'amp-block';
 export const MASK_TEXT_CLASS = 'amp-mask';
 export const UNMASK_TEXT_CLASS = 'amp-unmask';

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -45,6 +45,7 @@ export interface SessionReplayConfig extends Config {
   sampleRate: number;
   sessionReplayId?: string;
   privacyConfig?: SessionReplayPrivacyConfig;
+  debugMode?: boolean;
 }
 
 export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -290,6 +290,18 @@ describe('SessionReplayPlugin', () => {
         '[Amplitude] Session Replay ID': null,
       });
     });
+
+    test('should return debug property', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
+      sessionReplay.getShouldRecord = () => true;
+
+      const result = sessionReplay.getSessionReplayProperties();
+      expect(result).toEqual({
+        '[Amplitude] Session Replay ID': '1a2b3c/123',
+        '[Amplitude] Session Replay Debug': '{"appHash":"-109988594"}',
+      });
+    });
   });
 
   describe('initalize', () => {
@@ -1849,6 +1861,14 @@ describe('SessionReplayPlugin', () => {
       const sessionReplay = new SessionReplay();
       sessionReplay.config = undefined;
       expect(sessionReplay.getBlockSelectors()).not.toBeDefined();
+    });
+  });
+
+  describe('getSessionReplayDebugPropertyValue', () => {
+    test('null config', () => {
+      const sessionReplay = new SessionReplay();
+      sessionReplay.config = undefined;
+      expect(sessionReplay.getSessionReplayDebugPropertyValue()).toBe('{"appHash":""}');
     });
   });
 });


### PR DESCRIPTION
### Summary
Adds an optional configuration that turns on debug mode. 

When debug mode is turned on, additional debug information is captured in the `[Amplitude] Session Replay Debug` event property. Currently it only contains the hash of the app, can capture additional information such as errors in the future.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
