### PR TITLE
feat(session replay): store remote config in indexeddb

### DIFF
--- a/packages/session-replay-browser/src/events-manager.ts
+++ b/packages/session-replay-browser/src/events-manager.ts
@@ -1,7 +1,7 @@
 import { MAX_EVENT_LIST_SIZE_IN_BYTES, MAX_INTERVAL, MIN_INTERVAL } from './constants';
 import {
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
-  SessionReplaySessionIDBStore as AmplitudeSessionReplayEventsStorage,
+  SessionReplaySessionIDBStore as AmplitudeSessionReplaySessionIDBStore,
   SessionReplayTrackDestination as AmplitudeSessionReplayTrackDestination,
   Events,
   IDBStore,
@@ -9,7 +9,6 @@ import {
   SessionReplayConfig,
 } from './typings/session-replay';
 
-import { SessionReplaySessionIDBStore } from './session-idb-store';
 import { SessionReplayTrackDestination } from './track-destination';
 
 export class SessionReplayEventsManager implements AmplitudeSessionReplayEventsManager {
@@ -18,17 +17,20 @@ export class SessionReplayEventsManager implements AmplitudeSessionReplayEventsM
   maxPersistedEventsSize = MAX_EVENT_LIST_SIZE_IN_BYTES;
   interval = MIN_INTERVAL;
   timeAtLastSend: number | null = null;
-  sessionIDBStore: AmplitudeSessionReplayEventsStorage;
+  sessionIDBStore: AmplitudeSessionReplaySessionIDBStore;
   trackDestination: AmplitudeSessionReplayTrackDestination;
   config: SessionReplayConfig;
 
-  constructor({ config }: { config: SessionReplayConfig }) {
+  constructor({
+    config,
+    sessionIDBStore,
+  }: {
+    config: SessionReplayConfig;
+    sessionIDBStore: AmplitudeSessionReplaySessionIDBStore;
+  }) {
     this.config = config;
     this.trackDestination = new SessionReplayTrackDestination({ loggerProvider: this.config.loggerProvider });
-    this.sessionIDBStore = new SessionReplaySessionIDBStore({
-      loggerProvider: this.config.loggerProvider,
-      apiKey: this.config.apiKey,
-    });
+    this.sessionIDBStore = sessionIDBStore;
   }
 
   async initialize({

--- a/packages/session-replay-browser/src/remote-config-fetch.ts
+++ b/packages/session-replay-browser/src/remote-config-fetch.ts
@@ -1,45 +1,60 @@
 import { BaseTransport } from '@amplitude/analytics-core';
 import { Status } from '@amplitude/analytics-types';
 import { TargetingFlag } from '@amplitude/targeting';
-import { SESSION_REPLAY_SERVER_URL } from './constants';
 import { UNEXPECTED_ERROR_MESSAGE } from './messages';
 import {
   SessionReplayRemoteConfigFetch as AmplitudeSessionReplayRemoteConfigFetch,
+  SessionReplaySessionIDBStore as AmplitudeSessionReplaySessionIDBStore,
   SessionReplayConfig,
   SessionReplayRemoteConfig,
 } from './typings/session-replay';
 
-export const UNEXPECTED_NETWORK_ERROR_MESSAGE = 'Network error occurred, session replay remote config fetch failed';
-export const SUCCESS_REMOTE_CONFIG = 'Session replay remote config successfully fetched';
-export const MISSING_API_KEY_MESSAGE = 'Session replay remote config not fetched due to missing api key';
+const UNEXPECTED_NETWORK_ERROR_MESSAGE = 'Network error occurred, session replay remote config fetch failed';
+const SUCCESS_REMOTE_CONFIG = 'Session replay remote config successfully fetched';
+const SERVER_URL = '/sessions/v2/targeting.json';
 
 export class SessionReplayRemoteConfigFetch implements AmplitudeSessionReplayRemoteConfigFetch {
   config: SessionReplayConfig;
   remoteConfig: SessionReplayRemoteConfig | undefined;
+  sessionIDBStore: AmplitudeSessionReplaySessionIDBStore;
   retryTimeout = 1000;
   attempts = 0;
 
-  constructor({ config }: { config: SessionReplayConfig }) {
+  constructor({
+    config,
+    sessionIDBStore,
+  }: {
+    config: SessionReplayConfig;
+    sessionIDBStore: AmplitudeSessionReplaySessionIDBStore;
+  }) {
     this.config = config;
+    this.sessionIDBStore = sessionIDBStore;
   }
 
-  getRemoteConfig = (): Promise<SessionReplayRemoteConfig | void> => {
+  getRemoteConfig = async (sessionId: number): Promise<SessionReplayRemoteConfig | void> => {
+    // First check memory
     if (this.remoteConfig) {
       return Promise.resolve(this.remoteConfig);
     }
-    return this.fetchRemoteConfig();
+    // Then check IndexedDB for session
+    const remoteConfigFromIDB = await this.sessionIDBStore.getRemoteConfigForSession(sessionId);
+    if (remoteConfigFromIDB) {
+      return remoteConfigFromIDB;
+    }
+    // Finally fetch via API
+    return this.fetchRemoteConfig(sessionId);
   };
 
-  getTargetingConfig = async (): Promise<TargetingFlag | void> => {
-    const remoteConfig = await this.getRemoteConfig();
+  getTargetingConfig = async (sessionId: number): Promise<TargetingFlag | void> => {
+    const remoteConfig = await this.getRemoteConfig(sessionId);
     return remoteConfig?.sr_targeting_config;
   };
 
   getServerUrl() {
-    return SESSION_REPLAY_SERVER_URL;
+    return SERVER_URL;
   }
 
-  fetchRemoteConfig = async (): Promise<SessionReplayRemoteConfig | void> => {
+  fetchRemoteConfig = async (sessionId: number): Promise<SessionReplayRemoteConfig | void> => {
     try {
       const options: RequestInit = {
         headers: {
@@ -49,8 +64,7 @@ export class SessionReplayRemoteConfigFetch implements AmplitudeSessionReplayRem
         },
         method: 'GET',
       };
-      const urlParams = new URLSearchParams({});
-      const server_url = `${this.getServerUrl()}?${urlParams.toString()}`;
+      const server_url = `${this.getServerUrl()}`;
       const res = await fetch(server_url, options);
       this.attempts += 1;
       if (res === null) {
@@ -59,9 +73,9 @@ export class SessionReplayRemoteConfigFetch implements AmplitudeSessionReplayRem
       const parsedStatus = new BaseTransport().buildStatus(res.status);
       switch (parsedStatus) {
         case Status.Success:
-          return this.parseAndStoreConfig(res);
+          return this.parseAndStoreConfig(sessionId, res);
         case Status.Failed:
-          return this.maybeRetryFetch();
+          return this.maybeRetryFetch(sessionId);
         default:
           return this.completeRequest({ err: UNEXPECTED_NETWORK_ERROR_MESSAGE });
       }
@@ -70,18 +84,19 @@ export class SessionReplayRemoteConfigFetch implements AmplitudeSessionReplayRem
     }
   };
 
-  maybeRetryFetch = async (): Promise<SessionReplayRemoteConfig | void> => {
+  maybeRetryFetch = async (sessionId: number): Promise<SessionReplayRemoteConfig | void> => {
     if (this.attempts < this.config.flushMaxRetries) {
       await new Promise((resolve) => setTimeout(resolve, this.attempts * this.retryTimeout));
-      return this.fetchRemoteConfig();
+      return this.fetchRemoteConfig(sessionId);
     }
     return this.completeRequest({ err: UNEXPECTED_NETWORK_ERROR_MESSAGE });
   };
 
-  parseAndStoreConfig = async (res: Response): Promise<SessionReplayRemoteConfig> => {
+  parseAndStoreConfig = async (sessionId: number, res: Response): Promise<SessionReplayRemoteConfig> => {
     const remoteConfig: SessionReplayRemoteConfig = (await res.json()) as SessionReplayRemoteConfig;
     this.completeRequest({ success: SUCCESS_REMOTE_CONFIG });
     this.remoteConfig = remoteConfig;
+    void this.sessionIDBStore.storeRemoteConfigForSession(sessionId, remoteConfig);
     return remoteConfig;
   };
 

--- a/packages/session-replay-browser/src/session-idb-store.ts
+++ b/packages/session-replay-browser/src/session-idb-store.ts
@@ -8,6 +8,7 @@ import {
   IDBStore,
   IDBStoreSession,
   RecordingStatus,
+  SessionReplayRemoteConfig,
 } from './typings/session-replay';
 
 export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessionIDBStore {
@@ -52,6 +53,35 @@ export class SessionReplaySessionIDBStore implements AmplitudeSessionReplaySessi
           },
         };
       });
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+  };
+
+  storeRemoteConfigForSession = async (sessionId: number, remoteConfig: SessionReplayRemoteConfig) => {
+    try {
+      await IDBKeyVal.update(this.storageKey, (sessionMap: IDBStore = {}): IDBStore => {
+        const session: IDBStoreSession = sessionMap[sessionId] || { ...defaultSessionStore };
+
+        session.remoteConfig = remoteConfig;
+
+        return {
+          ...sessionMap,
+          [sessionId]: {
+            ...session,
+          },
+        };
+      });
+    } catch (e) {
+      this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
+    }
+  };
+
+  getRemoteConfigForSession = async (sessionId: number): Promise<SessionReplayRemoteConfig | void> => {
+    try {
+      const sessionMap: IDBStore = (await IDBKeyVal.get(this.storageKey)) || {};
+      const session: IDBStoreSession = sessionMap[sessionId];
+      return session?.remoteConfig;
     } catch (e) {
       this.loggerProvider.warn(`${STORAGE_FAILURE}: ${e as string}`);
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -12,9 +12,11 @@ import {
 import { SessionReplayEventsManager } from './events-manager';
 import { generateHashCode, generateSessionReplayId, isSessionInSample, maskInputFn } from './helpers';
 import { SessionIdentifiers } from './identifiers';
+import { SessionReplaySessionIDBStore } from './session-idb-store';
 import {
   AmplitudeSessionReplay,
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
+  SessionReplaySessionIDBStore as AmplitudeSessionReplaySessionIDBStore,
   SessionIdentifiers as ISessionIdentifiers,
   SessionReplayConfig as ISessionReplayConfig,
   SessionReplayOptions,
@@ -25,6 +27,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   config: ISessionReplayConfig | undefined;
   identifiers: ISessionIdentifiers | undefined;
   eventsManager: AmplitudeSessionReplayEventsManager | undefined;
+  sessionIDBStore: AmplitudeSessionReplaySessionIDBStore | undefined;
   loggerProvider: ILogger;
   recordCancelCallback: ReturnType<typeof record> | null = null;
 
@@ -40,9 +43,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.config = new SessionReplayConfig(apiKey, options);
     this.loggerProvider = this.config.loggerProvider;
     this.identifiers = new SessionIdentifiers(options, this.loggerProvider);
+    this.sessionIDBStore = new SessionReplaySessionIDBStore({
+      loggerProvider: this.config.loggerProvider,
+      apiKey: this.config.apiKey,
+    });
 
     this.eventsManager = new SessionReplayEventsManager({
       config: this.config,
+      sessionIDBStore: this.sessionIDBStore,
     });
 
     this.loggerProvider.log('Installing @amplitude/session-replay-browser.');

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -3,6 +3,10 @@ import { TargetingFlag } from '@amplitude/targeting';
 
 export type Events = string[];
 
+export interface SessionReplayRemoteConfig {
+  sr_targeting_config: TargetingFlag;
+}
+
 export interface SessionReplayDestination {
   events: Events;
   sequenceId: number;
@@ -32,6 +36,7 @@ export interface IDBStoreSequence {
 
 export interface IDBStoreSession {
   currentSequenceId: number;
+  remoteConfig?: SessionReplayRemoteConfig;
   sessionSequences: {
     [sequenceId: number]: IDBStoreSequence;
   };
@@ -44,6 +49,8 @@ export interface IDBStore {
 export interface SessionReplaySessionIDBStore {
   getAllSessionDataFromStore(): Promise<IDBStore | undefined>;
   storeEventsForSession(events: Events, sequenceId: number, sessionId: number): Promise<void>;
+  storeRemoteConfigForSession(sessionId: number, remoteConfig: SessionReplayRemoteConfig): Promise<void>;
+  getRemoteConfigForSession(sessionId: number): Promise<SessionReplayRemoteConfig | void>;
   cleanUpSessionEventsStore(sessionId: number, sequenceId: number): Promise<void>;
 }
 
@@ -84,8 +91,8 @@ export interface SessionReplayTrackDestination {
 }
 
 export interface SessionReplayRemoteConfigFetch {
-  getRemoteConfig: () => Promise<SessionReplayRemoteConfig | void>;
-  getTargetingConfig: () => Promise<TargetingFlag | void>;
+  getRemoteConfig: (sessionId: number) => Promise<SessionReplayRemoteConfig | void>;
+  getTargetingConfig: (sessionId: number) => Promise<TargetingFlag | void>;
 }
 export interface SessionReplayRemoteConfig {
   sr_targeting_config: TargetingFlag;

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import { SessionReplayConfig } from '../src/config';
 import { SessionReplayEventsManager } from '../src/events-manager';
+import { SessionReplaySessionIDBStore } from '../src/session-idb-store';
 import { IDBStore, RecordingStatus } from '../src/typings/session-replay';
 
 jest.mock('idb-keyval');
@@ -40,6 +41,10 @@ describe('SessionReplayEventsManager', () => {
     loggerProvider: mockLoggerProvider,
     sampleRate: 1,
   });
+  const sessionIDBStore = new SessionReplaySessionIDBStore({
+    loggerProvider: config.loggerProvider,
+    apiKey: config.apiKey,
+  });
   beforeEach(() => {
     jest.useFakeTimers();
     originalFetch = global.fetch;
@@ -57,7 +62,7 @@ describe('SessionReplayEventsManager', () => {
   });
   describe('initialize', () => {
     test('should read events from storage and send them if shouldSendStoredEvents is true', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
           currentSequenceId: 3,
@@ -96,7 +101,7 @@ describe('SessionReplayEventsManager', () => {
     });
 
     test('should not send stored events if shouldSendStoredEvents is false', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
           currentSequenceId: 3,
@@ -117,7 +122,7 @@ describe('SessionReplayEventsManager', () => {
       expect(send).toHaveBeenCalledTimes(0);
     });
     test('should return early if using old format of IDBStore', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution = Promise.resolve({
         123: {
           events: [mockEventString],
@@ -136,7 +141,7 @@ describe('SessionReplayEventsManager', () => {
       expect(send).toHaveBeenCalledTimes(0);
     });
     test('should configure current sequence id and events correctly if last sequence was sent', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
           currentSequenceId: 3,
@@ -154,7 +159,7 @@ describe('SessionReplayEventsManager', () => {
       expect(eventsManager.events).toEqual([]);
     });
     test('should configure current sequence id and events correctly if last sequence was recording', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution: Promise<IDBStore> = Promise.resolve({
         123: {
           currentSequenceId: 3,
@@ -172,7 +177,7 @@ describe('SessionReplayEventsManager', () => {
       expect(eventsManager.events).toEqual([mockEventString]);
     });
     test('should handle no stored events', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution = Promise.resolve({});
       get.mockReturnValueOnce(mockGetResolution);
       await eventsManager.initialize({ sessionId: 123, deviceId: '1a2b3c', shouldSendStoredEvents: true });
@@ -180,7 +185,7 @@ describe('SessionReplayEventsManager', () => {
       expect(eventsManager.events).toEqual([]);
     });
     test('should handle no stored sequences for session', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const mockGetResolution = Promise.resolve({
         123: {
           currentSequenceId: 0,
@@ -196,7 +201,7 @@ describe('SessionReplayEventsManager', () => {
 
   describe('sendStoredEvents', () => {
     test('should send all recording sequences except the current sequence for the current session', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       eventsManager.currentSequenceId = 3;
       const store: IDBStore = {
         123: {
@@ -260,7 +265,7 @@ describe('SessionReplayEventsManager', () => {
 
   describe('addEvent', () => {
     test('should store events in class and in IDB', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       eventsManager.addEvent({ event: mockEventString, sessionId: 123, deviceId: '1a2b3c' });
       expect(eventsManager.events).toEqual([mockEventString]);
       expect(update).toHaveBeenCalledTimes(1);
@@ -278,7 +283,7 @@ describe('SessionReplayEventsManager', () => {
     });
 
     test('should split the events list at an increasing interval and send', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       eventsManager.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
       jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
       const sendEventsList = jest.spyOn(eventsManager, 'sendEventsList');
@@ -301,7 +306,7 @@ describe('SessionReplayEventsManager', () => {
     });
 
     test('should split the events list at max size and send', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       eventsManager.maxPersistedEventsSize = 20;
       // Simulate as if many events have already been built up
       const events = ['#'.repeat(20)];
@@ -337,7 +342,7 @@ describe('SessionReplayEventsManager', () => {
 
   describe('sendEvents', () => {
     test('should call trackDestination sendEventsList', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       eventsManager.events = [mockEventString];
       eventsManager.currentSequenceId = 4;
       const trackSendEventsList = jest.spyOn(eventsManager.trackDestination, 'sendEventsList');
@@ -360,7 +365,7 @@ describe('SessionReplayEventsManager', () => {
       });
     });
     test('should update IDB store upon success', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const cleanUpSessionEventsStore = jest.spyOn(eventsManager.sessionIDBStore, 'cleanUpSessionEventsStore');
       eventsManager.events = [mockEventString];
       eventsManager.currentSequenceId = 4;
@@ -374,7 +379,7 @@ describe('SessionReplayEventsManager', () => {
       expect(update).toHaveBeenCalledWith('AMP_replay_unsent_static_key', expect.anything());
     });
     test('should remove session events from IDB store upon failure', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       eventsManager.events = [mockEventString];
       eventsManager.currentSequenceId = 4;
       const cleanUpSessionEventsStore = jest
@@ -395,7 +400,7 @@ describe('SessionReplayEventsManager', () => {
   describe('shouldSplitEventsList', () => {
     describe('event list size', () => {
       test('should return true if size of events list plus size of next event is over the max size', () => {
-        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
         const eventsList = ['#'.repeat(20)];
         eventsManager.events = eventsList;
         eventsManager.maxPersistedEventsSize = 20;
@@ -404,7 +409,7 @@ describe('SessionReplayEventsManager', () => {
         expect(result).toBe(true);
       });
       test('should return false if size of events list plus size of next event is under the max size', () => {
-        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
         const eventsList = ['#'.repeat(20)];
         eventsManager.events = eventsList;
         eventsManager.maxPersistedEventsSize = 22;
@@ -415,13 +420,13 @@ describe('SessionReplayEventsManager', () => {
     });
     describe('interval', () => {
       test('should return false if timeAtLastSend is null', () => {
-        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
         const nextEvent = 'a';
         const result = eventsManager.shouldSplitEventsList(nextEvent);
         expect(result).toBe(false);
       });
       test('should return false if it has not been long enough since last send', () => {
-        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
         eventsManager.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
         jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
         const nextEvent = 'a';
@@ -429,7 +434,7 @@ describe('SessionReplayEventsManager', () => {
         expect(result).toBe(false);
       });
       test('should return true if it has been long enough since last send and events have been emitted', () => {
-        const eventsManager = new SessionReplayEventsManager({ config });
+        const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
         eventsManager.events = [mockEventString];
         eventsManager.timeAtLastSend = new Date('2023-07-31 08:30:00').getTime();
         jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:33:00').getTime());
@@ -442,7 +447,7 @@ describe('SessionReplayEventsManager', () => {
 
   describe('flush', () => {
     test('should call track destination flush with useRetry as true', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const flushMock = jest.spyOn(eventsManager.trackDestination, 'flush');
 
       await eventsManager.flush(true);
@@ -450,7 +455,7 @@ describe('SessionReplayEventsManager', () => {
       expect(flushMock).toHaveBeenCalledWith(true);
     });
     test('should call track destination flush without useRetry', async () => {
-      const eventsManager = new SessionReplayEventsManager({ config });
+      const eventsManager = new SessionReplayEventsManager({ config, sessionIDBStore });
       const flushMock = jest.spyOn(eventsManager.trackDestination, 'flush');
 
       await eventsManager.flush();

--- a/packages/session-replay-browser/test/session-idb-store.test.ts
+++ b/packages/session-replay-browser/test/session-idb-store.test.ts
@@ -1,7 +1,12 @@
 import { Logger } from '@amplitude/analytics-types';
 import * as IDBKeyVal from 'idb-keyval';
 import { SessionReplaySessionIDBStore } from '../src/session-idb-store';
-import { IDBStore, RecordingStatus } from '../src/typings/session-replay';
+import { IDBStore, RecordingStatus, SessionReplayRemoteConfig } from '../src/typings/session-replay';
+import { flagConfig } from './flag-config-data';
+
+const mockRemoteConfig: SessionReplayRemoteConfig = {
+  sr_targeting_config: flagConfig,
+};
 
 jest.mock('idb-keyval');
 type MockedIDBKeyVal = jest.Mocked<typeof import('idb-keyval')>;
@@ -41,6 +46,23 @@ describe('SessionReplaySessionIDBStore', () => {
     });
   });
   describe('getAllSessionDataFromStore', () => {
+    test('should return the idb store', async () => {
+      const mockStore = {
+        123: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      };
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      get.mockResolvedValueOnce(mockStore);
+      const idbStore = await eventsStorage.getAllSessionDataFromStore();
+      expect(idbStore).toEqual(mockStore);
+    });
     test('should catch errors', async () => {
       const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
       get.mockImplementationOnce(() => Promise.reject('error'));
@@ -322,6 +344,29 @@ describe('SessionReplaySessionIDBStore', () => {
         },
       });
     });
+    test('should update session sequences if its an empty object', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {},
+        },
+      };
+      await eventsStorage.storeEventsForSession([mockEventString], 3, 123);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        123: {
+          currentSequenceId: 3,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      });
+    });
     test('should catch errors', async () => {
       const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
       update.mockImplementationOnce(() => Promise.reject('error'));
@@ -347,6 +392,150 @@ describe('SessionReplaySessionIDBStore', () => {
               status: RecordingStatus.RECORDING,
             },
           },
+        },
+      });
+    });
+  });
+  describe('getRemoteConfigForSession', () => {
+    test('should return the remote config from idb store', async () => {
+      const mockStore: IDBStore = {
+        123: {
+          currentSequenceId: 3,
+          remoteConfig: mockRemoteConfig,
+          sessionSequences: {
+            3: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+      };
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      get.mockResolvedValueOnce(mockStore);
+      const remoteConfig = await eventsStorage.getRemoteConfigForSession(123);
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+    });
+    test('should handle an undefined store', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      get.mockResolvedValueOnce(undefined);
+      const remoteConfig = await eventsStorage.getRemoteConfigForSession(123);
+      expect(remoteConfig).toEqual(undefined);
+    });
+    test('should catch errors', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      get.mockImplementationOnce(() => Promise.reject('error'));
+      await eventsStorage.getRemoteConfigForSession(123);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to store session replay events in IndexedDB: error',
+      );
+    });
+  });
+
+  describe('storeRemoteConfigForSession', () => {
+    test('should set the remote config on the session map', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await eventsStorage.storeRemoteConfigForSession(123, mockRemoteConfig);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        123: {
+          currentSequenceId: 2,
+          remoteConfig: mockRemoteConfig,
+          sessionSequences: {
+            2: {
+              events: [mockEventString],
+              status: RecordingStatus.RECORDING,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 1,
+          sessionSequences: {
+            1: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      });
+    });
+    test('should add a new entry if none exist for session id', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      const mockIDBStore: IDBStore = {
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+      };
+      await eventsStorage.storeRemoteConfigForSession(456, mockRemoteConfig);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][1](mockIDBStore)).toEqual({
+        123: {
+          currentSequenceId: 2,
+          sessionSequences: {
+            2: {
+              events: [],
+              status: RecordingStatus.SENT,
+            },
+          },
+        },
+        456: {
+          currentSequenceId: 0,
+          remoteConfig: mockRemoteConfig,
+          sessionSequences: {},
+        },
+      });
+    });
+    test('should catch errors', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      update.mockImplementationOnce(() => Promise.reject('error'));
+      await eventsStorage.storeRemoteConfigForSession(123, mockRemoteConfig);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to store session replay events in IndexedDB: error',
+      );
+    });
+    test('should handle an undefined store', async () => {
+      const eventsStorage = new SessionReplaySessionIDBStore({ apiKey, loggerProvider: mockLoggerProvider });
+      update.mockImplementationOnce(() => Promise.resolve());
+      await eventsStorage.storeRemoteConfigForSession(456, mockRemoteConfig);
+      expect(update.mock.calls[0][1](undefined)).toEqual({
+        456: {
+          currentSequenceId: 0,
+          remoteConfig: mockRemoteConfig,
+          sessionSequences: {},
         },
       });
     });


### PR DESCRIPTION
### Summary

Store remote config in indexeddb, allowing us to only make request to fetch config each time a session starts

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
