### PR TITLE
fix(session replay): rethrow external errors and fix block selectors null state

### DIFF
--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -42,7 +42,7 @@
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-remote-config": "^0.2.1",
     "@amplitude/analytics-types": ">=1 <3",
-    "@amplitude/rrweb": "^2.0.0-alpha.12",
+    "@amplitude/rrweb": "^2.0.0-alpha.14",
     "idb": "^8.0.0",
     "tslib": "^2.4.1"
   },

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -241,6 +241,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
   }
 
   getBlockSelectors(): string | string[] | undefined {
+    // For some reason, this defaults to empty array ([]) if undefined in the compiled script.
+    // Empty arrays cause errors when being evaluated in Safari.
+    // Force the selector to be undefined if it's an empty array.
+    if (
+      Array.isArray(this.config?.privacyConfig?.blockSelector) &&
+      this.config?.privacyConfig?.blockSelector.length === 0
+    ) {
+      return undefined;
+    }
     return this.config?.privacyConfig?.blockSelector;
   }
 
@@ -281,19 +290,27 @@ export class SessionReplay implements AmplitudeSessionReplay {
       maskTextClass: MASK_TEXT_CLASS,
       blockClass: BLOCK_CLASS,
       // rrweb only exposes string type through its types, but arrays are also be supported. #class, ['#class', 'id']
-      blockSelector: this.getBlockSelectors() as string,
+      blockSelector: this.getBlockSelectors() as string | undefined,
       maskInputFn: maskFn('input', privacyConfig),
       maskTextFn: maskFn('text', privacyConfig),
       // rrweb only exposes string type through its types, but arrays are also be supported. since rrweb uses .matches() which supports arrays.
       maskTextSelector: this.getMaskTextSelectors(),
       recordCanvas: false,
       errorHandler: (error) => {
-        const typedError = error as Error;
+        const typedError = error as Error & { _external_?: boolean };
 
         // styled-components relies on this error being thrown and bubbled up, rrweb is otherwise suppressing it
         if (typedError.message.includes('insertRule') && typedError.message.includes('CSSStyleSheet')) {
           throw typedError;
         }
+
+        // rrweb does monkey patching on certain window functions such as CSSStyleSheet.proptype.insertRule,
+        // and errors from external clients calling these functions can get suppressed. Styled components depend
+        // on these errors being re-thrown.
+        if (typedError._external_) {
+          throw typedError;
+        }
+
         this.loggerProvider.warn('Error while recording: ', typedError.toString());
         // Return true so that we don't clutter user's consoles with internal rrweb errors
         return true;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -244,13 +244,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // For some reason, this defaults to empty array ([]) if undefined in the compiled script.
     // Empty arrays cause errors when being evaluated in Safari.
     // Force the selector to be undefined if it's an empty array.
-    if (
-      Array.isArray(this.config?.privacyConfig?.blockSelector) &&
-      this.config?.privacyConfig?.blockSelector.length === 0
-    ) {
+    const blockSelector = this.config?.privacyConfig?.blockSelector ?? [];
+    if (blockSelector.length === 0) {
       return undefined;
     }
-    return this.config?.privacyConfig?.blockSelector;
+    return blockSelector;
   }
 
   getMaskTextSelectors(): string | undefined {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -754,6 +754,18 @@ describe('SessionReplay', () => {
         recordArg?.errorHandler && recordArg?.errorHandler(new Error(stylesheetErrorMessage));
       }).toThrow(stylesheetErrorMessage);
     });
+
+    test('should rethrow external errors', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.recordEvents();
+      const recordArg = record.mock.calls[0][0];
+      const error = new Error('test') as Error & { _external_?: boolean };
+      error._external_ = true;
+      expect(() => {
+        recordArg?.errorHandler && recordArg?.errorHandler(error);
+      }).toThrow(error);
+    });
   });
 
   describe('getDeviceId', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@
   dependencies:
     "@amplitude/rrweb-snapshot" "^2.0.0-alpha.14"
 
-"@amplitude/rrweb@^2.0.0-alpha.12":
+"@amplitude/rrweb@^2.0.0-alpha.14":
   version "2.0.0-alpha.14"
   resolved "https://registry.yarnpkg.com/@amplitude/rrweb/-/rrweb-2.0.0-alpha.14.tgz#03016a68d5fd2d80dc59716d9df8ae8b109a4db9"
   integrity sha512-+dC4F3aikGBpxd6LrdLc0duh+tNg2ejJ7TKA7NnpoFU8+mM1iGIwQf7T4Y0cLUCYhSArtFjFb0OhHaMnaAIgcQ==


### PR DESCRIPTION
### Summary
* for errors that are marked external (as in triggered by clients outside of rrweb), rethrow those errors. Frameworks like styled components depend on these errors being thrown. 
* also fixed an issue I noticed while looking at safari and the default state of block selectors. 
WIP: needs the new version of rrweb

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
