### PR TITLE
feat(analytics-remote-config): add fetchTime

### DIFF
--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -29,14 +29,13 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   sessionTargetingMatch = false;
   configKeys: string[];
   // Timestamp when start to fetch remote config
-  fetchStartTime: number;
+  fetchStartTime = 0;
   // Time used to fetch remote config in milliseconds
   fetchTime = 0;
 
   constructor({ localConfig, configKeys }: { localConfig: Config; configKeys: string[] }) {
     this.localConfig = localConfig;
     this.configKeys = configKeys;
-    this.fetchStartTime = Date.now();
   }
 
   async initialize() {
@@ -52,6 +51,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     key: K,
     sessionId?: number,
   ): Promise<RemoteConfig[K] | undefined> => {
+    this.fetchStartTime = Date.now();
     // First check IndexedDB for session
     if (this.remoteConfigIDBStore) {
       const idbRemoteConfig = await this.remoteConfigIDBStore.getRemoteConfig(configNamespace, key);

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -6,7 +6,7 @@ export interface RemoteConfigAPIResponse<RemoteConfig extends { [key: string]: o
   };
 }
 
-export interface RemoteConfigFetch<T> {
+export interface BaseRemoteConfigFetch<T> {
   getRemoteConfig: <K extends keyof T>(
     configNamespace: string,
     key: K,
@@ -14,8 +14,12 @@ export interface RemoteConfigFetch<T> {
   ) => Promise<T[K] | undefined>;
 }
 
+export interface RemoteConfigFetch<T> extends BaseRemoteConfigFetch<T> {
+  fetchTime: number;
+}
+
 export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: object }>
-  extends RemoteConfigFetch<RemoteConfig> {
+  extends BaseRemoteConfigFetch<RemoteConfig> {
   storeRemoteConfig: (remoteConfig: RemoteConfigAPIResponse<RemoteConfig>, sessionId?: number) => Promise<void>;
   getLastFetchedSessionId: () => Promise<number | void>;
 }

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -49,6 +49,7 @@ describe('RemoteConfigFetch', () => {
   };
   let localConfig: IConfig;
   const mockConfigStore = {
+    fetchTime: 0,
     storeRemoteConfig: jest.fn(),
     getLastFetchedSessionId: jest.fn().mockResolvedValue(123),
     getRemoteConfig: jest.fn().mockResolvedValue(samplingConfig.sr_sampling_config),
@@ -462,5 +463,24 @@ describe('RemoteConfigFetch', () => {
       const remoteConfigFetch = createRemoteConfigFetch({ localConfig, configKeys: ['sessionReplay'] });
       expect(remoteConfigFetch).toBeDefined();
     });
+
+    test('should set fetchTime to 0 when initialization', async () => {
+      const remoteConfigFetch = await createRemoteConfigFetch({localConfig, configKeys: ['sessionReplay']});
+      expect(remoteConfigFetch.fetchTime).toEqual(0);
+    })
+  });
+
+  test('should calculate fetchTime', async () => {
+    const mockDateNow = jest.spyOn(global.Date, 'now');
+    const startTimestamp = 1000;
+    const endTimestamp = 2000;
+    mockDateNow.mockImplementationOnce(() => startTimestamp);
+    mockDateNow.mockImplementationOnce(() => endTimestamp);
+
+    await initialize();
+    await remoteConfigFetch.getRemoteConfig('sessionReplay', 'sr_sampling_config', 456);
+    expect(remoteConfigFetch.fetchTime).toEqual(endTimestamp - startTimestamp);
+
+    mockDateNow.mockRestore();
   });
 });

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -70,6 +70,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
+      fetchTime: 0,
     });
     jest.useFakeTimers();
   });

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -71,6 +71,7 @@ describe('module level integration', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
+      fetchTime: 0,
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     jest.useFakeTimers();

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -83,6 +83,7 @@ describe('module level integration', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
+      fetchTime: 0,
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     jest.useFakeTimers({ doNotFake: ['nextTick'] });

--- a/packages/session-replay-browser/test/session-replay-factory.test.ts
+++ b/packages/session-replay-browser/test/session-replay-factory.test.ts
@@ -8,6 +8,7 @@ describe('session replay factory', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
+      fetchTime: 0,
     });
   });
   describe('getLogConfig', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -86,6 +86,7 @@ describe('SessionReplay', () => {
     getRemoteConfigMock = jest.fn().mockResolvedValue(samplingConfig);
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
+      fetchTime: 0,
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     sessionReplay = new SessionReplay();


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add `fetchTime`, the total time spent in milliseconds to get remote config. 
The timer starts at the beginning of `getRemoteConfig()` and ends when `getRemoteConfig()` returns.


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
