### PR TITLE
fix(session replay): fix event tagging 

### DIFF
--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -85,3 +85,8 @@ const sessionReplayTracking = sessionReplayPlugin({
   }
 });
 ```
+
+## Debugging 
+
+### Using debugMode when developing locally
+Since the Session Replay plugin only records and tags events when the page is in focus, this can sometimes be problematic when developing locally with the browser console open. If you are having issues with the replays not showing up (while your quota usage going up). Try turning setting `debugMode:true` to see if that helps with the issue.

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -30,12 +30,15 @@ class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
       sessionReplay.setSessionId(this.config.sessionId);
     }
 
-    const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
-    event.event_properties = {
-      ...event.event_properties,
-      ...sessionRecordingProperties,
-    };
-
+    // Treating config.sessionId as source of truth, if the event's session id doesn't match, the
+    // event is not of the current session (offline/late events). In that case, don't tag the events
+    if (this.config.sessionId && this.config.sessionId === event.session_id) {
+      const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+      event.event_properties = {
+        ...event.event_properties,
+        ...sessionRecordingProperties,
+      };
+    }
     return Promise.resolve(event);
   }
 }

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -274,7 +274,7 @@ describe('SessionReplayPlugin', () => {
       });
     });
 
-    test('should not add event property for for even with mismatching session id.', async () => {
+    test('should not add event property for for event with mismatching session id.', async () => {
       const sessionReplay = sessionReplayPlugin();
       await sessionReplay.setup(mockConfig, mockAmplitude);
       getSessionReplayProperties.mockReturnValueOnce({

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -120,7 +120,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.loggerProvider.error('Session replay init has not been called, cannot get session recording properties.');
       return {};
     }
-    const shouldRecord = this.getShouldRecord(true /* ignoreFocus = true */);
+
+    // If the user is in debug mode, ignore the focus handler when tagging events.
+    // this is a common mishap when someone is developing locally and not seeing events getting tagged.
+    const ignoreFocus = !!this.config.debugMode;
+    const shouldRecord = this.getShouldRecord(ignoreFocus);
 
     if (shouldRecord) {
       const eventProperties = {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -320,6 +320,23 @@ describe('SessionReplayPlugin', () => {
       });
     });
 
+    test('should ignore focus handler when debug mode is on.', async () => {
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+        ...mockGlobalScope,
+        document: {
+          hasFocus: () => false,
+        },
+      } as typeof globalThis);
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
+      const result = sessionReplay.getSessionReplayProperties();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(result).toEqual({
+        '[Amplitude] Session Replay ID': '1a2b3c/123',
+        '[Amplitude] Session Replay Debug': '{"appHash":"-109988594"}',
+      });
+    });
+
     test('should return session replay id property with null', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions }).promise;


### PR DESCRIPTION
### Summary
Fixes the event tagging issues from last PR, mainly: 
1. we should not tag events that have mismatching session id with the current session (these are likely late/out of session events) 
2. only tag events when we are in focus/recording. The focus handler is only ignored when in debug mode, this can be used for people who are developing with the console open (which makes the page out of focus). 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
