### PR TITLE
fix: fix event flush process

### DIFF
--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -303,24 +303,28 @@ export class Destination implements DestinationPlugin {
   }
 
   /**
+   * This is called on
+   * 1) new events are added to queue; or
+   * 2) response comes back for a request
+   *
    * update the event storage
    */
-  async updateEventStorage(filterList: Context[], newContext?: Context[]) {
+  async updateEventStorage(eventsToRemove: Context[], eventsToAdd?: Context[]) {
     if (!this.config.storageProvider) {
       return;
     }
 
-    const filterEventInsertIdSet = filterList.reduce((filtered, context) => {
+    const filterEventInsertIdSet = eventsToRemove.reduce((filtered, context) => {
       if (context.event.insert_id) {
         filtered.add(context.event.insert_id);
       }
       return filtered;
     }, new Set<string>());
 
-    const savedEvent = await this.config.storageProvider.get(this.storageKey);
-    const updatedEvents: Event[] = newContext?.map((context) => context.event) || [];
+    const savedEvents = await this.config.storageProvider.get(this.storageKey);
+    const updatedEvents: Event[] = eventsToAdd?.map((context) => context.event) || [];
 
-    savedEvent?.forEach((event) => {
+    savedEvents?.forEach((event) => {
       if (event.insert_id && !filterEventInsertIdSet.has(event.insert_id)) {
         updatedEvents.push(event);
       }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -320,13 +320,11 @@ export class Destination implements DestinationPlugin {
     const savedEvent = await this.config.storageProvider.get(this.storageKey);
     const updatedEvents: Event[] = newContext?.map((context) => context.event) || [];
 
-    if (savedEvent) {
-      savedEvent.filter((event) => {
-        if (event.insert_id && !filterEventInsertIdSet.has(event.insert_id)) {
-          updatedEvents.push(event);
-        }
-      });
-    }
+    savedEvent?.forEach((event) => {
+      if (event.insert_id && !filterEventInsertIdSet.has(event.insert_id)) {
+        updatedEvents.push(event);
+      }
+    });
     await this.config.storageProvider.set(this.storageKey, updatedEvents);
   }
 }

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -548,12 +548,12 @@ describe('destination', () => {
     });
   });
 
-  describe('updateEvents', () => {
+  describe('filterEvent', () => {
     test('should be ok with no storage provider', async () => {
       const destination = new Destination();
       destination.config = useDefaultConfig();
       destination.config.storageProvider = undefined;
-      expect(await destination.updateEvent(new Set())).toBe(undefined);
+      expect(await destination.filterEvent(new Set())).toBe(undefined);
     });
 
     test('should filter dropped event and update the storage provider', async () => {
@@ -575,7 +575,7 @@ describe('destination', () => {
       ];
       const get = jest.spyOn(destination.config.storageProvider, 'get').mockResolvedValueOnce(storedEvents);
       const set = jest.spyOn(destination.config.storageProvider, 'set').mockResolvedValueOnce(undefined);
-      await destination.updateEvent(new Set(['filtered_event1', 'filtered_event2']));
+      await destination.filterEvent(new Set(['filtered_event1', 'filtered_event2']));
       expect(get).toHaveBeenCalledTimes(1);
       expect(set).toHaveBeenCalledTimes(1);
       expect(set).toHaveBeenCalledWith(

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -553,7 +553,7 @@ describe('destination', () => {
       const destination = new Destination();
       destination.config = useDefaultConfig();
       destination.config.storageProvider = undefined;
-      expect(await destination.filterEvent([])).toBe(undefined);
+      expect(await destination.updateEventStorage([])).toBe(undefined);
     });
 
     test('should filter dropped event and update the storage provider', async () => {
@@ -577,10 +577,36 @@ describe('destination', () => {
         callback: () => undefined,
         timeout: 0,
       };
-      await destination.filterEvent([context]);
+      await destination.updateEventStorage([context]);
       expect(get).toHaveBeenCalledTimes(1);
       expect(set).toHaveBeenCalledTimes(1);
       expect(set).toHaveBeenCalledWith('', expect.objectContaining([event1]));
+    });
+
+    test('should save event to the storage provider', async () => {
+      const destination = new Destination();
+      destination.config = useDefaultConfig();
+      destination.config.storageProvider = {
+        isEnabled: async () => true,
+        get: async () => undefined,
+        set: async () => undefined,
+        remove: async () => undefined,
+        reset: async () => undefined,
+        getRaw: async () => undefined,
+      };
+      const event = { event_type: 'event', insert_id: '1' };
+      const get = jest.spyOn(destination.config.storageProvider, 'get').mockResolvedValueOnce([]);
+      const set = jest.spyOn(destination.config.storageProvider, 'set').mockResolvedValueOnce(undefined);
+      const context = {
+        event: event,
+        attempts: 0,
+        callback: () => undefined,
+        timeout: 0,
+      };
+      await destination.updateEventStorage([], [context]);
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith('', expect.objectContaining([event]));
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
The issue was:

[In the setup](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-core/src/plugins/destination.ts#L62), we get all events from the storage, put them into a local storage and clean the cookies storage. 
However, some customers, as noted in [Jira 1](https://amplitude.atlassian.net/browse/AMP-93344) and [Jira 2](https://amplitude.atlassian.net/browse/AMP-93297), are missing session start/session end events when redirecting to another page. After investigation, we found that the event_id has been incremented, but the server did not receive this event. We think the original logic might have caused the events to be dropped after we cleared the storage.

Current logic:
While adding an event to the queue, we saved the event to the storage. In line #106.
After fulfillRequest, we removed the events from the storage. In line #309.

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
