### PR TITLE
fix: have session and device IDs ready before plugin setup

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -69,7 +69,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     // Step 2: Create browser config
     const browserOptions = await useBrowserConfig(options.apiKey, options, this);
-    await super._init(browserOptions);
+    this.config = browserOptions;
 
     // Step 3: Set session ID
     // Priority 1: `options.sessionId`
@@ -77,6 +77,8 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     // Default: `Date.now()`
     // Session ID is handled differently than device ID and user ID due to session events
     this.setSessionId(options.sessionId ?? this.config.sessionId ?? Date.now());
+
+    await super._init(this.config);
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -157,11 +157,12 @@ describe('browser-client', () => {
       expect(parseLegacyCookies).toHaveBeenCalledTimes(1);
     });
 
-    test('should init with session Id before plugin setup', async () => {
+    test('should init with session Id and device Id before plugin setup', async () => {
       class MockedSessionReplayPlugin implements DestinationPlugin {
         type = 'destination' as const;
         async setup(_config: Config.BrowserConfig, _clinet: CoreClient) {
           expect(client.config.sessionId).toBeDefined();
+          expect(client.config.deviceId).toBeDefined();
         }
         execute = jest.fn(async (event: Event): Promise<Result> => {
           return Promise.resolve({


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR fixes the bug described at https://amplitude.atlassian.net/browse/AMP-94551 where `SessionReplayPlugin` throws an "session Id and device Id not found" error because `plugin.setup()` is executed before `client.config` is set. 

This PR is made in the consideration of not breaking the fix of https://github.com/amplitude/Amplitude-TypeScript/pull/426, specifically the session Id of the session end event should be the one fetched from storage rather than `options.sessionId`. That being said, we cannot simply solve this by 
- Change this [line](https://github.com/amplitude/Amplitude-TypeScript/blob/d9e6fc678e6d364f209f0a942ebd57143966992e/packages/analytics-browser/src/config.ts#L226) in `useBrowserConfig()` to be `const sessionId = options.sessionId ?? previousCookies?.sessionId ?? legacyCookies.sessionId;`


And have to make sure

```diff
  protected async _init(options: BrowserOptions & { apiKey: string }) {
    ...
    // When called, make sure config.sessionId is the previous session Id for session end event 
    this.setSessionId(options.sessionId ?? this.config.sessionId ?? Date.now());
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
