### PR TITLE
fix(session replay): throw error for styled-components

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -227,8 +227,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
       recordCanvas: false,
       errorHandler: (error) => {
         const typedError = error as Error;
-        this.loggerProvider.warn('Error while recording: ', typedError.toString());
 
+        // styled-components relies on this error being thrown and bubbled up, rrweb is otherwise suppressing it
+        if (typedError.message.includes('insertRule') && typedError.message.includes('CSSStyleSheet')) {
+          throw typedError;
+        }
+        this.loggerProvider.warn('Error while recording: ', typedError.toString());
+        // Return true so that we don't clutter user's consoles with internal rrweb errors
         return true;
       },
     });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -735,6 +735,18 @@ describe('SessionReplayPlugin', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalled();
       expect(errorHandlerReturn).toBe(true);
     });
+
+    test('should rethrow CSSStylesheet errors', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.recordEvents();
+      const recordArg = record.mock.calls[0][0];
+      const stylesheetErrorMessage =
+        "Failed to execute 'insertRule' on 'CSSStyleSheet': Failed to parse the rule 'body::-ms-expand{display: none}";
+      expect(() => {
+        recordArg?.errorHandler && recordArg?.errorHandler(new Error(stylesheetErrorMessage));
+      }).toThrow(stylesheetErrorMessage);
+    });
   });
 
   describe('getDeviceId', () => {


### PR DESCRIPTION
### Summary

Styled-components throws an error that is meant to be caught by their internals, however rrweb was catching it and suppressing it instead. This PR adds a special case in our error handler to re-throw that error when it occurs, allowing other rrweb internal errors to still be caught.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
