### PR TITLE
feat(session replay): add ability to wait for setSessionId process to complete

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -27,7 +27,7 @@ class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
     // Choosing not to read from event object here, concerned about offline/delayed events messing up the state stored
     // in SR.
     if (this.config.sessionId && this.config.sessionId !== sessionReplay.getSessionId()) {
-      sessionReplay.setSessionId(this.config.sessionId);
+      await sessionReplay.setSessionId(this.config.sessionId).promise;
     }
 
     // Treating config.sessionId as source of truth, if the event's session id doesn't match, the

--- a/packages/session-replay-browser/src/identifiers.ts
+++ b/packages/session-replay-browser/src/identifiers.ts
@@ -1,20 +1,17 @@
-import { Logger as ILogger } from '@amplitude/analytics-types';
 import { generateSessionReplayId } from './helpers';
-import { SessionIdentifiers as ISessionIdentifiers, SessionReplayOptions } from './typings/session-replay';
+import { SessionIdentifiers as ISessionIdentifiers } from './typings/session-replay';
 
 export class SessionIdentifiers implements ISessionIdentifiers {
   deviceId?: string | undefined;
   sessionId?: number | undefined;
   sessionReplayId?: string | undefined;
 
-  constructor(options: SessionReplayOptions, loggerProvider: ILogger) {
-    this.deviceId = options.deviceId;
-    this.sessionId = options.sessionId;
+  constructor({ sessionId, deviceId }: { sessionId?: number; deviceId?: string }) {
+    this.deviceId = deviceId;
+    this.sessionId = sessionId;
 
-    if (options.sessionId && options.deviceId) {
-      this.sessionReplayId = generateSessionReplayId(options.sessionId, options.deviceId);
-    } else {
-      loggerProvider.error('Please provide both sessionId and deviceId.');
+    if (sessionId && deviceId) {
+      this.sessionReplayId = generateSessionReplayId(sessionId, deviceId);
     }
   }
 }

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -64,7 +64,7 @@ export type SessionReplayOptions = Omit<Partial<SessionReplayLocalConfig & Sessi
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
-  setSessionId: (sessionId: number, deviceId?: string) => void;
+  setSessionId: (sessionId: number, deviceId?: string) => AmplitudeReturn<void>;
   getSessionId: () => number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   flush: (useRetry: boolean) => Promise<void>;


### PR DESCRIPTION
### Summary
Now that setSessionId has an async action, we should wait for it to complete before proceeding in the plugin. This PR adds an optional async interface to setSessionId via the AmplitudeReturn interface, `await setSessionId().promise`. This will allow us to properly tag start session events with the correct replay id, after fetching the remote config to ensure the replays shoul d be captured.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
