### PR TITLE
fix(core): correctly await promises called before init

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -30,8 +30,8 @@ export class AmplitudeCore implements CoreClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   timeline: Timeline;
-  protected q: CallableFunction[] = [];
-  protected dispatchQ: CallableFunction[] = [];
+  protected q: Array<CallableFunction | typeof returnWrapper> = [];
+  protected dispatchQ: Array<CallableFunction> = [];
 
   constructor(name = '$default') {
     this.timeline = new Timeline(this);
@@ -48,7 +48,15 @@ export class AmplitudeCore implements CoreClient {
     const queuedFunctions = this[queueName];
     this[queueName] = [];
     for (const queuedFunction of queuedFunctions) {
-      await queuedFunction();
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const val: ReturnType<typeof returnWrapper> | Promise<any> = queuedFunction();
+      if (val && 'promise' in val) {
+        await val.promise;
+      } else {
+        await val;
+      }
     }
   }
 


### PR DESCRIPTION
### Summary

We've observed that the SR plugin is not correctly awaited when added before the client is initialized. This is because the SR plugin performs some async behavior in setup, and the client timeline was not awaiting on the `.promise` of the `AmplitudeReturn` of `client.add`.

See the unit test in this PR for a good representation of the issue - I confirmed that this test fails without this fix.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
