### PR TITLE
fix(core): api calls should queue while awaiting queued promises

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -60,6 +60,10 @@ export class AmplitudeCore implements CoreClient {
         await val;
       }
     }
+    // Rerun queued functions if the queue has accrued more while awaiting promises
+    if (this[queueName].length) {
+      await this.runQueuedFunctions(queueName);
+    }
   }
 
   track(eventInput: BaseEvent | string, eventProperties?: Record<string, any>, eventOptions?: EventOptions) {


### PR DESCRIPTION
### Summary
I observed that it is possible to fire a track call while awaiting on a plugin to be setup, and in that case, the track call is dropped, as the call is not added to the queue. Instead it's processed immediately, but in the Browser SDK, the Destination plugin has not been registered, so the track call is not sent to the backend. 

This PR adds a property to core-client to determine if it has processed all functions in the queue. This property can be used to determine whether any API call should be added to the queue or processed immediately.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
