### PR TITLE
feat(session replay): evaluate targeting in SR init

### DIFF
--- a/packages/session-replay-browser/src/remote-config-fetch.ts
+++ b/packages/session-replay-browser/src/remote-config-fetch.ts
@@ -103,7 +103,7 @@ export class SessionReplayRemoteConfigFetch implements AmplitudeSessionReplayRem
   completeRequest({ err, success }: { err?: string; success?: string }) {
     this.attempts = 0; // Reset attempts back to 0 for restart
     if (err) {
-      this.config.loggerProvider.warn(err);
+      throw new Error(err);
     } else if (success) {
       this.config.loggerProvider.log(success);
     }

--- a/packages/session-replay-browser/src/session-idb-store.ts
+++ b/packages/session-replay-browser/src/session-idb-store.ts
@@ -87,6 +87,35 @@ export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessi
     }
   };
 
+  storeTargetingMatchForSession = async (sessionId: number, targetingMatch: boolean) => {
+    try {
+      await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {
+        const session: IDBStoreSession = sessionMap[sessionId] || { ...defaultSessionStore };
+
+        session.targetingMatch = targetingMatch;
+
+        return {
+          ...sessionMap,
+          [sessionId]: {
+            ...session,
+          },
+        };
+      });
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+  };
+
+  getTargetingMatchForSession = async (sessionId: number): Promise<boolean | void> => {
+    try {
+      const sessionMap: IDBStore = (await IDBKeyVal.get(this.storageKey)) || {};
+      const session: IDBStoreSession = sessionMap[sessionId];
+      return session?.targetingMatch;
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+  };
+
   cleanUpSessionEventsStore = async (sessionId: number, sequenceId: number) => {
     try {
       await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -2,6 +2,7 @@ import { getAnalyticsConnector, getGlobalScope } from '@amplitude/analytics-clie
 import { Logger, returnWrapper } from '@amplitude/analytics-core';
 import { Logger as ILogger } from '@amplitude/analytics-types';
 import { pack, record } from '@amplitude/rrweb';
+import { TargetingParameters, evaluateTargeting } from '@amplitude/targeting';
 import { SessionReplayConfig } from './config';
 import {
   BLOCK_CLASS,
@@ -12,10 +13,12 @@ import {
 import { SessionReplayEventsManager } from './events-manager';
 import { generateHashCode, generateSessionReplayId, isSessionInSample, maskInputFn } from './helpers';
 import { SessionIdentifiers } from './identifiers';
+import { SessionReplayRemoteConfigFetch } from './remote-config-fetch';
 import { SessionReplaySessionIDBStore } from './session-idb-store';
 import {
   AmplitudeSessionReplay,
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
+  SessionReplayRemoteConfigFetch as AmplitudeSessionReplayRemoteConfigFetch,
   SessionReplaySessionIDBStore as AmplitudeSessionReplaySessionIDBStore,
   SessionIdentifiers as ISessionIdentifiers,
   SessionReplayConfig as ISessionReplayConfig,
@@ -26,10 +29,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
   name = '@amplitude/session-replay-browser';
   config: ISessionReplayConfig | undefined;
   identifiers: ISessionIdentifiers | undefined;
+  remoteConfigFetch: AmplitudeSessionReplayRemoteConfigFetch | undefined;
   eventsManager: AmplitudeSessionReplayEventsManager | undefined;
   sessionIDBStore: AmplitudeSessionReplaySessionIDBStore | undefined;
   loggerProvider: ILogger;
   recordCancelCallback: ReturnType<typeof record> | null = null;
+  sessionTargetingMatch = false;
 
   constructor() {
     this.loggerProvider = new Logger();
@@ -48,10 +53,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
       apiKey: this.config.apiKey,
     });
 
-    this.eventsManager = new SessionReplayEventsManager({
+    this.remoteConfigFetch = new SessionReplayRemoteConfigFetch({
       config: this.config,
       sessionIDBStore: this.sessionIDBStore,
     });
+    this.eventsManager = new SessionReplayEventsManager({ config: this.config, sessionIDBStore: this.sessionIDBStore });
 
     this.loggerProvider.log('Installing @amplitude/session-replay-browser.');
 
@@ -134,6 +140,34 @@ export class SessionReplay implements AmplitudeSessionReplay {
     void this.initialize();
   };
 
+  evaluateTargeting = async (targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>) => {
+    if (!this.identifiers || !this.identifiers.sessionId || !this.remoteConfigFetch || !this.config) {
+      this.loggerProvider.error('Session replay init has not been called, cannot evaluate targeting.');
+      return;
+    }
+
+    try {
+      const targetingConfig = await this.remoteConfigFetch.getTargetingConfig(this.identifiers.sessionId);
+      console.log('targetingConfig', targetingConfig);
+      if (targetingConfig && Object.keys(targetingConfig).length > 0) {
+        const targetingResult = evaluateTargeting({
+          flag: targetingConfig,
+          sessionId: this.identifiers.sessionId,
+          deviceId: this.getDeviceId(),
+          ...targetingParams,
+        });
+        this.sessionTargetingMatch =
+          this.sessionTargetingMatch === false && targetingResult.sr_targeting_config.key === 'on';
+        // todo, need to save this in idb too
+      } else {
+        this.sessionTargetingMatch = true;
+      }
+    } catch (err: unknown) {
+      const knownError = err as Error;
+      this.config.loggerProvider.warn(knownError.message);
+    }
+  };
+
   stopRecordingAndSendEvents(sessionId?: number) {
     this.stopRecordingEvents();
 
@@ -159,6 +193,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
         shouldSendStoredEvents,
         deviceId,
       }));
+
+    let userProperties;
+    if (this.config?.instanceName) {
+      const identityStore = getAnalyticsConnector(this.config.instanceName).identityStore;
+      userProperties = identityStore.getIdentity().userProperties;
+    }
+    await this.evaluateTargeting({ userProperties });
 
     this.recordEvents();
   }

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,5 +1,5 @@
 import { AmplitudeReturn, Config, LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
-import { TargetingFlag } from '@amplitude/targeting';
+import { TargetingFlag, TargetingParameters } from '@amplitude/targeting';
 
 export type Events = string[];
 
@@ -37,6 +37,7 @@ export interface IDBStoreSequence {
 export interface IDBStoreSession {
   currentSequenceId: number;
   remoteConfig?: SessionReplayRemoteConfig;
+  targetingMatch?: boolean;
   sessionSequences: {
     [sequenceId: number]: IDBStoreSequence;
   };
@@ -51,6 +52,8 @@ export interface SessionReplaySessionIDBStore {
   storeEventsForSession(events: Events, sequenceId: number, sessionId: number): Promise<void>;
   storeRemoteConfigForSession(sessionId: number, remoteConfig: SessionReplayRemoteConfig): Promise<void>;
   getRemoteConfigForSession(sessionId: number): Promise<SessionReplayRemoteConfig | void>;
+  storeTargetingMatchForSession(sessionId: number, targetingMatch: boolean): Promise<void>;
+  getTargetingMatchForSession(sessionId: number): Promise<boolean | void>;
   cleanUpSessionEventsStore(sessionId: number, sequenceId: number): Promise<void>;
 }
 
@@ -93,6 +96,7 @@ export interface SessionReplayTrackDestination {
 export interface SessionReplayRemoteConfigFetch {
   getRemoteConfig: (sessionId: number) => Promise<SessionReplayRemoteConfig | void>;
   getTargetingConfig: (sessionId: number) => Promise<TargetingFlag | void>;
+  evaluateTargeting: (targetingParams: Omit<TargetingParameters, 'flag'>) => Promise<void>;
 }
 export interface SessionReplayRemoteConfig {
   sr_targeting_config: TargetingFlag;

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -3,7 +3,11 @@ import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
 import * as RRWeb from '@amplitude/rrweb';
 import * as IDBKeyVal from 'idb-keyval';
 import { SessionReplayOptions } from 'src/typings/session-replay';
-import { DEFAULT_SAMPLE_RATE, DEFAULT_SESSION_REPLAY_PROPERTY } from '../src/constants';
+import {
+  DEFAULT_SAMPLE_RATE,
+  DEFAULT_SESSION_REPLAY_PROPERTY,
+  SESSION_REPLAY_EU_URL as SESSION_REPLAY_EU_SERVER_URL,
+} from '../src/constants';
 import * as Helpers from '../src/helpers';
 import { UNEXPECTED_ERROR_MESSAGE, getSuccessMessage } from '../src/messages';
 import { SessionReplay } from '../src/session-replay';
@@ -100,7 +104,7 @@ describe('module level integration', () => {
       expect(record).not.toHaveBeenCalled();
       expect(update).not.toHaveBeenCalled();
       await runScheduleTimers();
-      expect(fetch).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalledWith(SESSION_REPLAY_EU_SERVER_URL);
     });
     test('should record session if included due to sampling', async () => {
       jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => true);
@@ -122,7 +126,10 @@ describe('module level integration', () => {
       recordArg?.emit && recordArg?.emit(mockEvent);
       sessionReplay.stopRecordingAndSendEvents();
       await runScheduleTimers();
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenLastCalledWith(
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=0`,
+        expect.anything(),
+      );
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -141,7 +148,7 @@ describe('module level integration', () => {
       expect(record).not.toHaveBeenCalled();
       expect(update).not.toHaveBeenCalled();
       await runScheduleTimers();
-      expect(fetch).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalledWith(SESSION_REPLAY_EU_SERVER_URL);
     });
     test('should not record session if sample rate of value 0 is provided', async () => {
       jest.spyOn(Helpers, 'isSessionInSample').mockImplementation(() => false);
@@ -154,7 +161,7 @@ describe('module level integration', () => {
       expect(record).not.toHaveBeenCalled();
       expect(update).not.toHaveBeenCalled();
       await runScheduleTimers();
-      expect(fetch).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalledWith(SESSION_REPLAY_EU_SERVER_URL);
     });
   });
 
@@ -164,163 +171,176 @@ describe('module level integration', () => {
       await sessionReplay.init(apiKey, { ...mockOptions, optOut: true }).promise;
       expect(record).not.toHaveBeenCalled();
       await runScheduleTimers();
-      expect(fetch).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalledWith(SESSION_REPLAY_EU_SERVER_URL);
     });
   });
-  test('should handle unexpected error', async () => {
-    const sessionReplay = new SessionReplay();
-    (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
-    await sessionReplay.init(apiKey, { ...mockOptions }).promise;
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('API Failure');
-  });
-  test('should not retry for 400 error', async () => {
-    (fetch as jest.Mock)
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 400,
-        });
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-        });
-      });
-    const sessionReplay = new SessionReplay();
-    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-    // Log is called from init, but that's not what we're testing here
-    mockLoggerProvider.log.mockClear();
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-  });
-  test('should not retry for 413 error', async () => {
-    (fetch as jest.Mock)
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 413,
-        });
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-        });
-      });
-    const sessionReplay = new SessionReplay();
-    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-  });
-  test('should handle retry for 500 error', async () => {
-    (fetch as jest.Mock)
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 500,
-        });
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-        });
-      });
-    const sessionReplay = new SessionReplay();
-    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(2);
-  });
-
-  test('should only retry once for 500 error, even if config set to higher than one retry', async () => {
-    (fetch as jest.Mock)
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 500,
-        });
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 500,
-        });
-      });
-    const sessionReplay = new SessionReplay();
-    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 10 }).promise;
-
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(2);
-  });
-  test('should handle retry for 503 error', async () => {
-    (fetch as jest.Mock)
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 503,
-        });
-      })
-      .mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-        });
-      });
-    const sessionReplay = new SessionReplay();
-    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(2);
-  });
-  test('should handle unexpected error where fetch response is null', async () => {
-    (fetch as jest.Mock).mockImplementationOnce(() => {
-      return Promise.resolve(null);
+  describe('tracking replay events', () => {
+    test('should handle unexpected error', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions }).promise;
+      (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenLastCalledWith(
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=0`,
+        expect.anything(),
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith('API Failure');
     });
-    const sessionReplay = new SessionReplay();
-    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+    test('should not retry for 400 error', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 400,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+          });
+        });
+      // Log is called from init, but that's not what we're testing here
+      mockLoggerProvider.log.mockClear();
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenLastCalledWith(
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=0`,
+        expect.anything(),
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith('Network error occurred, event batch rejected');
+    });
+    test('should not retry for 413 error', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 413,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+          });
+        });
 
-    if (!sessionReplay.eventsManager) {
-      return;
-    }
-    sessionReplay.eventsManager.events = [mockEventString];
-    sessionReplay.stopRecordingAndSendEvents();
-    await runScheduleTimers();
-    expect(fetch).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(UNEXPECTED_ERROR_MESSAGE);
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenLastCalledWith(
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=0`,
+        expect.anything(),
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith('Network error occurred, event batch rejected');
+    });
+    test('should handle retry for 500 error', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+      (fetch as jest.Mock).mockReset();
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 500,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+          });
+        });
+
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('should only retry once for 500 error, even if config set to higher than one retry', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 10 }).promise;
+      (fetch as jest.Mock).mockReset();
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 500,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 500,
+          });
+        });
+
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+    test('should handle retry for 503 error', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+      (fetch as jest.Mock).mockReset();
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 503,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+          });
+        });
+
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+    test('should handle unexpected error where fetch response is null', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve(null);
+      });
+
+      if (!sessionReplay.eventsManager) {
+        return;
+      }
+      sessionReplay.eventsManager.events = [mockEventString];
+      sessionReplay.stopRecordingAndSendEvents();
+      await runScheduleTimers();
+      expect(fetch).toHaveBeenLastCalledWith(
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=0`,
+        expect.anything(),
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(UNEXPECTED_ERROR_MESSAGE);
+    });
   });
 });

--- a/packages/session-replay-browser/test/remote-config-fetch.test.ts
+++ b/packages/session-replay-browser/test/remote-config-fetch.test.ts
@@ -1,6 +1,5 @@
 import { Logger } from '@amplitude/analytics-types';
 import { SessionReplayConfig } from '../src/config';
-import { UNEXPECTED_ERROR_MESSAGE } from '../src/messages';
 import { SessionReplayRemoteConfigFetch } from '../src/remote-config-fetch';
 import { SessionReplaySessionIDBStore } from '../src/session-idb-store';
 import { SessionReplayRemoteConfig } from '../src/typings/session-replay';
@@ -168,14 +167,16 @@ describe('SessionReplayRemoteConfigFetch', () => {
       (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
       const fetchPromise = remoteConfigFetch.fetchRemoteConfig(123);
       await runScheduleTimers();
-      return fetchPromise.then(() => {
-        expect(fetch).toHaveBeenCalledTimes(1);
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('API Failure');
-        expect(remoteConfigFetch.attempts).toBe(0);
-      });
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('API Failure');
+          expect(remoteConfigFetch.attempts).toBe(0);
+        });
     });
     test('should not retry for 400 error', async () => {
       (fetch as jest.Mock)
@@ -191,12 +192,16 @@ describe('SessionReplayRemoteConfigFetch', () => {
         });
       const fetchPromise = remoteConfigFetch.fetchRemoteConfig(123);
       await runScheduleTimers();
-      return fetchPromise.then(() => {
-        expect(fetch).toHaveBeenCalledTimes(1);
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-        expect(remoteConfigFetch.attempts).toBe(0);
-      });
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Error: Network error occurred, session replay remote config fetch failed');
+          expect(remoteConfigFetch.attempts).toBe(0);
+        });
     });
     test('should not retry for 413 error', async () => {
       (fetch as jest.Mock)
@@ -213,12 +218,16 @@ describe('SessionReplayRemoteConfigFetch', () => {
         });
       const fetchPromise = remoteConfigFetch.fetchRemoteConfig(123);
       await runScheduleTimers();
-      return fetchPromise.then(() => {
-        expect(fetch).toHaveBeenCalledTimes(1);
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-        expect(remoteConfigFetch.attempts).toBe(0);
-      });
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Error: Network error occurred, session replay remote config fetch failed');
+          expect(remoteConfigFetch.attempts).toBe(0);
+        });
     });
     test('should handle retry for 500 error', async () => {
       (fetch as jest.Mock)
@@ -251,10 +260,16 @@ describe('SessionReplayRemoteConfigFetch', () => {
       remoteConfigFetch.config.flushMaxRetries = 2;
       const fetchPromise = remoteConfigFetch.fetchRemoteConfig(123);
       await runScheduleTimers();
-      return fetchPromise.then(() => {
-        expect(fetch).toHaveBeenCalledTimes(2);
-        expect(remoteConfigFetch.attempts).toBe(0);
-      });
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(2);
+          expect(err.message).toEqual('Network error occurred, session replay remote config fetch failed');
+          expect(remoteConfigFetch.attempts).toBe(0);
+        });
     });
     test('should handle retry for 503 error', async () => {
       (fetch as jest.Mock)
@@ -282,14 +297,16 @@ describe('SessionReplayRemoteConfigFetch', () => {
       });
       const fetchPromise = remoteConfigFetch.fetchRemoteConfig(123);
       await runScheduleTimers();
-      return fetchPromise.then(() => {
-        expect(fetch).toHaveBeenCalledTimes(1);
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(UNEXPECTED_ERROR_MESSAGE);
-        expect(remoteConfigFetch.attempts).toBe(0);
-      });
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Error: Unexpected error occurred');
+          expect(remoteConfigFetch.attempts).toBe(0);
+        });
     });
   });
 });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1,15 +1,10 @@
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
 import * as RRWeb from '@amplitude/rrweb';
-import * as Targeting from '@amplitude/targeting';
 import { DEFAULT_SAMPLE_RATE } from '../src/constants';
 import * as Helpers from '../src/helpers';
 import { SessionReplay } from '../src/session-replay';
 import { SessionReplayConfig, SessionReplayOptions } from '../src/typings/session-replay';
-import { flagConfig } from './flag-config-data';
-
-jest.mock('@amplitude/targeting');
-type MockedTargeting = jest.Mocked<typeof import('@amplitude/targeting')>;
 
 jest.mock('@amplitude/rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
@@ -24,7 +19,6 @@ const mockEvent = {
 const mockEventString = JSON.stringify(mockEvent);
 
 describe('SessionReplayPlugin', () => {
-  const { evaluateTargeting } = Targeting as MockedTargeting;
   const { record } = RRWeb as MockedRRWeb;
   let originalFetch: typeof global.fetch;
   let globalSpy: jest.SpyInstance;
@@ -781,10 +775,17 @@ describe('SessionReplayPlugin', () => {
 
   describe('evaluateTargeting', () => {
     let sessionReplay: SessionReplay;
+    let evaluateTargetingMock: jest.Mock;
     beforeEach(async () => {
+      evaluateTargetingMock = jest.fn();
       sessionReplay = new SessionReplay();
       sessionReplay.initialize = jest.fn(); // Mock out the initialize method as it calls evaluateTargeting, creates testing conflicts
       await sessionReplay.init(apiKey, { ...mockOptions }).promise;
+
+      if (!sessionReplay.remoteConfigFetch) {
+        throw new Error('no remote config fetch');
+      }
+      sessionReplay.remoteConfigFetch.evaluateTargeting = evaluateTargetingMock;
     });
     test('should return undefined if no identifiers set', async () => {
       sessionReplay.identifiers = undefined;
@@ -793,86 +794,20 @@ describe('SessionReplayPlugin', () => {
       expect(mockLoggerProvider.error).toHaveBeenCalledWith(
         'Session replay init has not been called, cannot evaluate targeting.',
       );
+      expect(evaluateTargetingMock).not.toHaveBeenCalled();
     });
 
-    test('should fetch remote config and use it to determine targeting match', async () => {
-      expect(sessionReplay.sessionTargetingMatch).toBe(false);
-      const getTargetingConfigMock = jest.fn().mockResolvedValue(flagConfig);
-      if (!sessionReplay.remoteConfigFetch) {
-        return;
-      }
-      evaluateTargeting.mockReturnValueOnce({
-        sr_targeting_config: {
-          key: 'on',
-        },
-      });
-      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
-      await sessionReplay.evaluateTargeting();
-      expect(evaluateTargeting).toHaveBeenCalledWith({
-        flag: flagConfig,
-        sessionId: mockOptions.sessionId,
-        deviceId: mockOptions.deviceId,
-      });
-      expect(sessionReplay.sessionTargetingMatch).toBe(true);
-    });
-    test('should pass user properties to evaluateTargeting', async () => {
-      expect(sessionReplay.sessionTargetingMatch).toBe(false);
-      const getTargetingConfigMock = jest.fn().mockResolvedValue(flagConfig);
-      if (!sessionReplay.remoteConfigFetch) {
-        return;
-      }
-      evaluateTargeting.mockReturnValueOnce({
-        sr_targeting_config: {
-          key: 'on',
-        },
-      });
+    test('should pass identifiers and user properties to evaluateTargeting', async () => {
       const mockUserProperties = {
         country: 'US',
         city: 'San Francisco',
       };
-      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
       await sessionReplay.evaluateTargeting({ userProperties: mockUserProperties });
-      expect(evaluateTargeting).toHaveBeenCalled();
-      expect(evaluateTargeting).toHaveBeenCalledWith({
-        flag: flagConfig,
+      expect(evaluateTargetingMock).toHaveBeenCalledWith({
         sessionId: mockOptions.sessionId,
         deviceId: mockOptions.deviceId,
         userProperties: mockUserProperties,
       });
-      expect(sessionReplay.sessionTargetingMatch).toBe(true);
-    });
-    test('should set sessionTargetingMatch to true if no targeting config returned', async () => {
-      const getTargetingConfigMock = jest.fn().mockResolvedValue(undefined);
-      if (!sessionReplay.remoteConfigFetch) {
-        return;
-      }
-      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
-      await sessionReplay.evaluateTargeting();
-      expect(evaluateTargeting).not.toHaveBeenCalled();
-      expect(sessionReplay.sessionTargetingMatch).toBe(true);
-    });
-    test('should set sessionTargetingMatch to true if targeting config returned as empty object', async () => {
-      const getTargetingConfigMock = jest.fn().mockResolvedValue({});
-      if (!sessionReplay.remoteConfigFetch) {
-        return;
-      }
-      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
-      await sessionReplay.evaluateTargeting();
-      expect(evaluateTargeting).not.toHaveBeenCalled();
-      expect(sessionReplay.sessionTargetingMatch).toBe(true);
-    });
-    test('should not update sessionTargetingMatch getTargetingConfig throws error', async () => {
-      expect(sessionReplay.sessionTargetingMatch).toBe(false);
-      const getTargetingConfigMock = jest.fn().mockImplementation(() => {
-        throw new Error();
-      });
-      if (!sessionReplay.remoteConfigFetch) {
-        return;
-      }
-      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
-      await sessionReplay.evaluateTargeting();
-      expect(evaluateTargeting).not.toHaveBeenCalled();
-      expect(sessionReplay.sessionTargetingMatch).toBe(false);
     });
   });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1,10 +1,15 @@
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
 import * as RRWeb from '@amplitude/rrweb';
+import * as Targeting from '@amplitude/targeting';
 import { DEFAULT_SAMPLE_RATE } from '../src/constants';
 import * as Helpers from '../src/helpers';
 import { SessionReplay } from '../src/session-replay';
 import { SessionReplayConfig, SessionReplayOptions } from '../src/typings/session-replay';
+import { flagConfig } from './flag-config-data';
+
+jest.mock('@amplitude/targeting');
+type MockedTargeting = jest.Mocked<typeof import('@amplitude/targeting')>;
 
 jest.mock('@amplitude/rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
@@ -19,6 +24,7 @@ const mockEvent = {
 const mockEventString = JSON.stringify(mockEvent);
 
 describe('SessionReplayPlugin', () => {
+  const { evaluateTargeting } = Targeting as MockedTargeting;
   const { record } = RRWeb as MockedRRWeb;
   let originalFetch: typeof global.fetch;
   let globalSpy: jest.SpyInstance;
@@ -431,6 +437,42 @@ describe('SessionReplayPlugin', () => {
       });
       expect(record).toHaveBeenCalledTimes(1);
     });
+    test('should evaluate targeting based on existing user properties', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
+      const mockUserProperties = {
+        country: 'US',
+        city: 'San Francisco',
+      };
+      jest.spyOn(AnalyticsClientCommon, 'getAnalyticsConnector').mockReturnValue({
+        identityStore: {
+          getIdentity: () => {
+            return {
+              userProperties: mockUserProperties,
+            };
+          },
+        },
+      } as unknown as ReturnType<typeof AnalyticsClientCommon.getAnalyticsConnector>);
+      const evaluateTargetingSpy = jest.spyOn(sessionReplay, 'evaluateTargeting').mockResolvedValueOnce();
+
+      await sessionReplay.initialize(true);
+      expect(evaluateTargetingSpy).toHaveBeenCalledWith({
+        userProperties: mockUserProperties,
+      });
+    });
+    test('should evaluate pass nothing to evaluate targeting if config not set', async () => {
+      const sessionReplay = new SessionReplay();
+      sessionReplay.identifiers = {
+        sessionId: mockOptions.sessionId,
+        deviceId: mockOptions.deviceId,
+        sessionReplayId: `${mockOptions.deviceId || 0}/${mockOptions.sessionId || 0}`,
+      };
+      sessionReplay.config = undefined;
+      const evaluateTargetingSpy = jest.spyOn(sessionReplay, 'evaluateTargeting').mockResolvedValueOnce();
+
+      await sessionReplay.initialize(true);
+      expect(evaluateTargetingSpy).toHaveBeenCalledWith({});
+    });
   });
 
   describe('shouldOptOut', () => {
@@ -734,6 +776,103 @@ describe('SessionReplayPlugin', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.warn).toHaveBeenCalled();
       expect(errorHandlerReturn).toBe(true);
+    });
+  });
+
+  describe('evaluateTargeting', () => {
+    let sessionReplay: SessionReplay;
+    beforeEach(async () => {
+      sessionReplay = new SessionReplay();
+      sessionReplay.initialize = jest.fn(); // Mock out the initialize method as it calls evaluateTargeting, creates testing conflicts
+      await sessionReplay.init(apiKey, { ...mockOptions }).promise;
+    });
+    test('should return undefined if no identifiers set', async () => {
+      sessionReplay.identifiers = undefined;
+      await sessionReplay.evaluateTargeting();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.error).toHaveBeenCalledWith(
+        'Session replay init has not been called, cannot evaluate targeting.',
+      );
+    });
+
+    test('should fetch remote config and use it to determine targeting match', async () => {
+      expect(sessionReplay.sessionTargetingMatch).toBe(false);
+      const getTargetingConfigMock = jest.fn().mockResolvedValue(flagConfig);
+      if (!sessionReplay.remoteConfigFetch) {
+        return;
+      }
+      evaluateTargeting.mockReturnValueOnce({
+        sr_targeting_config: {
+          key: 'on',
+        },
+      });
+      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
+      await sessionReplay.evaluateTargeting();
+      expect(evaluateTargeting).toHaveBeenCalledWith({
+        flag: flagConfig,
+        sessionId: mockOptions.sessionId,
+        deviceId: mockOptions.deviceId,
+      });
+      expect(sessionReplay.sessionTargetingMatch).toBe(true);
+    });
+    test('should pass user properties to evaluateTargeting', async () => {
+      expect(sessionReplay.sessionTargetingMatch).toBe(false);
+      const getTargetingConfigMock = jest.fn().mockResolvedValue(flagConfig);
+      if (!sessionReplay.remoteConfigFetch) {
+        return;
+      }
+      evaluateTargeting.mockReturnValueOnce({
+        sr_targeting_config: {
+          key: 'on',
+        },
+      });
+      const mockUserProperties = {
+        country: 'US',
+        city: 'San Francisco',
+      };
+      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
+      await sessionReplay.evaluateTargeting({ userProperties: mockUserProperties });
+      expect(evaluateTargeting).toHaveBeenCalled();
+      expect(evaluateTargeting).toHaveBeenCalledWith({
+        flag: flagConfig,
+        sessionId: mockOptions.sessionId,
+        deviceId: mockOptions.deviceId,
+        userProperties: mockUserProperties,
+      });
+      expect(sessionReplay.sessionTargetingMatch).toBe(true);
+    });
+    test('should set sessionTargetingMatch to true if no targeting config returned', async () => {
+      const getTargetingConfigMock = jest.fn().mockResolvedValue(undefined);
+      if (!sessionReplay.remoteConfigFetch) {
+        return;
+      }
+      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
+      await sessionReplay.evaluateTargeting();
+      expect(evaluateTargeting).not.toHaveBeenCalled();
+      expect(sessionReplay.sessionTargetingMatch).toBe(true);
+    });
+    test('should set sessionTargetingMatch to true if targeting config returned as empty object', async () => {
+      const getTargetingConfigMock = jest.fn().mockResolvedValue({});
+      if (!sessionReplay.remoteConfigFetch) {
+        return;
+      }
+      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
+      await sessionReplay.evaluateTargeting();
+      expect(evaluateTargeting).not.toHaveBeenCalled();
+      expect(sessionReplay.sessionTargetingMatch).toBe(true);
+    });
+    test('should not update sessionTargetingMatch getTargetingConfig throws error', async () => {
+      expect(sessionReplay.sessionTargetingMatch).toBe(false);
+      const getTargetingConfigMock = jest.fn().mockImplementation(() => {
+        throw new Error();
+      });
+      if (!sessionReplay.remoteConfigFetch) {
+        return;
+      }
+      sessionReplay.remoteConfigFetch = { getTargetingConfig: getTargetingConfigMock, getRemoteConfig: jest.fn() };
+      await sessionReplay.evaluateTargeting();
+      expect(evaluateTargeting).not.toHaveBeenCalled();
+      expect(sessionReplay.sessionTargetingMatch).toBe(false);
     });
   });
 

--- a/packages/targeting/src/index.ts
+++ b/packages/targeting/src/index.ts
@@ -1,2 +1,3 @@
-export { Targeting } from './targeting';
-export { TargetingFlag } from './typings/targeting';
+import targeting from './targeting-factory';
+export const { evaluateTargeting } = targeting;
+export { TargetingFlag, TargetingParameters } from './typings/targeting';

--- a/packages/targeting/src/targeting-factory.ts
+++ b/packages/targeting/src/targeting-factory.ts
@@ -1,0 +1,11 @@
+import { Targeting } from './targeting';
+import { Targeting as AmplitudeTargeting } from './typings/targeting';
+
+const createInstance: () => AmplitudeTargeting = () => {
+  const targeting = new Targeting();
+  return {
+    evaluateTargeting: targeting.evaluateTargeting.bind(targeting),
+  };
+};
+
+export default createInstance();

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -8,7 +8,7 @@ export class Targeting implements AmplitudeTargeting {
     this.evaluationEngine = new EvaluationEngine();
   }
 
-  evaluateTargeting({ event, sessionId, userProperties, deviceId, flag }: TargetingParameters) {
+  evaluateTargeting = ({ event, sessionId, userProperties, deviceId, flag }: TargetingParameters) => {
     const context = {
       session_id: sessionId,
       event,
@@ -18,5 +18,5 @@ export class Targeting implements AmplitudeTargeting {
       },
     };
     return this.evaluationEngine.evaluate(context, [flag]);
-  }
+  };
 }

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -1,15 +1,15 @@
-import { Event, IdentifyUserProperties } from '@amplitude/analytics-types';
+import { Event } from '@amplitude/analytics-types';
 import { EvaluationFlag, EvaluationVariant } from '@amplitude/experiment-core';
 
 export type TargetingFlag = EvaluationFlag;
 export interface TargetingParameters {
   event?: Event;
-  userProperties?: IdentifyUserProperties;
+  userProperties?: { [key: string]: any };
   deviceId?: string;
   flag: EvaluationFlag;
-  sessionId?: string;
+  sessionId: number;
 }
 
 export interface Targeting {
-  evaluateTargeting(args: TargetingParameters): Record<string, EvaluationVariant>;
+  evaluateTargeting: (args: TargetingParameters) => Record<string, EvaluationVariant>;
 }


### PR DESCRIPTION
### Summary

Evaluate targeting in SR init, storing the result in IndexedDB. With this PR we are not actually doing anything with the result, that will come later. I decided to put the logic for evaluation in the RemoteConfigFetch class, as it felt like too much for the base SessionReplay class to have to know about, I may update the name of RemoteConfigFetch in a future PR to make it a little more inclusive of targeting logic.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
