### PR TITLE
fix(session replay): add error handling for indexeddb

### DIFF
--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -2,6 +2,7 @@
 import { Logger } from '@amplitude/analytics-types';
 import { IDBPDatabase, openDB } from 'idb';
 import * as EventsIDBStore from '../src/events/events-idb-store';
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { SessionReplayDB, SessionReplayEventsIDBStore } from '../src/events/events-idb-store';
 
 type MockedLogger = jest.Mocked<Logger>;
@@ -368,6 +369,35 @@ describe('SessionReplayEventsIDBStore', () => {
 
       await eventsStorage.transitionFromKeyValStore();
       expect(global.indexedDB.deleteDatabase).not.toHaveBeenCalled();
+    });
+
+    test('should reject when global scope is undefined', async () => {
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+
+      await expect(EventsIDBStore.keyValDatabaseExists()).rejects.toThrow('Global scope not found');
+    });
+
+    test('should reject when indexedDB does not exist', async () => {
+      const mockGlobalScope = {} as Omit<typeof globalThis, 'indexedDB'>;
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope as typeof globalThis);
+
+      await expect(EventsIDBStore.keyValDatabaseExists()).rejects.toThrow(
+        'IndexedDB is not available in the global scope',
+      );
+    });
+
+    test('should reject when indexedDB.open throws an error', async () => {
+      const mockGlobalScope = {
+        indexedDB: {
+          open: jest.fn().mockImplementation(() => {
+            throw new Error('Test error');
+          }),
+        },
+      } as unknown as typeof globalThis;
+
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+
+      await expect(EventsIDBStore.keyValDatabaseExists()).rejects.toThrow('Test error');
     });
 
     test('should add current session events to new idb sessionCurrentSequence', async () => {


### PR DESCRIPTION
### Summary

Adding error handling for [AMP-101119](https://amplitude.atlassian.net/browse/AMP-101119) to defer issues as warnings and not trigger errors in client. 


https://amplitude.atlassian.net/browse/DDI-489


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no


[AMP-101119]: https://amplitude.atlassian.net/browse/AMP-101119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ