### PR TITLE
refactor(session replay): separate out session identifiers from the rest of config

### DIFF
--- a/packages/session-replay-browser/src/config.ts
+++ b/packages/session-replay-browser/src/config.ts
@@ -1,13 +1,12 @@
 import { FetchTransport } from '@amplitude/analytics-client-common';
 import { Config, Logger } from '@amplitude/analytics-core';
 import { LogLevel } from '@amplitude/analytics-types';
+import { DEFAULT_SAMPLE_RATE, DEFAULT_SERVER_ZONE } from './constants';
 import {
   SessionReplayConfig as ISessionReplayConfig,
   SessionReplayOptions,
   SessionReplayPrivacyConfig,
 } from './typings/session-replay';
-import { DEFAULT_SAMPLE_RATE, DEFAULT_SERVER_ZONE } from './constants';
-import { generateSessionReplayId } from './helpers';
 
 export const getDefaultConfig = () => ({
   flushMaxRetries: 2,
@@ -19,9 +18,6 @@ export const getDefaultConfig = () => ({
 export class SessionReplayConfig extends Config implements ISessionReplayConfig {
   apiKey: string;
   sampleRate: number;
-  deviceId?: string | undefined;
-  sessionId?: number | undefined;
-  sessionReplayId?: string | undefined;
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
 
@@ -39,15 +35,7 @@ export class SessionReplayConfig extends Config implements ISessionReplayConfig 
 
     this.apiKey = apiKey;
     this.sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
-    this.deviceId = options.deviceId;
-    this.sessionId = options.sessionId;
     this.serverZone = options.serverZone || DEFAULT_SERVER_ZONE;
-
-    if (options.sessionId && options.deviceId) {
-      this.sessionReplayId = generateSessionReplayId(options.sessionId, options.deviceId);
-    } else {
-      this.loggerProvider.error('Please provide both sessionId and deviceId.');
-    }
 
     if (options.privacyConfig) {
       this.privacyConfig = options.privacyConfig;

--- a/packages/session-replay-browser/src/identifiers.ts
+++ b/packages/session-replay-browser/src/identifiers.ts
@@ -1,0 +1,20 @@
+import { Logger as ILogger } from '@amplitude/analytics-types';
+import { generateSessionReplayId } from './helpers';
+import { SessionIdentifiers as ISessionIdentifiers, SessionReplayOptions } from './typings/session-replay';
+
+export class SessionIdentifiers implements ISessionIdentifiers {
+  deviceId?: string | undefined;
+  sessionId?: number | undefined;
+  sessionReplayId?: string | undefined;
+
+  constructor(options: SessionReplayOptions, loggerProvider: ILogger) {
+    this.deviceId = options.deviceId;
+    this.sessionId = options.sessionId;
+
+    if (options.sessionId && options.deviceId) {
+      this.sessionReplayId = generateSessionReplayId(options.sessionId, options.deviceId);
+    } else {
+      loggerProvider.error('Please provide both sessionId and deviceId.');
+    }
+  }
+}

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -52,18 +52,21 @@ export interface SessionReplayPrivacyConfig {
 
 export interface SessionReplayConfig extends Config {
   apiKey: string;
-  deviceId?: string;
-  sessionId?: number;
   loggerProvider: Logger;
   logLevel: LogLevel;
   flushMaxRetries: number;
   sampleRate: number;
-  sessionReplayId?: string;
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
 }
 
-export type SessionReplayOptions = Omit<Partial<SessionReplayConfig>, 'apiKey'>;
+export interface SessionIdentifiers {
+  deviceId?: string;
+  sessionId?: number;
+  sessionReplayId?: string;
+}
+
+export type SessionReplayOptions = Omit<Partial<SessionReplayConfig & SessionIdentifiers>, 'apiKey'>;
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;


### PR DESCRIPTION
### Summary

This PR in the Session Replay SDK creates a distinction between config that is set once upon initialization, and identifiers that can be updated throughout the SDK lifecycle (session id, device id, and session replay id). This helps add clarity to which aspects of the configuration are changed in the lifecycle, and which we can expect to remain static.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
