### PR TITLE
refactor(session replay): move events storage logic in idb to separate class

### DIFF
--- a/packages/session-replay-browser/src/session-idb-store.ts
+++ b/packages/session-replay-browser/src/session-idb-store.ts
@@ -19,7 +19,7 @@ export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessi
     this.storageKey = `${STORAGE_PREFIX}_${apiKey.substring(0, 10)}`;
   }
 
-  async getAllSessionDataFromStore() {
+  getAllSessionDataFromStore = async () => {
     try {
       const storedReplaySessionContexts: IDBStore | undefined = await IDBKeyVal.get(this.storageKey);
 
@@ -28,9 +28,9 @@ export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessi
       this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
     }
     return undefined;
-  }
+  };
 
-  async storeEventsForSession(events: Events, sequenceId: number, sessionId: number) {
+  storeEventsForSession = async (events: Events, sequenceId: number, sessionId: number) => {
     try {
       await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {
         const session: IDBStoreSession = sessionMap[sessionId] || { ...defaultSessionStore };
@@ -55,9 +55,9 @@ export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessi
     } catch (e) {
       this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
     }
-  }
+  };
 
-  async cleanUpSessionEventsStore(sessionId: number, sequenceId: number) {
+  cleanUpSessionEventsStore = async (sessionId: number, sequenceId: number) => {
     try {
       await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {
         const session: IDBStoreSession = sessionMap[sessionId];
@@ -90,5 +90,5 @@ export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessi
     } catch (e) {
       this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
     }
-  }
+  };
 }

--- a/packages/session-replay-browser/src/session-idb-store.ts
+++ b/packages/session-replay-browser/src/session-idb-store.ts
@@ -1,0 +1,94 @@
+import { Logger as ILogger } from '@amplitude/analytics-types';
+import * as IDBKeyVal from 'idb-keyval';
+import { MAX_IDB_STORAGE_LENGTH, STORAGE_PREFIX, defaultSessionStore } from './constants';
+import { STORAGE_FAILURE } from './messages';
+import {
+  SessionReplaySessionIDBStore as AmplitudeSessionReplaySessionIDBStore,
+  Events,
+  IDBStore,
+  IDBStoreSession,
+  RecordingStatus,
+} from './typings/session-replay';
+
+export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessionIDBStore {
+  apiKey: string | undefined;
+  storageKey = '';
+  loggerProvider: ILogger;
+  constructor({ apiKey, loggerProvider }: { apiKey: string; loggerProvider: ILogger }) {
+    this.loggerProvider = loggerProvider;
+    this.storageKey = `${STORAGE_PREFIX}_${apiKey.substring(0, 10)}`;
+  }
+
+  async getAllSessionDataFromStore() {
+    try {
+      const storedReplaySessionContexts: IDBStore | undefined = await IDBKeyVal.get(this.storageKey);
+
+      return storedReplaySessionContexts;
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+    return undefined;
+  }
+
+  async storeEventsForSession(events: Events, sequenceId: number, sessionId: number) {
+    try {
+      await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {
+        const session: IDBStoreSession = sessionMap[sessionId] || { ...defaultSessionStore };
+        session.currentSequenceId = sequenceId;
+
+        const currentSequence = (session.sessionSequences && session.sessionSequences[sequenceId]) || {};
+
+        currentSequence.events = events;
+        currentSequence.status = RecordingStatus.RECORDING;
+
+        return {
+          ...sessionMap,
+          [sessionId]: {
+            ...session,
+            sessionSequences: {
+              ...session.sessionSequences,
+              [sequenceId]: currentSequence,
+            },
+          },
+        };
+      });
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+  }
+
+  async cleanUpSessionEventsStore(sessionId: number, sequenceId: number) {
+    try {
+      await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {
+        const session: IDBStoreSession = sessionMap[sessionId];
+        const sequenceToUpdate = session?.sessionSequences && session.sessionSequences[sequenceId];
+        if (!sequenceToUpdate) {
+          return sessionMap;
+        }
+
+        sequenceToUpdate.events = [];
+        sequenceToUpdate.status = RecordingStatus.SENT;
+
+        // Delete sent sequences for current session
+        Object.entries(session.sessionSequences).forEach(([storedSeqId, sequence]) => {
+          const numericStoredSeqId = parseInt(storedSeqId, 10);
+          if (sequence.status === RecordingStatus.SENT && sequenceId !== numericStoredSeqId) {
+            delete session.sessionSequences[numericStoredSeqId];
+          }
+        });
+
+        // Delete any sessions that are older than 3 days
+        Object.keys(sessionMap).forEach((sessionId: string) => {
+          const numericSessionId = parseInt(sessionId, 10);
+          if (Date.now() - numericSessionId >= MAX_IDB_STORAGE_LENGTH) {
+            delete sessionMap[numericSessionId];
+          }
+        });
+
+        return sessionMap;
+      });
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+  }
+}

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -336,7 +336,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       deviceId: this.getDeviceId(),
       sampleRate: this.config.sampleRate,
       serverZone: this.config.serverZone,
-      onComplete: this.sessionIDBStore.cleanUpSessionEventsStore.bind(this),
+      onComplete: this.sessionIDBStore.cleanUpSessionEventsStore.bind(this.sessionIDBStore),
     });
   }
 

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -40,6 +40,12 @@ export interface IDBStore {
   [sessionId: number]: IDBStoreSession;
 }
 
+export interface SessionReplaySessionIDBStore {
+  getAllSessionDataFromStore(): Promise<IDBStore | undefined>;
+  storeEventsForSession(events: Events, sequenceId: number, sessionId: number): Promise<void>;
+  cleanUpSessionEventsStore(sessionId: number, sequenceId: number): Promise<void>;
+}
+
 export interface SessionReplayPrivacyConfig {
   blockSelector?: string | string[];
 }

--- a/packages/session-replay-browser/test/session-idb-store.test.ts
+++ b/packages/session-replay-browser/test/session-idb-store.test.ts
@@ -1,0 +1,354 @@
+import { Logger } from '@amplitude/analytics-types';
+import * as IDBKeyVal from 'idb-keyval';
+import { SessionReplaySessionIDBStore } from '../src/session-idb-store';
+import { IDBStore, RecordingStatus } from '../src/typings/session-replay';
+
+jest.mock('idb-keyval');
+type MockedIDBKeyVal = jest.Mocked<typeof import('idb-keyval')>;
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const apiKey = 'static_key';
+const mockEvent = {
+  type: 4,
+  data: { href: 'https://analytics.amplitude.com/', width: 1728, height: 154 },
+  timestamp: 1687358660935,
+};
+const mockEventString = JSON.stringify(mockEvent);
+
+describe('SessionReplaySessionIDBStore', () => {
+  const { get, update } = IDBKeyVal as MockedIDBKeyVal;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('init', () => {
+    test('should create a storage key', () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      expect(eventsStorage.storageKey).toBe('AMP_replay_unsent_static_key');
+    });
+  });
+  describe('getAllSessionDataFromStore', () => {
+    test('should catch errors', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      get.mockImplementationOnce(() => Promise.reject('error'));
+      await eventsStorage.getAllSessionDataFromStore();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to store session replay events in IndexedDB: error',
+      );
+    });
+  });
+
+  describe('cleanUpSessionEventsStore', () => {
+    test('should update events and status for current session', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const currentSessionId = new Date('2023-07-31 07:30:00').getTime();
+      const mockIDBStore: IDBStore = {
+        [currentSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      };
+      await eventsStorage.cleanUpSessionEventsStore(currentSessionId, 3);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        [currentSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+            3: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+    });
+
+    test('should delete sent sequences for current session', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const currentSessionId = new Date('2023-07-31 07:30:00').getTime();
+      const mockIDBStore: IDBStore = {
+        [currentSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            2: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      };
+      await eventsStorage.cleanUpSessionEventsStore(currentSessionId, 3);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        [currentSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+    });
+
+    test('should keep sessions that are less than 3 days old, and delete sessions that are more than 3 days old', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      const fourDayOldSessionId = new Date('2023-07-27 07:30:00').getTime();
+      const oneDayOldSessionId = new Date('2023-07-30 07:30:00').getTime();
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        [oneDayOldSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        [fourDayOldSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await eventsStorage.cleanUpSessionEventsStore(oneDayOldSessionId, 3);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        [oneDayOldSessionId]: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+    });
+    test('should catch errors', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      update.mockImplementationOnce(() => Promise.reject('error'));
+      await eventsStorage.cleanUpSessionEventsStore(123, 1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to store session replay events in IndexedDB: error',
+      );
+    });
+    test('should handle an undefined store', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      update.mockImplementationOnce(() => Promise.resolve());
+      await eventsStorage.cleanUpSessionEventsStore(123, 1);
+      expect(update.mock.calls[0][1](undefined)).toEqual({});
+    });
+  });
+
+  describe('storeEventsForSession', () => {
+    test('should update the session current sequence id, and the current sequence events and status', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await eventsStorage.storeEventsForSession([mockEventString], 2, 123);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+    });
+    test('should add a new entry if none exist for sequence id', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        123: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await eventsStorage.storeEventsForSession([mockEventString], 2, 123);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+    });
+    test('should add a new entry if none exist for session id', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await eventsStorage.storeEventsForSession([mockEventString], 0, 456);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 0,
+          sessionSequences: {
+            0: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+    });
+    test('should catch errors', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      update.mockImplementationOnce(() => Promise.reject('error'));
+      await eventsStorage.storeEventsForSession([mockEventString], 0, 123);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to store session replay events in IndexedDB: error',
+      );
+    });
+    test('should handle an undefined store', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      update.mockImplementationOnce(() => Promise.resolve());
+      await eventsStorage.storeEventsForSession([mockEventString], 0, 456);
+      expect(update.mock.calls[0][1](undefined)).toEqual({
+        456: {
+          currentSequenceId: 0,
+          sessionSequences: {
+            0: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1015,6 +1015,7 @@ describe('SessionReplayPlugin', () => {
       await runScheduleTimers();
       expect(cleanUpSessionEventsStore).toHaveBeenCalledTimes(1);
       expect(cleanUpSessionEventsStore.mock.calls[0]).toEqual([123, 4]);
+      expect(update).toHaveBeenCalledWith('AMP_replay_unsent_static_key', expect.anything());
     });
     test('should remove session events from IDB store upon failure', async () => {
       const sessionReplay = new SessionReplay();


### PR DESCRIPTION
### Summary

Reimplement #704 , with a fix for this binding on `cleanUpSessionEventsStore`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
