### PR TITLE
feat(targeting): introduce new package for targeting

### DIFF
--- a/packages/targeting/CHANGELOG.md
+++ b/packages/targeting/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/targeting/README.md
+++ b/packages/targeting/README.md
@@ -1,0 +1,10 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>
+
+# @amplitude/targeting
+
+Internal Node package for Amplitude

--- a/packages/targeting/jest.config.js
+++ b/packages/targeting/jest.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require('../../jest.config.js');
+const package = require('./package');
+
+module.exports = {
+  ...baseConfig,
+  displayName: package.name,
+  rootDir: '.',
+  testEnvironment: 'jsdom',
+  coveragePathIgnorePatterns: ['index.ts'],
+};

--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@amplitude/targeting",
+  "version": "0.0.1",
+  "description": "",
+  "author": "Amplitude Inc",
+  "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
+  "license": "MIT",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
+  },
+  "scripts": {
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
+    "bundle": "rollup --config rollup.config.js",
+    "build:es5": "tsc -p ./tsconfig.es5.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "clean": "rimraf node_modules lib coverage",
+    "fix": "yarn fix:eslint & yarn fix:prettier",
+    "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
+    "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
+    "lint": "yarn lint:eslint & yarn lint:prettier",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
+    "publish": "node ../../scripts/publish/upload-to-s3.js",
+    "test": "jest",
+    "typecheck": "tsc -p ./tsconfig.json",
+    "version": "yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\" @amplitude/analytics-core@\">=1 <3\"",
+    "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
+  },
+  "bugs": {
+    "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
+  },
+  "dependencies": {
+    "@amplitude/analytics-types": ">=1 <3",
+    "@amplitude/experiment-core": "0.7.2",
+    "tslib": "^2.4.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^23.0.4",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^10.0.1",
+    "rollup": "^2.79.1",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/packages/targeting/rollup.config.js
+++ b/packages/targeting/rollup.config.js
@@ -1,0 +1,6 @@
+import { iife, umd } from '../../scripts/build/rollup.config';
+
+iife.input = umd.input;
+iife.output.name = 'targeting';
+
+export default [umd, iife];

--- a/packages/targeting/src/index.ts
+++ b/packages/targeting/src/index.ts
@@ -1,0 +1,1 @@
+export { Targeting } from './targeting';

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -8,8 +8,9 @@ export class Targeting implements AmplitudeTargeting {
     this.evaluationEngine = new EvaluationEngine();
   }
 
-  evaluateTargeting({ event, userProperties, deviceId, flag }: TargetingParameters) {
+  evaluateTargeting({ event, sessionId, userProperties, deviceId, flag }: TargetingParameters) {
     const context = {
+      session_id: sessionId,
       event,
       user: {
         device_id: deviceId,

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -1,0 +1,21 @@
+import { EvaluationEngine } from '@amplitude/experiment-core';
+import { Targeting as AmplitudeTargeting, TargetingParameters } from './typings/targeting';
+
+export class Targeting implements AmplitudeTargeting {
+  evaluationEngine: EvaluationEngine;
+
+  constructor() {
+    this.evaluationEngine = new EvaluationEngine();
+  }
+
+  evaluateTargeting({ event, userProperties, deviceId, flag }: TargetingParameters) {
+    const context = {
+      event,
+      user: {
+        device_id: deviceId,
+        user_properties: userProperties,
+      },
+    };
+    return this.evaluationEngine.evaluate(context, [flag]);
+  }
+}

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -3,8 +3,9 @@ import { EvaluationFlag, EvaluationVariant } from '@amplitude/experiment-core';
 export interface TargetingParameters {
   event?: Event;
   userProperties?: IdentifyUserProperties;
-  deviceId: string;
+  deviceId?: string;
   flag: EvaluationFlag;
+  sessionId?: string;
 }
 
 export interface Targeting {

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -1,0 +1,12 @@
+import { Event, IdentifyUserProperties } from '@amplitude/analytics-types';
+import { EvaluationFlag, EvaluationVariant } from '@amplitude/experiment-core';
+export interface TargetingParameters {
+  event?: Event;
+  userProperties?: IdentifyUserProperties;
+  deviceId: string;
+  flag: EvaluationFlag;
+}
+
+export interface Targeting {
+  evaluateTargeting(args: TargetingParameters): Record<string, EvaluationVariant>;
+}

--- a/packages/targeting/test/flag-config-data.ts
+++ b/packages/targeting/test/flag-config-data.ts
@@ -1,0 +1,84 @@
+export const flagConfig = {
+  key: 'session-replay-targeting',
+  variants: {
+    on: { key: 'on' },
+    off: { key: 'off' },
+  },
+  segments: [
+    {
+      metadata: { segmentName: 'sign in trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 19], // Selects 20% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event', 'event_type'],
+            op: 'is',
+            values: ['Sign In'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'user property' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'Rpr5h4vy', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 14], // Selects 15% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'user', 'user_properties', 'country'],
+            op: 'set contains any',
+            values: ['united states'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'leftover allocation' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'T5lhyRo', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 9], // Selects 10% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      variant: 'off',
+    },
+  ],
+};

--- a/packages/targeting/test/targeting.test.ts
+++ b/packages/targeting/test/targeting.test.ts
@@ -1,0 +1,33 @@
+import { Targeting } from '../src/targeting';
+import { flagConfig } from './flag-config-data';
+
+const mockEvent = {
+  event_type: 'sign_in',
+};
+const mockUserProperties = {};
+
+describe('targeting', () => {
+  describe('evaluateTargeting', () => {
+    test('should call evaluation engine evaluate', () => {
+      const targeting = new Targeting();
+      const mockEngineEvaluate = jest.fn();
+      targeting.evaluationEngine.evaluate = mockEngineEvaluate;
+      targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        event: mockEvent,
+        userProperties: mockUserProperties,
+        flag: flagConfig,
+      });
+      expect(mockEngineEvaluate).toHaveBeenCalledWith(
+        {
+          event: mockEvent,
+          user: {
+            device_id: '1a2b3c',
+            user_properties: mockUserProperties,
+          },
+        },
+        [flagConfig],
+      );
+    });
+  });
+});

--- a/packages/targeting/tsconfig.es5.json
+++ b/packages/targeting/tsconfig.es5.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "lib/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/packages/targeting/tsconfig.esm.json
+++ b/packages/targeting/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "es6",
+    "noEmit": false,
+    "outDir": "lib/esm",
+    "rootDir": "./src"
+  }
+}

--- a/packages/targeting/tsconfig.json
+++ b/packages/targeting/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "noEmit": true,
+    "rootDir": ".",
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,6 +42,13 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.1.1.tgz#89ef85397c4e6bc3a6aeaae4f3d4354ebb7de297"
   integrity sha512-H3vebPR9onRdp0WzAZmI/4qmAE903uLOd2ZfMeHsVc1zaFTTCk46SoCuV4IrlF+VILrDw9Fy6gC9yl5N2PZcJQ==
 
+"@amplitude/experiment-core@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.7.2.tgz#f94219d68d86322e8d580c8fbe0672dcd29f86bb"
+  integrity sha512-Wc2NWvgQ+bLJLeF0A9wBSPIaw0XuqqgkPKsoNFQrmS7r5Djd56um75In05tqmVntPJZRvGKU46pAp8o5tdf4mA==
+  dependencies:
+    js-base64 "^3.7.5"
+
 "@amplitude/plugin-page-view-tracking-browser@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.4.tgz#294c050f66810619816caa9027cfe6c61567e9b6"
@@ -8470,6 +8477,11 @@ joi@^17.2.1:
     "@sideway/address" "^4.1.3"
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
+
+js-base64@^3.7.5:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
 
 js-sdsl@^4.1.4:
   version "4.2.0"


### PR DESCRIPTION
### Summary

This PR introduces the base of a new package called `targeting`, that will provide a wrapper around the experiment-core Evaluation Engine. This package will manage the storage of some event and user property data, but ultimately be a concise interface between Session Replay and future action based products to the Evaluation Engine.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:   no 
