### PR TITLE
fix: fix the session event fire too often issue

### DIFF
--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -369,7 +369,8 @@ describe('Web attribution', () => {
         cleanup();
       });
 
-      test('should track all UTMs and referrers while processing any event', async () => {
+      //The SPA won't reload the page when redirected. We don't track campaign updates without reinitializing the SDK (reloading the page) for now.
+      test('Not track campaign change while processing any event', async () => {
         const url = 'https://www.example.com?utm_source=test_utm_source';
         navigateTo(url);
 
@@ -406,7 +407,6 @@ describe('Web attribution', () => {
                 generateSessionStartEvent(++eventId),
                 generatePageViewEvent(++eventId, 1, url),
                 generateSessionEndEvent(++eventId),
-                generateAttributionEvent(++eventId, newCampaignURL),
                 generateSessionStartEvent(++eventId),
                 generateEvent(++eventId, 'test event after session timeout'),
               ],

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -300,9 +300,6 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       (!event.session_id || event.session_id === this.getSessionId())
     ) {
       if (isEventInNewSession || shouldSetSessionIdOnNewCampaign) {
-        // Reinitialize the web attribution to refetch the current campaign in the new session
-        // if the campaign changed without a page reload (SPA's run into this scenario).
-        await this.webAttribution?.init();
         this.setSessionId(currentTime);
         if (shouldSetSessionIdOnNewCampaign) {
           this.config.loggerProvider.log('Created a new session for new campaign.');

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -7,8 +7,7 @@ import {
 } from '@amplitude/analytics-client-common';
 import { WebAttribution } from '@amplitude/analytics-client-common/src';
 import * as core from '@amplitude/analytics-core';
-import { Logger, UUID } from '@amplitude/analytics-core';
-import { BrowserConfig, LogLevel, OfflineDisabled, UserSession } from '@amplitude/analytics-types';
+import { LogLevel, OfflineDisabled, UserSession } from '@amplitude/analytics-types';
 import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
 import { AmplitudeBrowser } from '../src/browser-client';
 import * as Config from '../src/config';
@@ -998,42 +997,6 @@ describe('browser-client', () => {
         event_type: 'event',
       });
       expect(track).toHaveBeenCalled();
-    });
-
-    test('should reinit web attribution when procee new session event', async () => {
-      const mockConfig: BrowserConfig = {
-        apiKey: UUID(),
-        flushIntervalMillis: 0,
-        flushMaxRetries: 0,
-        flushQueueSize: 0,
-        logLevel: LogLevel.None,
-        loggerProvider: new Logger(),
-        offline: false,
-        optOut: false,
-        serverUrl: undefined,
-        transportProvider: new FetchTransport(),
-        useBatch: false,
-        cookieOptions: undefined,
-        cookieStorage: new CookieStorage(),
-        sessionTimeout: 30 * 60 * 1000,
-        trackingOptions: {
-          ipAddress: true,
-          language: true,
-          platform: true,
-        },
-        lastEventTime: Date.now() - 30 * 60 * 1000 * 2,
-      };
-      const webAttribution = new WebAttribution({}, mockConfig);
-      client.config = mockConfig;
-      client.webAttribution = webAttribution;
-      const webAttributionInit = jest.spyOn(webAttribution, 'init');
-      const setSessionId = jest.spyOn(client, 'setSessionId');
-
-      //new session event
-      await client.process({ event_type: 'test event' });
-
-      expect(webAttributionInit).toHaveBeenCalledTimes(1);
-      expect(setSessionId).toHaveBeenCalledTimes(1);
     });
 
     test('should proceed with unexpired session', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
Customers are seeing the session events fire too often. 
https://amplitude.atlassian.net/browse/AMP-99237
https://amplitude.atlassian.net/browse/AMP-100016
https://amplitude.atlassian.net/browse/AMP-100149

The issue is that we never await on process. If there are too many events being processed, it will cause a blockage at line 305 and alll events are treated as new session events because we update the lastEvent time in the setSessionId after line 305. Removing await on webAttribution.init() allows every process call to run sequentially. The first event in the new session will set this.config.lastEventTime in setSessionId, and then process the subsequent event.

However, removing line 305 means we won't catch cases in single-page applications (SPAs) where, after the session expires, users click an internal link updating the page URL (without a hard refresh). If the web attribution is dropped or updated, we won't detect this change. We will continue to monitor this until there is a specific request for change.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
