### PR TITLE
fix: don't use global window directly

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,6 +1,7 @@
 import { BrowserClient, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { DEFAULT_FILE_DOWNLOAD_EVENT, FILE_EXTENSION, FILE_NAME, LINK_ID, LINK_TEXT, LINK_URL } from '../constants';
 import { BrowserConfig } from '../config';
+import { getGlobalScope } from '@amplitude/analytics-client-common';
 
 interface EventListener {
   element: Element;
@@ -33,8 +34,8 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
     // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
     // after the body is built. When Amplitud gets initialized in a script tag, the body tag is still unavailable. So register this
     // only after the window is loaded
-    // eslint-disable-next-line no-restricted-globals
-    window.addEventListener('load', function () {
+    /* istanbul ignore next */
+    getGlobalScope()?.addEventListener('load', function () {
       /* istanbul ignore if */
       if (!amplitude) {
         // TODO: Add required minimum version of @amplitude/analytics-browser

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -7,6 +7,7 @@ import {
   FORM_DESTINATION,
 } from '../constants';
 import { BrowserConfig } from '../config';
+import { getGlobalScope } from '@amplitude/analytics-client-common';
 
 interface EventListener {
   element: Element;
@@ -41,8 +42,8 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
     // after the body is built. When Amplitud gets initialized in a script tag, the body tag is still unavailable. So register this
     // only after the window is loaded
-    // eslint-disable-next-line no-restricted-globals
-    window.addEventListener('load', function () {
+    /* istanbul ignore next */
+    getGlobalScope()?.addEventListener('load', function () {
       /* istanbul ignore if */
       if (!amplitude) {
         // TODO: Add required minimum version of @amplitude/analytics-browser


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Avoid using window global variable directly and instead use `getGlobalScope()`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
