### PR TITLE
feat(analytics remote config): introduce generic remote config fetch and storage package

### DIFF
--- a/packages/analytics-remote-config/CHANGELOG.md
+++ b/packages/analytics-remote-config/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/analytics-remote-config/README.md
+++ b/packages/analytics-remote-config/README.md
@@ -1,0 +1,8 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>
+
+# @amplitude/analytics-remote-config

--- a/packages/analytics-remote-config/jest.config.js
+++ b/packages/analytics-remote-config/jest.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require('../../jest.config.js');
+const package = require('./package');
+
+module.exports = {
+  ...baseConfig,
+  displayName: package.name,
+  rootDir: '.',
+  testEnvironment: 'jsdom',
+  coveragePathIgnorePatterns: ['index.ts'],
+};

--- a/packages/analytics-remote-config/package.json
+++ b/packages/analytics-remote-config/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@amplitude/analytics-remote-config",
+  "version": "0.0.1",
+  "description": "",
+  "author": "Amplitude Inc",
+  "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
+  "license": "MIT",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
+  },
+  "scripts": {
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
+    "bundle": "rollup --config rollup.config.js",
+    "build:es5": "tsc -p ./tsconfig.es5.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "clean": "rimraf node_modules lib coverage",
+    "fix": "yarn fix:eslint & yarn fix:prettier",
+    "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
+    "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
+    "lint": "yarn lint:eslint & yarn lint:prettier",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
+    "publish": "node ../../scripts/publish/upload-to-s3.js",
+    "test": "jest",
+    "typecheck": "tsc -p ./tsconfig.json",
+    "version": "yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\" @amplitude/analytics-core@\">=1 <3\"",
+    "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
+  },
+  "bugs": {
+    "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
+  },
+  "dependencies": {
+    "@amplitude/analytics-core": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
+    "idb": "8.0.0",
+    "tslib": "^2.4.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^23.0.4",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^10.0.1",
+    "rollup": "^2.79.1",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/packages/analytics-remote-config/rollup.config.js
+++ b/packages/analytics-remote-config/rollup.config.js
@@ -1,0 +1,6 @@
+import { iife, umd } from '../../scripts/build/rollup.config';
+
+iife.input = umd.input;
+iife.output.name = 'remoteConfig';
+
+export default [umd, iife];

--- a/packages/analytics-remote-config/src/index.ts
+++ b/packages/analytics-remote-config/src/index.ts
@@ -1,0 +1,3 @@
+import * as remoteConfigFetch from './remote-config';
+export { ConfigNamespace } from './types';
+export const { createRemoteConfigFetch, RemoteConfigFetch } = remoteConfigFetch;

--- a/packages/analytics-remote-config/src/remote-config-idb-store.ts
+++ b/packages/analytics-remote-config/src/remote-config-idb-store.ts
@@ -1,0 +1,87 @@
+import { Logger as ILogger } from '@amplitude/analytics-types';
+import { DBSchema, openDB } from 'idb';
+import {
+  ConfigNamespace,
+  RemoteConfig,
+  RemoteConfigAPIResponse,
+  RemoteConfigIDBStore,
+  SessionReplayRemoteConfig,
+} from './types';
+
+export interface RemoteConfigDB extends DBSchema {
+  [ConfigNamespace.SESSION_REPLAY]: {
+    key: string;
+    value: SessionReplayRemoteConfig;
+    indexes: { sessionId: number };
+  };
+  lastFetchedSessionId: {
+    key: string;
+    value: number;
+  };
+}
+
+export const createStore = async (dbName: string) => {
+  return await openDB<RemoteConfigDB>(dbName, 1, {
+    upgrade: (db) => {
+      if (!db.objectStoreNames.contains(ConfigNamespace.SESSION_REPLAY)) {
+        db.createObjectStore(ConfigNamespace.SESSION_REPLAY);
+      }
+      if (!db.objectStoreNames.contains('lastFetchedSessionId')) {
+        db.createObjectStore('lastFetchedSessionId');
+      }
+    },
+  });
+};
+
+export const createRemoteConfigIDBStore = async ({
+  loggerProvider,
+  apiKey,
+}: {
+  loggerProvider: ILogger;
+  apiKey: string;
+}): Promise<RemoteConfigIDBStore> => {
+  const dbName = `${apiKey.substring(0, 10)}_amp_config`;
+  const db = await createStore(dbName);
+
+  const storeRemoteConfig = async (remoteConfig: RemoteConfigAPIResponse, sessionId?: number) => {
+    try {
+      if (sessionId) {
+        await db.put<'lastFetchedSessionId'>('lastFetchedSessionId', sessionId, 'sessionId');
+      }
+      let configNamespace: ConfigNamespace;
+      for (configNamespace in remoteConfig.configs) {
+        await db.put(configNamespace, {
+          ...remoteConfig.configs[configNamespace],
+        });
+      }
+    } catch (e) {
+      loggerProvider.warn(`Failed to store remote config: ${e as string}`);
+    }
+  };
+
+  const getLastFetchedSessionId = async (): Promise<number | void> => {
+    try {
+      const lastFetchedSessionId = await db.get('lastFetchedSessionId', 'sessionId');
+      return lastFetchedSessionId;
+    } catch (e) {
+      loggerProvider.warn(`Failed to fetch lastFetchedSessionId: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  const getRemoteConfig = async (configNamespace: ConfigNamespace, key: string): Promise<RemoteConfig | void> => {
+    try {
+      const config = await db.get(configNamespace, key);
+      return config;
+    } catch (e) {
+      loggerProvider.warn(`Failed to fetch remote config: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  return {
+    storeRemoteConfig,
+    getRemoteConfig,
+    getLastFetchedSessionId,
+  };
+};

--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -1,0 +1,164 @@
+import { BaseTransport } from '@amplitude/analytics-core';
+import { Config, ServerZone, Status } from '@amplitude/analytics-types';
+import * as RemoteConfigAPIStore from './remote-config-idb-store';
+import {
+  ConfigNamespace,
+  RemoteConfigFetch as IRemoteConfigFetch,
+  RemoteConfig,
+  RemoteConfigAPIResponse,
+  RemoteConfigIDBStore,
+} from './types';
+
+const UNEXPECTED_NETWORK_ERROR_MESSAGE = 'Network error occurred, remote config fetch failed';
+const SUCCESS_REMOTE_CONFIG = 'Remote config successfully fetched';
+const MAX_RETRIES_EXCEEDED_MESSAGE = 'Remote config fetch rejected due to exceeded retry count';
+const TIMEOUT_MESSAGE = 'Remote config fetch rejected due to timeout after 5 seconds';
+const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred';
+
+export const REMOTE_CONFIG_SERVER_URL = 'https://sr-client-cfg.amplitude.com/config';
+export const REMOTE_CONFIG_SERVER_URL_STAGING = 'https://sr-client-cfg.stag2.amplitude.com/config';
+export const REMOTE_CONFIG_SERVER_URL_EU = 'https://sr-client-cfg.eu.amplitude.com/config';
+
+export class RemoteConfigFetch implements IRemoteConfigFetch {
+  localConfig: Config;
+  remoteConfigIDBStore: RemoteConfigIDBStore | undefined;
+  retryTimeout = 1000;
+  attempts = 0;
+  lastFetchedSessionId: number | undefined;
+  sessionTargetingMatch = false;
+  configKeys: ConfigNamespace[];
+
+  constructor({ localConfig, configKeys }: { localConfig: Config; configKeys: ConfigNamespace[] }) {
+    this.localConfig = localConfig;
+    this.configKeys = configKeys;
+  }
+
+  async initialize() {
+    this.remoteConfigIDBStore = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+      apiKey: this.localConfig.apiKey,
+      loggerProvider: this.localConfig.loggerProvider,
+    });
+  }
+
+  getRemoteConfig = async (
+    configNamespace: ConfigNamespace,
+    key: string,
+    sessionId?: number,
+  ): Promise<RemoteConfig | void> => {
+    // Then check IndexedDB for session
+    if (this.remoteConfigIDBStore) {
+      const idbRemoteConfig = await this.remoteConfigIDBStore.getRemoteConfig(configNamespace, key);
+      const lastFetchedSessionId = await this.remoteConfigIDBStore.getLastFetchedSessionId();
+      if (idbRemoteConfig && lastFetchedSessionId === sessionId) {
+        return idbRemoteConfig;
+      }
+    }
+    // Finally fetch via API
+    const configAPIResponse = await this.fetchWithTimeout(sessionId);
+    return configAPIResponse && configAPIResponse.configs && configAPIResponse.configs[configNamespace];
+  };
+
+  getServerUrl() {
+    if (this.localConfig.serverZone === ServerZone.STAGING) {
+      return REMOTE_CONFIG_SERVER_URL_STAGING;
+    }
+
+    if (this.localConfig.serverZone === ServerZone.EU) {
+      return REMOTE_CONFIG_SERVER_URL_EU;
+    }
+
+    return REMOTE_CONFIG_SERVER_URL;
+  }
+
+  fetchWithTimeout = async (sessionId?: number): Promise<RemoteConfigAPIResponse | void> => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const remoteConfig = await this.fetchRemoteConfig(controller.signal, sessionId);
+    clearTimeout(timeoutId);
+    return remoteConfig;
+  };
+
+  fetchRemoteConfig = async (
+    signal: AbortController['signal'],
+    sessionId?: number,
+  ): Promise<RemoteConfigAPIResponse | void> => {
+    if (sessionId === this.lastFetchedSessionId && this.attempts >= this.localConfig.flushMaxRetries) {
+      return this.completeRequest({ err: MAX_RETRIES_EXCEEDED_MESSAGE });
+    } else if (signal.aborted) {
+      return this.completeRequest({ err: TIMEOUT_MESSAGE });
+    } else if (sessionId !== this.lastFetchedSessionId) {
+      this.lastFetchedSessionId = sessionId;
+      this.attempts = 0;
+    }
+
+    try {
+      const urlParams = new URLSearchParams({
+        api_key: this.localConfig.apiKey,
+        config_keys: this.configKeys.join(','),
+      });
+      const options: RequestInit = {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: '*/*',
+        },
+        method: 'GET',
+      };
+      const serverUrl = `${this.getServerUrl()}?${urlParams.toString()}`;
+      this.attempts += 1;
+      const res = await fetch(serverUrl, { ...options, signal: signal });
+      if (res === null) {
+        return this.completeRequest({ err: UNEXPECTED_ERROR_MESSAGE });
+      }
+      const parsedStatus = new BaseTransport().buildStatus(res.status);
+      switch (parsedStatus) {
+        case Status.Success:
+          return this.parseAndStoreConfig(res, sessionId);
+        case Status.Failed:
+          return this.retryFetch(signal, sessionId);
+        default:
+          return this.completeRequest({ err: UNEXPECTED_NETWORK_ERROR_MESSAGE });
+      }
+    } catch (e) {
+      const knownError = e as Error;
+      if (signal.aborted) {
+        return this.completeRequest({ err: TIMEOUT_MESSAGE });
+      }
+      return this.completeRequest({ err: knownError.message });
+    }
+  };
+
+  retryFetch = async (
+    signal: AbortController['signal'],
+    sessionId?: number,
+  ): Promise<RemoteConfigAPIResponse | void> => {
+    await new Promise((resolve) => setTimeout(resolve, this.attempts * this.retryTimeout));
+    return this.fetchRemoteConfig(signal, sessionId);
+  };
+
+  parseAndStoreConfig = async (res: Response, sessionId?: number): Promise<RemoteConfigAPIResponse> => {
+    const remoteConfig: RemoteConfigAPIResponse = (await res.json()) as RemoteConfigAPIResponse;
+    this.completeRequest({ success: SUCCESS_REMOTE_CONFIG });
+    this.remoteConfigIDBStore && void this.remoteConfigIDBStore.storeRemoteConfig(remoteConfig, sessionId);
+    return remoteConfig;
+  };
+
+  completeRequest({ err, success }: { err?: string; success?: string }) {
+    if (err) {
+      throw new Error(err);
+    } else if (success) {
+      this.localConfig.loggerProvider.log(success);
+    }
+  }
+}
+
+export const createRemoteConfigFetch = async ({
+  localConfig,
+  configKeys,
+}: {
+  localConfig: Config;
+  configKeys: ConfigNamespace[];
+}): Promise<RemoteConfigFetch> => {
+  const remoteConfigFetch = new RemoteConfigFetch({ localConfig, configKeys });
+  await remoteConfigFetch.initialize();
+  return remoteConfigFetch;
+};

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -1,0 +1,30 @@
+export interface SessionReplaySamplingConfig {
+  sample_rate: number;
+  capture_enabled: boolean;
+}
+
+export interface SessionReplayRemoteConfig {
+  sr_sampling_config: SessionReplaySamplingConfig;
+}
+
+export type RemoteConfig = SessionReplayRemoteConfig;
+
+export enum ConfigNamespace {
+  SESSION_REPLAY = 'sessionReplay',
+}
+
+export interface RemoteConfigAPIResponse {
+  configs: {
+    [ConfigNamespace.SESSION_REPLAY]: SessionReplayRemoteConfig;
+  };
+}
+
+export interface RemoteConfigFetch {
+  getRemoteConfig: (configNamespace: ConfigNamespace, key: string, sessionId?: number) => Promise<RemoteConfig | void>;
+}
+
+export interface RemoteConfigIDBStore {
+  storeRemoteConfig: (remoteConfig: RemoteConfigAPIResponse, sessionId?: number) => Promise<void>;
+  getRemoteConfig: (configNamespace: ConfigNamespace, key: string) => Promise<RemoteConfig | void>;
+  getLastFetchedSessionId: () => Promise<number | void>;
+}

--- a/packages/analytics-remote-config/test/remote-config-idb-store.test.ts
+++ b/packages/analytics-remote-config/test/remote-config-idb-store.test.ts
@@ -1,0 +1,202 @@
+import { Logger } from '@amplitude/analytics-types';
+import * as IDB from 'idb';
+import { IDBPDatabase } from 'idb';
+import * as RemoteConfigAPIStore from '../src/remote-config-idb-store';
+import { RemoteConfigDB } from '../src/remote-config-idb-store';
+import { ConfigNamespace, RemoteConfigAPIResponse } from '../src/types';
+
+jest.mock('idb-keyval');
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const apiKey = 'static_key';
+
+const samplingConfig = {
+  sample_rate: 1,
+  capture_enabled: true,
+};
+const mockRemoteConfig: RemoteConfigAPIResponse = {
+  configs: {
+    sessionReplay: {
+      sr_sampling_config: samplingConfig,
+    },
+  },
+};
+
+describe('RemoteConfigIDBStore', () => {
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  let putMock: jest.Mock;
+  let mockDB: IDBPDatabase<RemoteConfigAPIStore.RemoteConfigDB>;
+  beforeEach(() => {
+    putMock = jest.fn();
+    mockDB = {
+      get: jest.fn().mockImplementation(async (objectStoreName) => {
+        if (objectStoreName === 'lastFetchedSessionId') {
+          return 123;
+        }
+        return mockRemoteConfig;
+      }),
+      put: putMock,
+    } as unknown as IDBPDatabase<RemoteConfigAPIStore.RemoteConfigDB>;
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('init', () => {
+    test('should create a store with the api key in the name', async () => {
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(RemoteConfigAPIStore.createStore).toHaveBeenCalledWith('static_key_amp_config');
+    });
+  });
+
+  describe('getRemoteConfig', () => {
+    test('should return the remote config from idb store', async () => {
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      const remoteConfig = await store.getRemoteConfig(ConfigNamespace.SESSION_REPLAY, 'sr_sampling_config');
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+    });
+    test('should handle an undefined store', async () => {
+      mockDB.get = jest.fn().mockResolvedValue(undefined);
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      const remoteConfig = await store.getRemoteConfig(ConfigNamespace.SESSION_REPLAY, 'sr_sampling_config');
+      expect(remoteConfig).toEqual(undefined);
+    });
+    test('should catch errors', async () => {
+      mockDB.get = jest.fn().mockImplementationOnce(() => Promise.reject('error'));
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      await store.getRemoteConfig(ConfigNamespace.SESSION_REPLAY, 'sr_sampling_config');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('Failed to fetch remote config: error');
+    });
+  });
+
+  describe('getLastFetchedSessionId', () => {
+    test('should return the last fetched session id from idb store', async () => {
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      const lastFetchedSessionId = await store.getLastFetchedSessionId();
+      expect(lastFetchedSessionId).toEqual(123);
+    });
+    test('should catch errors', async () => {
+      mockDB.get = jest.fn().mockImplementationOnce(() => Promise.reject('error'));
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      await store.getLastFetchedSessionId();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('Failed to fetch lastFetchedSessionId: error');
+    });
+  });
+
+  describe('storeRemoteConfig', () => {
+    test('should store the last fetched session id and the remote config', async () => {
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      await store.storeRemoteConfig(mockRemoteConfig, 456);
+
+      expect(putMock).toHaveBeenCalledTimes(2);
+      expect(putMock).toHaveBeenCalledWith('lastFetchedSessionId', 456, 'sessionId');
+      expect(putMock).toHaveBeenCalledWith(
+        ConfigNamespace.SESSION_REPLAY,
+        mockRemoteConfig.configs[ConfigNamespace.SESSION_REPLAY],
+      );
+    });
+
+    test('should handle undefined session id', async () => {
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      await store.storeRemoteConfig(mockRemoteConfig);
+
+      expect(putMock).toHaveBeenCalledTimes(1);
+      expect(putMock).toHaveBeenCalledWith(
+        ConfigNamespace.SESSION_REPLAY,
+        mockRemoteConfig.configs[ConfigNamespace.SESSION_REPLAY],
+      );
+    });
+    test('should catch errors', async () => {
+      mockDB.put = jest.fn().mockImplementationOnce(() => Promise.reject('error'));
+      jest.spyOn(RemoteConfigAPIStore, 'createStore').mockResolvedValueOnce(mockDB);
+      const store = await RemoteConfigAPIStore.createRemoteConfigIDBStore({
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      await store.storeRemoteConfig(mockRemoteConfig, 123);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('Failed to store remote config: error');
+    });
+  });
+
+  describe('createStore', () => {
+    let createObjectStoreMock: jest.Mock;
+    beforeEach(() => {
+      createObjectStoreMock = jest.fn();
+      const mockDB = {
+        objectStoreNames: {
+          contains: () => false,
+        },
+        createObjectStore: createObjectStoreMock,
+      } as unknown as IDBPDatabase<RemoteConfigDB>;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      jest.spyOn(IDB, 'openDB').mockImplementation(async (_dbName, _version, callbacks) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/unbound-method
+        const upgrade = callbacks?.upgrade as CallableFunction;
+        upgrade(mockDB);
+        return Promise.resolve(mockDB);
+      });
+    });
+    test('should create an object store for session replay', async () => {
+      await RemoteConfigAPIStore.createStore('myDB');
+      expect(createObjectStoreMock).toHaveBeenCalledWith(ConfigNamespace.SESSION_REPLAY);
+    });
+
+    test('should create an object store for lastFetchedSessionId', async () => {
+      await RemoteConfigAPIStore.createStore('myDB');
+      expect(createObjectStoreMock).toHaveBeenCalledWith('lastFetchedSessionId');
+    });
+  });
+});

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -1,0 +1,482 @@
+import { Config } from '@amplitude/analytics-core';
+import { Config as IConfig, Logger, ServerZone } from '@amplitude/analytics-types';
+import {
+  REMOTE_CONFIG_SERVER_URL,
+  REMOTE_CONFIG_SERVER_URL_EU,
+  REMOTE_CONFIG_SERVER_URL_STAGING,
+  RemoteConfigFetch,
+  createRemoteConfigFetch,
+} from '../src/remote-config';
+import * as RemoteConfigAPIStore from '../src/remote-config-idb-store';
+import { ConfigNamespace, RemoteConfig, RemoteConfigAPIResponse } from '../src/types';
+// import { RemoteConfigFetch as IRemoteConfigFetch } from '../src/types';
+
+type MockedLogger = jest.Mocked<Logger>;
+const samplingConfig = {
+  sample_rate: 0.4,
+  capture_enabled: true,
+};
+const mockRemoteConfig: RemoteConfig = {
+  sr_sampling_config: samplingConfig,
+};
+
+const mockRemoteConfigAPIResponse: RemoteConfigAPIResponse = {
+  configs: {
+    sessionReplay: mockRemoteConfig,
+  },
+};
+
+async function runScheduleTimers() {
+  // exhause first setTimeout
+  jest.runAllTimers();
+  // wait for next tick to call nested setTimeout
+  await Promise.resolve();
+  // exhause nested setTimeout
+  jest.runAllTimers();
+}
+
+describe('RemoteConfigFetch', () => {
+  let originalFetch: typeof global.fetch;
+  let originalAbortController: typeof global.AbortController;
+  const abortMock = jest.fn();
+  const mockSignal = {
+    aborted: false,
+  } as AbortSignal;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  let localConfig: IConfig;
+  const mockConfigStore = {
+    storeRemoteConfig: jest.fn(),
+    getLastFetchedSessionId: jest.fn().mockResolvedValue(123),
+    getRemoteConfig: jest.fn().mockResolvedValue(mockRemoteConfig),
+  };
+
+  let remoteConfigFetch: RemoteConfigFetch;
+  let fetchMock: jest.Mock;
+  async function initialize(config = localConfig) {
+    remoteConfigFetch = new RemoteConfigFetch({ localConfig: config, configKeys: [ConfigNamespace.SESSION_REPLAY] });
+    await remoteConfigFetch.initialize();
+    fetchMock = jest.fn();
+    remoteConfigFetch.fetchWithTimeout = fetchMock;
+    fetchMock.mockResolvedValue(mockRemoteConfigAPIResponse);
+  }
+  beforeEach(() => {
+    jest.spyOn(RemoteConfigAPIStore, 'createRemoteConfigIDBStore').mockResolvedValue(mockConfigStore);
+    localConfig = new Config({
+      loggerProvider: mockLoggerProvider,
+      apiKey: 'static_key',
+      transportProvider: { send: async () => null },
+    });
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+      }),
+    ) as jest.Mock;
+    global.AbortController = jest.fn(() => {
+      return {
+        abort: abortMock,
+        signal: mockSignal,
+      };
+    });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+    global.AbortController = originalAbortController;
+
+    jest.useRealTimers();
+  });
+
+  describe('getRemoteConfig', () => {
+    beforeEach(async () => {
+      await initialize();
+    });
+    test('should return remote config from indexedDB if it exists and matches session id', async () => {
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig(
+        ConfigNamespace.SESSION_REPLAY,
+        'sr_sampling_config',
+        123,
+      );
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockConfigStore.getRemoteConfig).toHaveBeenCalled();
+    });
+    test('should call fetchWithTimeout if lastFetchedSessionId does not match session id', async () => {
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig(
+        ConfigNamespace.SESSION_REPLAY,
+        'sr_sampling_config',
+        456,
+      );
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    test('should call fetchWithTimeout if remoteConfigIDBStore is not defined', async () => {
+      remoteConfigFetch.remoteConfigIDBStore = undefined;
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig(
+        ConfigNamespace.SESSION_REPLAY,
+        'sr_sampling_config',
+        456,
+      );
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    test('should call fetchWithTimeout if lastFetchedSessionId is undefined', async () => {
+      mockConfigStore.getLastFetchedSessionId = jest.fn().mockResolvedValue(undefined);
+      jest.spyOn(RemoteConfigAPIStore, 'createRemoteConfigIDBStore').mockResolvedValueOnce(mockConfigStore);
+      await initialize();
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig(
+        ConfigNamespace.SESSION_REPLAY,
+        'sr_sampling_config',
+        123,
+      );
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    test('should call fetchWithTimeout if sessionId is undefined', async () => {
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig(
+        ConfigNamespace.SESSION_REPLAY,
+        'sr_sampling_config',
+      );
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    test('should call fetchWithTimeout if no config exists in memory or indexeddb', async () => {
+      mockConfigStore.getRemoteConfig = jest.fn().mockResolvedValue(undefined);
+      jest.spyOn(RemoteConfigAPIStore, 'createRemoteConfigIDBStore').mockResolvedValue(mockConfigStore);
+      await initialize();
+
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig(
+        ConfigNamespace.SESSION_REPLAY,
+        'sr_sampling_config',
+        123,
+      );
+      expect(remoteConfig).toEqual(mockRemoteConfig);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchRemoteConfig', () => {
+    beforeEach(async () => {
+      await initialize();
+    });
+    test('should fetch and return config', async () => {
+      (fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => mockRemoteConfigAPIResponse,
+        }),
+      );
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      return fetchPromise.then((remoteConfig) => {
+        expect(fetch).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLoggerProvider.log).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual('Remote config successfully fetched');
+        expect(remoteConfig).toEqual(mockRemoteConfigAPIResponse);
+        expect(remoteConfigFetch.attempts).toBe(1);
+      });
+    });
+    test('should fetch and set config in indexedDB', async () => {
+      (fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => mockRemoteConfigAPIResponse,
+        }),
+      );
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(mockConfigStore.storeRemoteConfig).toHaveBeenCalledWith(mockRemoteConfigAPIResponse, 123);
+      });
+    });
+    test('should handle unexpected error', async () => {
+      (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject(new Error('API Failure')));
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('API Failure');
+          expect(remoteConfigFetch.attempts).toBe(1);
+        });
+    });
+    test('should handle timeout error', async () => {
+      const signalToAbort = {
+        aborted: false,
+      };
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        signalToAbort.aborted = true;
+        return Promise.reject(new Error('API Failure'));
+      });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(signalToAbort as AbortSignal, 123);
+      await runScheduleTimers();
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Remote config fetch rejected due to timeout after 5 seconds');
+          expect(remoteConfigFetch.attempts).toBe(1);
+        });
+    });
+    test('should not retry for 400 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 400,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+          });
+        });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Network error occurred, remote config fetch failed');
+          expect(remoteConfigFetch.attempts).toBe(1);
+        });
+    });
+    test('should not retry for 413 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 413,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+            json: () => mockRemoteConfigAPIResponse,
+          });
+        });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Network error occurred, remote config fetch failed');
+          expect(remoteConfigFetch.attempts).toBe(1);
+        });
+    });
+    test('should return early if signal has been aborted', async () => {
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      });
+      const abortedMockSignal = {
+        aborted: true,
+      } as AbortSignal;
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(abortedMockSignal, 123);
+
+      await runScheduleTimers();
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(0);
+          expect(err.message).toEqual('Remote config fetch rejected due to timeout after 5 seconds');
+        });
+    });
+    test('should handle retry for 500 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 500,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+            json: () => mockRemoteConfigAPIResponse,
+          });
+        });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(remoteConfigFetch.attempts).toBe(2);
+      });
+    });
+
+    test('should only retry up to flushMaxRetries for 500 error', async () => {
+      // Set overall mock implementation, so it returns 500 repeatedly
+      (fetch as jest.Mock).mockImplementation(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      });
+      remoteConfigFetch.localConfig.flushMaxRetries = 2;
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+
+      // Need to run 3x to get through all setTimeout calls
+      await runScheduleTimers();
+      await runScheduleTimers();
+      await runScheduleTimers();
+
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(2);
+          expect(err.message).toEqual('Remote config fetch rejected due to exceeded retry count');
+          expect(remoteConfigFetch.attempts).toBe(2);
+        });
+    });
+    test('should reset attempts when new sessionId', async () => {
+      // Set overall mock implementation, so it returns 500 repeatedly
+      (fetch as jest.Mock).mockImplementation(() => {
+        return Promise.resolve({
+          status: 500,
+        });
+      });
+      remoteConfigFetch.localConfig.flushMaxRetries = 1;
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+
+      await runScheduleTimers();
+      try {
+        await fetchPromise;
+      } catch (e) {
+        // Error is expected, let's swallow it and move on
+      }
+
+      expect(remoteConfigFetch.attempts).toBe(1);
+
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve({
+          status: 200,
+          json: () => mockRemoteConfigAPIResponse,
+        });
+      });
+
+      const fetchPromiseNextSession = remoteConfigFetch.fetchRemoteConfig(mockSignal, 456);
+
+      return fetchPromiseNextSession.finally(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(remoteConfigFetch.attempts).toBe(1);
+        expect(remoteConfigFetch.lastFetchedSessionId).toBe(456);
+      });
+    });
+    test('should handle retry for 503 error', async () => {
+      (fetch as jest.Mock)
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 503,
+          });
+        })
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            status: 200,
+            json: () => mockRemoteConfigAPIResponse,
+          });
+        });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      return fetchPromise.then(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(remoteConfigFetch.attempts).toBe(2);
+      });
+    });
+    test('should handle unexpected error where fetch response is null', async () => {
+      (fetch as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve(null);
+      });
+      const fetchPromise = remoteConfigFetch.fetchRemoteConfig(mockSignal, 123);
+      await runScheduleTimers();
+      let err: Error;
+      return fetchPromise
+        .catch((e: Error) => {
+          err = e;
+        })
+        .finally(() => {
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(err.message).toEqual('Unexpected error occurred');
+          expect(remoteConfigFetch.attempts).toBe(1);
+        });
+    });
+  });
+
+  describe('fetchWithTimeout', () => {
+    beforeEach(async () => {
+      remoteConfigFetch = new RemoteConfigFetch({ localConfig, configKeys: [ConfigNamespace.SESSION_REPLAY] });
+      await remoteConfigFetch.initialize();
+      const fetchMock = jest.fn();
+      remoteConfigFetch.fetchRemoteConfig = fetchMock;
+    });
+    test('should set up a controller to cancel fetch requests after 5 seconds', async () => {
+      remoteConfigFetch.localConfig.flushMaxRetries = 2;
+      remoteConfigFetch.fetchRemoteConfig = jest.fn().mockResolvedValue(mockRemoteConfig);
+      const fetchPromise = remoteConfigFetch.fetchWithTimeout(123);
+
+      // Need to run 3x to get through all setTimeout calls
+      await runScheduleTimers();
+
+      return fetchPromise
+        .then((remoteConfigResponse) => {
+          expect(remoteConfigResponse).toEqual(mockRemoteConfig);
+        })
+        .finally(() => {
+          expect(remoteConfigFetch.fetchRemoteConfig).toHaveBeenCalledTimes(1);
+          expect(abortMock).toHaveBeenCalledTimes(1);
+        });
+    });
+  });
+
+  describe('getServerUrl', () => {
+    test('should return us server url if us server zone config set', async () => {
+      await initialize();
+      expect(remoteConfigFetch.getServerUrl()).toEqual(REMOTE_CONFIG_SERVER_URL);
+    });
+    test('should return eu server url if eu server zone config set', async () => {
+      const config = { ...localConfig, optOut: localConfig.optOut, serverZone: ServerZone.EU };
+      await initialize(config);
+      expect(remoteConfigFetch.getServerUrl()).toEqual(REMOTE_CONFIG_SERVER_URL_EU);
+    });
+
+    test('should return staging server url if staging config set', async () => {
+      const config = { ...localConfig, optOut: localConfig.optOut, serverZone: ServerZone.STAGING };
+      await initialize(config);
+      expect(remoteConfigFetch.getServerUrl()).toEqual(REMOTE_CONFIG_SERVER_URL_STAGING);
+    });
+  });
+
+  describe('createRemoteConfigFetch', () => {
+    test('should create a new RemoteConfigFetch instance and initialize', () => {
+      const remoteConfigFetch = createRemoteConfigFetch({ localConfig, configKeys: [ConfigNamespace.SESSION_REPLAY] });
+      expect(remoteConfigFetch).toBeDefined();
+    });
+  });
+});

--- a/packages/analytics-remote-config/tsconfig.es5.json
+++ b/packages/analytics-remote-config/tsconfig.es5.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "lib/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/packages/analytics-remote-config/tsconfig.esm.json
+++ b/packages/analytics-remote-config/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "es6",
+    "noEmit": false,
+    "outDir": "lib/esm",
+    "rootDir": "./src"
+  }
+}

--- a/packages/analytics-remote-config/tsconfig.json
+++ b/packages/analytics-remote-config/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "noEmit": true,
+    "rootDir": ".",
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7502,6 +7502,11 @@ idb-keyval@^6.2.1:
   resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
   integrity sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==
 
+idb@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.0.tgz#33d7ed894ed36e23bcb542fb701ad579bfaad41f"
+  integrity sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
### Summary

Introduce a generic version of SR's remote config fetch package, to be shared across different products/plugins. This package handles fetching remote config based on passed configKeys, and storing the results in Indexeddb. Config is stored in it's own DB, with object stores for each config namespace (ie, Session Replay config will be retrievable independently from Browser SDK config).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
