### PR TITLE
feat(session replay): add argument to setSessionId to allow for updating deviceId

### DIFF
--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -62,6 +62,10 @@ Any time that the session id for the user changes, the session replay SDK must b
 ```typescript
 sessionReplay.setSessionId(UNIX_TIMESTAMP)
 ```
+You can optionally pass a new device id as a second argument as well:
+```typescript
+sessionReplay.setSessionId(UNIX_TIMESTAMP, deviceId)
+```
 
 ### 5. Shutdown (optional)
 If at any point you would like to discontinue collection of session replays, for example in a part of your application where you would not like sessions to be collected, you can use the following method to stop collection and remove collection event listeners.

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -13,14 +13,14 @@ import {
   MAX_IDB_STORAGE_LENGTH,
   MAX_INTERVAL,
   MIN_INTERVAL,
+  SESSION_REPLAY_DEBUG_PROPERTY,
   SESSION_REPLAY_EU_URL as SESSION_REPLAY_EU_SERVER_URL,
-  SESSION_REPLAY_STAGING_URL as SESSION_REPLAY_STAGING_SERVER_URL,
   SESSION_REPLAY_SERVER_URL,
+  SESSION_REPLAY_STAGING_URL as SESSION_REPLAY_STAGING_SERVER_URL,
   STORAGE_PREFIX,
   defaultSessionStore,
-  SESSION_REPLAY_DEBUG_PROPERTY,
 } from './constants';
-import { isSessionInSample, maskInputFn, getCurrentUrl, generateSessionReplayId, generateHashCode } from './helpers';
+import { generateHashCode, generateSessionReplayId, getCurrentUrl, isSessionInSample, maskInputFn } from './helpers';
 import {
   MAX_RETRIES_EXCEEDED_MESSAGE,
   MISSING_API_KEY_MESSAGE,
@@ -84,15 +84,19 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
   }
 
-  setSessionId(sessionId: number) {
+  setSessionId(sessionId: number, deviceId?: string) {
     if (!this.config) {
       this.loggerProvider.error('Session replay init has not been called, cannot set session id.');
       return;
     }
+
+    if (deviceId) {
+      this.config.deviceId = deviceId;
+    }
     // use a consistent device id.
-    const deviceId = this.getDeviceId();
-    if (sessionId && deviceId) {
-      this.config.sessionReplayId = generateSessionReplayId(sessionId, deviceId);
+    const deviceIdForReplayId = this.getDeviceId();
+    if (sessionId && deviceIdForReplayId) {
+      this.config.sessionReplayId = generateSessionReplayId(sessionId, deviceIdForReplayId);
     } else {
       this.loggerProvider.error('Must provide either session replay id or session id when starting a new session.');
       return;

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -6,8 +6,8 @@ import * as IDBKeyVal from 'idb-keyval';
 import {
   DEFAULT_SAMPLE_RATE,
   DEFAULT_SESSION_REPLAY_PROPERTY,
-  SESSION_REPLAY_SERVER_URL,
   SESSION_REPLAY_EU_URL,
+  SESSION_REPLAY_SERVER_URL,
   SESSION_REPLAY_STAGING_URL,
 } from '../src/constants';
 import * as Helpers from '../src/helpers';
@@ -239,6 +239,7 @@ describe('SessionReplayPlugin', () => {
       sessionReplay.setSessionId(456);
       expect(stopRecordingMock).toHaveBeenCalled();
       expect(sessionReplay.config?.sessionId).toEqual(456);
+      expect(sessionReplay.config?.sessionReplayId).toEqual('1a2b3c/456');
       expect(sessionReplay.events).toEqual([]);
       expect(sessionReplay.currentSequenceId).toEqual(0);
     });
@@ -253,6 +254,18 @@ describe('SessionReplayPlugin', () => {
       expect(stopRecordingMock).not.toHaveBeenCalled();
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.error).toHaveBeenCalled();
+    });
+
+    test('should update the device id if passed', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.loggerProvider = mockLoggerProvider;
+
+      sessionReplay.setSessionId(456, '9l8m7n');
+      expect(sessionReplay.config?.sessionId).toEqual(456);
+      expect(sessionReplay.config?.sessionReplayId).toEqual('9l8m7n/456');
+      expect(sessionReplay.config?.deviceId).toEqual('9l8m7n');
+      expect(sessionReplay.getDeviceId()).toEqual('9l8m7n');
     });
   });
 


### PR DESCRIPTION
### Summary

Update setSessionId to allow for updating the device id at the same time. Useful for consumers who want to use device id to track users, such as moving between an anonymous part of the site to a logged in part of the site.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
