### PR TITLE
feat: support sessionId from url for cross domain tracking

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -89,16 +89,10 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     // Default: `Date.now()`
     // Session ID is handled differently than device ID and user ID due to session events
     const queryParams = getQueryParams();
-    this.setSessionId(
-      options.sessionId ??
-        (queryParams.ampSessionId
-          ? Number.isNaN(Number(queryParams.ampSessionId))
-            ? undefined
-            : Number(queryParams.ampSessionId)
-          : undefined) ??
-        this.config.sessionId ??
-        Date.now(),
-    );
+    const querySessionId = Number.isNaN(Number(queryParams.ampSessionId))
+      ? undefined
+      : Number(queryParams.ampSessionId);
+    this.setSessionId(options.sessionId ?? querySessionId ?? this.config.sessionId ?? Date.now());
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -84,14 +84,18 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     // Step 3: Set session ID
     // Priority 1: `options.sessionId`
-    // Priority 2: sessionId from url
+    // Priority 2: sessionId from url if it's Number
     // Priority 3: last known sessionId from user identity storage
     // Default: `Date.now()`
     // Session ID is handled differently than device ID and user ID due to session events
     const queryParams = getQueryParams();
     this.setSessionId(
       options.sessionId ??
-        (queryParams.ampSessionId ? Number(queryParams.ampSessionId) : undefined) ??
+        (queryParams.ampSessionId
+          ? Number.isNaN(Number(queryParams.ampSessionId))
+            ? undefined
+            : Number(queryParams.ampSessionId)
+          : undefined) ??
         this.config.sessionId ??
         Date.now(),
     );

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -13,6 +13,7 @@ import {
   isNewSession,
   isPageViewTrackingEnabled,
   WebAttribution,
+  getQueryParams,
 } from '@amplitude/analytics-client-common';
 import {
   BrowserClient,
@@ -83,10 +84,17 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     // Step 3: Set session ID
     // Priority 1: `options.sessionId`
-    // Priority 2: last known sessionId from user identity storage
+    // Priority 2: sessionId from url
+    // Priority 3: last known sessionId from user identity storage
     // Default: `Date.now()`
     // Session ID is handled differently than device ID and user ID due to session events
-    this.setSessionId(options.sessionId ?? this.config.sessionId ?? Date.now());
+    const queryParams = getQueryParams();
+    this.setSessionId(
+      options.sessionId ??
+        (queryParams.sessionId ? Number(queryParams.sessionId) : undefined) ??
+        this.config.sessionId ??
+        Date.now(),
+    );
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -91,7 +91,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     const queryParams = getQueryParams();
     this.setSessionId(
       options.sessionId ??
-        (queryParams.sessionId ? Number(queryParams.sessionId) : undefined) ??
+        (queryParams.ampSessionId ? Number(queryParams.ampSessionId) : undefined) ??
         this.config.sessionId ??
         Date.now(),
     );

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -219,7 +219,12 @@ export const useBrowserConfig = async (
 
   // Step 3: Reconcile user identity
   const deviceId =
-    options.deviceId ?? queryParams.deviceId ?? previousCookies?.deviceId ?? legacyCookies.deviceId ?? UUID();
+    options.deviceId ??
+    queryParams.ampDeviceId ??
+    queryParams.deviceId ??
+    previousCookies?.deviceId ??
+    legacyCookies.deviceId ??
+    UUID();
   const lastEventId = previousCookies?.lastEventId ?? legacyCookies.lastEventId;
   const lastEventTime = previousCookies?.lastEventTime ?? legacyCookies.lastEventTime;
   const optOut = options.optOut ?? previousCookies?.optOut ?? legacyCookies.optOut;

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -397,6 +397,8 @@ describe('browser-client', () => {
         writable: true,
       });
 
+      const setSessionId = jest.spyOn(client, 'setSessionId');
+
       await client.init(apiKey, userId, {
         defaultTracking: {
           attribution: false,
@@ -407,6 +409,8 @@ describe('browser-client', () => {
         },
       }).promise;
       expect(client.config.sessionId).toEqual(testSessionId);
+      expect(setSessionId).toHaveBeenCalledTimes(1);
+      expect(setSessionId).toHaveBeenLastCalledWith(testSessionId);
 
       Object.defineProperty(window, 'location', {
         value: originalLocation,

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -420,6 +420,46 @@ describe('browser-client', () => {
         writable: true,
       });
     });
+
+    test('should fall back to other options when session id from url is not Number', async () => {
+      // Mock window.location
+      const originalLocation = window.location;
+      const urlWithNaNSessionId = new URL(`https://www.example.com?ampSessionId=test}`);
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: urlWithNaNSessionId.search,
+        } as Location,
+        writable: true,
+      });
+
+      // Mock Date.now()
+      const originalDate = Date.now;
+      const currentTimestamp = Date.now();
+      Date.now = jest.fn(() => currentTimestamp);
+
+      const setSessionId = jest.spyOn(client, 'setSessionId');
+      await client.init(apiKey, userId, {
+        defaultTracking: {
+          attribution: false,
+          fileDownloads: false,
+          formInteractions: false,
+          pageViews: false,
+          sessions: true,
+        },
+      }).promise;
+
+      // Should fall back to use Date.now() because "test" from ampSessionId is NaN
+      expect(client.config.sessionId).toEqual(currentTimestamp);
+      expect(setSessionId).toHaveBeenCalledTimes(1);
+      expect(setSessionId).toHaveBeenLastCalledWith(currentTimestamp);
+
+      // Restore mocks
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
+      Date.now = originalDate;
+    });
   });
 
   describe('getUserId', () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -22,6 +22,9 @@ describe('browser-client', () => {
   let userId = '';
   let deviceId = '';
   let client = new AmplitudeBrowser();
+  const testDeviceId = 'test-device-id';
+  const testSessionId = 12345;
+  const url = new URL(`https://www.example.com?deviceId=${testDeviceId}&sessionId=${testSessionId}`);
   const defaultTracking = {
     attribution: false,
     fileDownloadTracking: false,
@@ -360,6 +363,55 @@ describe('browser-client', () => {
 
       getGlobalScopeMock.mockRestore();
       addEventListenerMock.mockRestore();
+    });
+
+    test('should set device id from url', async () => {
+      const originalLocation = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...originalLocation,
+          search: url.search,
+        } as Location,
+        writable: true,
+      });
+
+      await client.init(apiKey, userId, {
+        defaultTracking: false,
+      }).promise;
+      expect(client.config.deviceId).toEqual(testDeviceId);
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
+    });
+
+    test('should set session id from url', async () => {
+      const originalLocation = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: url.search,
+        } as Location,
+        writable: true,
+      });
+
+      await client.init(apiKey, userId, {
+        defaultTracking: {
+          attribution: false,
+          fileDownloads: false,
+          formInteractions: false,
+          pageViews: false,
+          sessions: true,
+        },
+      }).promise;
+      expect(client.config.sessionId).toEqual(testSessionId);
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
     });
   });
 

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -24,7 +24,7 @@ describe('browser-client', () => {
   let client = new AmplitudeBrowser();
   const testDeviceId = 'test-device-id';
   const testSessionId = 12345;
-  const url = new URL(`https://www.example.com?deviceId=${testDeviceId}&sessionId=${testSessionId}`);
+  const url = new URL(`https://www.example.com?ampDeviceId=${testDeviceId}&ampSessionId=${testSessionId}`);
   const defaultTracking = {
     attribution: false,
     fileDownloadTracking: false,
@@ -365,27 +365,30 @@ describe('browser-client', () => {
       addEventListenerMock.mockRestore();
     });
 
-    test('should set device id from url', async () => {
-      const originalLocation = window.location;
+    test.each([[url], [new URL(`https://www.example.com?deviceId=${testDeviceId}`)]])(
+      'should set device id from url',
+      async (mockedUrl) => {
+        const originalLocation = window.location;
 
-      Object.defineProperty(window, 'location', {
-        value: {
-          ...originalLocation,
-          search: url.search,
-        } as Location,
-        writable: true,
-      });
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: mockedUrl.search,
+          } as Location,
+          writable: true,
+        });
 
-      await client.init(apiKey, userId, {
-        defaultTracking: false,
-      }).promise;
-      expect(client.config.deviceId).toEqual(testDeviceId);
+        await client.init(apiKey, userId, {
+          defaultTracking: false,
+        }).promise;
+        expect(client.config.deviceId).toEqual(testDeviceId);
 
-      Object.defineProperty(window, 'location', {
-        value: originalLocation,
-        writable: true,
-      });
-    });
+        Object.defineProperty(window, 'location', {
+          value: originalLocation,
+          writable: true,
+        });
+      },
+    );
 
     test('should set session id from url', async () => {
       const originalLocation = window.location;

--- a/packages/analytics-client-common/test/analytics-connector.test.ts
+++ b/packages/analytics-client-common/test/analytics-connector.test.ts
@@ -27,6 +27,9 @@ describe('analytics-connector', () => {
         updateUserProperties: function () {
           return this;
         },
+        setOptOut: function () {
+          return this;
+        },
         commit,
       };
       const instance = new AnalyticsConnector();
@@ -52,6 +55,9 @@ describe('analytics-connector', () => {
           return this;
         },
         updateUserProperties: function () {
+          return this;
+        },
+        setOptOut: function () {
           return this;
         },
         commit,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
[AMP-93936]

This PR allows the Browser SDK to get and set sessionId from `ampSessionId` url parameter of the url (`window.location`). This allows the same sessionId and thus continuous user journey for cross domain tracking. 

This PR also changes how the SDK gets deviceId from the url.
- Previously, the SDK only supports `deviceId` url parameter
- Now, the SDK gets deviceId from `ampDeviceId` url parameter first and then falls back to `deviceId`

We add `amp` prefix because `deviceId` and `sessionId` are very generic names. 

For example, the SDK will automatically use the deviceId `my-device-id` and sessionId `1716245958483` from `https://www.example.com?ampDeviceId=my-device-id&ampSessionId=1716245958483`. 

It's recommended to follow the same sessionId format as the Browser SDK by using `Date.now()`. Because the SDK checks whether an event is in session every time an event is tracked.

```
# https://www.example.com?deviceId=my-device-id&sessionId=12345
amplitude.init(API_KEY)

# client.config.sessionId = 12345

amplitude.track("event")

# client.config.sessionId will set to Date.now() because "event" is not in the previous session 12345
# this logic is in browser-client.process()

```

#### Implementation
`useBrowserConfig()` should remain unchanged and return sessionId from cookie storage because `_init()` calls `setSessionId()` which starts a new session by comparing to the sessionId from storage. 

#### Note

Changing `packages/analytics-client-common/test/analytics-connector.test.ts` because the error below. This error happens even if running `yarn test` on the latest main branch. 
```
feat: support sessionId from url for cross domain tracking
Test suite failed to run

    test/analytics-connector.test.ts:36:78 - error TS2345: Argument of type '{ setUserId: () => ...; setDeviceId: () => ...; setUserProperties: () => ...; updateUserProperties: () => ...; commit: Mock<any, any>; }' is not assignable to parameter of type 'IdentityEditor'.
      Property 'setOptOut' is missing in type '{ setUserId: () => ...; setDeviceId: () => ...; setUserProperties: () => ...; updateUserProperties: () => ...; commit: Mock<any, any>; }' but required in type 'IdentityEditor'.

    36       jest.spyOn(instance.identityStore, 'editIdentity').mockReturnValueOnce(identityEditor);
                                                                                    ~~~~~~~~~~~~~~

      ../../node_modules/@amplitude/analytics-connector/dist/types/src/identityStore.d.ts:19:5
        19     setOptOut(optOut: boolean): IdentityEditor;
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        'setOptOut' is declared here.


```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-93936]: https://amplitude.atlassian.net/browse/AMP-93936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ