### PR TITLE
fix(session replay): prevent multiple of the same sequences from being added to send queue

### DIFF
--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -65,6 +65,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       return false;
     });
     tryable.forEach((context) => {
+      // Prevent duplicates from being added to the queue
+      if (this.queue.findIndex((qContext) => qContext.sequenceId === context.sequenceId) !== -1) {
+        return;
+      }
       this.queue = this.queue.concat(context);
       if (context.timeout === 0) {
         this.schedule(0);

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -323,4 +323,22 @@ describe('module level integration', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(UNEXPECTED_ERROR_MESSAGE);
   });
+  test('should not allow multiple of the same list to be sent', async () => {
+    (fetch as jest.Mock).mockImplementation(() => {
+      return Promise.resolve({
+        status: 200,
+      });
+    });
+    const sessionReplay = new SessionReplay();
+    await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+
+    if (!sessionReplay.eventsManager) {
+      return;
+    }
+    sessionReplay.eventsManager.events = [mockEventString];
+    sessionReplay.stopRecordingAndSendEvents();
+    sessionReplay.stopRecordingAndSendEvents();
+    await runScheduleTimers();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION

### Summary

A customer discovered a race condition where its possible to add multiple of the same sequences to the send queue in specific circumstances, particularly upon blur. This adds a check to the queue to prevent the same sequence number from being added and sent

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
