### PR TITLE
fix: should not install page view tracking plugin based on config

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -11,6 +11,7 @@ import {
   setConnectorDeviceId,
   setConnectorUserId,
   isNewSession,
+  isPageViewTrackingEnabled,
 } from '@amplitude/analytics-client-common';
 import {
   BrowserClient,
@@ -114,7 +115,9 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     }
 
     // Add page view plugin
-    await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;
+    if (isPageViewTrackingEnabled(this.config.defaultTracking)) {
+      await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;
+    }
 
     this.initializing = false;
 

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -15,6 +15,7 @@ import * as fileDownloadTracking from '../src/plugins/file-download-tracking';
 import * as formInteractionTracking from '../src/plugins/form-interaction-tracking';
 import * as webAttributionPlugin from '@amplitude/plugin-web-attribution-browser';
 import * as networkConnectivityChecker from '../src/plugins/network-connectivity-checker';
+import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
 
 describe('browser-client', () => {
   let apiKey = '';
@@ -282,6 +283,30 @@ describe('browser-client', () => {
         offline: OfflineDisabled,
       }).promise;
       expect(networkConnectivityCheckerPlugin).toHaveBeenCalledTimes(0);
+    });
+
+    test('should add page view tracking plugin by default', async () => {
+      const pageViewTrackingPlugin = jest.spyOn(pageViewTracking, 'pageViewTrackingPlugin');
+      await client.init(apiKey, userId).promise;
+      expect(pageViewTrackingPlugin).toHaveBeenCalledTimes(1);
+    });
+
+    test('should NOT add page view tracking plugin when DET is disabled', async () => {
+      const pageViewTrackingPlugin = jest.spyOn(pageViewTracking, 'pageViewTrackingPlugin');
+      await client.init(apiKey, userId, {
+        defaultTracking: false,
+      }).promise;
+      expect(pageViewTrackingPlugin).toHaveBeenCalledTimes(0);
+    });
+
+    test('should NOT add page view tracking plugin when page view is disabled', async () => {
+      const pageViewTrackingPlugin = jest.spyOn(pageViewTracking, 'pageViewTrackingPlugin');
+      await client.init(apiKey, userId, {
+        defaultTracking: {
+          pageViews: false,
+        },
+      }).promise;
+      expect(pageViewTrackingPlugin).toHaveBeenCalledTimes(0);
     });
 
     test('should listen for network change to online', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Workaround to https://github.com/amplitude/Amplitude-TypeScript/issues/500 where `TypeError: globalScope.addEventListener is not a function` happens in Next.js application. This PR will prevent page view tracking plugin from installing based on config when `config.defaultTracking = false` or `config.defaultTracking.pageViews = false`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
