### PR TITLE
fix: #664 Handle URL-encoded cookie values

### DIFF
--- a/packages/analytics-client-common/src/storage/cookie.ts
+++ b/packages/analytics-client-common/src/storage/cookie.ts
@@ -37,7 +37,7 @@ export class CookieStorage<T> implements Storage<T> {
     }
     try {
       try {
-        value = decodeURIComponent(atob(value));
+        value = decodeURIComponent(atob(decodeURIComponent(value)));
       } catch {
         // value not encoded
       }


### PR DESCRIPTION
### Summary

Fixes #664

Cookie values are often URL-encoded. In Rails, for example, there is no way to opt out of url-encoding cookies. So [this code in the docs](https://www.docs.developers.amplitude.com/experiment/sdks/ruby-sdk/#access-amplitude-cookies) does not work.


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
