### PR TITLE
fix(deta plugin): type and error issues

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/package.json
+++ b/packages/plugin-default-event-tracking-advanced-browser/package.json
@@ -31,14 +31,16 @@
     "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
-    "typecheck": "tsc -p ./tsconfig.json"
+    "typecheck": "tsc -p ./tsconfig.json",
+    "version": "yarn version-file && yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\"",
+    "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^1.2.2",
-    "@amplitude/analytics-types": "^1.3.4",
+    "@amplitude/analytics-client-common": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
     "tslib": "^2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Summary
fix(deta plugin): type and error issues

- adjust the `@amplitude/analytics-types` version based on user installed version, so it won't display the type error like:
```
Argument of type 'BrowserEnrichmentPlugin' is not assignable to parameter of type 'Plugin<BrowserClient, BrowserConfig>'.
```
- in the case that `<html>` document doesn't have the `<body>` yet, it runs the scripts (sync) inside `<head>`, we mount the mutation observer later after page load finishes
- in some cases, `finder` might throw error, e.g., if an element is removed from the document tree, we fallback to use a simple strategy to get the selector

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
