### PR TITLE
feat(session replay): stricter check for no sample rate

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -224,14 +224,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
     } else if (!this.config.sessionId) {
       this.loggerProvider.warn(`Session is not being recorded due to lack of session id.`);
       return false;
-    } else if (typeof this.config?.sampleRate === 'number' && this.config.sampleRate >= 0) {
-      const isInSample = isSessionInSample(this.config.sessionId, this.config.sampleRate);
-      if (!isInSample) {
-        this.loggerProvider.log(`Opting session ${this.config.sessionId} out of recording due to sample rate.`);
-      }
-      return isInSample;
     }
-    return true;
+
+    const isInSample = isSessionInSample(this.config.sessionId, this.getSampleRate());
+    if (!isInSample) {
+      this.loggerProvider.log(`Opting session ${this.config.sessionId} out of recording due to sample rate.`);
+    }
+    return isInSample;
   }
 
   getBlockSelectors(): string | string[] | undefined {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -224,7 +224,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     } else if (!this.config.sessionId) {
       this.loggerProvider.warn(`Session is not being recorded due to lack of session id.`);
       return false;
-    } else if (this.config.sampleRate) {
+    } else if (typeof this.config?.sampleRate === 'number' && this.config.sampleRate >= 0) {
       const isInSample = isSessionInSample(this.config.sessionId, this.config.sampleRate);
       if (!isInSample) {
         this.loggerProvider.log(`Opting session ${this.config.sessionId} out of recording due to sample rate.`);
@@ -423,7 +423,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const url = getCurrentUrl();
     const version = VERSION;
     const sampleRate = this.getSampleRate();
-
     const urlParams = new URLSearchParams({
       device_id: deviceId,
       session_id: `${context.sessionId}`,

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -617,12 +617,16 @@ describe('SessionReplayPlugin', () => {
     test('should return true if there are options', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, mockOptions).promise;
+      const sampleRate = sessionReplay.getSampleRate();
+      expect(sampleRate).toBe(mockOptions.sampleRate);
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(true);
     });
     test('should return false if no options', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, mockEmptyOptions).promise;
+      const sampleRate = sessionReplay.getSampleRate();
+      expect(sampleRate).toBe(DEFAULT_SAMPLE_RATE);
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(false);
     });
@@ -1273,6 +1277,8 @@ describe('SessionReplayPlugin', () => {
         jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.2 }).promise;
+        const sampleRate = sessionReplay.getSampleRate();
+        expect(sampleRate).toBe(0.2);
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
         expect(sessionRecordingProperties).toMatchObject({});
         expect(record).not.toHaveBeenCalled();

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -635,6 +635,8 @@ describe('SessionReplayPlugin', () => {
 
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.2 }).promise;
+      const sampleRate = sessionReplay.getSampleRate();
+      expect(sampleRate).toBe(0.2);
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(false);
     });
@@ -1317,7 +1319,22 @@ describe('SessionReplayPlugin', () => {
       test('should not record session if no sample rate is provided', async () => {
         jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
         const sessionReplay = new SessionReplay();
-        await sessionReplay.init(apiKey, { ...mockOptions }).promise;
+        await sessionReplay.init(apiKey, { ...mockEmptyOptions }).promise;
+        const sampleRate = sessionReplay.getSampleRate();
+        expect(sampleRate).toBe(DEFAULT_SAMPLE_RATE);
+        const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+        expect(sessionRecordingProperties).toMatchObject({});
+        expect(record).not.toHaveBeenCalled();
+        expect(update).not.toHaveBeenCalled();
+        await runScheduleTimers();
+        expect(fetch).not.toHaveBeenCalled();
+      });
+      test('should not record session if sample rate of value 0 is provided', async () => {
+        jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
+        const sessionReplay = new SessionReplay();
+        await sessionReplay.init(apiKey, { ...mockEmptyOptions, sampleRate: 0 }).promise;
+        const sampleRate = sessionReplay.getSampleRate();
+        expect(sampleRate).toBe(DEFAULT_SAMPLE_RATE);
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
         expect(sessionRecordingProperties).toMatchObject({});
         expect(record).not.toHaveBeenCalled();


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixing issue with sample rate and adding additional test coverage regarding default of 0. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
