### PR TITLE
feat(session replay): introduce remote config fetch class

### DIFF
--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -42,6 +42,7 @@
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-types": ">=1 <3",
     "@amplitude/rrweb": "^2.0.0-alpha.12",
+    "@amplitude/targeting": "0.1.0",
     "idb-keyval": "^6.2.1",
     "tslib": "^2.4.1"
   },

--- a/packages/session-replay-browser/src/remote-config-fetch.ts
+++ b/packages/session-replay-browser/src/remote-config-fetch.ts
@@ -1,0 +1,96 @@
+import { BaseTransport } from '@amplitude/analytics-core';
+import { Status } from '@amplitude/analytics-types';
+import { TargetingFlag } from '@amplitude/targeting';
+import { SESSION_REPLAY_SERVER_URL } from './constants';
+import { UNEXPECTED_ERROR_MESSAGE } from './messages';
+import {
+  SessionReplayRemoteConfigFetch as AmplitudeSessionReplayRemoteConfigFetch,
+  SessionReplayConfig,
+  SessionReplayRemoteConfig,
+} from './typings/session-replay';
+
+export const UNEXPECTED_NETWORK_ERROR_MESSAGE = 'Network error occurred, session replay remote config fetch failed';
+export const SUCCESS_REMOTE_CONFIG = 'Session replay remote config successfully fetched';
+export const MISSING_API_KEY_MESSAGE = 'Session replay remote config not fetched due to missing api key';
+
+export class SessionReplayRemoteConfigFetch implements AmplitudeSessionReplayRemoteConfigFetch {
+  config: SessionReplayConfig;
+  remoteConfig: SessionReplayRemoteConfig | undefined;
+  retryTimeout = 1000;
+  attempts = 0;
+
+  constructor({ config }: { config: SessionReplayConfig }) {
+    this.config = config;
+  }
+
+  getRemoteConfig = (): Promise<SessionReplayRemoteConfig | void> => {
+    if (this.remoteConfig) {
+      return Promise.resolve(this.remoteConfig);
+    }
+    return this.fetchRemoteConfig();
+  };
+
+  getTargetingConfig = async (): Promise<TargetingFlag | void> => {
+    const remoteConfig = await this.getRemoteConfig();
+    return remoteConfig?.sr_targeting_config;
+  };
+
+  getServerUrl() {
+    return SESSION_REPLAY_SERVER_URL;
+  }
+
+  fetchRemoteConfig = async (): Promise<SessionReplayRemoteConfig | void> => {
+    try {
+      const options: RequestInit = {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: '*/*',
+          Authorization: `Bearer ${this.config.apiKey}`,
+        },
+        method: 'GET',
+      };
+      const urlParams = new URLSearchParams({});
+      const server_url = `${this.getServerUrl()}?${urlParams.toString()}`;
+      const res = await fetch(server_url, options);
+      this.attempts += 1;
+      if (res === null) {
+        return this.completeRequest({ err: UNEXPECTED_ERROR_MESSAGE });
+      }
+      const parsedStatus = new BaseTransport().buildStatus(res.status);
+      switch (parsedStatus) {
+        case Status.Success:
+          return this.parseAndStoreConfig(res);
+        case Status.Failed:
+          return this.maybeRetryFetch();
+        default:
+          return this.completeRequest({ err: UNEXPECTED_NETWORK_ERROR_MESSAGE });
+      }
+    } catch (e) {
+      return this.completeRequest({ err: e as string });
+    }
+  };
+
+  maybeRetryFetch = async (): Promise<SessionReplayRemoteConfig | void> => {
+    if (this.attempts < this.config.flushMaxRetries) {
+      await new Promise((resolve) => setTimeout(resolve, this.attempts * this.retryTimeout));
+      return this.fetchRemoteConfig();
+    }
+    return this.completeRequest({ err: UNEXPECTED_NETWORK_ERROR_MESSAGE });
+  };
+
+  parseAndStoreConfig = async (res: Response): Promise<SessionReplayRemoteConfig> => {
+    const remoteConfig: SessionReplayRemoteConfig = (await res.json()) as SessionReplayRemoteConfig;
+    this.completeRequest({ success: SUCCESS_REMOTE_CONFIG });
+    this.remoteConfig = remoteConfig;
+    return remoteConfig;
+  };
+
+  completeRequest({ err, success }: { err?: string; success?: string }) {
+    this.attempts = 0; // Reset attempts back to 0 for restart
+    if (err) {
+      this.config.loggerProvider.warn(err);
+    } else if (success) {
+      this.config.loggerProvider.log(success);
+    }
+  }
+}

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,4 +1,5 @@
 import { AmplitudeReturn, Config, LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
+import { TargetingFlag } from '@amplitude/targeting';
 
 export type Events = string[];
 
@@ -80,6 +81,14 @@ export interface AmplitudeSessionReplay {
 export interface SessionReplayTrackDestination {
   sendEventsList: (destinationData: SessionReplayDestination) => void;
   flush: (useRetry: boolean) => Promise<void>;
+}
+
+export interface SessionReplayRemoteConfigFetch {
+  getRemoteConfig: () => Promise<SessionReplayRemoteConfig | void>;
+  getTargetingConfig: () => Promise<TargetingFlag | void>;
+}
+export interface SessionReplayRemoteConfig {
+  sr_targeting_config: TargetingFlag;
 }
 
 export interface SessionReplayEventsManager {

--- a/packages/session-replay-browser/test/flag-config-data.ts
+++ b/packages/session-replay-browser/test/flag-config-data.ts
@@ -1,0 +1,84 @@
+export const flagConfig = {
+  key: 'session-replay-targeting',
+  variants: {
+    on: { key: 'on' },
+    off: { key: 'off' },
+  },
+  segments: [
+    {
+      metadata: { segmentName: 'sign in trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 19], // Selects 20% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event', 'event_type'],
+            op: 'is',
+            values: ['Sign In'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'user property' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'Rpr5h4vy', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 14], // Selects 15% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'user', 'user_properties', 'country'],
+            op: 'set contains any',
+            values: ['united states'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'leftover allocation' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'T5lhyRo', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 9], // Selects 10% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      variant: 'off',
+    },
+  ],
+};

--- a/packages/session-replay-browser/test/remote-config-fetch.test.ts
+++ b/packages/session-replay-browser/test/remote-config-fetch.test.ts
@@ -1,0 +1,269 @@
+import { Logger } from '@amplitude/analytics-types';
+import { SessionReplayConfig } from '../src/config';
+import { UNEXPECTED_ERROR_MESSAGE } from '../src/messages';
+import { SessionReplayRemoteConfigFetch } from '../src/remote-config-fetch';
+import { SessionReplayRemoteConfig } from '../src/typings/session-replay';
+import { flagConfig } from './flag-config-data';
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const mockRemoteConfig: SessionReplayRemoteConfig = {
+  sr_targeting_config: flagConfig,
+};
+
+async function runScheduleTimers() {
+  // exhause first setTimeout
+  jest.runAllTimers();
+  // wait for next tick to call nested setTimeout
+  await Promise.resolve();
+  // exhause nested setTimeout
+  jest.runAllTimers();
+}
+
+describe('SessionReplayRemoteConfigFetch', () => {
+  let originalFetch: typeof global.fetch;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  let config: SessionReplayConfig;
+  beforeEach(() => {
+    config = new SessionReplayConfig('static_key', {
+      loggerProvider: mockLoggerProvider,
+      sampleRate: 1,
+    });
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+      }),
+    ) as jest.Mock;
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+
+    jest.useRealTimers();
+  });
+
+  describe('getRemoteConfig', () => {
+    test('should return remote config from memory if it exists', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      remoteConfigFetch.remoteConfig = mockRemoteConfig;
+      const fetchMock = jest.fn();
+      remoteConfigFetch.fetchRemoteConfig = fetchMock;
+
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig();
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+    test('should call fetchRemoteConfig if no config exists in memory', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+
+      const fetchMock = jest.fn().mockResolvedValueOnce(mockRemoteConfig);
+      remoteConfigFetch.fetchRemoteConfig = fetchMock;
+
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig();
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('getTargetingConfig', () => {
+    test('should return sr_targeting_config from remote config', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      remoteConfigFetch.getRemoteConfig = jest.fn().mockResolvedValue(mockRemoteConfig);
+      const targetingConfig = await remoteConfigFetch.getTargetingConfig();
+      expect(targetingConfig).toEqual(flagConfig);
+    });
+    test('should return undefined if no remote config', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      remoteConfigFetch.getRemoteConfig = jest.fn().mockResolvedValue(undefined);
+      const targetingConfig = await remoteConfigFetch.getTargetingConfig();
+      expect(targetingConfig).toEqual(undefined);
+    });
+  });
+
+  describe('fetchRemoteConfig', () => {
+    test('should fetch and return config', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      (fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => mockRemoteConfig,
+        }),
+      );
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then((remoteConfig) => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual('Session replay remote config successfully fetched');
+        expect(remoteConfig).toEqual(mockRemoteConfig);
+      });
+    });
+    test('should fetch and set config in memory', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      (fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => mockRemoteConfig,
+        }),
+      );
+      // Ensure remote config has not been set yet
+      expect(remoteConfigFetch.remoteConfig).toEqual(undefined);
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual('Session replay remote config successfully fetched');
+        expect(remoteConfigFetch.remoteConfig).toEqual(mockRemoteConfig);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+    test('should handle unexpected error', async () => {
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('API Failure');
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+    test('should not retry for 400 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 400,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+          });
+        });
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+    test('should not retry for 413 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 413,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+            json: () => mockRemoteConfig,
+          });
+        });
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+    test('should handle retry for 500 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 500,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+            json: () => mockRemoteConfig,
+          });
+        });
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+
+    test('should only retry less than flushMaxRetries for 500 error', async () => {
+      // Set overall mock implementation, so it returns 500 repeatedly
+      (fetch as jest.Mock).mockImplementation(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      });
+      config.flushMaxRetries = 2;
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+    test('should handle retry for 503 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 503,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+            json: () => mockRemoteConfig,
+          });
+        });
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+    test('should handle unexpected error where fetch response is null', async () => {
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve(null);
+      });
+      const remoteConfigFetch = new SessionReplayRemoteConfigFetch({ config });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig();
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(UNEXPECTED_ERROR_MESSAGE);
+        expect(remoteConfigFetch.attempts).toBe(0);
+      });
+    });
+  });
+});

--- a/packages/targeting/src/index.ts
+++ b/packages/targeting/src/index.ts
@@ -1,1 +1,2 @@
 export { Targeting } from './targeting';
+export { TargetingFlag } from './typings/targeting';

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -1,5 +1,7 @@
 import { Event, IdentifyUserProperties } from '@amplitude/analytics-types';
 import { EvaluationFlag, EvaluationVariant } from '@amplitude/experiment-core';
+
+export type TargetingFlag = EvaluationFlag;
 export interface TargetingParameters {
   event?: Event;
   userProperties?: IdentifyUserProperties;


### PR DESCRIPTION
### Summary

Add a RemoteConfigFetch class to the Session Replay SDK. This will allow us to fetch targeting config in the initialization of the SR SDK

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
