### PR TITLE
fix(session replay): add a timeout to remote config fetch

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -75,8 +75,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
   }
 
   async asyncSetSessionId(sessionId: number, deviceId?: string) {
-    if (this.identifiers && this.identifiers.sessionId) {
-      this.stopRecordingAndSendEvents(this.identifiers.sessionId);
+    const previousSessionId = this.identifiers && this.identifiers.sessionId;
+    if (previousSessionId) {
+      this.stopRecordingAndSendEvents(previousSessionId);
     }
 
     const deviceIdForReplayId = deviceId || this.getDeviceId();
@@ -86,7 +87,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
     });
 
     this.eventsManager && this.eventsManager.resetSequence();
-    if (this.joinedConfigGenerator) {
+    // If there is no previous session id, SDK is being initialized for the first time,
+    // and config was just fetched in initialization, so no need to fetch it a second time
+    if (this.joinedConfigGenerator && previousSessionId) {
       this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
     }
     this.recordEvents();


### PR DESCRIPTION
### Summary

This PR adds a 5000ms timeout to the remote config fetch logic. This will prevent any long hanging remote config API calls from blocking execution of the rest of the SDK.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
