### PR TITLE
fix: error when sending data to Amplitude should get retried

### DIFF
--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -193,7 +193,7 @@ export class Destination implements DestinationPlugin {
     } catch (e) {
       const errorMessage = getErrorMessage(e);
       this.config.loggerProvider.error(errorMessage);
-      this.fulfillRequest(list, 0, errorMessage);
+      this.handleResponse({ status: Status.Failed, statusCode: 0 }, list);
     }
   }
 

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -555,7 +555,7 @@ describe('destination', () => {
       });
     });
 
-    test('should handle unexpected error', async () => {
+    test('should not drop data on unexpected error', async () => {
       const destination = new Destination();
       const callback = jest.fn();
       const context = {
@@ -576,7 +576,8 @@ describe('destination', () => {
         transportProvider,
       });
       await destination.send([context]);
-      expect(callback).toHaveBeenCalledTimes(1);
+      // We should not fulfill request when the request fails with an unknown error. This should be retried
+      expect(callback).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -1187,7 +1188,7 @@ describe('destination', () => {
 
         expect(transportProvider.send).toHaveBeenCalledTimes(eventCount + 1);
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
+        expect(loggerProvider.warn).toHaveBeenCalledTimes(eventCount);
         // eslint-disable-next-line @typescript-eslint/unbound-method,@typescript-eslint/restrict-template-expressions
         expect(loggerProvider.warn).toHaveBeenCalledWith(jsons(response.body));
       },
@@ -1220,7 +1221,8 @@ describe('destination', () => {
         loggerProvider,
       });
       await destination.send([context]);
-      expect(callback).toHaveBeenCalledTimes(1);
+      // Callback should not be called since errors get retried
+      expect(callback).toHaveBeenCalledTimes(0);
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(loggerProvider.error).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/unbound-method


### PR DESCRIPTION
### Summary

When the page gets reloaded while the amplitude client is trying to send a request, the browser kills the request. When this happens, the event should not be dropped and should be retried the next time the client gets loaded.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
