### PR TITLE
feat: pass iselementselectable to visual selector

### DIFF
--- a/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/constants.ts
@@ -30,7 +30,7 @@ export const AMPLITUDE_ORIGINS_MAP = {
 };
 
 export const AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL =
-  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.2.1.js.gz';
+  'https://cdn.amplitude.com/libs/visual-tagging-selector-0.2.2.js.gz';
 // This is the class name used by the visual tagging selector to highlight the selected element.
 // Should not use this class in the selector.
 export const AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS = 'amp-visual-tagging-selector-highlight';

--- a/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/default-event-tracking-advanced-plugin.ts
@@ -12,9 +12,9 @@ import {
   getSelector,
 } from './helpers';
 import { Messenger, WindowMessenger } from './libs/messenger';
+import { ActionType } from './typings/default-event-tracking-advanced';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
-type ActionType = 'click' | 'change';
 
 export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
   'a',
@@ -284,6 +284,7 @@ export const defaultEventTrackingAdvancedPlugin = (options: Options = {}): Brows
       visualTaggingOptions.messenger?.setup({
         logger: config?.loggerProvider,
         ...(config?.serverZone && { endpoint: constants.AMPLITUDE_ORIGINS_MAP[config.serverZone] }),
+        isElementSelectable: shouldTrackEvent,
       });
     }
   };

--- a/packages/plugin-default-event-tracking-advanced-browser/src/typings/default-event-tracking-advanced.ts
+++ b/packages/plugin-default-event-tracking-advanced-browser/src/typings/default-event-tracking-advanced.ts
@@ -1,0 +1,1 @@
+export type ActionType = 'click' | 'change';


### PR DESCRIPTION
### Summary
Related to https://github.com/amplitude/visual-tagging-selector/pull/15.

This PR:
- get `actionType` from the message
- pass the `isElementSelectable` to visual tagging selector

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
