### PR TITLE
fix: adding ability to enable debug logs using cookies

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -1946,7 +1946,7 @@ describe('integration', () => {
 
         expect(logger.debug).toHaveBeenCalledTimes(3);
         /* eslint-disable */
-        const debugContext = JSON.parse(logger.debug.mock.calls[0]);
+        const debugContext = JSON.parse(logger.debug.mock.calls[2]);
         expect(debugContext.type).toBeDefined();
         expect(debugContext.name).toEqual('track');
         expect(debugContext.args).toBeDefined();
@@ -1974,7 +1974,7 @@ describe('integration', () => {
 
         expect(logger.debug).toHaveBeenCalledTimes(3);
         /* eslint-disable */
-        const debugContext = JSON.parse(logger.debug.mock.calls[0]);
+        const debugContext = JSON.parse(logger.debug.mock.calls[2]);
         expect(debugContext.type).toBeDefined();
         expect(debugContext.name).toEqual('setOptOut');
         expect(debugContext.args).toBeDefined();

--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -1944,7 +1944,7 @@ describe('integration', () => {
         expect(response.message).toBe(SUCCESS_MESSAGE);
         scope.done();
 
-        expect(logger.debug).toHaveBeenCalledTimes(1);
+        expect(logger.debug).toHaveBeenCalledTimes(3);
         /* eslint-disable */
         const debugContext = JSON.parse(logger.debug.mock.calls[0]);
         expect(debugContext.type).toBeDefined();
@@ -1972,7 +1972,7 @@ describe('integration', () => {
         }).promise;
         client.setOptOut(true);
 
-        expect(logger.debug).toHaveBeenCalledTimes(1);
+        expect(logger.debug).toHaveBeenCalledTimes(3);
         /* eslint-disable */
         const debugContext = JSON.parse(logger.debug.mock.calls[0]);
         expect(debugContext.type).toBeDefined();

--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -34,7 +34,7 @@
     "lint:eslint": "eslint '{src,test}/**/*.ts'",
     "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
     "playground:html": "cp lib/scripts/amplitude-min.js playground/html/amplitude.js && http-server ./playground/html",
-    "playground:react-spa": "cp lib/scripts/amplitude-min.js playground/react-spa/public/amplitude.js && cd ./playground/react-spa && yarn start",
+    "playground:react-spa": "cp lib/scripts/amplitude-min.js playground/react-spa/public/amplitude.js && cd ./playground/react-spa && yarn install && yarn start",
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -328,12 +328,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     return super.process(event);
   }
 
-  private logBrowserOptions(browserConfig: BrowserOptions) {
+  private logBrowserOptions(browserConfig: BrowserOptions & { apiKey: string }) {
     try {
       const browserConfigCopy = {
         ...browserConfig,
-        // get first 5 characters of api key and redact the rest
-        apiKey: 'REDACTED',
+        apiKey: browserConfig.apiKey.substring(0, 10) + '********',
       };
       this.config.loggerProvider.debug('Initialized Amplitude with BrowserConfig:', JSON.stringify(browserConfigCopy));
     } catch (e) {

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -37,6 +37,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
   protected _sessionId?: number;
   protected _userId?: string;
   protected _pageCounter?: number;
+  protected _debugLogsEnabled?: boolean;
   constructor(
     public apiKey: string,
     public appVersion?: string,
@@ -79,6 +80,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     public useBatch: boolean = false,
     userId?: string,
     pageCounter?: number,
+    debugLogsEnabled?: boolean,
   ) {
     super({ apiKey, storageProvider, transportProvider: createTransport(transport) });
     this._cookieStorage = cookieStorage;
@@ -89,7 +91,12 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     this.sessionId = sessionId;
     this.pageCounter = pageCounter;
     this.userId = userId;
-    this.loggerProvider.enable(this.logLevel);
+    this.debugLogsEnabled = debugLogsEnabled;
+    if (debugLogsEnabled) {
+      this.loggerProvider.enable(LogLevel.Debug);
+    } else {
+      this.loggerProvider.enable(this.logLevel);
+    }
   }
 
   get cookieStorage() {
@@ -180,6 +187,13 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     }
   }
 
+  set debugLogsEnabled(debugLogsEnabled: boolean | undefined) {
+    if (this._debugLogsEnabled !== debugLogsEnabled) {
+      this._debugLogsEnabled = debugLogsEnabled;
+      this.updateStorage();
+    }
+  }
+
   private updateStorage() {
     const cache = {
       deviceId: this._deviceId,
@@ -189,6 +203,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
       lastEventTime: this._lastEventTime,
       lastEventId: this._lastEventId,
       pageCounter: this._pageCounter,
+      debugLogsEnabled: this._debugLogsEnabled,
     };
     void this.cookieStorage.set(getCookieName(this.apiKey), cache);
   }
@@ -239,6 +254,7 @@ export const useBrowserConfig = async (
     platform: options.trackingOptions?.platform ?? true,
   };
   const pageCounter = previousCookies?.pageCounter;
+  const debugLogsEnabled = previousCookies?.debugLogsEnabled;
 
   return new BrowserConfig(
     apiKey,
@@ -272,6 +288,7 @@ export const useBrowserConfig = async (
     options.useBatch,
     userId,
     pageCounter,
+    debugLogsEnabled,
   );
 };
 

--- a/packages/analytics-types/src/user-session.ts
+++ b/packages/analytics-types/src/user-session.ts
@@ -6,4 +6,5 @@ export interface UserSession {
   optOut: boolean;
   lastEventId?: number;
   pageCounter?: number;
+  debugLogsEnabled?: boolean;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Enable debug logs by setting `debugLogsEnabled` in the AMP_* cookie

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
