### PR TITLE
fix: response with non-json format

### DIFF
--- a/packages/analytics-browser/src/transports/xhr.ts
+++ b/packages/analytics-browser/src/transports/xhr.ts
@@ -17,13 +17,13 @@ export class XHRTransport extends BaseTransport implements Transport {
       xhr.open('POST', serverUrl, true);
       xhr.onreadystatechange = () => {
         if (xhr.readyState === this.state.done) {
-          const responsePayload = xhr.responseText;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const parsedResponsePayload: Record<string, any> = responsePayload
-            ? JSON.parse(responsePayload)
-            : { code: xhr.status };
-          const result = this.buildResponse(parsedResponsePayload);
-          resolve(result);
+          const responseText = xhr.responseText;
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            resolve(this.buildResponse(JSON.parse(responseText)));
+          } catch {
+            resolve(this.buildResponse({ code: xhr.status }));
+          }
         }
       };
       xhr.setRequestHeader('Content-Type', 'application/json');

--- a/packages/analytics-browser/test/transport/xhr.test.ts
+++ b/packages/analytics-browser/test/transport/xhr.test.ts
@@ -6,6 +6,7 @@ describe('xhr', () => {
     test.each([
       ['{}'], // ideally response body should be json format to an application/json request
       [''], // test the edge case where response body is non-json format
+      ['<'],
     ])('should resolve with response', async (body) => {
       const transport = new XHRTransport();
       const url = 'http://localhost:3000';

--- a/packages/analytics-client-common/src/transports/fetch.ts
+++ b/packages/analytics-client-common/src/transports/fetch.ts
@@ -17,8 +17,11 @@ export class FetchTransport extends BaseTransport implements Transport {
     };
     const response = await fetch(serverUrl, options);
     const responseText = await response.text();
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.buildResponse(responseText ? JSON.parse(responseText) : { code: response.status });
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      return this.buildResponse(JSON.parse(responseText));
+    } catch {
+      return this.buildResponse({ code: response.status });
+    }
   }
 }

--- a/packages/analytics-client-common/test/transports/fetch.test.ts
+++ b/packages/analytics-client-common/test/transports/fetch.test.ts
@@ -7,6 +7,7 @@ describe('fetch', () => {
     test.each([
       ['{}'], // ideally response body should be json format to an application/json request
       [''], // test the edge case where response body is non-json format
+      ['<'],
     ])('should resolve with response', async (body) => {
       const transport = new FetchTransport();
       const url = 'http://localhost:3000';

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -42,9 +42,8 @@ export class Http extends BaseTransport implements Transport {
               const parsedResponsePayload: Record<string, any> = JSON.parse(responsePayload);
               const result = this.buildResponse(parsedResponsePayload);
               resolve(result);
-              return;
             } catch {
-              resolve(null);
+              resolve(this.buildResponse({ code: res.statusCode }));
             }
           }
         });

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -133,6 +133,7 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       cb({
+        statusCode: 502,
         complete: true,
         on: jest.fn().mockImplementation((event: string, callback: (data?: string) => void) => {
           if (event === 'data') {
@@ -152,7 +153,8 @@ describe('http transport', () => {
     });
 
     const response = await provider.send(url, payload);
-    expect(response).toBe(null);
+    expect(response?.status).toBe(Status.Failed);
+    expect(response?.statusCode).toBe(502);
     expect(request).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This is a make-up commit to https://github.com/amplitude/Amplitude-TypeScript/pull/755 which allows responses with empty body. In addition to that, this PR adds try-catch block to allow responses with non-json format body and build Amplitude custom response based on the status code

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
