### PR TITLE
test: web attribution integration test

### DIFF
--- a/packages/analytics-browser-test/test/helper.ts
+++ b/packages/analytics-browser-test/test/helper.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { BaseEvent, Campaign } from '@amplitude/analytics-types';
+import { uuidPattern } from './constants';
+
+const uuid: string = expect.stringMatching(uuidPattern) as string;
+const userAgent = expect.any(String) as string;
+const library = expect.stringMatching(/^amplitude-ts\/.+/) as string;
+const number = expect.any(Number) as number;
+
+const BASE_CAMPAIGN: Campaign = {
+  utm_campaign: undefined,
+  utm_content: undefined,
+  utm_id: undefined,
+  utm_medium: undefined,
+  utm_source: undefined,
+  utm_term: undefined,
+  referrer: undefined,
+  referring_domain: undefined,
+  dclid: undefined,
+  gbraid: undefined,
+  gclid: undefined,
+  fbclid: undefined,
+  ko_click_id: undefined,
+  li_fat_id: undefined,
+  msclkid: undefined,
+  rtd_cid: undefined,
+  ttclid: undefined,
+  twclid: undefined,
+  wbraid: undefined,
+};
+
+const parseQueryString = (url: string) => {
+  const params: { [key: string]: string } = {};
+  // Extract the query string part from the URL
+  const queryString = url.split('?')[1];
+  if (queryString) {
+    // Split the query string into key-value pairs
+    queryString.split('&').forEach((part) => {
+      const [key, value] = part.split('=');
+      // Decode URI components and add to the params object
+      params[decodeURIComponent(key)] = decodeURIComponent(value);
+    });
+  }
+  return params;
+};
+
+const generateAttributionUserProps = (campaignURL: string) => {
+  const campaign = parseQueryString(campaignURL);
+  const campaignObject: Campaign = {
+    ...BASE_CAMPAIGN,
+    ...campaign,
+  };
+  const hasNoCampaign = Object.entries(campaign).length == 0;
+  const operationObject: { [key: string]: { [key: string]: string } } = {
+    $setOnce: {},
+    $unset: {},
+    ...(!hasNoCampaign ? { $set: {} } : {}),
+  };
+
+  const user_properties = Object.keys(campaignObject).reduce((operationObject, key) => {
+    // Assign each key-value pair to the $set object
+    if (campaignObject[key] !== undefined) {
+      operationObject.$setOnce['initial_' + key] = campaignObject[key] as string;
+      operationObject.$set[key] = campaignObject[key] as string; // Assert that the value is a string
+    } else {
+      operationObject.$setOnce['initial_' + key] = 'EMPTY';
+      operationObject.$unset[key] = '-';
+    }
+
+    return operationObject;
+  }, operationObject);
+
+  return user_properties;
+};
+
+export const generateEvent = (event_id: number, event_type: string): BaseEvent => {
+  return {
+    device_id: uuid,
+    event_id,
+    event_type,
+    insert_id: uuid,
+    ip: '$remote',
+    language: 'en-US',
+    library,
+    partner_id: undefined,
+    plan: undefined,
+    platform: 'Web',
+    session_id: number,
+    time: number,
+    user_agent: userAgent,
+    user_id: 'user1@amplitude.com',
+  };
+};
+
+export const generateAttributionEvent = (event_id: number, campaignURL: string) => {
+  const attributionEvent = generateEvent(event_id, '$identify');
+  attributionEvent.user_properties = generateAttributionUserProps(campaignURL);
+  return attributionEvent;
+};
+
+export const generateSessionStartEvent = (event_id: number) => {
+  return generateEvent(event_id, 'session_start');
+};
+
+export const generateSessionEndEvent = (event_id: number) => {
+  return generateEvent(event_id, 'session_end');
+};
+
+const generatePageViewEventProps = (pageCounter: number, urlString: string, referrerString?: string) => {
+  let referrerObj = {};
+  if (referrerString) {
+    const referrerURL = new URL(referrerString);
+    const referrer = referrerURL.href.split('?')[0];
+    const referring_domain = referrerURL.hostname;
+    referrerObj = {
+      referrer,
+      referring_domain,
+    };
+  }
+
+  const url = new URL(urlString);
+  const campaign = parseQueryString(urlString);
+
+  return {
+    '[Amplitude] Page Counter': pageCounter,
+    '[Amplitude] Page Domain': url.hostname,
+    '[Amplitude] Page Location': url.href,
+    '[Amplitude] Page Path': url.pathname,
+    '[Amplitude] Page Title': '',
+    '[Amplitude] Page URL': url.href.split('?')[0],
+    ...campaign,
+    ...referrerObj,
+  };
+};
+
+export const generatePageViewEvent = (event_id: number, pageCounter: number, url: string, referrer?: string) => {
+  const generatePageViewEvent = generateEvent(event_id, '[Amplitude] Page Viewed');
+  generatePageViewEvent.event_properties = generatePageViewEventProps(pageCounter, url, referrer);
+  return generatePageViewEvent;
+};
+
+export const navigateTo = (urlString: string, referrer?: string) => {
+  if (referrer) {
+    Object.defineProperty(document, 'referrer', { value: referrer, configurable: true });
+  }
+
+  const url = new URL(urlString);
+  // eslint-disable-next-line no-restricted-globals
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: url.hostname,
+      href: url.href,
+      pathname: url.pathname,
+      search: url.search,
+    },
+    writable: true,
+  });
+};

--- a/packages/analytics-browser-test/test/helpers.ts
+++ b/packages/analytics-browser-test/test/helpers.ts
@@ -32,9 +32,9 @@ const getReferrerObject = (referrerString?: string) => {
   const referring_domain = referrerURL.hostname;
   return { referrer, referring_domain };
 };
+
 const generateAttributionUserProps = (campaignURL: string, referrerString?: string) => {
   const referrer = getReferrerObject(referrerString);
-
   const campaign = parseQueryString(campaignURL);
   const campaignObject: Campaign = {
     ...BASE_CAMPAIGN,

--- a/packages/analytics-browser-test/test/helpers.ts
+++ b/packages/analytics-browser-test/test/helpers.ts
@@ -2,34 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { BaseEvent, Campaign } from '@amplitude/analytics-types';
+import { BASE_CAMPAIGN } from '@amplitude/analytics-client-common';
 import { uuidPattern } from './constants';
 
 const uuid: string = expect.stringMatching(uuidPattern) as string;
 const userAgent = expect.any(String) as string;
 const library = expect.stringMatching(/^amplitude-ts\/.+/) as string;
 const number = expect.any(Number) as number;
-
-const BASE_CAMPAIGN: Campaign = {
-  utm_campaign: undefined,
-  utm_content: undefined,
-  utm_id: undefined,
-  utm_medium: undefined,
-  utm_source: undefined,
-  utm_term: undefined,
-  referrer: undefined,
-  referring_domain: undefined,
-  dclid: undefined,
-  gbraid: undefined,
-  gclid: undefined,
-  fbclid: undefined,
-  ko_click_id: undefined,
-  li_fat_id: undefined,
-  msclkid: undefined,
-  rtd_cid: undefined,
-  ttclid: undefined,
-  twclid: undefined,
-  wbraid: undefined,
-};
 
 const parseQueryString = (url: string) => {
   const params: { [key: string]: string } = {};
@@ -52,15 +31,15 @@ const generateAttributionUserProps = (campaignURL: string) => {
     ...BASE_CAMPAIGN,
     ...campaign,
   };
-  const hasNoCampaign = Object.entries(campaign).length == 0;
+  const hasNoCampaign = Object.entries(campaign).length === 0;
+  const hasAllCampaign = Object.entries(campaign).length === Object.entries(BASE_CAMPAIGN).length;
   const operationObject: { [key: string]: { [key: string]: string } } = {
     $setOnce: {},
-    $unset: {},
+    ...(!hasAllCampaign ? { $unset: {} } : {}),
     ...(!hasNoCampaign ? { $set: {} } : {}),
   };
 
   const user_properties = Object.keys(campaignObject).reduce((operationObject, key) => {
-    // Assign each key-value pair to the $set object
     if (campaignObject[key] !== undefined) {
       operationObject.$setOnce['initial_' + key] = campaignObject[key] as string;
       operationObject.$set[key] = campaignObject[key] as string; // Assert that the value is a string

--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -1,0 +1,1290 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import * as amplitude from '@amplitude/analytics-browser';
+import { UUID } from '@amplitude/analytics-core';
+import { default as nock } from 'nock';
+import { path, url as httpEndPoint, uuidPattern } from './constants';
+import { success } from './responses';
+import 'isomorphic-fetch';
+
+describe('Web attribution', () => {
+  const uuid: string = expect.stringMatching(uuidPattern) as string;
+  const library = expect.stringMatching(/^amplitude-ts\/.+/) as string;
+  const number = expect.any(Number) as number;
+  const userAgent = expect.any(String) as string;
+  const defaultTracking = {
+    attribution: false,
+    fileDownloads: false,
+    formInteractions: false,
+    pageViews: true,
+    sessions: false,
+  };
+
+  let apiKey = '';
+  let client = amplitude.createInstance();
+  const previousSessionId = Date.now() - 31 * 60 * 1000; // now minus 31 minutes
+  const previousSessionLastEventTime = Date.now() - 31 * 60 * 1000; // now minus 31 minutes
+  const previousSessionLastEventId = 99;
+  const previousSessionDeviceId = 'a7a96s8d';
+  const previousSessionUserId = 'a7a96s8d';
+
+  const event_upload_time = '2023-01-01T12:00:00:000Z';
+  Date.prototype.toISOString = jest.fn(() => event_upload_time);
+
+  beforeEach(() => {
+    // setup expired previous session
+    setLegacyCookie(
+      apiKey,
+      previousSessionDeviceId,
+      previousSessionUserId,
+      undefined,
+      previousSessionId,
+      previousSessionLastEventTime,
+      previousSessionLastEventId,
+    );
+    client = amplitude.createInstance();
+    apiKey = UUID();
+  });
+
+  afterEach(() => {
+    // clean up cookies
+    document.cookie = `amp_${apiKey.substring(0, 6)}=null; expires=1 Jan 1970 00:00:00 GMT`;
+    document.cookie = `AMP_${apiKey.substring(0, 10)}=null; expires=1 Jan 1970 00:00:00 GMT`;
+    document.cookie = `AMP_MKTG_${apiKey.substring(0, 10)}=null; expires=1 Jan 1970 00:00:00 GMT`;
+    (window.location as any) = {
+      hostname: '',
+      href: '',
+      pathname: '',
+      search: '',
+    };
+    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
+  });
+
+  /*
+1. during a session, shouldSetSessionIdOnNewCampaign = true. webAttribution.init will refetch. 
+make sure the campaign event is right
+2. in new session. not initialized,  campaign can be fetched as expcted
+   in the new session, refresh the page test 314. we should catch the changes because it's reloading the page.
+   
+*/
+
+  describe('init SDK web attribution (hard refresh the page)', () => {
+    describe('in a new session', () => {
+      test('Should track all UTMs and referrers', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        //     Object.defineProperty(window.location, 'href', {
+        //      writable: true,
+        //     value: 'https://www.somthing.com/test.html?query=true'
+        //   });
+
+        //const newURL = new URL('https://www.example.com?utm_source=test_utm_source');
+        //mockWindowLocationFromURL(newURL);
+        //window.history.pushState(undefined, newURL.href); // push state not refreshing the page.
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+
+      test('Should not track all UTMs and referrers if the referrer is excluded referrer', async () => {
+        const excludedReferrer = 'https://www.google.com/';
+        Object.defineProperty(document, 'referrer', { value: excludedReferrer, configurable: true });
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+        console.log(document.referrer);
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: {
+              excludeReferrers: ['www.google.com'],
+            },
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                    referrer: 'https://www.google.com/',
+                    referring_domain: 'www.google.com',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+    });
+
+    describe('during a session', () => {
+      test('Should not fire campaign identify event for direct traffic', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // refresh during the session.
+        const directUrl = new URL('https://www.example.com/home');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: directUrl.hostname,
+            href: directUrl.href,
+            pathname: directUrl.pathname,
+            search: directUrl.search,
+          },
+          writable: true,
+        });
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 2,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/home',
+                    '[Amplitude] Page Path': '/home',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/home',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+
+      test('Should track all UTMs and referrers if any campaign changed and not direct traffic', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // mock refresh during the session with updated campaign change.
+        const newCampaignURL = new URL(
+          'https://www.example.com/?utm_source=second_utm_source&utm_content=test_utm_content',
+        );
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: newCampaignURL.hostname,
+            href: newCampaignURL.href,
+            pathname: newCampaignURL.pathname,
+            search: newCampaignURL.search,
+          },
+          writable: true,
+        });
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'second_utm_source',
+                      utm_content: 'test_utm_content',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'test_utm_content',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'second_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 4,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 2,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location':
+                      'https://www.example.com/?utm_source=second_utm_source&utm_content=test_utm_content',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'second_utm_source',
+                    utm_content: 'test_utm_content',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+    });
+  });
+
+  // Should not track UTMs  while process any event in the new session if it's excluded referrer
+  describe('process event web attribution (not hard refresh the page)', () => {
+    describe('in a new session', () => {
+      test('Should track all UTMs and referrers while process any event', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // update the url and fire the first event after session timeout
+        setTimeout(() => {
+          const url = new URL('https://www.example.com?utm_source=second_utm_source&utm_content=test_utm_content');
+          Object.defineProperty(window, 'location', {
+            value: {
+              hostname: url.hostname,
+              href: url.href,
+              pathname: url.pathname,
+              search: url.search,
+            },
+            writable: true,
+          });
+
+          client.track('test event after session timeout');
+        }, 500);
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: 'session_end',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 4,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'second_utm_source',
+                      utm_content: 'test_utm_content',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'test_utm_content',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'second_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 5,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 6,
+                  event_type: 'test event after session timeout',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+    });
+
+    describe('during a session', () => {
+      test('should not track updated campaign during a session for SPA', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: true,
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // update the url and fire the first event during the same session without refreshing the page
+        const newCampaignURL = new URL(
+          'https://www.example.com?utm_source=second_utm_source&utm_content=test_utm_content',
+        );
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: newCampaignURL.hostname,
+            href: newCampaignURL.href,
+            pathname: newCampaignURL.pathname,
+            search: newCampaignURL.search,
+          },
+          writable: true,
+        });
+
+        client.track('test event after session timeout');
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: 'test event after session timeout',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+    });
+  });
+});
+
+const setLegacyCookie = (
+  apiKey: string,
+  deviceId?: string,
+  userId?: string,
+  optOut?: '1',
+  sessionId?: number,
+  lastEventTime?: number,
+  eventId?: number,
+) => {
+  document.cookie = `amp_${apiKey.substring(0, 6)}=${[
+    deviceId,
+    btoa(userId || ''),
+    optOut,
+    sessionId ? sessionId.toString(32) : '',
+    lastEventTime ? lastEventTime.toString(32) : '',
+    eventId ? eventId.toString(32) : '',
+  ].join('.')}`;
+};
+/*
+const mockWindowLocationFromURL = (url: URL) => {
+    window.location.assign(url);
+    window.location.search = url.search;
+    window.location.hostname = url.hostname;
+    window.location.pathname = url.pathname;
+};  
+*/

--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -48,8 +48,9 @@ describe('Web attribution', () => {
       });
 
       test('should track all UTMs and referrers', async () => {
+        const referrer = 'https://www.google.com/';
         const url = 'https://www.example.com?utm_source=test_utm_source';
-        navigateTo(url);
+        navigateTo(url, referrer);
 
         let payload: any = undefined;
         const scope = nock(httpEndPoint)
@@ -72,9 +73,9 @@ describe('Web attribution', () => {
               api_key: apiKey,
               client_upload_time: event_upload_time,
               events: [
-                generateAttributionEvent(++eventId, url),
+                generateAttributionEvent(++eventId, url, referrer),
                 generateSessionStartEvent(++eventId),
-                generatePageViewEvent(++eventId, 1, url),
+                generatePageViewEvent(++eventId, 1, url, referrer),
               ],
               options: {
                 min_id_length: undefined,
@@ -477,6 +478,7 @@ describe('Web attribution', () => {
       });
     });
 
+    // Specific tests for an SPA. The SPA won't reload the page when redirected. We don't track campaign updates without reinitializing the SDK (reloading the page).
     describe('during a session', () => {
       let eventId = -1;
       beforeEach(() => {
@@ -487,7 +489,7 @@ describe('Web attribution', () => {
         cleanup();
       });
 
-      test('should not track updated campaign during', async () => {
+      test('should not track updated campaign', async () => {
         const url = 'https://www.example.com?utm_source=test_utm_source';
         navigateTo(url);
 
@@ -510,7 +512,7 @@ describe('Web attribution', () => {
         const newCampaignURL = 'https://www.example.com?utm_source=second_utm_source&utm_content=test_utm_content';
         navigateTo(newCampaignURL);
 
-        client.track('test event after session timeout');
+        client.track('test event in the same session');
 
         return new Promise<void>((resolve) => {
           setTimeout(() => {
@@ -521,7 +523,7 @@ describe('Web attribution', () => {
                 generateAttributionEvent(++eventId, url),
                 generateSessionStartEvent(++eventId),
                 generatePageViewEvent(++eventId, 1, url),
-                generateEvent(++eventId, 'test event after session timeout'),
+                generateEvent(++eventId, 'test event in the same session'),
               ],
               options: {
                 min_id_length: undefined,

--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -14,7 +14,7 @@ import {
   generateSessionEndEvent,
   generatePageViewEvent,
   navigateTo,
-} from './helper';
+} from './helpers';
 
 describe('Web attribution', () => {
   const defaultTracking = {

--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -14,64 +14,31 @@ describe('Web attribution', () => {
   const number = expect.any(Number) as number;
   const userAgent = expect.any(String) as string;
   const defaultTracking = {
-    attribution: false,
+    attribution: true,
     fileDownloads: false,
     formInteractions: false,
     pageViews: true,
-    sessions: false,
+    sessions: true,
   };
 
   let apiKey = '';
   let client = amplitude.createInstance();
-  const previousSessionId = Date.now() - 31 * 60 * 1000; // now minus 31 minutes
-  const previousSessionLastEventTime = Date.now() - 31 * 60 * 1000; // now minus 31 minutes
-  const previousSessionLastEventId = 99;
-  const previousSessionDeviceId = 'a7a96s8d';
-  const previousSessionUserId = 'a7a96s8d';
 
   const event_upload_time = '2023-01-01T12:00:00:000Z';
   Date.prototype.toISOString = jest.fn(() => event_upload_time);
 
   beforeEach(() => {
-    // setup expired previous session
-    setLegacyCookie(
-      apiKey,
-      previousSessionDeviceId,
-      previousSessionUserId,
-      undefined,
-      previousSessionId,
-      previousSessionLastEventTime,
-      previousSessionLastEventId,
-    );
     client = amplitude.createInstance();
     apiKey = UUID();
   });
 
-  afterEach(() => {
-    // clean up cookies
-    document.cookie = `amp_${apiKey.substring(0, 6)}=null; expires=1 Jan 1970 00:00:00 GMT`;
-    document.cookie = `AMP_${apiKey.substring(0, 10)}=null; expires=1 Jan 1970 00:00:00 GMT`;
-    document.cookie = `AMP_MKTG_${apiKey.substring(0, 10)}=null; expires=1 Jan 1970 00:00:00 GMT`;
-    (window.location as any) = {
-      hostname: '',
-      href: '',
-      pathname: '',
-      search: '',
-    };
-    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
-  });
-
-  /*
-1. during a session, shouldSetSessionIdOnNewCampaign = true. webAttribution.init will refetch. 
-make sure the campaign event is right
-2. in new session. not initialized,  campaign can be fetched as expcted
-   in the new session, refresh the page test 314. we should catch the changes because it's reloading the page.
-   
-*/
-
-  describe('init SDK web attribution (hard refresh the page)', () => {
+  describe('Page load', () => {
     describe('in a new session', () => {
-      test('Should track all UTMs and referrers', async () => {
+      afterEach(() => {
+        cleanup();
+      });
+
+      test('should track all UTMs and referrers', async () => {
         const url = new URL('https://www.example.com?utm_source=test_utm_source');
         Object.defineProperty(window, 'location', {
           value: {
@@ -91,22 +58,9 @@ make sure the campaign event is right
           })
           .reply(200, success);
 
-        //     Object.defineProperty(window.location, 'href', {
-        //      writable: true,
-        //     value: 'https://www.somthing.com/test.html?query=true'
-        //   });
-
-        //const newURL = new URL('https://www.example.com?utm_source=test_utm_source');
-        //mockWindowLocationFromURL(newURL);
-        //window.history.pushState(undefined, newURL.href); // push state not refreshing the page.
-
         await client.init(apiKey, 'user1@amplitude.com', {
           deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: true,
-            sessions: true,
-          },
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -231,7 +185,151 @@ make sure the campaign event is right
         });
       });
 
-      test('Should not track all UTMs and referrers if the referrer is excluded referrer', async () => {
+      test('should track no campaign if no UTMs and no referrer', async () => {
+        const url = new URL('https://www.example.com');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking,
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'EMPTY',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_source: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+
+      test('should not track all UTMs and referrers if the referrer is excluded referrer', async () => {
         const excludedReferrer = 'https://www.google.com/';
         Object.defineProperty(document, 'referrer', { value: excludedReferrer, configurable: true });
         const url = new URL('https://www.example.com?utm_source=test_utm_source');
@@ -260,7 +358,6 @@ make sure the campaign event is right
             attribution: {
               excludeReferrers: ['www.google.com'],
             },
-            sessions: true,
           },
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
@@ -325,317 +422,14 @@ make sure the campaign event is right
           }, 4000);
         });
       });
-
-      test('Should not fire campaign identify event for direct traffic', async () => {
-        const url = new URL('https://www.example.com?utm_source=test_utm_source');
-        Object.defineProperty(window, 'location', {
-          value: {
-            hostname: url.hostname,
-            href: url.href,
-            pathname: url.pathname,
-            search: url.search,
-          },
-          writable: true,
-        });
-
-        let payload: any = undefined;
-        const scope = nock(httpEndPoint)
-          .post(path, (body: Record<string, any>) => {
-            payload = body;
-            return true;
-          })
-          .reply(200, success);
-
-        nock(httpEndPoint)
-          .post(path, (body: Record<string, any>) => {
-            payload = body;
-            return true;
-          })
-          .reply(200, success);
-
-        await client.init(apiKey, 'user1@amplitude.com', {
-          deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: {
-              resetSessionOnNewCampaign: true,
-            },
-            sessions: true,
-          },
-          sessionTimeout: 500,
-          flushIntervalMillis: 3000,
-        }).promise;
-
-        // refresh during the session.
-        const directUrl = new URL('https://www.example.com/?utm_content=test_utm_content');
-        Object.defineProperty(window, 'location', {
-          value: {
-            hostname: directUrl.hostname,
-            href: directUrl.href,
-            pathname: directUrl.pathname,
-            search: directUrl.search,
-          },
-          writable: true,
-        });
-
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        setTimeout(async () => {
-          await client.init(apiKey, 'user1@amplitude.com', {
-            deviceId: UUID(),
-            defaultTracking: {
-              ...defaultTracking,
-              attribution: {
-                resetSessionOnNewCampaign: true,
-              },
-              sessions: true,
-            },
-            sessionTimeout: 500,
-            flushIntervalMillis: 3000,
-          }).promise;
-        }, 400);
-
-        return new Promise<void>((resolve) => {
-          setTimeout(() => {
-            expect(payload).toEqual({
-              api_key: apiKey,
-              client_upload_time: event_upload_time,
-              events: [
-                {
-                  device_id: uuid,
-                  event_id: 0,
-                  event_type: '$identify',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                  user_properties: {
-                    $set: {
-                      utm_source: 'test_utm_source',
-                    },
-                    $setOnce: {
-                      initial_dclid: 'EMPTY',
-                      initial_fbclid: 'EMPTY',
-                      initial_gbraid: 'EMPTY',
-                      initial_gclid: 'EMPTY',
-                      initial_ko_click_id: 'EMPTY',
-                      initial_li_fat_id: 'EMPTY',
-                      initial_msclkid: 'EMPTY',
-                      initial_referrer: 'EMPTY',
-                      initial_referring_domain: 'EMPTY',
-                      initial_rtd_cid: 'EMPTY',
-                      initial_ttclid: 'EMPTY',
-                      initial_twclid: 'EMPTY',
-                      initial_utm_campaign: 'EMPTY',
-                      initial_utm_content: 'EMPTY',
-                      initial_utm_id: 'EMPTY',
-                      initial_utm_medium: 'EMPTY',
-                      initial_utm_source: 'test_utm_source',
-                      initial_utm_term: 'EMPTY',
-                      initial_wbraid: 'EMPTY',
-                    },
-                    $unset: {
-                      dclid: '-',
-                      fbclid: '-',
-                      gbraid: '-',
-                      gclid: '-',
-                      ko_click_id: '-',
-                      li_fat_id: '-',
-                      msclkid: '-',
-                      referrer: '-',
-                      referring_domain: '-',
-                      rtd_cid: '-',
-                      ttclid: '-',
-                      twclid: '-',
-                      utm_campaign: '-',
-                      utm_content: '-',
-                      utm_id: '-',
-                      utm_medium: '-',
-                      utm_term: '-',
-                      wbraid: '-',
-                    },
-                  },
-                },
-                {
-                  device_id: uuid,
-                  event_id: 1,
-                  event_type: 'session_start',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                },
-                {
-                  device_id: uuid,
-                  event_id: 2,
-                  event_properties: {
-                    '[Amplitude] Page Counter': 1,
-                    '[Amplitude] Page Domain': 'www.example.com',
-                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
-                    '[Amplitude] Page Path': '/',
-                    '[Amplitude] Page Title': '',
-                    '[Amplitude] Page URL': 'https://www.example.com/',
-                    utm_source: 'test_utm_source',
-                  },
-                  event_type: '[Amplitude] Page Viewed',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                },
-                {
-                  device_id: uuid,
-                  event_id: 3,
-                  event_type: 'session_end',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                },
-                {
-                  device_id: uuid,
-                  event_id: 4,
-                  event_type: '$identify',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                  user_properties: {
-                    $set: {
-                      utm_content: 'test_utm_content',
-                    },
-                    $setOnce: {
-                      initial_dclid: 'EMPTY',
-                      initial_fbclid: 'EMPTY',
-                      initial_gbraid: 'EMPTY',
-                      initial_gclid: 'EMPTY',
-                      initial_ko_click_id: 'EMPTY',
-                      initial_li_fat_id: 'EMPTY',
-                      initial_msclkid: 'EMPTY',
-                      initial_referrer: 'EMPTY',
-                      initial_referring_domain: 'EMPTY',
-                      initial_rtd_cid: 'EMPTY',
-                      initial_ttclid: 'EMPTY',
-                      initial_twclid: 'EMPTY',
-                      initial_utm_campaign: 'EMPTY',
-                      initial_utm_content: 'test_utm_content',
-                      initial_utm_id: 'EMPTY',
-                      initial_utm_medium: 'EMPTY',
-                      initial_utm_source: 'EMPTY',
-                      initial_utm_term: 'EMPTY',
-                      initial_wbraid: 'EMPTY',
-                    },
-                    $unset: {
-                      dclid: '-',
-                      fbclid: '-',
-                      gbraid: '-',
-                      gclid: '-',
-                      ko_click_id: '-',
-                      li_fat_id: '-',
-                      msclkid: '-',
-                      referrer: '-',
-                      referring_domain: '-',
-                      rtd_cid: '-',
-                      ttclid: '-',
-                      twclid: '-',
-                      utm_campaign: '-',
-                      utm_id: '-',
-                      utm_medium: '-',
-                      utm_source: '-',
-                      utm_term: '-',
-                      wbraid: '-',
-                    },
-                  },
-                },
-                {
-                  device_id: uuid,
-                  event_id: 5,
-                  event_type: 'session_start',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                },
-                {
-                  device_id: uuid,
-                  event_id: 6,
-                  event_properties: {
-                    '[Amplitude] Page Counter': 2,
-                    '[Amplitude] Page Domain': 'www.example.com',
-                    '[Amplitude] Page Location': 'https://www.example.com/?utm_content=test_utm_content',
-                    '[Amplitude] Page Path': '/',
-                    '[Amplitude] Page Title': '',
-                    '[Amplitude] Page URL': 'https://www.example.com/',
-                    utm_content: 'test_utm_content',
-                  },
-                  event_type: '[Amplitude] Page Viewed',
-                  insert_id: uuid,
-                  ip: '$remote',
-                  language: 'en-US',
-                  library,
-                  partner_id: undefined,
-                  plan: undefined,
-                  platform: 'Web',
-                  session_id: number,
-                  time: number,
-                  user_agent: userAgent,
-                  user_id: 'user1@amplitude.com',
-                },
-              ],
-              options: {
-                min_id_length: undefined,
-              },
-            });
-            scope.done();
-            resolve();
-          }, 4000);
-        });
-      });
     });
 
     describe('during a session', () => {
-      test('Should not fire campaign identify event for direct traffic', async () => {
+      afterEach(() => {
+        cleanup();
+      });
+
+      test('should not fire campaign identify event for direct traffic', async () => {
         const url = new URL('https://www.example.com?utm_source=test_utm_source');
         Object.defineProperty(window, 'location', {
           value: {
@@ -657,11 +451,7 @@ make sure the campaign event is right
 
         await client.init(apiKey, 'user1@amplitude.com', {
           deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: true,
-            sessions: true,
-          },
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -680,11 +470,7 @@ make sure the campaign event is right
 
         await client.init(apiKey, 'user1@amplitude.com', {
           deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: true,
-            sessions: true,
-          },
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -833,7 +619,7 @@ make sure the campaign event is right
         });
       });
 
-      test('Should track all UTMs and referrers if any campaign changed and not direct traffic', async () => {
+      test('should track all UTMs and referrers if any campaign changed and not direct traffic', async () => {
         const url = new URL('https://www.example.com?utm_source=test_utm_source');
         Object.defineProperty(window, 'location', {
           value: {
@@ -855,11 +641,7 @@ make sure the campaign event is right
 
         await client.init(apiKey, 'user1@amplitude.com', {
           deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: true,
-            sessions: true,
-          },
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -880,11 +662,7 @@ make sure the campaign event is right
 
         await client.init(apiKey, 'user1@amplitude.com', {
           deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: true,
-            sessions: true,
-          },
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -1097,13 +875,321 @@ make sure the campaign event is right
           }, 4000);
         });
       });
+
+      test('should start a new session with resetSessionCampaign enable and track campaign updates', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: {
+              resetSessionOnNewCampaign: true,
+            },
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // refresh during the session.
+        const directUrl = new URL('https://www.example.com/?utm_content=test_utm_content');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: directUrl.hostname,
+            href: directUrl.href,
+            pathname: directUrl.pathname,
+            search: directUrl.search,
+          },
+          writable: true,
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        setTimeout(async () => {
+          await client.init(apiKey, 'user1@amplitude.com', {
+            deviceId: UUID(),
+            defaultTracking: {
+              ...defaultTracking,
+              attribution: {
+                resetSessionOnNewCampaign: true,
+              },
+            },
+            sessionTimeout: 500,
+            flushIntervalMillis: 3000,
+          }).promise;
+        }, 100);
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: 'session_end',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 4,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_content: 'test_utm_content',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'test_utm_content',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'EMPTY',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_source: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 5,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 6,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_content=test_utm_content',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_content: 'test_utm_content',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
     });
   });
 
-  // Should not track UTMs  while process any event in the new session if it's excluded referrer
-  describe('process event web attribution (not hard refresh the page)', () => {
+  describe('process event', () => {
     describe('in a new session', () => {
-      test('Should track all UTMs and referrers while process any event', async () => {
+      afterEach(() => {
+        cleanup();
+      });
+
+      test('should track all UTMs and referrers while processing any event', async () => {
         const url = new URL('https://www.example.com?utm_source=test_utm_source');
         Object.defineProperty(window, 'location', {
           value: {
@@ -1125,11 +1211,7 @@ make sure the campaign event is right
 
         await client.init(apiKey, 'user1@amplitude.com', {
           deviceId: UUID(),
-          defaultTracking: {
-            ...defaultTracking,
-            attribution: true,
-            sessions: true,
-          },
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -1148,7 +1230,7 @@ make sure the campaign event is right
           });
 
           client.track('test event after session timeout');
-        }, 500);
+        }, 600);
 
         return new Promise<void>((resolve) => {
           setTimeout(() => {
@@ -1379,10 +1461,10 @@ make sure the campaign event is right
           }, 4000);
         });
       });
-    });
 
-    describe('during a session', () => {
-      test('should not track updated campaign during a session for SPA', async () => {
+      test('should not track UTMs and referrers if the referrer is excluded referrer', async () => {
+        const excludedReferrer = 'https://www.google.com/';
+        Object.defineProperty(document, 'referrer', { value: excludedReferrer, configurable: true });
         const url = new URL('https://www.example.com?utm_source=test_utm_source');
         Object.defineProperty(window, 'location', {
           value: {
@@ -1406,9 +1488,168 @@ make sure the campaign event is right
           deviceId: UUID(),
           defaultTracking: {
             ...defaultTracking,
-            attribution: true,
+            attribution: {
+              excludeReferrers: ['www.google.com'],
+            },
             sessions: true,
           },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // update the url and fire the first event after session timeout
+        setTimeout(() => {
+          const url = new URL('https://www.example.com?utm_source=second_utm_source&utm_content=test_utm_content');
+          Object.defineProperty(window, 'location', {
+            value: {
+              hostname: url.hostname,
+              href: url.href,
+              pathname: url.pathname,
+              search: url.search,
+            },
+            writable: true,
+          });
+
+          client.track('test event after session timeout');
+        }, 600);
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                    referrer: 'https://www.google.com/',
+                    referring_domain: 'www.google.com',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_type: 'session_end',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 4,
+                  event_type: 'test event after session timeout',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+    });
+
+    describe('during a session', () => {
+      afterEach(() => {
+        cleanup();
+      });
+
+      test('should not track updated campaign during', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking,
           sessionTimeout: 500,
           flushIntervalMillis: 3000,
         }).promise;
@@ -1564,33 +1805,203 @@ make sure the campaign event is right
           }, 4000);
         });
       });
+
+      test('should not track campaign with resetSessionCampaign enable', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: {
+              resetSessionOnNewCampaign: true,
+            },
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // refresh during the session.
+        const directUrl = new URL('https://www.example.com/?utm_content=test_utm_content');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: directUrl.hostname,
+            href: directUrl.href,
+            pathname: directUrl.pathname,
+            search: directUrl.search,
+          },
+          writable: true,
+        });
+
+        client.track('test event in same session');
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: 'test event in same session',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
     });
   });
-});
 
-const setLegacyCookie = (
-  apiKey: string,
-  deviceId?: string,
-  userId?: string,
-  optOut?: '1',
-  sessionId?: number,
-  lastEventTime?: number,
-  eventId?: number,
-) => {
-  document.cookie = `amp_${apiKey.substring(0, 6)}=${[
-    deviceId,
-    btoa(userId || ''),
-    optOut,
-    sessionId ? sessionId.toString(32) : '',
-    lastEventTime ? lastEventTime.toString(32) : '',
-    eventId ? eventId.toString(32) : '',
-  ].join('.')}`;
-};
-/*
-const mockWindowLocationFromURL = (url: URL) => {
-    window.location.assign(url);
-    window.location.search = url.search;
-    window.location.hostname = url.hostname;
-    window.location.pathname = url.pathname;
-};  
-*/
+  const cleanup = () => {
+    // clean up cookies
+    document.cookie = `amp_${apiKey.substring(0, 6)}=null; expires=1 Jan 1970 00:00:00 GMT`;
+    document.cookie = `AMP_${apiKey.substring(0, 10)}=null; expires=1 Jan 1970 00:00:00 GMT`;
+    document.cookie = `AMP_MKTG_${apiKey.substring(0, 10)}=null; expires=1 Jan 1970 00:00:00 GMT`;
+    (window.location as any) = {
+      hostname: '',
+      href: '',
+      pathname: '',
+      search: '',
+    };
+    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
+  };
+});

--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -244,7 +244,6 @@ make sure the campaign event is right
           },
           writable: true,
         });
-        console.log(document.referrer);
 
         let payload: any = undefined;
         const scope = nock(httpEndPoint)
@@ -302,6 +301,313 @@ make sure the campaign event is right
                     utm_source: 'test_utm_source',
                     referrer: 'https://www.google.com/',
                     referring_domain: 'www.google.com',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+              ],
+              options: {
+                min_id_length: undefined,
+              },
+            });
+            scope.done();
+            resolve();
+          }, 4000);
+        });
+      });
+
+      test('Should not fire campaign identify event for direct traffic', async () => {
+        const url = new URL('https://www.example.com?utm_source=test_utm_source');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: url.hostname,
+            href: url.href,
+            pathname: url.pathname,
+            search: url.search,
+          },
+          writable: true,
+        });
+
+        let payload: any = undefined;
+        const scope = nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        nock(httpEndPoint)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, 'user1@amplitude.com', {
+          deviceId: UUID(),
+          defaultTracking: {
+            ...defaultTracking,
+            attribution: {
+              resetSessionOnNewCampaign: true,
+            },
+            sessions: true,
+          },
+          sessionTimeout: 500,
+          flushIntervalMillis: 3000,
+        }).promise;
+
+        // refresh during the session.
+        const directUrl = new URL('https://www.example.com/?utm_content=test_utm_content');
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: directUrl.hostname,
+            href: directUrl.href,
+            pathname: directUrl.pathname,
+            search: directUrl.search,
+          },
+          writable: true,
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        setTimeout(async () => {
+          await client.init(apiKey, 'user1@amplitude.com', {
+            deviceId: UUID(),
+            defaultTracking: {
+              ...defaultTracking,
+              attribution: {
+                resetSessionOnNewCampaign: true,
+              },
+              sessions: true,
+            },
+            sessionTimeout: 500,
+            flushIntervalMillis: 3000,
+          }).promise;
+        }, 400);
+
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            expect(payload).toEqual({
+              api_key: apiKey,
+              client_upload_time: event_upload_time,
+              events: [
+                {
+                  device_id: uuid,
+                  event_id: 0,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_source: 'test_utm_source',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'EMPTY',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'test_utm_source',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_content: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 1,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 2,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 1,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_source=test_utm_source',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_source: 'test_utm_source',
+                  },
+                  event_type: '[Amplitude] Page Viewed',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 3,
+                  event_type: 'session_end',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 4,
+                  event_type: '$identify',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                  user_properties: {
+                    $set: {
+                      utm_content: 'test_utm_content',
+                    },
+                    $setOnce: {
+                      initial_dclid: 'EMPTY',
+                      initial_fbclid: 'EMPTY',
+                      initial_gbraid: 'EMPTY',
+                      initial_gclid: 'EMPTY',
+                      initial_ko_click_id: 'EMPTY',
+                      initial_li_fat_id: 'EMPTY',
+                      initial_msclkid: 'EMPTY',
+                      initial_referrer: 'EMPTY',
+                      initial_referring_domain: 'EMPTY',
+                      initial_rtd_cid: 'EMPTY',
+                      initial_ttclid: 'EMPTY',
+                      initial_twclid: 'EMPTY',
+                      initial_utm_campaign: 'EMPTY',
+                      initial_utm_content: 'test_utm_content',
+                      initial_utm_id: 'EMPTY',
+                      initial_utm_medium: 'EMPTY',
+                      initial_utm_source: 'EMPTY',
+                      initial_utm_term: 'EMPTY',
+                      initial_wbraid: 'EMPTY',
+                    },
+                    $unset: {
+                      dclid: '-',
+                      fbclid: '-',
+                      gbraid: '-',
+                      gclid: '-',
+                      ko_click_id: '-',
+                      li_fat_id: '-',
+                      msclkid: '-',
+                      referrer: '-',
+                      referring_domain: '-',
+                      rtd_cid: '-',
+                      ttclid: '-',
+                      twclid: '-',
+                      utm_campaign: '-',
+                      utm_id: '-',
+                      utm_medium: '-',
+                      utm_source: '-',
+                      utm_term: '-',
+                      wbraid: '-',
+                    },
+                  },
+                },
+                {
+                  device_id: uuid,
+                  event_id: 5,
+                  event_type: 'session_start',
+                  insert_id: uuid,
+                  ip: '$remote',
+                  language: 'en-US',
+                  library,
+                  partner_id: undefined,
+                  plan: undefined,
+                  platform: 'Web',
+                  session_id: number,
+                  time: number,
+                  user_agent: userAgent,
+                  user_id: 'user1@amplitude.com',
+                },
+                {
+                  device_id: uuid,
+                  event_id: 6,
+                  event_properties: {
+                    '[Amplitude] Page Counter': 2,
+                    '[Amplitude] Page Domain': 'www.example.com',
+                    '[Amplitude] Page Location': 'https://www.example.com/?utm_content=test_utm_content',
+                    '[Amplitude] Page Path': '/',
+                    '[Amplitude] Page Title': '',
+                    '[Amplitude] Page URL': 'https://www.example.com/',
+                    utm_content: 'test_utm_content',
                   },
                   event_type: '[Amplitude] Page Viewed',
                   insert_id: uuid,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
Jira [AMP-98581](https://amplitude.atlassian.net/browse/AMP-98581)
Add web attribution integration test
The test covers
1. Page reload. The test uses double init to mock hard page reload. 
   a. In a new session should track all UTMs and referrers
   b. In a new session should track no campaign if no UTMs and no referrer
   c. In a new session should not track all UTMs and referrers if the referrer is excluded referrer
   d. During a session should not fire campaign identify event for direct traffic
   e. During a session  should track all UTMs and referrers if any campaign changed and not direct traffic
   f.  During a session should start a new session with resetSessionCampaign enable and track campaign updates

2. Process event, when any events under process, which include SPA redirect 
  a.  in a new session Should track all UTMs and referrers while processing any event
  b.  in a new session  Should not track UTMs and referrers if the referrer is excluded referrer 
  c. during a session Should not track updated campaign during
  d. during a session  Should not track campaign with resetSessionCampaign enable


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-98581]: https://amplitude.atlassian.net/browse/AMP-98581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ