### PR TITLE
fix(remote config): close db before deleting

### DIFF
--- a/packages/analytics-remote-config/src/remote-config-idb-store.ts
+++ b/packages/analytics-remote-config/src/remote-config-idb-store.ts
@@ -49,6 +49,7 @@ export const createRemoteConfigIDBStore = async <RemoteConfig extends { [key: st
   try {
     const lastFetchedSessionId = await metaDB.get('lastFetchedSessionId', 'sessionId');
     if (lastFetchedSessionId && Date.now() - lastFetchedSessionId >= MAX_IDB_STORAGE_TIME) {
+      remoteConfigDB.close();
       await deleteDB(remoteConfigDBName);
       remoteConfigDB = await openOrCreateRemoteConfigStore(apiKey, configKeys);
     }


### PR DESCRIPTION
### Summary
I just ran into the deleteDB call hanging because the db wasn't closed first. Somewhat surprised this doesn't happen automatically in idb, but this change closes the DB before trying to delete it.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
