### PR TITLE
fix: register download and form listeners after window is loaded

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -30,75 +30,81 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-file-download-tracking-browser';
   const type = 'enrichment';
   const setup = async (config: BrowserConfig, amplitude: BrowserClient) => {
-    /* istanbul ignore if */
-    if (!amplitude) {
-      // TODO: Add required minimum version of @amplitude/analytics-browser
-      config.loggerProvider.warn(
-        'File download tracking requires a later version of @amplitude/analytics-browser. File download events are not tracked.',
-      );
-      return;
-    }
-
-    /* istanbul ignore if */
-    if (typeof document === 'undefined') {
-      return;
-    }
-
-    const addFileDownloadListener = (a: HTMLAnchorElement) => {
-      let url: URL;
-      try {
-        // eslint-disable-next-line no-restricted-globals
-        url = new URL(a.href, window.location.href);
-      } catch {
-        /* istanbul ignore next */
+    // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
+    // after the body is built. When Amplitud gets initialized in a script tag, the body tag is still unavailable. So register this
+    // only after the window is loaded
+    // eslint-disable-next-line no-restricted-globals
+    window.addEventListener('load', function () {
+      /* istanbul ignore if */
+      if (!amplitude) {
+        // TODO: Add required minimum version of @amplitude/analytics-browser
+        config.loggerProvider.warn(
+          'File download tracking requires a later version of @amplitude/analytics-browser. File download events are not tracked.',
+        );
         return;
       }
-      const result = ext.exec(url.href);
-      const fileExtension = result?.[1];
 
-      if (fileExtension) {
-        addEventListener(a, 'click', () => {
-          if (fileExtension) {
-            amplitude.track(DEFAULT_FILE_DOWNLOAD_EVENT, {
-              [FILE_EXTENSION]: fileExtension,
-              [FILE_NAME]: url.pathname,
-              [LINK_ID]: a.id,
-              [LINK_TEXT]: a.text,
-              [LINK_URL]: a.href,
-            });
-          }
-        });
+      /* istanbul ignore if */
+      if (typeof document === 'undefined') {
+        return;
       }
-    };
 
-    const ext =
-      /\.(pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma)$/;
+      const addFileDownloadListener = (a: HTMLAnchorElement) => {
+        let url: URL;
+        try {
+          // eslint-disable-next-line no-restricted-globals
+          url = new URL(a.href, window.location.href);
+        } catch {
+          /* istanbul ignore next */
+          return;
+        }
+        const result = ext.exec(url.href);
+        const fileExtension = result?.[1];
 
-    // Adds listener to existing anchor tags
-    const links = Array.from(document.getElementsByTagName('a'));
-    links.forEach(addFileDownloadListener);
-
-    // Adds listener to anchor tags added after initial load
-    /* istanbul ignore else */
-    if (typeof MutationObserver !== 'undefined') {
-      observer = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          mutation.addedNodes.forEach((node) => {
-            if (node.nodeName === 'A') {
-              addFileDownloadListener(node as HTMLAnchorElement);
-            }
-            if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
-              Array.from(node.querySelectorAll('a') as HTMLAnchorElement[]).map(addFileDownloadListener);
+        if (fileExtension) {
+          addEventListener(a, 'click', () => {
+            if (fileExtension) {
+              amplitude.track(DEFAULT_FILE_DOWNLOAD_EVENT, {
+                [FILE_EXTENSION]: fileExtension,
+                [FILE_NAME]: url.pathname,
+                [LINK_ID]: a.id,
+                [LINK_TEXT]: a.text,
+                [LINK_URL]: a.href,
+              });
             }
           });
-        });
-      });
+        }
+      };
 
-      observer.observe(document.body, {
-        subtree: true,
-        childList: true,
-      });
-    }
+      const ext =
+        /\.(pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma)$/;
+
+      // Adds listener to existing anchor tags
+      const links = Array.from(document.getElementsByTagName('a'));
+      links.forEach(addFileDownloadListener);
+
+      // Adds listener to anchor tags added after initial load
+      /* istanbul ignore else */
+      if (typeof MutationObserver !== 'undefined') {
+        observer = new MutationObserver((mutations) => {
+          mutations.forEach((mutation) => {
+            mutation.addedNodes.forEach((node) => {
+              if (node.nodeName === 'A') {
+                addFileDownloadListener(node as HTMLAnchorElement);
+              }
+              if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+                Array.from(node.querySelectorAll('a') as HTMLAnchorElement[]).map(addFileDownloadListener);
+              }
+            });
+          });
+        });
+
+        observer.observe(document.body, {
+          subtree: true,
+          childList: true,
+        });
+      }
+    });
   };
   const execute = async (event: Event) => event;
   const teardown = async () => {

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -28,6 +28,7 @@ describe('fileDownloadTracking', () => {
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // trigger click event
     document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
@@ -57,6 +58,7 @@ describe('fileDownloadTracking', () => {
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // add anchor element dynamically
     const link = document.createElement('a');
@@ -106,6 +108,7 @@ describe('fileDownloadTracking', () => {
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // add anchor element dynamically
     const link = document.createElement('a');
@@ -142,6 +145,7 @@ describe('fileDownloadTracking', () => {
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // trigger change event
     document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -22,6 +22,20 @@ describe('fileDownloadTracking', () => {
     document.querySelector('a#my-link-id')?.remove();
   });
 
+  test('should not track file_download event if window load event was not triggered', async () => {
+    // setup
+    document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');
+    const config = createConfigurationMock();
+    const plugin = fileDownloadTracking();
+    await plugin.setup?.(config, amplitude);
+
+    // trigger click event
+    document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
+
+    // assert file download event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(0);
+  });
+
   test('should track file_download event', async () => {
     // setup
     document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -37,6 +37,7 @@ describe('formInteractionTracking', () => {
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // trigger change event
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
@@ -61,6 +62,7 @@ describe('formInteractionTracking', () => {
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // add form element dynamically
     const form = document.createElement('form');
@@ -134,6 +136,7 @@ describe('formInteractionTracking', () => {
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // add form element dynamically
     const form = document.createElement('form');
@@ -182,6 +185,7 @@ describe('formInteractionTracking', () => {
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // trigger change event again
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
@@ -211,6 +215,7 @@ describe('formInteractionTracking', () => {
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
 
     // trigger change event
     document.getElementById('my-form-id')?.dispatchEvent(new Event('submit'));

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -32,6 +32,19 @@ describe('formInteractionTracking', () => {
     document.querySelector('form#my-form-id')?.remove();
   });
 
+  test('should not track form_start event when window load event was not triggered', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = formInteractionTracking();
+    await plugin.setup?.(config, amplitude);
+
+    // trigger change event
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
+
+    // assert first event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(0);
+  });
+
   test('should track form_start event', async () => {
     // setup
     const config = createConfigurationMock();


### PR DESCRIPTION
### Summary

When the amplitude script tag is added before the body tag, the file download listeners and form listeners weren't able to attach themselves to the body of the page (since the body was still not loaded). Fixing this by setting up the listener after the window is loaded

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
