### PR TITLE
refactor(session replay): create events manager class

### DIFF
--- a/packages/session-replay-browser/src/events-manager.ts
+++ b/packages/session-replay-browser/src/events-manager.ts
@@ -1,0 +1,176 @@
+import { MAX_EVENT_LIST_SIZE_IN_BYTES, MAX_INTERVAL, MIN_INTERVAL } from './constants';
+import {
+  SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
+  SessionReplaySessionIDBStore as AmplitudeSessionReplayEventsStorage,
+  SessionReplayTrackDestination as AmplitudeSessionReplayTrackDestination,
+  Events,
+  IDBStore,
+  RecordingStatus,
+  SessionReplayConfig,
+} from './typings/session-replay';
+
+import { SessionReplaySessionIDBStore } from './session-idb-store';
+import { SessionReplayTrackDestination } from './track-destination';
+
+export class SessionReplayEventsManager implements AmplitudeSessionReplayEventsManager {
+  events: Events = [];
+  currentSequenceId = 0;
+  maxPersistedEventsSize = MAX_EVENT_LIST_SIZE_IN_BYTES;
+  interval = MIN_INTERVAL;
+  timeAtLastSend: number | null = null;
+  sessionIDBStore: AmplitudeSessionReplayEventsStorage;
+  trackDestination: AmplitudeSessionReplayTrackDestination;
+  config: SessionReplayConfig;
+
+  constructor({ config }: { config: SessionReplayConfig }) {
+    this.config = config;
+    this.trackDestination = new SessionReplayTrackDestination({ loggerProvider: this.config.loggerProvider });
+    this.sessionIDBStore = new SessionReplaySessionIDBStore({
+      loggerProvider: this.config.loggerProvider,
+      apiKey: this.config.apiKey,
+    });
+  }
+
+  async initialize({
+    sessionId,
+    deviceId,
+    shouldSendStoredEvents = false,
+  }: {
+    sessionId: number;
+    deviceId: string;
+    shouldSendStoredEvents?: boolean;
+  }) {
+    this.timeAtLastSend = Date.now(); // Initialize this so we have a point of comparison when events are recorded
+    const storedReplaySessions = await this.sessionIDBStore.getAllSessionDataFromStore();
+
+    const storedSequencesForSession = storedReplaySessions && storedReplaySessions[sessionId];
+    if (storedReplaySessions && storedSequencesForSession && storedSequencesForSession.sessionSequences) {
+      const storedSeqId = storedSequencesForSession.currentSequenceId;
+      const lastSequence = storedSequencesForSession.sessionSequences[storedSeqId];
+      if (lastSequence && lastSequence.status !== RecordingStatus.RECORDING) {
+        this.currentSequenceId = storedSeqId + 1;
+        this.events = [];
+      } else {
+        // Pick up recording where it was left off in another tab or window
+        this.currentSequenceId = storedSeqId;
+        this.events = lastSequence?.events || [];
+      }
+    }
+    if (shouldSendStoredEvents && storedReplaySessions) {
+      this.sendStoredEvents({ storedReplaySessions, deviceId, sessionId });
+    }
+  }
+
+  sendStoredEvents({
+    storedReplaySessions,
+    sessionId,
+    deviceId,
+  }: {
+    storedReplaySessions: IDBStore;
+    sessionId: number;
+    deviceId: string;
+  }) {
+    for (const storedSessionId in storedReplaySessions) {
+      const storedSequences = storedReplaySessions[storedSessionId].sessionSequences;
+      for (const storedSeqId in storedSequences) {
+        const seq = storedSequences[storedSeqId];
+        const numericSeqId = parseInt(storedSeqId, 10);
+        const numericSessionId = parseInt(storedSessionId, 10);
+        if (numericSessionId === sessionId && numericSeqId === this.currentSequenceId) {
+          continue;
+        }
+
+        if (seq.events && seq.events.length && seq.status === RecordingStatus.RECORDING) {
+          this.sendEventsList({
+            events: seq.events,
+            sequenceId: numericSeqId,
+            sessionId: numericSessionId,
+            deviceId,
+          });
+        }
+      }
+    }
+  }
+
+  resetSequence() {
+    this.events = [];
+    this.currentSequenceId = 0;
+  }
+
+  addEvent({ event, sessionId, deviceId }: { event: string; sessionId: number; deviceId: string }) {
+    const shouldSplit = this.shouldSplitEventsList(event);
+    if (shouldSplit) {
+      this.sendEventsList({
+        events: this.events,
+        sequenceId: this.currentSequenceId,
+        sessionId,
+        deviceId,
+      });
+      this.events = [];
+      this.currentSequenceId++;
+    }
+    this.events.push(event);
+    void this.sessionIDBStore.storeEventsForSession(this.events, this.currentSequenceId, sessionId);
+  }
+
+  /**
+   * Determines whether to send the events list to the backend and start a new
+   * empty events list, based on the size of the list as well as the last time sent
+   * @param nextEventString
+   * @returns boolean
+   */
+  shouldSplitEventsList = (nextEventString: string): boolean => {
+    const sizeOfNextEvent = new Blob([nextEventString]).size;
+    const sizeOfEventsList = new Blob(this.events).size;
+    if (sizeOfEventsList + sizeOfNextEvent >= this.maxPersistedEventsSize) {
+      return true;
+    }
+    if (this.timeAtLastSend !== null && Date.now() - this.timeAtLastSend > this.interval && this.events.length) {
+      this.interval = Math.min(MAX_INTERVAL, this.interval + MIN_INTERVAL);
+      this.timeAtLastSend = Date.now();
+      return true;
+    }
+    return false;
+  };
+
+  sendEvents({ sessionId, deviceId }: { sessionId: number; deviceId: string }) {
+    if (this.events.length && sessionId) {
+      this.sendEventsList({
+        events: this.events,
+        sequenceId: this.currentSequenceId,
+        sessionId,
+        deviceId,
+      });
+    }
+  }
+
+  sendEventsList({
+    events,
+    sequenceId,
+    sessionId,
+    deviceId,
+  }: {
+    events: string[];
+    sequenceId: number;
+    sessionId: number;
+    deviceId: string;
+  }) {
+    this.trackDestination.sendEventsList({
+      events: events,
+      sequenceId: sequenceId,
+      sessionId: sessionId,
+      flushMaxRetries: this.config.flushMaxRetries,
+      apiKey: this.config.apiKey,
+      deviceId: deviceId,
+      sampleRate: this.config.sampleRate,
+      serverZone: this.config.serverZone,
+      onComplete: this.sessionIDBStore.cleanUpSessionEventsStore.bind(this.sessionIDBStore),
+    });
+  }
+
+  async flush(useRetry = false) {
+    if (this.trackDestination) {
+      return this.trackDestination.flush(useRetry);
+    }
+  }
+}

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -32,10 +32,6 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     this.loggerProvider = loggerProvider;
   }
 
-  setLoggerProvider(loggerProvider: ILogger) {
-    this.loggerProvider = loggerProvider;
-  }
-
   sendEventsList(destinationData: SessionReplayDestination) {
     this.addToQueue({
       ...destinationData,

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -79,6 +79,22 @@ export interface AmplitudeSessionReplay {
 
 export interface SessionReplayTrackDestination {
   sendEventsList: (destinationData: SessionReplayDestination) => void;
-  setLoggerProvider: (loggerProvider: Logger) => void;
   flush: (useRetry: boolean) => Promise<void>;
+}
+
+export interface SessionReplayEventsManager {
+  initialize({
+    sessionId,
+    shouldSendStoredEvents,
+    deviceId,
+  }: {
+    sessionId: number;
+    shouldSendStoredEvents: boolean;
+    deviceId: string;
+  }): Promise<void>;
+  addEvent({ sessionId, event, deviceId }: { sessionId: number; event: string; deviceId: string }): void;
+  sendEvents({ sessionId, deviceId }: { sessionId: number; deviceId: string }): void;
+  resetSequence(): void;
+  flush(useRetry?: boolean): Promise<void>;
+  events: Events;
 }

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -1,0 +1,461 @@
+import { Logger } from '@amplitude/analytics-types';
+import * as IDBKeyVal from 'idb-keyval';
+import { SessionReplayConfig } from '../src/config';
+import { SessionReplayEventsManager } from '../src/events-manager';
+import { IDBStore, RecordingStatus } from '../src/typings/session-replay';
+
+jest.mock('idb-keyval');
+type MockedIDBKeyVal = jest.Mocked<typeof import('idb-keyval')>;
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const mockEvent = {
+  type: 4,
+  data: { href: 'https://analytics.amplitude.com/', width: 1728, height: 154 },
+  timestamp: 1687358660935,
+};
+const mockEventString = JSON.stringify(mockEvent);
+
+async function runScheduleTimers() {
+  // exhause first setTimeout
+  jest.runAllTimers();
+  // wait for next tick to call nested setTimeout
+  await Promise.resolve();
+  // exhause nested setTimeout
+  jest.runAllTimers();
+}
+
+describe('SessionReplayEventsManager', () => {
+  let originalFetch: typeof global.fetch;
+  const { get, update } = IDBKeyVal as MockedIDBKeyVal;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  const config = new SessionReplayConfig('static_key', {
+    loggerProvider: mockLoggerProvider,
+    sampleRate: 1,
+  });
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+      }),
+    ) as jest.Mock;
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+
+    jest.useRealTimers();
+  });
+  describe('initialize', () => {
+    test('should read events from storage and send them if shouldSendStoredEvents is true', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution: Promise<IDBStore> = Promise.resolve({
+        123: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+      get.mockReturnValueOnce(mockGetResolution);
+      const send = jest.spyOn(eventsManager, 'sendEventsList').mockReturnValueOnce();
+
+      await eventsManager.initialize({ sessionId: 456, deviceId: '1a2b3c', shouldSendStoredEvents: true });
+      await mockGetResolution;
+      jest.runAllTimers();
+      expect(send).toHaveBeenCalledTimes(1);
+
+      // Should send only events from sequences marked as recording and not current session
+      expect(send.mock.calls[0][0]).toEqual({
+        events: [mockEventString],
+        sequenceId: 3,
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+    });
+
+    test('should not send stored events if shouldSendStoredEvents is false', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution: Promise<IDBStore> = Promise.resolve({
+        123: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+      get.mockReturnValueOnce(mockGetResolution);
+      const send = jest.spyOn(eventsManager, 'sendEventsList').mockReturnValueOnce();
+
+      await eventsManager.initialize({ sessionId: 456, deviceId: '1a2b3c' });
+      await mockGetResolution;
+      jest.runAllTimers();
+      expect(send).toHaveBeenCalledTimes(0);
+    });
+    test('should return early if using old format of IDBStore', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution = Promise.resolve({
+        123: {
+          events: [mockEventString],
+          sequenceId: 1,
+        },
+        456: {
+          events: [mockEventString],
+          sequenceId: 1,
+        },
+      });
+      get.mockReturnValueOnce(mockGetResolution);
+      const send = jest.spyOn(eventsManager, 'sendEventsList').mockReturnValueOnce();
+      await eventsManager.initialize({ sessionId: 123, deviceId: '1a2b3c', shouldSendStoredEvents: true });
+      await mockGetResolution;
+      jest.runAllTimers();
+      expect(send).toHaveBeenCalledTimes(0);
+    });
+    test('should configure current sequence id and events correctly if last sequence was sent', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution: Promise<IDBStore> = Promise.resolve({
+        123: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+      get.mockReturnValueOnce(mockGetResolution);
+      await eventsManager.initialize({ sessionId: 123, deviceId: '1a2b3c', shouldSendStoredEvents: true });
+      expect(eventsManager.currentSequenceId).toEqual(4);
+      expect(eventsManager.events).toEqual([]);
+    });
+    test('should configure current sequence id and events correctly if last sequence was recording', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution: Promise<IDBStore> = Promise.resolve({
+        123: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+      get.mockReturnValueOnce(mockGetResolution);
+      await eventsManager.initialize({ sessionId: 123, deviceId: '1a2b3c', shouldSendStoredEvents: true });
+      expect(eventsManager.currentSequenceId).toEqual(3);
+      expect(eventsManager.events).toEqual([mockEventString]);
+    });
+    test('should handle no stored events', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution = Promise.resolve({});
+      get.mockReturnValueOnce(mockGetResolution);
+      await eventsManager.initialize({ sessionId: 123, deviceId: '1a2b3c', shouldSendStoredEvents: true });
+      expect(eventsManager.currentSequenceId).toBe(0);
+      expect(eventsManager.events).toEqual([]);
+    });
+    test('should handle no stored sequences for session', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const mockGetResolution = Promise.resolve({
+        123: {
+          currentSequenceId: 0,
+          sessionSequences: {},
+        },
+      });
+      get.mockReturnValueOnce(mockGetResolution);
+      await eventsManager.initialize({ sessionId: 123, deviceId: '1a2b3c', shouldSendStoredEvents: true });
+      expect(eventsManager.currentSequenceId).toBe(0);
+      expect(eventsManager.events).toEqual([]);
+    });
+  });
+
+  describe('sendStoredEvents', () => {
+    test('should send all recording sequences except the current sequence for the current session', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      eventsManager.currentSequenceId = 3;
+      const store: IDBStore = {
+        123: {
+          currentSequenceId: 5,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+            4: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+            5: {
+              events: [mockEventString, mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            1: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+            2: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      };
+      const sendEventsList = jest.spyOn(eventsManager, 'sendEventsList');
+      eventsManager.sendStoredEvents({ storedReplaySessions: store, sessionId: 456, deviceId: '1a2b3c' });
+      expect(sendEventsList).toHaveBeenCalledTimes(3);
+      expect(sendEventsList.mock.calls[0][0]).toEqual({
+        events: [mockEventString],
+        sequenceId: 3,
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+      expect(sendEventsList.mock.calls[1][0]).toEqual({
+        events: [mockEventString, mockEventString],
+        sequenceId: 5,
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+      expect(sendEventsList.mock.calls[2][0]).toEqual({
+        events: [mockEventString],
+        sequenceId: 1,
+        sessionId: 456,
+        deviceId: '1a2b3c',
+      });
+    });
+  });
+
+  describe('addEvent', () => {
+    test('should store events in class and in IDB', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      eventsManager.addEvent({ event: mockEventString, sessionId: 123, deviceId: '1a2b3c' });
+      expect(eventsManager.events).toEqual([mockEventString]);
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1]({})).toEqual({
+        123: {
+          currentSequenceId: 0,
+          sessionSequences: {
+            0: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+    });
+
+    test('should split the events list at an increasing interval and send', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      eventsManager.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      const sendEventsList = jest.spyOn(eventsManager, 'sendEventsList');
+      // Add first event, which is not sent immediately
+      eventsManager.addEvent({ event: mockEventString, sessionId: 123, deviceId: '1a2b3c' });
+
+      expect(sendEventsList).toHaveBeenCalledTimes(0);
+      // Add second event and advance timers to interval
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:31:00').getTime());
+      eventsManager.addEvent({ event: mockEventString, sessionId: 123, deviceId: '1a2b3c' });
+      expect(sendEventsList).toHaveBeenCalledTimes(1);
+      expect(sendEventsList).toHaveBeenCalledWith({
+        events: [mockEventString],
+        sequenceId: 0,
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+      expect(eventsManager.events).toEqual([mockEventString]);
+      expect(eventsManager.currentSequenceId).toEqual(1);
+    });
+
+    test('should split the events list at max size and send', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      eventsManager.maxPersistedEventsSize = 20;
+      // Simulate as if many events have already been built up
+      const events = ['#'.repeat(20)];
+      eventsManager.events = events;
+      const sendEventsListMock = jest
+        .spyOn(eventsManager, 'sendEventsList')
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        .mockImplementationOnce(() => {});
+      eventsManager.addEvent({ event: mockEventString, sessionId: 123, deviceId: '1a2b3c' });
+      expect(sendEventsListMock).toHaveBeenCalledTimes(1);
+      expect(sendEventsListMock).toHaveBeenCalledWith({
+        events,
+        sequenceId: 0,
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+
+      expect(eventsManager.events).toEqual([mockEventString]);
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1]({})).toEqual({
+        123: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('sendEvents', () => {
+    test('should call trackDestination sendEventsList', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      eventsManager.events = [mockEventString];
+      eventsManager.currentSequenceId = 4;
+      const trackSendEventsList = jest.spyOn(eventsManager.trackDestination, 'sendEventsList');
+      eventsManager.sendEvents({
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+
+      expect(trackSendEventsList).toHaveBeenCalledWith({
+        events: [mockEventString],
+        sequenceId: 4,
+        sessionId: 123,
+        flushMaxRetries: config.flushMaxRetries,
+        apiKey: config.apiKey,
+        deviceId: '1a2b3c',
+        sampleRate: config.sampleRate,
+        serverZone: config.serverZone,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        onComplete: expect.anything(),
+      });
+    });
+    test('should update IDB store upon success', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const cleanUpSessionEventsStore = jest.spyOn(eventsManager.sessionIDBStore, 'cleanUpSessionEventsStore');
+      eventsManager.events = [mockEventString];
+      eventsManager.currentSequenceId = 4;
+      eventsManager.sendEvents({
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+      await runScheduleTimers();
+      expect(cleanUpSessionEventsStore).toHaveBeenCalledTimes(1);
+      expect(cleanUpSessionEventsStore.mock.calls[0]).toEqual([123, 4]);
+      expect(update).toHaveBeenCalledWith('AMP_replay_unsent_static_key', expect.anything());
+    });
+    test('should remove session events from IDB store upon failure', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      eventsManager.events = [mockEventString];
+      eventsManager.currentSequenceId = 4;
+      const cleanUpSessionEventsStore = jest
+        .spyOn(eventsManager.sessionIDBStore, 'cleanUpSessionEventsStore')
+        .mockReturnValueOnce(Promise.resolve());
+      (global.fetch as jest.Mock).mockImplementationOnce(() => Promise.reject());
+
+      eventsManager.sendEvents({
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+      await runScheduleTimers();
+      expect(cleanUpSessionEventsStore).toHaveBeenCalledTimes(1);
+      expect(cleanUpSessionEventsStore.mock.calls[0]).toEqual([123, 4]);
+    });
+  });
+
+  describe('shouldSplitEventsList', () => {
+    describe('event list size', () => {
+      test('should return true if size of events list plus size of next event is over the max size', () => {
+        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsList = ['#'.repeat(20)];
+        eventsManager.events = eventsList;
+        eventsManager.maxPersistedEventsSize = 20;
+        const nextEvent = 'a';
+        const result = eventsManager.shouldSplitEventsList(nextEvent);
+        expect(result).toBe(true);
+      });
+      test('should return false if size of events list plus size of next event is under the max size', () => {
+        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsList = ['#'.repeat(20)];
+        eventsManager.events = eventsList;
+        eventsManager.maxPersistedEventsSize = 22;
+        const nextEvent = 'a';
+        const result = eventsManager.shouldSplitEventsList(nextEvent);
+        expect(result).toBe(false);
+      });
+    });
+    describe('interval', () => {
+      test('should return false if timeAtLastSend is null', () => {
+        const eventsManager = new SessionReplayEventsManager({ config });
+        const nextEvent = 'a';
+        const result = eventsManager.shouldSplitEventsList(nextEvent);
+        expect(result).toBe(false);
+      });
+      test('should return false if it has not been long enough since last send', () => {
+        const eventsManager = new SessionReplayEventsManager({ config });
+        eventsManager.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
+        jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+        const nextEvent = 'a';
+        const result = eventsManager.shouldSplitEventsList(nextEvent);
+        expect(result).toBe(false);
+      });
+      test('should return true if it has been long enough since last send and events have been emitted', () => {
+        const eventsManager = new SessionReplayEventsManager({ config });
+        eventsManager.events = [mockEventString];
+        eventsManager.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
+        jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:33:00').getTime());
+        const nextEvent = 'a';
+        const result = eventsManager.shouldSplitEventsList(nextEvent);
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('flush', () => {
+    test('should call track destination flush with useRetry as true', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const flushMock = jest.spyOn(eventsManager.trackDestination, 'flush');
+
+      await eventsManager.flush(true);
+      expect(flushMock).toHaveBeenCalled();
+      expect(flushMock).toHaveBeenCalledWith(true);
+    });
+    test('should call track destination flush without useRetry', async () => {
+      const eventsManager = new SessionReplayEventsManager({ config });
+      const flushMock = jest.spyOn(eventsManager.trackDestination, 'flush');
+
+      await eventsManager.flush();
+      expect(flushMock).toHaveBeenCalled();
+      expect(flushMock).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -1,0 +1,326 @@
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
+import * as RRWeb from '@amplitude/rrweb';
+import * as IDBKeyVal from 'idb-keyval';
+import { SessionReplayOptions } from 'src/typings/session-replay';
+import { DEFAULT_SAMPLE_RATE, DEFAULT_SESSION_REPLAY_PROPERTY } from '../src/constants';
+import * as Helpers from '../src/helpers';
+import { UNEXPECTED_ERROR_MESSAGE, getSuccessMessage } from '../src/messages';
+import { SessionReplay } from '../src/session-replay';
+
+jest.mock('idb-keyval');
+type MockedIDBKeyVal = jest.Mocked<typeof import('idb-keyval')>;
+type MockedLogger = jest.Mocked<Logger>;
+jest.mock('@amplitude/rrweb');
+type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
+
+const mockEvent = {
+  type: 4,
+  data: { href: 'https://analytics.amplitude.com/', width: 1728, height: 154 },
+  timestamp: 1687358660935,
+};
+const mockEventString = JSON.stringify(mockEvent);
+
+async function runScheduleTimers() {
+  // exhause first setTimeout
+  jest.runAllTimers();
+  // wait for next tick to call nested setTimeout
+  await Promise.resolve();
+  // exhause nested setTimeout
+  jest.runAllTimers();
+}
+describe('module level integration', () => {
+  const { update } = IDBKeyVal as MockedIDBKeyVal;
+  const { record } = RRWeb as MockedRRWeb;
+  const addEventListenerMock = jest.fn() as jest.Mock<typeof window.addEventListener>;
+  const removeEventListenerMock = jest.fn() as jest.Mock<typeof window.removeEventListener>;
+  const mockGlobalScope = {
+    addEventListener: addEventListenerMock,
+    removeEventListener: removeEventListenerMock,
+    document: {
+      hasFocus: () => true,
+    },
+  } as unknown as typeof globalThis;
+  let originalFetch: typeof global.fetch;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  const apiKey = 'static_key';
+  const mockOptions: SessionReplayOptions = {
+    flushIntervalMillis: 0,
+    flushMaxRetries: 1,
+    flushQueueSize: 0,
+    logLevel: LogLevel.None,
+    loggerProvider: mockLoggerProvider,
+    deviceId: '1a2b3c',
+    optOut: false,
+    sampleRate: 1,
+    sessionId: 123,
+    serverZone: ServerZone.EU,
+  };
+  const mockEmptyOptions: SessionReplayOptions = {
+    flushIntervalMillis: 0,
+    flushMaxRetries: 1,
+    flushQueueSize: 0,
+    logLevel: LogLevel.None,
+    loggerProvider: mockLoggerProvider,
+    deviceId: '1a2b3c',
+    sessionId: 123,
+  };
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+      }),
+    ) as jest.Mock;
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(global.Math, 'random').mockRestore();
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+  describe('with a sample rate', () => {
+    test('should not record session if excluded due to sampling', async () => {
+      jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.2 }).promise;
+      const sampleRate = sessionReplay.config?.sampleRate;
+      expect(sampleRate).toBe(0.2);
+      const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+      expect(sessionRecordingProperties).toMatchObject({});
+      expect(record).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+      await runScheduleTimers();
+      expect(fetch).not.toHaveBeenCalled();
+    });
+    test('should record session if included due to sampling', async () => {
+      jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => true);
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 200,
+        });
+      });
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.8 }).promise;
+      const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+      expect(sessionRecordingProperties).toMatchObject({
+        [DEFAULT_SESSION_REPLAY_PROPERTY]: '1a2b3c/123',
+      });
+      // Log is called from setup, but that's not what we're testing here
+      mockLoggerProvider.log.mockClear();
+      expect(record).toHaveBeenCalled();
+      const recordArg = record.mock.calls[0][0];
+      recordArg?.emit && recordArg?.emit(mockEvent);
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual(getSuccessMessage(123));
+    });
+  });
+  describe('without a sample rate', () => {
+    test('should not record session if no sample rate is provided', async () => {
+      jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockEmptyOptions }).promise;
+      const sampleRate = sessionReplay.config?.sampleRate;
+      expect(sampleRate).toBe(DEFAULT_SAMPLE_RATE);
+      const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+      expect(sessionRecordingProperties).toMatchObject({});
+      expect(record).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+      await runScheduleTimers();
+      expect(fetch).not.toHaveBeenCalled();
+    });
+    test('should not record session if sample rate of value 0 is provided', async () => {
+      jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockEmptyOptions, sampleRate: 0 }).promise;
+      const sampleRate = sessionReplay.config?.sampleRate;
+      expect(sampleRate).toBe(DEFAULT_SAMPLE_RATE);
+      const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
+      expect(sessionRecordingProperties).toMatchObject({});
+      expect(record).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+      await runScheduleTimers();
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with optOut in config', () => {
+    test('should not record session if excluded due to optOut', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, optOut: true }).promise;
+      expect(record).not.toHaveBeenCalled();
+      await runScheduleTimers();
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+  test('should handle unexpected error', async () => {
+    const sessionReplay = new SessionReplay();
+    (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
+    await sessionReplay.init(apiKey, { ...mockOptions }).promise;
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('API Failure');
+  });
+  test('should not retry for 400 error', async () => {
+    (fetch as jest.Mock)
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 400,
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 200,
+        });
+      });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+    // Log is called from init, but that's not what we're testing here
+    mockLoggerProvider.log.mockClear();
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+  });
+  test('should not retry for 413 error', async () => {
+    (fetch as jest.Mock)
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 413,
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 200,
+        });
+      });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+  });
+  test('should handle retry for 500 error', async () => {
+    (fetch as jest.Mock)
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 200,
+        });
+      });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('should only retry once for 500 error, even if config set to higher than one retry', async () => {
+    (fetch as jest.Mock)
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 10 }).promise;
+
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+  test('should handle retry for 503 error', async () => {
+    (fetch as jest.Mock)
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 503,
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 200,
+        });
+      });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+  test('should handle unexpected error where fetch response is null', async () => {
+    (fetch as jest.Mock).mockImplementationOnce(() => {
+      return Promise.resolve(null);
+    });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(UNEXPECTED_ERROR_MESSAGE);
+  });
+});


### PR DESCRIPTION
### Summary

This PR introduces an SessionReplayEventsManager class to the Session Replay SDK architecture. This class is responsible for all handling of rrweb events - both storage and at what cadence to send them to the backend. This refactor will make it much easier to introduce targeting, which will modify the timing of both storage and backend submissions.

There are two commits in this PR, that may be easier to review independently:
[The first commit introduces the class](https://github.com/amplitude/Amplitude-TypeScript/pull/708/commits/bd81ad033416c33d146d1c59c5bcdfcd9244bf5e), changing as little as possible in the tests to show that there are no regressions based on this refactor
[The second commit reworks the tests](https://github.com/amplitude/Amplitude-TypeScript/pull/708/commits/026adf5c3b249eed377a3deac3f1df62c276d21c) to more appropriately fit the new architecture.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
