### PR TITLE
revert(browser): fix: have session and device IDs ready before plugin setup

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -71,7 +71,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     // Step 2: Create browser config
     const browserOptions = await useBrowserConfig(options.apiKey, options, this);
-    this.config = browserOptions;
+    await super._init(browserOptions);
 
     // Add web attribution plugin
     if (isAttributionTrackingEnabled(this.config.defaultTracking)) {
@@ -87,8 +87,6 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     // Default: `Date.now()`
     // Session ID is handled differently than device ID and user ID due to session events
     this.setSessionId(options.sessionId ?? this.config.sessionId ?? Date.now());
-
-    await super._init(this.config);
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -971,6 +971,34 @@ describe('browser-client', () => {
 
       expect(logSpy).toHaveBeenCalledWith('Created a new session for new campaign.');
     });
+    test('should track web attribution if change in campaign information', async () => {
+      const track = jest.spyOn(client, 'dispatch').mockReturnValue(
+        Promise.resolve({
+          code: 200,
+          message: '',
+          event: {
+            event_type: 'event_type',
+          },
+        }),
+      );
+      await client.init(apiKey, {
+        optOut: true,
+        logLevel: LogLevel.Warn,
+        defaultTracking: {
+          attribution: {
+            resetSessionOnNewCampaign: true,
+          },
+        },
+      }).promise;
+
+      client.webAttribution = new WebAttribution({}, { ...client.config, lastEventTime: undefined });
+      client.webAttribution.shouldTrackNewCampaign = true;
+      jest.spyOn(AnalyticsClientCommon, 'isNewSession').mockReturnValueOnce(false);
+      await client.process({
+        event_type: 'event',
+      });
+      expect(track).toHaveBeenCalled();
+    });
 
     test('should reinit web attribution when procee new session event', async () => {
       const mockConfig: BrowserConfig = {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1,31 +1,22 @@
-import { AmplitudeBrowser } from '../src/browser-client';
-import * as core from '@amplitude/analytics-core';
-import * as Config from '../src/config';
-import * as CookieMigration from '../src/cookie-migration';
-import {
-  OfflineDisabled,
-  UserSession,
-  CoreClient,
-  DestinationPlugin,
-  Event,
-  Result,
-  LogLevel,
-  BrowserConfig,
-} from '@amplitude/analytics-types';
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import {
   CookieStorage,
   FetchTransport,
   getAnalyticsConnector,
   getCookieName,
 } from '@amplitude/analytics-client-common';
-import * as SnippetHelper from '../src/utils/snippet-helper';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import { WebAttribution } from '@amplitude/analytics-client-common/src';
+import * as core from '@amplitude/analytics-core';
+import { Logger, UUID } from '@amplitude/analytics-core';
+import { BrowserConfig, LogLevel, OfflineDisabled, UserSession } from '@amplitude/analytics-types';
+import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
+import { AmplitudeBrowser } from '../src/browser-client';
+import * as Config from '../src/config';
+import * as CookieMigration from '../src/cookie-migration';
 import * as fileDownloadTracking from '../src/plugins/file-download-tracking';
 import * as formInteractionTracking from '../src/plugins/form-interaction-tracking';
 import * as networkConnectivityChecker from '../src/plugins/network-connectivity-checker';
-import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
-import { WebAttribution } from '@amplitude/analytics-client-common/src';
-import { Logger, UUID } from '@amplitude/analytics-core';
+import * as SnippetHelper from '../src/utils/snippet-helper';
 
 describe('browser-client', () => {
   let apiKey = '';
@@ -165,26 +156,6 @@ describe('browser-client', () => {
       expect(client.getDeviceId()).toBe(deviceId);
       expect(client.getSessionId()).toBe(1);
       expect(parseLegacyCookies).toHaveBeenCalledTimes(1);
-    });
-
-    test('should init with session Id and device Id before plugin setup', async () => {
-      class MockedSessionReplayPlugin implements DestinationPlugin {
-        type = 'destination' as const;
-        async setup(_config: Config.BrowserConfig, _clinet: CoreClient) {
-          expect(client.config.sessionId).toBeDefined();
-          expect(client.config.deviceId).toBeDefined();
-        }
-        execute = jest.fn(async (event: Event): Promise<Result> => {
-          return Promise.resolve({
-            event,
-            code: 200,
-            message: 'success',
-          });
-        });
-      }
-
-      client.add(new MockedSessionReplayPlugin());
-      await client.init().promise;
     });
 
     test('should call prevent concurrent init executions', async () => {


### PR DESCRIPTION
…691)"

This reverts commit 83e3eca5a529838a19f6c2afb59e1d8a5f2ac650.


### Summary
This change made it not possible to tag start session events with the session replay ID

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
