### PR TITLE
fix(session replay): expose deviceid on setSessionId type

### DIFF
--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -52,7 +52,7 @@ export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
-  setSessionId: (sessionId: number) => void;
+  setSessionId: (sessionId: number, deviceId?: string) => void;
   getSessionId: () => number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   flush: (useRetry: boolean) => Promise<void>;


### PR DESCRIPTION
### Summary

Expose an updated interface to setSessionId via updated typing. This optional argument was added in #690  

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
