### PR TITLE
feat(session replay): added ability to change maskTextFn

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -105,6 +105,7 @@ export class SessionReplayPlugin implements DestinationPlugin {
       sampleRate: this.options.sampleRate,
       privacyConfig: {
         blockSelector: this.options.privacyConfig?.blockSelector,
+        maskTextFn: this.options.privacyConfig?.maskTextFn,
       },
       debugMode: this.options.debugMode,
     }).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,5 +1,6 @@
 export interface SessionReplayPrivacyConfig {
   blockSelector?: string | string[];
+  maskTextFn?: (text: string, element: HTMLElement | null) => string;
 }
 export interface SessionReplayOptions {
   sampleRate?: number;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -221,6 +221,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       blockClass: BLOCK_CLASS,
       // rrweb only exposes array type through its types, but arrays are also be supported. #class, ['#class', 'id']
       blockSelector: this.getBlockSelectors() as string,
+      maskTextFn: this.config?.privacyConfig?.maskTextFn,
       maskInputFn,
       recordCanvas: false,
       errorHandler: (error) => {

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -48,6 +48,7 @@ export interface SessionReplaySessionIDBStore {
 
 export interface SessionReplayPrivacyConfig {
   blockSelector?: string | string[];
+  maskTextFn?: (text: string, element: HTMLElement | null) => string;
 }
 
 export interface SessionReplayConfig extends Config {


### PR DESCRIPTION
### Summary

Allow to change maskTextFn: passes maskTextFn deep down to rrweb

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
