### PR TITLE
fix: location is polyfilled to an empty object

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -301,11 +301,15 @@ export const createTransport = (transport?: TransportType) => {
 };
 
 export const getTopLevelDomain = async (url?: string) => {
-  if (!(await new CookieStorage<number>().isEnabled()) || (!url && typeof location === 'undefined')) {
+  const host = url ?? (typeof location !== 'undefined' ? location.hostname : '');
+
+  // Return an empty string if
+  // 1. cookie storage is disabled
+  // 2. host is empty
+  if (!(await new CookieStorage<string>().isEnabled()) || !host) {
     return '';
   }
 
-  const host = url ?? location.hostname;
   const parts = host.split('.');
   const levels = [];
   const storageKey = 'AMP_TLDTEST';

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -301,15 +301,14 @@ export const createTransport = (transport?: TransportType) => {
 };
 
 export const getTopLevelDomain = async (url?: string) => {
-  const host = url ?? (typeof location !== 'undefined' ? location.hostname : '');
-
-  // Return an empty string if
-  // 1. cookie storage is disabled
-  // 2. host is empty
-  if (!(await new CookieStorage<string>().isEnabled()) || !host) {
+  if (
+    !(await new CookieStorage<number>().isEnabled()) ||
+    (!url && (typeof location === 'undefined' || !location.hostname))
+  ) {
     return '';
   }
 
+  const host = url ?? location.hostname;
   const parts = host.split('.');
   const levels = [];
   const storageKey = 'AMP_TLDTEST';

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -377,5 +377,21 @@ describe('config', () => {
         configurable: true,
       });
     });
+
+    test('should return empty string when location is undefined', async () => {
+      const originalLocation = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: undefined,
+        configurable: true,
+      });
+
+      expect(await Config.getTopLevelDomain()).toBe('');
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        configurable: true,
+      });
+    });
   });
 });

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -361,5 +361,21 @@ describe('config', () => {
         });
       expect(await Config.getTopLevelDomain('www.legislation.gov.uk')).toBe('.legislation.gov.uk');
     });
+
+    test('should not throw an error when location is an empty object', async () => {
+      const originalLocation = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {} as Location,
+        configurable: true,
+      });
+
+      expect(await Config.getTopLevelDomain()).toBe('');
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        configurable: true,
+      });
+    });
   });
 });

--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -269,11 +269,15 @@ export const createEventsStorage = async (overrides?: ReactNativeOptions): Promi
 };
 
 export const getTopLevelDomain = async (url?: string) => {
-  if (!(await new CookieStorage<string>().isEnabled()) || (!url && typeof location === 'undefined')) {
+  const host = url ?? (typeof location !== 'undefined' ? location.hostname : '');
+
+  // Return an empty string if
+  // 1. cookie storage is disabled
+  // 2. host is empty
+  if (!(await new CookieStorage<string>().isEnabled()) || !host) {
     return '';
   }
 
-  const host = url ?? location.hostname;
   const parts = host.split('.');
   const levels = [];
   const storageKey = 'AMP_TLDTEST';

--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -269,15 +269,14 @@ export const createEventsStorage = async (overrides?: ReactNativeOptions): Promi
 };
 
 export const getTopLevelDomain = async (url?: string) => {
-  const host = url ?? (typeof location !== 'undefined' ? location.hostname : '');
-
-  // Return an empty string if
-  // 1. cookie storage is disabled
-  // 2. host is empty
-  if (!(await new CookieStorage<string>().isEnabled()) || !host) {
+  if (
+    !(await new CookieStorage<number>().isEnabled()) ||
+    (!url && (typeof location === 'undefined' || !location.hostname))
+  ) {
     return '';
   }
 
+  const host = url ?? location.hostname;
   const parts = host.split('.');
   const levels = [];
   const storageKey = 'AMP_TLDTEST';

--- a/packages/analytics-react-native/test/config.test.ts
+++ b/packages/analytics-react-native/test/config.test.ts
@@ -344,5 +344,21 @@ describe('config', () => {
         });
       expect(await Config.getTopLevelDomain('www.legislation.gov.uk')).toBe('.legislation.gov.uk');
     });
+
+    test('should not throw an error when location is an empty object', async () => {
+      const originalLocation = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {} as Location,
+        configurable: true,
+      });
+
+      expect(await Config.getTopLevelDomain()).toBe('');
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        configurable: true,
+      });
+    });
   });
 });

--- a/packages/analytics-react-native/test/config.test.ts
+++ b/packages/analytics-react-native/test/config.test.ts
@@ -360,5 +360,21 @@ describe('config', () => {
         configurable: true,
       });
     });
+
+    test('should return empty string when location is undefined', async () => {
+      const originalLocation = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: undefined,
+        configurable: true,
+      });
+
+      expect(await Config.getTopLevelDomain()).toBe('');
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        configurable: true,
+      });
+    });
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/browse/AMP-97294

If `window.location` is set to be an empty object in polyfills, 

```
global.window.location = global.window.location || {};
```
an error occurs "TypeError: Cannot read property 'split' of undefined".

This PR patches this edges cases with tests.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
