### PR TITLE
refactor(session replay): split out destination logic into separate class

### DIFF
--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -1,0 +1,209 @@
+import { BaseTransport } from '@amplitude/analytics-core';
+import { Logger as ILogger, ServerZone, Status } from '@amplitude/analytics-types';
+import {
+  SESSION_REPLAY_EU_URL as SESSION_REPLAY_EU_SERVER_URL,
+  SESSION_REPLAY_SERVER_URL,
+  SESSION_REPLAY_STAGING_URL as SESSION_REPLAY_STAGING_SERVER_URL,
+} from './constants';
+import { getCurrentUrl } from './helpers';
+import {
+  MAX_RETRIES_EXCEEDED_MESSAGE,
+  MISSING_API_KEY_MESSAGE,
+  MISSING_DEVICE_ID_MESSAGE,
+  UNEXPECTED_ERROR_MESSAGE,
+  UNEXPECTED_NETWORK_ERROR_MESSAGE,
+  getSuccessMessage,
+} from './messages';
+import {
+  SessionReplayTrackDestination as AmplitudeSessionReplayTrackDestination,
+  SessionReplayDestination,
+  SessionReplayDestinationContext,
+} from './typings/session-replay';
+import { VERSION } from './version';
+
+export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrackDestination {
+  loggerProvider: ILogger;
+  storageKey = '';
+  retryTimeout = 1000;
+  private scheduled: ReturnType<typeof setTimeout> | null = null;
+  queue: SessionReplayDestinationContext[] = [];
+
+  constructor({ loggerProvider }: { loggerProvider: ILogger }) {
+    this.loggerProvider = loggerProvider;
+  }
+
+  setLoggerProvider(loggerProvider: ILogger) {
+    this.loggerProvider = loggerProvider;
+  }
+
+  sendEventsList(destinationData: SessionReplayDestination) {
+    this.addToQueue({
+      ...destinationData,
+      attempts: 0,
+      timeout: 0,
+    });
+  }
+
+  getServerUrl(serverZone?: keyof typeof ServerZone) {
+    if (serverZone === ServerZone.STAGING) {
+      return SESSION_REPLAY_STAGING_SERVER_URL;
+    }
+
+    if (serverZone === ServerZone.EU) {
+      return SESSION_REPLAY_EU_SERVER_URL;
+    }
+
+    return SESSION_REPLAY_SERVER_URL;
+  }
+
+  addToQueue(...list: SessionReplayDestinationContext[]) {
+    const tryable = list.filter((context) => {
+      if (context.attempts < (context.flushMaxRetries || 0)) {
+        context.attempts += 1;
+        return true;
+      }
+      this.completeRequest({
+        context,
+        err: `${MAX_RETRIES_EXCEEDED_MESSAGE}, batch sequence id, ${context.sequenceId}`,
+      });
+      return false;
+    });
+    tryable.forEach((context) => {
+      this.queue = this.queue.concat(context);
+      if (context.timeout === 0) {
+        this.schedule(0);
+        return;
+      }
+
+      setTimeout(() => {
+        context.timeout = 0;
+        this.schedule(0);
+      }, context.timeout);
+    });
+  }
+
+  schedule(timeout: number) {
+    if (this.scheduled) return;
+    this.scheduled = setTimeout(() => {
+      void this.flush(true).then(() => {
+        if (this.queue.length > 0) {
+          this.schedule(timeout);
+        }
+      });
+    }, timeout);
+  }
+
+  async flush(useRetry = false) {
+    const list: SessionReplayDestinationContext[] = [];
+    const later: SessionReplayDestinationContext[] = [];
+    this.queue.forEach((context) => (context.timeout === 0 ? list.push(context) : later.push(context)));
+    this.queue = later;
+
+    if (this.scheduled) {
+      clearTimeout(this.scheduled);
+      this.scheduled = null;
+    }
+
+    await Promise.all(list.map((context) => this.send(context, useRetry)));
+  }
+
+  async send(context: SessionReplayDestinationContext, useRetry = true) {
+    const apiKey = context.apiKey;
+    if (!apiKey) {
+      return this.completeRequest({ context, err: MISSING_API_KEY_MESSAGE });
+    }
+    const deviceId = context.deviceId;
+    if (!deviceId) {
+      return this.completeRequest({ context, err: MISSING_DEVICE_ID_MESSAGE });
+    }
+    const url = getCurrentUrl();
+    const version = VERSION;
+    const sampleRate = context.sampleRate;
+    const urlParams = new URLSearchParams({
+      device_id: deviceId,
+      session_id: `${context.sessionId}`,
+      seq_number: `${context.sequenceId}`,
+    });
+
+    const payload = {
+      version: 1,
+      events: context.events,
+    };
+
+    try {
+      const options: RequestInit = {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: '*/*',
+          Authorization: `Bearer ${apiKey}`,
+          'X-Client-Version': version,
+          'X-Client-Url': url,
+          'X-Client-Sample-Rate': `${sampleRate}`,
+        },
+        body: JSON.stringify(payload),
+        method: 'POST',
+      };
+      const server_url = `${this.getServerUrl(context.serverZone)}?${urlParams.toString()}`;
+      const res = await fetch(server_url, options);
+      if (res === null) {
+        this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE });
+        return;
+      }
+      if (!useRetry) {
+        let responseBody = '';
+        try {
+          responseBody = JSON.stringify(res.body, null, 2);
+        } catch {
+          // to avoid crash, but don't care about the error, add comment to avoid empty block lint error
+        }
+        this.completeRequest({ context, success: `${res.status}: ${responseBody}` });
+      } else {
+        this.handleReponse(res.status, context);
+      }
+    } catch (e) {
+      this.completeRequest({ context, err: e as string });
+    }
+  }
+
+  handleReponse(status: number, context: SessionReplayDestinationContext) {
+    const parsedStatus = new BaseTransport().buildStatus(status);
+    switch (parsedStatus) {
+      case Status.Success:
+        this.handleSuccessResponse(context);
+        break;
+      case Status.Failed:
+        this.handleOtherResponse(context);
+        break;
+      default:
+        this.completeRequest({ context, err: UNEXPECTED_NETWORK_ERROR_MESSAGE });
+    }
+  }
+
+  handleSuccessResponse(context: SessionReplayDestinationContext) {
+    this.completeRequest({ context, success: getSuccessMessage(context.sessionId) });
+  }
+
+  handleOtherResponse(context: SessionReplayDestinationContext) {
+    this.addToQueue({
+      ...context,
+      timeout: context.attempts * this.retryTimeout,
+    });
+  }
+
+  completeRequest({
+    context,
+    err,
+    success,
+  }: {
+    context: SessionReplayDestinationContext;
+    err?: string;
+    success?: string;
+  }) {
+    void context.onComplete(context.sessionId, context.sequenceId);
+    if (err) {
+      this.loggerProvider.warn(err);
+    } else if (success) {
+      this.loggerProvider.log(success);
+    }
+  }
+}

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,13 +1,22 @@
-import { AmplitudeReturn, Config, LogLevel, Logger } from '@amplitude/analytics-types';
+import { AmplitudeReturn, Config, LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
 
 export type Events = string[];
 
-export interface SessionReplayContext {
+export interface SessionReplayDestination {
   events: Events;
   sequenceId: number;
+  sessionId: number;
+  flushMaxRetries?: number;
+  apiKey?: string;
+  deviceId?: string;
+  sampleRate: number;
+  serverZone?: keyof typeof ServerZone;
+  onComplete: (sessionId: number, sequenceId: number) => Promise<void>;
+}
+
+export interface SessionReplayDestinationContext extends SessionReplayDestination {
   attempts: number;
   timeout: number;
-  sessionId: number;
 }
 
 export enum RecordingStatus {
@@ -57,4 +66,12 @@ export interface AmplitudeSessionReplay {
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;
+}
+
+export interface SessionReplayTrackDestination {
+  sendEventsList: (destinationData: SessionReplayDestination) => void;
+  setLoggerProvider: (loggerProvider: Logger) => void;
+  // send(context: SessionReplayDestinationContext, useRetry?: boolean): Promise<void>;
+  // schedule(timeout: number): void;
+  flush: (useRetry: boolean) => Promise<void>;
 }

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -71,7 +71,5 @@ export interface AmplitudeSessionReplay {
 export interface SessionReplayTrackDestination {
   sendEventsList: (destinationData: SessionReplayDestination) => void;
   setLoggerProvider: (loggerProvider: Logger) => void;
-  // send(context: SessionReplayDestinationContext, useRetry?: boolean): Promise<void>;
-  // schedule(timeout: number): void;
   flush: (useRetry: boolean) => Promise<void>;
 }

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1,0 +1,385 @@
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import { Logger, ServerZone } from '@amplitude/analytics-types';
+import { SESSION_REPLAY_EU_URL, SESSION_REPLAY_SERVER_URL, SESSION_REPLAY_STAGING_URL } from '../src/constants';
+import { SessionReplayTrackDestination } from '../src/track-destination';
+import { VERSION } from '../src/version';
+
+type MockedLogger = jest.Mocked<Logger>;
+const mockEvent = {
+  type: 4,
+  data: { href: 'https://analytics.amplitude.com/', width: 1728, height: 154 },
+  timestamp: 1687358660935,
+};
+const mockEventString = JSON.stringify(mockEvent);
+
+async function runScheduleTimers() {
+  // exhause first setTimeout
+  jest.runAllTimers();
+  // wait for next tick to call nested setTimeout
+  await Promise.resolve();
+  // exhause nested setTimeout
+  jest.runAllTimers();
+}
+const apiKey = 'static_key';
+
+describe('SessionReplayTrackDestination', () => {
+  let originalFetch: typeof global.fetch;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  const mockOnComplete = jest.fn();
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+      }),
+    ) as jest.Mock;
+
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({} as unknown as typeof globalThis);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(global.Math, 'random').mockRestore();
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+  describe('addToQueue', () => {
+    test('should add to queue and schedule a flush', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const schedule = jest.spyOn(trackDestination, 'schedule').mockReturnValueOnce(undefined);
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+        flushMaxRetries: 1,
+      };
+      trackDestination.addToQueue(context);
+      expect(schedule).toHaveBeenCalledTimes(1);
+      expect(schedule).toHaveBeenCalledWith(0);
+      expect(context.attempts).toBe(1);
+    });
+
+    test('should not add to queue if attemps are greater than allowed retries', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const completeRequest = jest.spyOn(trackDestination, 'completeRequest').mockReturnValueOnce(undefined);
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 1,
+        timeout: 0,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+      trackDestination.addToQueue(context);
+      expect(completeRequest).toHaveBeenCalledTimes(1);
+      expect(completeRequest).toHaveBeenCalledWith({
+        context: context,
+        err: 'Session replay event batch rejected due to exceeded retry count, batch sequence id, 1',
+      });
+    });
+  });
+
+  describe('schedule', () => {
+    test('should schedule a flush', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (trackDestination as any).scheduled = null;
+      trackDestination.queue = [
+        {
+          events: [mockEventString],
+          sequenceId: 1,
+          sessionId: 123,
+          apiKey,
+          attempts: 0,
+          timeout: 0,
+          flushMaxRetries: 1,
+          deviceId: '1a2b3c',
+          sampleRate: 1,
+          serverZone: ServerZone.US,
+          onComplete: mockOnComplete,
+        },
+      ];
+      const flush = jest
+        .spyOn(trackDestination, 'flush')
+        .mockImplementationOnce(() => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (trackDestination as any).scheduled = null;
+          return Promise.resolve(undefined);
+        })
+        .mockReturnValueOnce(Promise.resolve(undefined));
+      trackDestination.schedule(0);
+      await runScheduleTimers();
+      expect(flush).toHaveBeenCalledTimes(2);
+    });
+
+    test('should not schedule if one is already in progress', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (trackDestination as any).scheduled = setTimeout(jest.fn, 0);
+      const flush = jest.spyOn(trackDestination, 'flush').mockReturnValueOnce(Promise.resolve(undefined));
+      trackDestination.schedule(0);
+      expect(flush).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('flush', () => {
+    test('should call send', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      trackDestination.queue = [
+        {
+          events: [mockEventString],
+          sequenceId: 1,
+          sessionId: 123,
+          apiKey,
+          attempts: 0,
+          timeout: 0,
+          flushMaxRetries: 1,
+          deviceId: '1a2b3c',
+          sampleRate: 1,
+          serverZone: ServerZone.US,
+          onComplete: mockOnComplete,
+        },
+      ];
+      const send = jest.spyOn(trackDestination, 'send').mockReturnValueOnce(Promise.resolve());
+      const result = await trackDestination.flush();
+      expect(trackDestination.queue).toEqual([]);
+      expect(result).toBe(undefined);
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    test('should send later', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 1000,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+      trackDestination.queue = [context];
+      const send = jest.spyOn(trackDestination, 'send').mockReturnValueOnce(Promise.resolve());
+      const result = await trackDestination.flush();
+      expect(trackDestination.queue).toEqual([context]);
+      expect(result).toBe(undefined);
+      expect(send).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('getServerUrl', () => {
+    test('should return us server url if no config set', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      expect(trackDestination.getServerUrl()).toEqual(SESSION_REPLAY_SERVER_URL);
+    });
+
+    test('should return staging server url if staging config set', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      expect(trackDestination.getServerUrl(ServerZone.STAGING)).toEqual(SESSION_REPLAY_STAGING_URL);
+    });
+
+    test('should return eu server url if eu config set', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+
+      expect(trackDestination.getServerUrl(ServerZone.EU)).toEqual(SESSION_REPLAY_EU_URL);
+    });
+  });
+
+  describe('send', () => {
+    test('should not send anything if api key not set', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      trackDestination.loggerProvider = mockLoggerProvider;
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+      await trackDestination.send(context);
+      expect(fetch).not.toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    });
+    test('should not send anything if device id not set', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        deviceId: undefined,
+        flushMaxRetries: 1,
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+      await trackDestination.send(context);
+      expect(fetch).not.toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    });
+    test('should make a request correctly', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+
+      await trackDestination.send(context);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api-sr.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&seq_number=1',
+        {
+          body: JSON.stringify({ version: 1, events: [mockEventString] }),
+          headers: {
+            Accept: '*/*',
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer static_key',
+            'X-Client-Sample-Rate': '1',
+            'X-Client-Url': '',
+            'X-Client-Version': VERSION,
+          },
+          method: 'POST',
+        },
+      );
+    });
+    test('should make a request to eu', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        serverZone: ServerZone.EU,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        onComplete: mockOnComplete,
+      };
+
+      await trackDestination.send(context);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api-sr.eu.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&seq_number=1',
+        {
+          body: JSON.stringify({ version: 1, events: [mockEventString] }),
+          headers: {
+            Accept: '*/*',
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer static_key',
+            'X-Client-Sample-Rate': '1',
+            'X-Client-Url': '',
+            'X-Client-Version': VERSION,
+          },
+          method: 'POST',
+        },
+      );
+    });
+
+    test('should retry if retry param is true', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 500,
+          }),
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 200,
+          }),
+        );
+      const addToQueue = jest.spyOn(trackDestination, 'addToQueue');
+
+      await trackDestination.send(context, true);
+      expect(addToQueue).toHaveBeenCalledTimes(1);
+      expect(addToQueue).toHaveBeenCalledWith({
+        ...context,
+        attempts: 1,
+        timeout: 0,
+      });
+      await runScheduleTimers();
+    });
+
+    test('should not retry if retry param is false', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context = {
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        onComplete: mockOnComplete,
+      };
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 500,
+        }),
+      );
+      const addToQueue = jest.spyOn(trackDestination, 'addToQueue');
+
+      await trackDestination.send(context, false);
+      expect(addToQueue).toHaveBeenCalledTimes(0);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

In preparation for adding logic to support targeting, I am simplifying the core SessionReplay class. This class has grown large already as we've added functionality, and will continue to grow larger. This PR separates out all logic related to sending the sequence of events to the API into a new class, TrackDestination. There are no functional changes in this PR.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
