### PR TITLE
build: bump visual selector version to 0.2.1

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
@@ -30,7 +30,7 @@ export const AMPLITUDE_ORIGINS_MAP = {
 };
 
 export const AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL =
-  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.2.0.js.gz';
+  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.2.1.js.gz';
 // This is the class name used by the visual tagging selector to highlight the selected element.
 // Should not use this class in the selector.
 export const AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS = 'amp-visual-tagging-selector-highlight';


### PR DESCRIPTION
### Summary
build: bump visual selector version to 0.2.1

Related to: https://github.com/amplitude/visual-tagging-selector/pull/14

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
