### PR TITLE
fix(session replay): remove event listeners on init

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -49,6 +49,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     const globalScope = getGlobalScope();
     if (globalScope) {
+      globalScope.removeEventListener('blur', this.blurListener);
+      globalScope.removeEventListener('focus', this.focusListener);
       globalScope.addEventListener('blur', this.blurListener);
       globalScope.addEventListener('focus', this.focusListener);
     }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -795,6 +795,7 @@ describe('SessionReplayPlugin', () => {
     test('should remove event listeners', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, mockOptions).promise;
+      removeEventListenerMock.mockReset();
       sessionReplay.shutdown();
       expect(removeEventListenerMock).toHaveBeenCalledTimes(2);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
### Summary

Safety check in case users call init multiple times

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
