### PR TITLE
feat(session-replay-browser): fetch privacy configs remotely and join with local

### DIFF
--- a/packages/analytics-remote-config/src/remote-config-idb-store.ts
+++ b/packages/analytics-remote-config/src/remote-config-idb-store.ts
@@ -81,9 +81,12 @@ export const createRemoteConfigIDBStore = async <RemoteConfig extends { [key: st
     return undefined;
   };
 
-  const getRemoteConfig = async (configNamespace: string, key: string): Promise<RemoteConfig[typeof key] | void> => {
+  const getRemoteConfig = async <K extends keyof RemoteConfig>(
+    configNamespace: string,
+    key: K,
+  ): Promise<RemoteConfig[K] | undefined> => {
     try {
-      const config = (await remoteConfigDB.get(configNamespace, key)) as RemoteConfig[typeof key];
+      const config = (await remoteConfigDB.get(configNamespace, key as string)) as RemoteConfig[K];
       return config;
     } catch (e) {
       loggerProvider.warn(`Failed to fetch remote config: ${e as string}`);

--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -42,11 +42,11 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     });
   }
 
-  getRemoteConfig = async (
+  getRemoteConfig = async <K extends keyof RemoteConfig>(
     configNamespace: string,
-    key: string,
+    key: K,
     sessionId?: number,
-  ): Promise<RemoteConfig[typeof key] | void> => {
+  ): Promise<RemoteConfig[K] | undefined> => {
     // First check IndexedDB for session
     if (this.remoteConfigIDBStore) {
       const idbRemoteConfig = await this.remoteConfigIDBStore.getRemoteConfig(configNamespace, key);
@@ -61,9 +61,10 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     if (configAPIResponse) {
       const remoteConfig = configAPIResponse.configs && configAPIResponse.configs[configNamespace];
       if (remoteConfig) {
-        return remoteConfig[key] as RemoteConfig[typeof key];
+        return remoteConfig[key];
       }
     }
+    return undefined;
   };
 
   getServerUrl() {
@@ -160,7 +161,9 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   }
 }
 
-export const createRemoteConfigFetch: CreateRemoteConfigFetch = async <RemoteConfig extends { [key: string]: object }>({
+export const createRemoteConfigFetch: CreateRemoteConfigFetch = async <
+  RemoteConfig extends { [Property in keyof RemoteConfig]: RemoteConfig[Property] },
+>({
   localConfig,
   configKeys,
 }: {

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -6,17 +6,17 @@ export interface RemoteConfigAPIResponse<RemoteConfig extends { [key: string]: o
   };
 }
 
-export interface RemoteConfigFetch<RemoteConfig extends { [key: string]: object }> {
-  getRemoteConfig: (
+export interface RemoteConfigFetch<T> {
+  getRemoteConfig: <K extends keyof T>(
     configNamespace: string,
-    key: string,
+    key: K,
     sessionId?: number,
-  ) => Promise<RemoteConfig[typeof key] | void>;
+  ) => Promise<T[K] | undefined>;
 }
 
-export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: object }> {
+export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: object }>
+  extends RemoteConfigFetch<RemoteConfig> {
   storeRemoteConfig: (remoteConfig: RemoteConfigAPIResponse<RemoteConfig>, sessionId?: number) => Promise<void>;
-  getRemoteConfig: (configNamespace: string, key: string) => Promise<RemoteConfig[typeof key] | void>;
   getLastFetchedSessionId: () => Promise<number | void>;
 }
 

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -107,6 +107,7 @@ export class SessionReplayPlugin implements DestinationPlugin {
         blockSelector: this.options.privacyConfig?.blockSelector,
       },
       debugMode: this.options.debugMode,
+      configEndpointUrl: this.options.configEndpointUrl,
     }).promise;
 
     // add enrichment plugin to add session replay properties to events

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -6,4 +6,5 @@ export interface SessionReplayOptions {
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
   forceSessionTracking?: boolean;
+  configEndpointUrl?: string;
 }

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -4,6 +4,7 @@ import { SessionReplayLocalConfig } from './local-config';
 import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
   SessionReplayJoinedConfig,
+  SessionReplayPrivacyConfig,
   SessionReplayRemoteConfig,
 } from './types';
 
@@ -22,39 +23,86 @@ export class SessionReplayJoinedConfigGenerator {
     });
   }
 
-  async generateJoinedConfig(sessionId?: number) {
+  async generateJoinedConfig(sessionId?: number): Promise<SessionReplayJoinedConfig> {
     const config: SessionReplayJoinedConfig = { ...this.localConfig };
     // Special case here as optOut is implemented via getter/setter
     config.optOut = this.localConfig.optOut;
+    // We always want captureEnabled to be true, unless there's an override
+    // in the remote config.
+    config.captureEnabled = true;
+    let remoteConfig: SessionReplayRemoteConfig | undefined;
     try {
+      if (!this.remoteConfigFetch) {
+        return config;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const samplingConfig =
-        this.remoteConfigFetch &&
-        ((await this.remoteConfigFetch.getRemoteConfig(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        (await this.remoteConfigFetch.getRemoteConfig(
           'sessionReplay',
           'sr_sampling_config',
           sessionId,
-        )) as SessionReplayRemoteConfig['sr_sampling_config']);
+        )) as SessionReplayRemoteConfig['sr_sampling_config'];
 
-      if (samplingConfig && Object.keys(samplingConfig).length > 0) {
-        if (Object.prototype.hasOwnProperty.call(samplingConfig, 'capture_enabled')) {
-          config.captureEnabled = samplingConfig.capture_enabled;
-        } else {
-          config.captureEnabled = false;
-        }
+      const privacyConfig =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        (await this.remoteConfigFetch.getRemoteConfig(
+          'sessionReplay',
+          'sr_privacy_config',
+          sessionId,
+        )) as SessionReplayRemoteConfig['sr_privacy_config'];
 
-        if (samplingConfig.sample_rate) {
-          config.sampleRate = samplingConfig.sample_rate;
+      if (samplingConfig || privacyConfig) {
+        remoteConfig = {};
+        if (samplingConfig) {
+          remoteConfig.sr_sampling_config = samplingConfig;
         }
-      } else {
-        // If config API response was valid (ie 200), but no config returned, assume that
-        // customer has not yet set up config, and use sample rate from SDK options,
-        // allowing for immediate replay capture
-        config.captureEnabled = true;
+        if (privacyConfig) {
+          remoteConfig.sr_privacy_config = privacyConfig;
+        }
       }
     } catch (err: unknown) {
       const knownError = err as Error;
       this.localConfig.loggerProvider.warn(knownError.message);
       config.captureEnabled = true;
+    }
+
+    if (!remoteConfig) {
+      return config;
+    }
+
+    const { sr_sampling_config: samplingConfig, sr_privacy_config: privacyConfig } = remoteConfig;
+    if (samplingConfig && Object.keys(samplingConfig).length > 0) {
+      if (Object.prototype.hasOwnProperty.call(samplingConfig, 'capture_enabled')) {
+        config.captureEnabled = samplingConfig.capture_enabled;
+      } else {
+        config.captureEnabled = false;
+      }
+
+      if (samplingConfig.sample_rate) {
+        config.sampleRate = samplingConfig.sample_rate;
+      }
+    } else {
+      // If config API response was valid (ie 200), but no config returned, assume that
+      // customer has not yet set up config, and use sample rate from SDK options,
+      // allowing for immediate replay capture
+      config.captureEnabled = true;
+      this.localConfig.loggerProvider.debug(
+        'assuming config API response was valid, but no config returned. session replay capture enabled.',
+      );
+    }
+
+    // Override all keys in the local config with the remote privacy config.
+    if (privacyConfig && Object.keys(privacyConfig).length > 0) {
+      if (!config.privacyConfig) {
+        config.privacyConfig = {};
+      }
+
+      for (const key in privacyConfig) {
+        const k = key as keyof SessionReplayPrivacyConfig;
+        config.privacyConfig[k] = privacyConfig[k];
+      }
     }
 
     return config;

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -1,10 +1,10 @@
-import { createRemoteConfigFetch, RemoteConfigFetch } from '@amplitude/analytics-remote-config';
+import { RemoteConfigFetch, createRemoteConfigFetch } from '@amplitude/analytics-remote-config';
 import { SessionReplayOptions } from '../typings/session-replay';
 import { SessionReplayLocalConfig } from './local-config';
 import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
   SessionReplayJoinedConfig,
-  SessionReplayPrivacyConfig,
+  PrivacyConfig,
   SessionReplayRemoteConfig,
 } from './types';
 
@@ -36,22 +36,17 @@ export class SessionReplayJoinedConfigGenerator {
         return config;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const samplingConfig =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        (await this.remoteConfigFetch.getRemoteConfig(
-          'sessionReplay',
-          'sr_sampling_config',
-          sessionId,
-        )) as SessionReplayRemoteConfig['sr_sampling_config'];
+      const samplingConfig = await this.remoteConfigFetch.getRemoteConfig(
+        'sessionReplay',
+        'sr_sampling_config',
+        sessionId,
+      );
 
-      const privacyConfig =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        (await this.remoteConfigFetch.getRemoteConfig(
-          'sessionReplay',
-          'sr_privacy_config',
-          sessionId,
-        )) as SessionReplayRemoteConfig['sr_privacy_config'];
+      const privacyConfig = await this.remoteConfigFetch.getRemoteConfig(
+        'sessionReplay',
+        'sr_privacy_config',
+        sessionId,
+      );
 
       if (samplingConfig || privacyConfig) {
         remoteConfig = {};
@@ -89,7 +84,7 @@ export class SessionReplayJoinedConfigGenerator {
       // allowing for immediate replay capture
       config.captureEnabled = true;
       this.localConfig.loggerProvider.debug(
-        'assuming config API response was valid, but no config returned. session replay capture enabled.',
+        'Remote config successfully fetched, but no values set for project, Session Replay capture enabled.',
       );
     }
 
@@ -100,7 +95,7 @@ export class SessionReplayJoinedConfigGenerator {
       }
 
       for (const key in privacyConfig) {
-        const k = key as keyof SessionReplayPrivacyConfig;
+        const k = key as keyof PrivacyConfig;
         config.privacyConfig[k] = privacyConfig[k];
       }
     }

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -17,6 +17,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   sampleRate: number;
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
+  configEndpointUrl?: string;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -33,6 +34,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     this.apiKey = apiKey;
     this.sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
     this.serverZone = options.serverZone || DEFAULT_SERVER_ZONE;
+    this.configEndpointUrl = options.configEndpointUrl;
 
     if (options.privacyConfig) {
       this.privacyConfig = options.privacyConfig;

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -3,7 +3,7 @@ import { Config, Logger } from '@amplitude/analytics-core';
 import { LogLevel } from '@amplitude/analytics-types';
 import { DEFAULT_SAMPLE_RATE, DEFAULT_SERVER_ZONE } from '../constants';
 import { SessionReplayOptions } from '../typings/session-replay';
-import { SessionReplayLocalConfig as ISessionReplayLocalConfig, SessionReplayPrivacyConfig } from './types';
+import { SessionReplayLocalConfig as ISessionReplayLocalConfig, PrivacyConfig } from './types';
 
 export const getDefaultConfig = () => ({
   flushMaxRetries: 2,
@@ -15,7 +15,7 @@ export const getDefaultConfig = () => ({
 export class SessionReplayLocalConfig extends Config implements ISessionReplayLocalConfig {
   apiKey: string;
   sampleRate: number;
-  privacyConfig?: SessionReplayPrivacyConfig;
+  privacyConfig?: PrivacyConfig;
   debugMode?: boolean;
   configEndpointUrl?: string;
 

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -5,15 +5,6 @@ export interface SamplingConfig {
   capture_enabled: boolean;
 }
 
-/**
- * NOTE(lew): defining the type like this so that it's easy to convert to
- * the local config. This won't handle deep copies (probably), so it may
- * need to be updated in the future.
- */
-export type PrivacyConfig = {
-  [k in keyof SessionReplayPrivacyConfig]: SessionReplayPrivacyConfig[k];
-};
-
 export type SessionReplayRemoteConfig = {
   sr_sampling_config?: SamplingConfig;
   sr_privacy_config?: PrivacyConfig;
@@ -25,7 +16,7 @@ export interface SessionReplayRemoteConfigAPIResponse {
   };
 }
 
-export type SessionReplayPrivacyConfig = {
+export type PrivacyConfig = {
   blockSelector?: string | string[];
 };
 
@@ -35,7 +26,7 @@ export interface SessionReplayLocalConfig extends Config {
   logLevel: LogLevel;
   flushMaxRetries: number;
   sampleRate: number;
-  privacyConfig?: SessionReplayPrivacyConfig;
+  privacyConfig?: PrivacyConfig;
   debugMode?: boolean;
   configEndpointUrl?: string;
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -1,10 +1,22 @@
 import { Config, LogLevel, Logger } from '@amplitude/analytics-types';
 
+export interface SamplingConfig {
+  sample_rate: number;
+  capture_enabled: boolean;
+}
+
+/**
+ * NOTE(lew): defining the type like this so that it's easy to convert to
+ * the local config. This won't handle deep copies (probably), so it may
+ * need to be updated in the future.
+ */
+export type PrivacyConfig = {
+  [k in keyof SessionReplayPrivacyConfig]: SessionReplayPrivacyConfig[k];
+};
+
 export type SessionReplayRemoteConfig = {
-  sr_sampling_config: {
-    sample_rate: number;
-    capture_enabled: boolean;
-  };
+  sr_sampling_config?: SamplingConfig;
+  sr_privacy_config?: PrivacyConfig;
 };
 
 export interface SessionReplayRemoteConfigAPIResponse {
@@ -12,9 +24,10 @@ export interface SessionReplayRemoteConfigAPIResponse {
     sessionReplay: SessionReplayRemoteConfig;
   };
 }
-export interface SessionReplayPrivacyConfig {
+
+export type SessionReplayPrivacyConfig = {
   blockSelector?: string | string[];
-}
+};
 
 export interface SessionReplayLocalConfig extends Config {
   apiKey: string;
@@ -24,6 +37,7 @@ export interface SessionReplayLocalConfig extends Config {
   sampleRate: number;
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
+  configEndpointUrl?: string;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -49,7 +49,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
-    this.loggerProvider.debug(JSON.stringify(this.config, null, 2));
 
     this.eventsManager = new SessionReplayEventsManager({
       config: this.config,

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -49,6 +49,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
+    this.loggerProvider.debug(JSON.stringify(this.config, null, 2));
 
     this.eventsManager = new SessionReplayEventsManager({
       config: this.config,


### PR DESCRIPTION
[AMP-98593](https://amplitude.atlassian.net/browse/AMP-98593)

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Pulls and joins remote privacy config for the session replay browser package. Also adds a custom config endpoint URL for local testing.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No.


[AMP-98593]: https://amplitude.atlassian.net/browse/AMP-98593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ