### PR TITLE
fix: fetch the campaign in SPA at session start

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -303,14 +303,15 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     ) {
       if (isEventInNewSession || shouldSetSessionIdOnNewCampaign) {
         // Reinitialize the web attribution to refetch the current campaign in the new session
-        // To catch campaign change for the SPA new session event
+        // to catch campaign change for the SPA new session event.
         await this.webAttribution?.init();
         this.setSessionId(currentTime);
         if (shouldSetSessionIdOnNewCampaign) {
           this.config.loggerProvider.log('Created a new session for new campaign.');
         }
       } else if (!isEventInNewSession) {
-        // Web attribution should be track during the middle of the session if there has any new campaign
+        // Web attribution should be track during the middle of the session
+        // if there has any new campaign after page reloading.
         this.trackCampaignEventIfNeeded();
       }
     }

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -294,13 +294,15 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     const isEventInNewSession = isNewSession(this.config.sessionTimeout, this.config.lastEventTime);
     const shouldSetSessionIdOnNewCampaign =
       this.webAttribution && this.webAttribution.shouldSetSessionIdOnNewCampaign();
-
     if (
       event.event_type !== DEFAULT_SESSION_START_EVENT &&
       event.event_type !== DEFAULT_SESSION_END_EVENT &&
       (!event.session_id || event.session_id === this.getSessionId())
     ) {
       if (isEventInNewSession || shouldSetSessionIdOnNewCampaign) {
+        if (this.webAttribution) {
+          await this.webAttribution.init();
+        }
         this.setSessionId(currentTime);
         if (shouldSetSessionIdOnNewCampaign) {
           this.config.loggerProvider.log('Created a new session for new campaign.');

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -303,15 +303,15 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     ) {
       if (isEventInNewSession || shouldSetSessionIdOnNewCampaign) {
         // Reinitialize the web attribution to refetch the current campaign in the new session
-        // to catch campaign change for the SPA new session event.
+        // if the campaign changed without a page reload (SPA's run into this scenario).
         await this.webAttribution?.init();
         this.setSessionId(currentTime);
         if (shouldSetSessionIdOnNewCampaign) {
           this.config.loggerProvider.log('Created a new session for new campaign.');
         }
       } else if (!isEventInNewSession) {
-        // Web attribution should be track during the middle of the session
-        // if there has any new campaign after page reloading.
+        // Web attribution should be tracked during the middle of a session
+        // if there has been a chance in the campaign information.
         this.trackCampaignEventIfNeeded();
       }
     }

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -10,6 +10,7 @@ import {
   Event,
   Result,
   LogLevel,
+  BrowserConfig,
 } from '@amplitude/analytics-types';
 import {
   CookieStorage,
@@ -24,6 +25,7 @@ import * as formInteractionTracking from '../src/plugins/form-interaction-tracki
 import * as networkConnectivityChecker from '../src/plugins/network-connectivity-checker';
 import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
 import { WebAttribution } from '@amplitude/analytics-client-common/src';
+import { Logger, UUID } from '@amplitude/analytics-core';
 
 describe('browser-client', () => {
   let apiKey = '';
@@ -997,6 +999,42 @@ describe('browser-client', () => {
       });
 
       expect(logSpy).toHaveBeenCalledWith('Created a new session for new campaign.');
+    });
+
+    test('should reinit web attribution when procee new session event', async () => {
+      const mockConfig: BrowserConfig = {
+        apiKey: UUID(),
+        flushIntervalMillis: 0,
+        flushMaxRetries: 0,
+        flushQueueSize: 0,
+        logLevel: LogLevel.None,
+        loggerProvider: new Logger(),
+        offline: false,
+        optOut: false,
+        serverUrl: undefined,
+        transportProvider: new FetchTransport(),
+        useBatch: false,
+        cookieOptions: undefined,
+        cookieStorage: new CookieStorage(),
+        sessionTimeout: 30 * 60 * 1000,
+        trackingOptions: {
+          ipAddress: true,
+          language: true,
+          platform: true,
+        },
+        lastEventTime: Date.now() - 30 * 60 * 1000 * 2,
+      };
+      const webAttribution = new WebAttribution({}, mockConfig);
+      client.config = mockConfig;
+      client.webAttribution = webAttribution;
+      const webAttributionInit = jest.spyOn(webAttribution, 'init');
+      const setSessionId = jest.spyOn(client, 'setSessionId');
+
+      //new session event
+      await client.process({ event_type: 'test event' });
+
+      expect(webAttributionInit).toHaveBeenCalledTimes(1);
+      expect(setSessionId).toHaveBeenCalledTimes(1);
     });
 
     test('should proceed with unexpired session', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
The previous web attribution will only fetch the campaign change for page reloading. This PR is to cover the case of a Single Page Application (SPA) campaign change (without reloading the page) in a new session. 

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
