### PR TITLE
feat(session replay): improve initialization and event tagging

### DIFF
--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -40,7 +40,7 @@
     "@amplitude/analytics-client-common": ">=1 <3",
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-types": ">=1 <3",
-    "@amplitude/session-replay-browser": "^0.8.0-beta.0",
+    "@amplitude/session-replay-browser": ">=1 <3",
     "idb-keyval": "^6.2.1",
     "tslib": "^2.4.1"
   },

--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_SESSION_START_EVENT = 'session_start';

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -68,6 +68,24 @@ export class SessionReplayPlugin implements DestinationPlugin {
     this.client = client;
     this.config = config;
 
+    if (!this.options.disableSessionTracking) {
+      if (typeof config.defaultTracking === 'boolean') {
+        if (config.defaultTracking === false) {
+          config.defaultTracking = {
+            pageViews: false,
+            formInteractions: false,
+            fileDownloads: false,
+            sessions: true,
+          };
+        }
+      } else {
+        config.defaultTracking = {
+          ...config.defaultTracking,
+          sessions: true,
+        };
+      }
+    }
+
     await sessionReplay.init(config.apiKey, {
       instanceName: this.config.instanceName,
       deviceId: this.config.deviceId,

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -55,6 +55,10 @@ export class SessionReplayPlugin implements DestinationPlugin {
 
   constructor(options?: SessionReplayOptions) {
     this.options = { ...options };
+    // The user did not explicitly configure forceSessionTracking to false, default to true.
+    if (this.options.forceSessionTracking !== false) {
+      this.options.forceSessionTracking = true;
+    }
   }
 
   async setup(config: BrowserConfig, client?: BrowserClient) {
@@ -68,7 +72,7 @@ export class SessionReplayPlugin implements DestinationPlugin {
     this.client = client;
     this.config = config;
 
-    if (!this.options.disableSessionTracking) {
+    if (this.options.forceSessionTracking) {
       if (typeof config.defaultTracking === 'boolean') {
         if (config.defaultTracking === false) {
           config.defaultTracking = {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -7,21 +7,27 @@ import {
   Result,
 } from '@amplitude/analytics-types';
 import * as sessionReplay from '@amplitude/session-replay-browser';
-import { DEFAULT_SESSION_START_EVENT } from './constants';
 import { SessionReplayOptions } from './typings/session-replay';
 const ENRICHMENT_PLUGIN_NAME = '@amplitude/plugin-session-replay-enrichment-browser';
 
 class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
   name = ENRICHMENT_PLUGIN_NAME;
   type = 'enrichment' as const;
+  // this.config is defined in setup() which will always be called first
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  config: BrowserConfig;
 
   async setup(_config: BrowserConfig, _client: BrowserClient) {
-    // do nothing
+    this.config = _config;
   }
 
   async execute(event: Event) {
-    if (event.event_type === DEFAULT_SESSION_START_EVENT && event.session_id) {
-      sessionReplay.setSessionId(event.session_id);
+    // On event, synchronize the session id to the what's on the browserConfig (source of truth)
+    // Choosing not to read from event object here, concerned about offline/delayed events messing up the state stored
+    // in SR.
+    if (this.config.sessionId && this.config.sessionId !== sessionReplay.getSessionId()) {
+      sessionReplay.setSessionId(this.config.sessionId);
     }
 
     const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
@@ -61,22 +67,6 @@ export class SessionReplayPlugin implements DestinationPlugin {
 
     this.client = client;
     this.config = config;
-
-    if (typeof config.defaultTracking === 'boolean') {
-      if (config.defaultTracking === false) {
-        config.defaultTracking = {
-          pageViews: false,
-          formInteractions: false,
-          fileDownloads: false,
-          sessions: true,
-        };
-      }
-    } else {
-      config.defaultTracking = {
-        ...config.defaultTracking,
-        sessions: true,
-      };
-    }
 
     await sessionReplay.init(config.apiKey, {
       instanceName: this.config.instanceName,

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -5,4 +5,5 @@ export interface SessionReplayOptions {
   sampleRate?: number;
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
+  disableSessionTracking?: boolean;
 }

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -5,5 +5,5 @@ export interface SessionReplayOptions {
   sampleRate?: number;
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
-  disableSessionTracking?: boolean;
+  forceSessionTracking?: boolean;
 }

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -166,7 +166,7 @@ describe('SessionReplayPlugin', () => {
       });
 
       test('should not modify defaultTracking to enable sessions if session tracking is disbled', async () => {
-        const sessionReplay = new SessionReplayPlugin({ disableSessionTracking: true });
+        const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: false });
         await sessionReplay.setup(
           {
             ...mockConfig,
@@ -178,7 +178,7 @@ describe('SessionReplayPlugin', () => {
       });
 
       test('should not modify defaultTracking object to enable sessions if session tracking is disbled', async () => {
-        const sessionReplay = new SessionReplayPlugin({ disableSessionTracking: true });
+        const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: false });
         await sessionReplay.setup(
           {
             ...mockConfig,

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -130,8 +130,43 @@ describe('SessionReplayPlugin', () => {
         );
         expect(sessionReplay.config.defaultTracking).toBe(true);
       });
-      test('should not modify defaultTracking to enable sessions if its set to false', async () => {
+
+      test('should modify defaultTracking to enable sessions if its set to false', async () => {
         const sessionReplay = new SessionReplayPlugin();
+        await sessionReplay.setup(
+          {
+            ...mockConfig,
+            defaultTracking: false,
+          },
+          mockAmplitude,
+        );
+        expect(sessionReplay.config.defaultTracking).toEqual({
+          pageViews: false,
+          formInteractions: false,
+          fileDownloads: false,
+          sessions: true,
+        });
+      });
+
+      test('should modify defaultTracking to enable sessions if it is an object', async () => {
+        const sessionReplay = new SessionReplayPlugin();
+        await sessionReplay.setup(
+          {
+            ...mockConfig,
+            defaultTracking: {
+              pageViews: false,
+            },
+          },
+          mockAmplitude,
+        );
+        expect(sessionReplay.config.defaultTracking).toEqual({
+          pageViews: false,
+          sessions: true,
+        });
+      });
+
+      test('should not modify defaultTracking to enable sessions if session tracking is disbled', async () => {
+        const sessionReplay = new SessionReplayPlugin({ disableSessionTracking: true });
         await sessionReplay.setup(
           {
             ...mockConfig,
@@ -141,8 +176,9 @@ describe('SessionReplayPlugin', () => {
         );
         expect(sessionReplay.config.defaultTracking).toEqual(false);
       });
-      test('should not modify defaultTracking to enable sessions if it is an object', async () => {
-        const sessionReplay = new SessionReplayPlugin();
+
+      test('should not modify defaultTracking object to enable sessions if session tracking is disbled', async () => {
+        const sessionReplay = new SessionReplayPlugin({ disableSessionTracking: true });
         await sessionReplay.setup(
           {
             ...mockConfig,

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,2 +1,2 @@
 import sessionReplay from './session-replay-factory';
-export const { init, setSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
+export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -22,6 +22,11 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       'setSessionId',
       getLogConfig(sessionReplay),
     ),
+    getSessionId: debugWrapper(
+      sessionReplay.getSessionId.bind(sessionReplay),
+      'getSessionId',
+      getLogConfig(sessionReplay),
+    ),
     getSessionReplayProperties: debugWrapper(
       sessionReplay.getSessionReplayProperties.bind(sessionReplay),
       'getSessionReplayProperties',

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -53,6 +53,7 @@ export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
   setSessionId: (sessionId: number) => void;
+  getSessionId: () => number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -256,6 +256,39 @@ describe('SessionReplayPlugin', () => {
     });
   });
 
+  describe('getSessionId', () => {
+    test('should update session id', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const stopRecordingMock = jest.fn();
+      expect(sessionReplay.getSessionId()).toEqual(mockOptions.sessionId);
+
+      // Mock class as if it has already been recording events
+      sessionReplay.stopRecordingAndSendEvents = stopRecordingMock;
+
+      sessionReplay.setSessionId(456);
+      expect(stopRecordingMock).toHaveBeenCalled();
+      expect(sessionReplay.getSessionId()).toEqual(456);
+    });
+
+    test('should return null if not initialized', () => {
+      const sessionReplay = new SessionReplay();
+      expect(sessionReplay.getSessionId()).toBeUndefined();
+    });
+
+    test('should return early if no session id, device id is set', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, deviceId: undefined }).promise;
+      sessionReplay.loggerProvider = mockLoggerProvider;
+      const stopRecordingMock = jest.fn();
+
+      sessionReplay.setSessionId(123);
+      expect(stopRecordingMock).not.toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.error).toHaveBeenCalled();
+    });
+  });
+
   describe('getSessionReplayProperties', () => {
     test('should return an empty object if config not set', () => {
       const sessionReplay = new SessionReplay();


### PR DESCRIPTION

### Summary
This PR improves the general of the SR plugin by: 
1. By synchronizing Session Id between Browser SDK and SR plugin on each event. In the process also getting rid of the need to require start session event. 
2. Updates getSessionReplayProperties to ignore the focus state handler to enhance tagging of events. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
