### PR TITLE
fix: sends events in order

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -603,103 +603,111 @@ describe('integration', () => {
       second.done();
     });
 
-    test('should handle 429 error with throttled event', async () => {
-      const first = nock(url)
-        .post(path)
-        .reply(429, {
-          code: 429,
-          error: 'Too many requests for some devices and users',
-          throttled_events: [0],
+    describe('track with 429 error with throttled event', () => {
+      // Throttle timeout is 30000 million seconds, we need to extend the jest time because the default timeout is 5000.
+      // jest.setTimeout only works before the describe block.
+      jest.setTimeout(36000);
+      test('should handle 429 error with throttled event', async () => {
+        const first = nock(url)
+          .post(path)
+          .reply(429, {
+            code: 429,
+            error: 'Too many requests for some devices and users',
+            throttled_events: [0],
+          });
+
+        const second = nock(url).post(path).reply(200, success);
+
+        await client.init(apiKey, {
+          logLevel: 0,
+          defaultTracking,
+          flushIntervalMillis: 10,
+        }).promise;
+
+        const responses = await Promise.all([
+          client.track('test event 1').promise,
+          client.track('test event 2').promise,
+        ]);
+
+        responses.forEach((response, index) => {
+          expect(response.event).toEqual({
+            user_id: undefined,
+            device_id: uuid,
+            session_id: number,
+            time: number,
+            platform: 'Web',
+            language: 'en-US',
+            ip: '$remote',
+            insert_id: uuid,
+            partner_id: undefined,
+            event_type: `test event ${index + 1}`,
+            event_id: index,
+            library: library,
+            user_agent: userAgent,
+          });
+          expect(response.code).toBe(200);
+          expect(response.message).toBe(SUCCESS_MESSAGE);
         });
 
-      const second = nock(url).post(path).reply(200, success);
-
-      await client.init(apiKey, {
-        logLevel: 0,
-        defaultTracking,
-        flushIntervalMillis: 100,
-      }).promise;
-
-      const responses = await Promise.all([client.track('test event 1').promise, client.track('test event 2').promise]);
-
-      responses.forEach((response, index) => {
-        expect(response.event).toEqual({
-          user_id: undefined,
-          device_id: uuid,
-          session_id: number,
-          time: number,
-          platform: 'Web',
-          language: 'en-US',
-          ip: '$remote',
-          insert_id: uuid,
-          partner_id: undefined,
-          event_type: `test event ${index + 1}`,
-          event_id: index,
-          library: library,
-          user_agent: userAgent,
-        });
-        expect(response.code).toBe(200);
-        expect(response.message).toBe(SUCCESS_MESSAGE);
+        first.done();
+        second.done();
       });
 
-      first.done();
-      second.done();
-    });
+      test('should handle 429 error with throttled event async', async () => {
+        const first = nock(url)
+          .post(path)
+          .reply(429, {
+            code: 429,
+            error: 'Too many requests for some devices and users',
+            throttled_events: [0],
+          });
+        let payload: any = undefined;
 
-    test('should handle 429 error with throttled event async', async () => {
-      const first = nock(url)
-        .post(path)
-        .reply(429, {
-          code: 429,
-          error: 'Too many requests for some devices and users',
-          throttled_events: [0],
+        const second = nock(url)
+          .post(path, (body: Record<string, any>) => {
+            payload = body;
+            return true;
+          })
+          .reply(200, success);
+
+        await client.init(apiKey, {
+          logLevel: 0,
+          defaultTracking,
+          flushIntervalMillis: 100,
+        }).promise;
+
+        const eventTypes = ['test event 1', 'test event 2', 'test event 3'];
+        client.track(eventTypes[0]);
+        client.track(eventTypes[1]);
+        // Make sure throttled timeout and events have been sent to server
+        await client.track(eventTypes[2]).promise;
+
+        expect(payload).toEqual({
+          api_key: apiKey,
+          client_upload_time: event_upload_time,
+          events: eventTypes.map((eventType, index) => ({
+            device_id: uuid,
+            event_id: index,
+            event_type: eventType,
+            insert_id: uuid,
+            ip: '$remote',
+            language: 'en-US',
+            library,
+            partner_id: undefined,
+            plan: undefined,
+            platform: 'Web',
+            session_id: number,
+            time: number,
+            user_agent: userAgent,
+          })),
+          options: {
+            min_id_length: undefined,
+          },
         });
-      let payload: any = undefined;
 
-      const second = nock(url)
-        .post(path, (body: Record<string, any>) => {
-          payload = body;
-          return true;
-        })
-        .reply(200, success);
-
-      await client.init(apiKey, {
-        logLevel: 0,
-        defaultTracking,
-        flushIntervalMillis: 500,
-      }).promise;
-
-      const eventTypes = ['test event 1', 'test event 2', 'test event 3'];
-      client.track(eventTypes[0]);
-      client.track(eventTypes[1]);
-      // Make sure throttled timeout and events have been sent to server
-      await client.track(eventTypes[2]).promise;
-
-      expect(payload).toEqual({
-        api_key: apiKey,
-        client_upload_time: event_upload_time,
-        events: eventTypes.map((eventType, index) => ({
-          device_id: uuid,
-          event_id: index,
-          event_type: eventType,
-          insert_id: uuid,
-          ip: '$remote',
-          language: 'en-US',
-          library,
-          partner_id: undefined,
-          plan: undefined,
-          platform: 'Web',
-          session_id: number,
-          time: number,
-          user_agent: userAgent,
-        })),
-        options: {
-          min_id_length: undefined,
-        },
+        first.done();
+        second.done();
       });
-
-      first.done();
-      second.done();
     });
 
     test('should handle 500 error', async () => {

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -106,15 +106,7 @@ export class Destination implements DestinationPlugin {
   }
 
   sendEventsIfReady() {
-    if (this.config.offline) {
-      return;
-    }
-
-    if (this.queue.length >= this.config.flushQueueSize) {
-      void this.flush(true);
-    }
-
-    if (this.scheduled) {
+    if (this.config.offline || this.scheduled) {
       return;
     }
 
@@ -125,8 +117,6 @@ export class Destination implements DestinationPlugin {
         }
       });
     }, this.config.flushIntervalMillis);
-
-    return;
   }
 
   // flush the queue

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -104,7 +104,6 @@ export class Destination implements DestinationPlugin {
     // if batching enabled, check if min threshold met for batch size
     if (this.queue.length >= this.config.flushQueueSize) {
       void this.flush(true);
-      // return;
     }
 
     this.scheduled = setTimeout(() => {
@@ -303,10 +302,9 @@ export class Destination implements DestinationPlugin {
    * This is called on response comes back for a request
    */
   removeEvents(eventsToRemove: Context[]) {
-    this.queue = this.queue.filter((queuedContext) => {
-      const test = !eventsToRemove.some((context) => context.event.insert_id === queuedContext.event.insert_id);
-      return test;
-    });
+    this.queue = this.queue.filter(
+      (queuedContext) => !eventsToRemove.some((context) => context.event.insert_id === queuedContext.event.insert_id),
+    );
 
     this.saveEvents();
   }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -98,6 +98,7 @@ export class Destination implements DestinationPlugin {
       void this.fulfillRequest([context], 500, MAX_RETRIES_EXCEEDED_MESSAGE);
       return false;
     });
+    console.log('queue in fliter triableList :');
   }
 
   sendEventIfReady() {

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -161,7 +161,7 @@ export class Destination implements DestinationPlugin {
     }
   }
 
-  async send(list: Context[], useRetry = true) {
+  async send(list: Context[], useRetry = true): Promise<Status> {
     if (!this.config.apiKey) {
       this.fulfillRequest(list, 400, MISSING_API_KEY_MESSAGE);
       return Status.Invalid;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -103,7 +103,6 @@ export class Destination implements DestinationPlugin {
     // if batching enabled, check if min threshold met for batch size
     if (this.queue.length >= this.config.flushQueueSize) {
       void this.flush(true);
-      // return;
     }
 
     this.scheduled = setTimeout(() => {
@@ -130,13 +129,16 @@ export class Destination implements DestinationPlugin {
       this.scheduled = null;
     }
 
+    this.filterTriableList();
+    if (this.queue.length === 0) {
+      return;
+    }
+
     const currentFlushQueue = this.queue.slice(0, this.config.flushQueueSize);
     await this.send(currentFlushQueue, useRetry);
   }
 
   async send(list: Context[], useRetry = true) {
-    this.filterTriableList();
-
     if (!this.config.apiKey) {
       return this.fulfillRequest(list, 400, MISSING_API_KEY_MESSAGE);
     }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -81,8 +81,8 @@ export class Destination implements DestinationPlugin {
 
   addToQueue(...list: Context[]) {
     this.queue = this.queue.concat(list);
-    this.sendEventIfReady();
     this.saveEvents();
+    this.sendEventIfReady();
   }
 
   filterTriableList() {

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -237,12 +237,12 @@ export class Destination implements DestinationPlugin {
     return isFullfilledRequest;
   }
 
-  handleSuccessResponse(res: SuccessResponse, list: Context[]) {
+  handleSuccessResponse(res: SuccessResponse, list: Context[]): boolean {
     this.fulfillRequest(list, res.statusCode, SUCCESS_MESSAGE);
     return true;
   }
 
-  handleInvalidResponse(res: InvalidResponse, list: Context[]) {
+  handleInvalidResponse(res: InvalidResponse, list: Context[]): boolean {
     if (res.body.missingField || res.body.error.startsWith(INVALID_API_KEY)) {
       this.fulfillRequest(list, res.statusCode, res.body.error);
       return true;
@@ -273,7 +273,7 @@ export class Destination implements DestinationPlugin {
     return true;
   }
 
-  handlePayloadTooLargeResponse(res: PayloadTooLargeResponse, list: Context[]) {
+  handlePayloadTooLargeResponse(res: PayloadTooLargeResponse, list: Context[]): boolean {
     if (list.length === 1) {
       this.fulfillRequest(list, res.statusCode, res.body.error);
       return true;
@@ -287,7 +287,7 @@ export class Destination implements DestinationPlugin {
     return false;
   }
 
-  handleRateLimitResponse(res: RateLimitResponse, list: Context[]) {
+  handleRateLimitResponse(res: RateLimitResponse, list: Context[]): boolean {
     const dropUserIds = Object.keys(res.body.exceededDailyQuotaUsers);
     const dropDeviceIds = Object.keys(res.body.exceededDailyQuotaDevices);
     const dropUserIdsSet = new Set(dropUserIds);

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -308,6 +308,45 @@ describe('destination', () => {
       expect(result).toBe(undefined);
       expect(send).toHaveBeenCalledTimes(1);
     });
+
+    test('should update the attempts', async () => {
+      const destination = new Destination();
+      destination.config = {
+        ...useDefaultConfig(),
+      };
+      destination.queue = [
+        {
+          event: {
+            event_type: 'event_type_1',
+            insert_id: '1',
+          },
+          attempts: 0,
+          callback: () => undefined,
+        },
+        {
+          event: {
+            event_type: 'event_type_2',
+            insert_id: '2',
+          },
+          attempts: 0,
+          callback: () => undefined,
+        },
+      ];
+
+      const context = [
+        {
+          event: {
+            event_type: 'event_type_2',
+            insert_id: '2',
+          },
+          attempts: 0,
+          callback: () => undefined,
+        },
+      ];
+      destination.increaseAttempts(context);
+      expect(destination.queue[0].attempts).toBe(0);
+      expect(destination.queue[1].attempts).toBe(1);
+    });
   });
 
   describe('send', () => {

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -620,7 +620,7 @@ describe('destination', () => {
       const transportProvider = {
         send: jest.fn().mockImplementationOnce(() => {
           return Promise.resolve({
-            status: Status.PayloadTooLarge,
+            status: Status.Invalid,
             statusCode: 400,
             body: {
               code: 400,

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -877,8 +877,6 @@ describe('destination', () => {
       }
       const transportProvider = new Http();
       const destination = new Destination();
-      // destination.retryTimeout = 10;
-      //destination.throttleTimeout = 1;
       const config = {
         ...useDefaultConfig(),
         flushQueueSize: 4,
@@ -940,7 +938,6 @@ describe('destination', () => {
       }
       const transportProvider = new Http();
       const destination = new Destination();
-      //destination.retryTimeout = 10;
       const config = {
         ...useDefaultConfig(),
         flushQueueSize: 2,

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -8,7 +8,6 @@ import {
   UNEXPECTED_ERROR_MESSAGE,
 } from '../../src/messages';
 import { uuidPattern } from '../helpers/util';
-//import { UUID } from '../../src/utils/uuid';
 
 const jsons = (obj: any) => JSON.stringify(obj, null, 2);
 describe('destination', () => {

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -150,10 +150,10 @@ describe('destination', () => {
       jest.useRealTimers();
     });
 
-    /*     test('should schedule a flush', async () => {
+    test('should schedule a flush', async () => {
       const destination = new Destination();
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      (destination as any).scheduled = false;
+      (destination as any).scheduled = null;
       destination.queue = [
         {
           event: { event_type: 'event_type' },
@@ -162,7 +162,7 @@ describe('destination', () => {
         },
       ];
       destination.config = {
-        ...destination.config,
+        ...useDefaultConfig(),
         offline: false,
         flushIntervalMillis: 0,
       };
@@ -170,7 +170,7 @@ describe('destination', () => {
         .spyOn(destination, 'flush')
         .mockImplementationOnce(() => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          (destination as any).scheduled = false;
+          (destination as any).scheduled = null;
           return Promise.resolve(undefined);
         })
         .mockReturnValueOnce(Promise.resolve(undefined));
@@ -182,7 +182,7 @@ describe('destination', () => {
       // exhause nested setTimeout
       jest.runAllTimers();
       expect(flush).toHaveBeenCalledTimes(2);
-    });*/
+    });
 
     test('should not schedule a flush if offline', async () => {
       const destination = new Destination();
@@ -980,7 +980,6 @@ describe('destination', () => {
       }
       const transportProvider = new Http();
       const destination = new Destination();
-      //destination.retryTimeout = 10;
       const config = {
         ...useDefaultConfig(),
         flushMaxRetries: 1,

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -265,7 +265,7 @@ describe('destination', () => {
           callback: () => undefined,
         },
       ];
-      const send = jest.spyOn(destination, 'send').mockReturnValueOnce(Promise.resolve(Status.Success));
+      const send = jest.spyOn(destination, 'send').mockReturnValueOnce(Promise.resolve(true));
       await destination.flush();
       expect(send).toHaveBeenCalledTimes(0);
       expect(loggerProvider.debug).toHaveBeenCalledTimes(1);
@@ -285,7 +285,7 @@ describe('destination', () => {
           callback: () => undefined,
         },
       ];
-      const send = jest.spyOn(destination, 'send').mockReturnValueOnce(Promise.resolve(Status.Success));
+      const send = jest.spyOn(destination, 'send').mockReturnValueOnce(Promise.resolve(true));
       const result = await destination.flush();
       expect(result).toBe(undefined);
       expect(send).toHaveBeenCalledTimes(1);
@@ -303,7 +303,7 @@ describe('destination', () => {
           callback: () => undefined,
         },
       ];
-      const send = jest.spyOn(destination, 'send').mockReturnValueOnce(Promise.resolve(Status.Success));
+      const send = jest.spyOn(destination, 'send').mockReturnValueOnce(Promise.resolve(true));
       const result = await destination.flush();
       expect(result).toBe(undefined);
       expect(send).toHaveBeenCalledTimes(1);
@@ -384,13 +384,14 @@ describe('destination', () => {
         apiKey: API_KEY,
         minIdLength: 10,
       });
-      await destination.send([context]);
+      const isFullfilledRequest = await destination.send([context]);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,
         code: 200,
         message: SUCCESS_MESSAGE,
       });
+      expect(isFullfilledRequest).toBe(true);
     });
 
     test('should include min id length', async () => {
@@ -424,13 +425,14 @@ describe('destination', () => {
         apiKey: API_KEY,
         minIdLength: 10,
       });
-      await destination.send([context]);
+      const isFullfilledRequest = await destination.send([context]);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,
         code: 200,
         message: SUCCESS_MESSAGE,
       });
+      expect(isFullfilledRequest).toBe(true);
     });
 
     test('should not include extra', async () => {
@@ -466,13 +468,14 @@ describe('destination', () => {
         apiKey: API_KEY,
         minIdLength: 10,
       });
-      await destination.send([context]);
+      const isFullfilledRequest = await destination.send([context]);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,
         code: 200,
         message: SUCCESS_MESSAGE,
       });
+      expect(isFullfilledRequest).toBe(true);
     });
 
     test('should not retry', async () => {
@@ -499,13 +502,14 @@ describe('destination', () => {
         transportProvider,
         apiKey: API_KEY,
       });
-      await destination.send([context], false);
+      const isFullfilledRequest = await destination.send([context], false);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,
         code: 500,
         message: Status.Failed,
       });
+      expect(isFullfilledRequest).toBe(true);
     });
 
     test('should provide error details', async () => {
@@ -537,13 +541,14 @@ describe('destination', () => {
         transportProvider,
         apiKey: API_KEY,
       });
-      await destination.send([context], false);
+      const isFullfilledRequest = await destination.send([context], false);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,
         code: 400,
         message: `${Status.Invalid}: ${jsons(body)}`,
       });
+      expect(isFullfilledRequest).toBe(true);
     });
 
     test('should handle no api key', async () => {
@@ -567,13 +572,14 @@ describe('destination', () => {
         transportProvider,
         apiKey: '',
       });
-      await destination.send([context]);
+      const isFullfilledRequest = await destination.send([context]);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,
         code: 400,
         message: MISSING_API_KEY_MESSAGE,
       });
+      expect(isFullfilledRequest).toBe(true);
     });
 
     test('should not drop data on unexpected error', async () => {
@@ -595,9 +601,10 @@ describe('destination', () => {
         ...useDefaultConfig(),
         transportProvider,
       });
-      await destination.send([context]);
+      const isFullfilledRequest = await destination.send([context]);
       // We should not fulfill request when the request fails with an unknown error. This should be retried
       expect(callback).toHaveBeenCalledTimes(0);
+      expect(isFullfilledRequest).toBe(false);
     });
 
     test.each([

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -652,6 +652,38 @@ describe('destination', () => {
         callback,
         event: {
           event_type: 'event_type',
+        },
+      };
+
+      const transportProvider = {
+        send: jest.fn().mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: Status.PayloadTooLarge,
+            statusCode: 413,
+            body: {
+              code: 413,
+              error: 'error',
+            },
+          });
+        }),
+      };
+
+      await destination.setup({
+        ...useDefaultConfig(),
+        transportProvider,
+      });
+      const isFullfilledRequest = await destination.send([context]);
+      expect(isFullfilledRequest).toBe(true);
+    });
+
+    test('should marked as fillfiled request for 429 response if no retried events', async () => {
+      const destination = new Destination();
+      const callback = jest.fn();
+      const context = {
+        attempts: 0,
+        callback,
+        event: {
+          event_type: 'event_type',
           device_id: '0',
         },
       };

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -706,7 +706,6 @@ describe('destination', () => {
       }
       const transportProvider = new Http();
       const destination = new Destination();
-      //destination.retryTimeout = 10;
       const config = {
         ...useDefaultConfig(),
         flushQueueSize: 2,
@@ -717,11 +716,9 @@ describe('destination', () => {
       const results = await Promise.all([
         destination.execute({
           event_type: 'event_type',
-          insert_id: '0',
         }),
         destination.execute({
           event_type: 'event_type',
-          insert_id: '1',
         }),
       ]);
       expect(results[0].code).toBe(400);
@@ -889,28 +886,24 @@ describe('destination', () => {
           event_type: 'event_type',
           user_id: '0',
           device_id: '0',
-          insert_id: '0',
         }),
         // exceed daily device quota
         destination.execute({
           event_type: 'event_type',
           user_id: '1',
           device_id: '1',
-          insert_id: '1',
         }),
         // exceed daily user quota
         destination.execute({
           event_type: 'event_type',
           user_id: '2',
           device_id: '2',
-          insert_id: '2',
         }),
         // success
         destination.execute({
           event_type: 'event_type',
           user_id: '3',
           device_id: '3',
-          insert_id: '3',
         }),
       ]);
       expect(results[0].code).toBe(200);
@@ -986,11 +979,9 @@ describe('destination', () => {
       const results = await Promise.all([
         destination.execute({
           event_type: 'event_type',
-          insert_id: '0',
         }),
         destination.execute({
           event_type: 'event_type',
-          insert_id: '1',
         }),
       ]);
       expect(results[0].code).toBe(500);

--- a/packages/analytics-types/src/destination-context.ts
+++ b/packages/analytics-types/src/destination-context.ts
@@ -3,7 +3,6 @@ import { EventCallback } from './event-callback';
 
 export interface DestinationContext {
   event: Event;
-  attempts: number;
   callback: EventCallback;
-  timeout: number;
+  attempts: number;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
[Jira AMP-98809
](https://amplitude.atlassian.net/browse/AMP-98809)

This change is for making sure the events sent into the backend are in order.
Previously in the Typescript SDK, we 
- Sent different promises in parallel using Promise.all, which led to race conditions.
- Scheduled individual events based on their own timeout, which also resulted in events being sent out of order.

Current behavior:
- In the event of an error, we filter out problematic events while keeping all other events in the queue. These events will be retried with the next trigger.

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
