### PR TITLE
fix(analytics-browser): add remote config fetch time

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -7,7 +7,7 @@ import { success } from './responses';
 import 'isomorphic-fetch';
 import { path, url, SUCCESS_MESSAGE, uuidPattern } from './constants';
 import { LogLevel } from '@amplitude/analytics-types';
-import { UUID } from '@amplitude/analytics-core';
+import { RequestMetadata, UUID } from '@amplitude/analytics-core';
 
 describe('integration', () => {
   const uuid: string = expect.stringMatching(uuidPattern) as string;
@@ -26,6 +26,7 @@ describe('integration', () => {
   let client = amplitude.createInstance();
 
   const event_upload_time = '2023-01-01T12:00:00:000Z';
+  const request_metadata = new RequestMetadata();
   Date.prototype.toISOString = jest.fn(() => event_upload_time);
 
   beforeAll(() => {
@@ -250,6 +251,7 @@ describe('integration', () => {
           },
         ],
         options: {},
+        request_metadata: request_metadata,
       });
       scope1.done();
     });
@@ -1066,6 +1068,7 @@ describe('integration', () => {
             options: {
               min_id_length: undefined,
             },
+            request_metadata: request_metadata,
           });
           scope.done();
           resolve();
@@ -1274,6 +1277,7 @@ describe('integration', () => {
             options: {
               min_id_length: undefined,
             },
+            request_metadata: request_metadata,
           });
           scope.done();
           resolve();
@@ -1369,6 +1373,7 @@ describe('integration', () => {
             options: {
               min_id_length: undefined,
             },
+            request_metadata: request_metadata,
           });
           scope.done();
           resolve();
@@ -1574,6 +1579,7 @@ describe('integration', () => {
             options: {
               min_id_length: undefined,
             },
+            request_metadata: request_metadata,
           });
           scope.done();
           resolve();
@@ -1722,6 +1728,7 @@ describe('integration', () => {
             options: {
               min_id_length: undefined,
             },
+            request_metadata: request_metadata,
           });
           scope.done();
           resolve();
@@ -1778,6 +1785,7 @@ describe('integration', () => {
             options: {
               min_id_length: undefined,
             },
+            request_metadata: request_metadata,
           });
           scope.done();
           resolve();

--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as amplitude from '@amplitude/analytics-browser';
-import { UUID } from '@amplitude/analytics-core';
+import { RequestMetadata, UUID } from '@amplitude/analytics-core';
 import { default as nock } from 'nock';
 import { path, url as httpEndPoint } from './constants';
 import { success } from './responses';
@@ -29,6 +29,7 @@ describe('Web attribution', () => {
   let client = amplitude.createInstance();
 
   const event_upload_time = '2023-01-01T12:00:00:000Z';
+  const request_metadata = new RequestMetadata();
   Date.prototype.toISOString = jest.fn(() => event_upload_time);
 
   beforeEach(() => {
@@ -80,6 +81,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -119,6 +121,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -161,6 +164,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -223,6 +227,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -275,6 +280,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -349,6 +355,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -413,6 +420,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -470,6 +478,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -528,6 +537,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();
@@ -580,6 +590,7 @@ describe('Web attribution', () => {
               options: {
                 min_id_length: undefined,
               },
+              request_metadata: request_metadata,
             });
             scope.done();
             resolve();

--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@amplitude/analytics-client-common": "^2.2.1",
     "@amplitude/analytics-core": "^2.2.8",
-    "@amplitude/analytics-remote-config": "^0.2.1",
+    "@amplitude/analytics-remote-config": "^0.3.0",
     "@amplitude/analytics-types": "^2.5.1",
     "@amplitude/plugin-autocapture-browser": "^0.9.2",
     "@amplitude/plugin-page-view-tracking-browser": "^2.2.13",

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -1,6 +1,7 @@
 import { BrowserConfig as IBrowserConfig } from '@amplitude/analytics-types';
 import { createRemoteConfigFetch, RemoteConfigFetch } from '@amplitude/analytics-remote-config';
 import { BrowserRemoteConfig } from './types';
+import { RequestMetadata } from '@amplitude/analytics-core';
 
 export class BrowserJoinedConfigGenerator {
   // Local config before generateJoinedConfig is called
@@ -31,6 +32,9 @@ export class BrowserJoinedConfigGenerator {
       this.config.defaultTracking = remoteConfig.defaultTracking;
     }
     this.config.loggerProvider.debug('Joined configuration: ', JSON.stringify(remoteConfig, null, 2));
+    if (this.remoteConfigFetch && this.remoteConfigFetch.fetchTime) {
+      this.config.requestMetadata = new RequestMetadata(this.remoteConfigFetch.fetchTime);
+    }
     return this.config;
   }
 }

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -33,7 +33,7 @@ export class BrowserJoinedConfigGenerator {
     }
     this.config.loggerProvider.debug('Joined configuration: ', JSON.stringify(remoteConfig, null, 2));
     this.config.requestMetadata ??= new RequestMetadata();
-    this.config.requestMetadata.sdk.metrics.histogram.remote_config_fetch_time = this.remoteConfigFetch?.fetchTime;
+    this.config.requestMetadata.recordHistogram('remote_config_fetch_time', this.remoteConfigFetch?.fetchTime);
     return this.config;
   }
 }

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -32,9 +32,8 @@ export class BrowserJoinedConfigGenerator {
       this.config.defaultTracking = remoteConfig.defaultTracking;
     }
     this.config.loggerProvider.debug('Joined configuration: ', JSON.stringify(remoteConfig, null, 2));
-    if (this.remoteConfigFetch && this.remoteConfigFetch.fetchTime) {
-      this.config.requestMetadata = new RequestMetadata(this.remoteConfigFetch.fetchTime);
-    }
+    this.config.requestMetadata ??= new RequestMetadata();
+    this.config.requestMetadata.sdk.metrics.histogram.remote_config_fetch_time = this.remoteConfigFetch?.fetchTime;
     return this.config;
   }
 }

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -12,6 +12,7 @@ describe('joined-config', () => {
   let localConfig: IBrowserConfig;
   let mockRemoteConfigFetch: RemoteConfigFetch<BrowserRemoteConfig>;
   let generator: BrowserJoinedConfigGenerator;
+  const fetchTime = 100;
 
   beforeEach(() => {
     localConfig = { ...createConfigurationMock(), defaultTracking: false };
@@ -20,8 +21,7 @@ describe('joined-config', () => {
       getRemoteConfig: jest.fn().mockResolvedValue({
         defaultTracking: true,
       }),
-      // TODO(xinyi): uncomment this line when fetchTime is used in the joined config
-      // fetchTime: 23,
+      fetchTime: fetchTime,
     };
 
     // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
@@ -78,6 +78,13 @@ describe('joined-config', () => {
         expect(generator.remoteConfigFetch).toBeUndefined();
         const joinedConfig = await generator.generateJoinedConfig();
         expect(joinedConfig).toEqual(localConfig);
+      });
+
+      test('should set requestMetadata', async () => {
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+        expect(joinedConfig.requestMetadata).not.toBeUndefined();
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time).toBe(fetchTime);
       });
     });
   });

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -80,12 +80,16 @@ describe('joined-config', () => {
         expect(joinedConfig).toEqual(localConfig);
       });
 
-      test('should set requestMetadata', async () => {
-        await generator.initialize();
-        const joinedConfig = await generator.generateJoinedConfig();
-        expect(joinedConfig.requestMetadata).not.toBeUndefined();
-        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time).toBe(fetchTime);
-      });
+      test.each([undefined, { sdk: { metrics: { histogram: { remote_config_fetch_time: 0 } } } }])(
+        'should set requestMetadata',
+        async (requestMetadata) => {
+          await generator.initialize();
+          generator.config.requestMetadata = requestMetadata;
+          const joinedConfig = await generator.generateJoinedConfig();
+          expect(joinedConfig.requestMetadata).not.toBeUndefined();
+          expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time).toBe(fetchTime);
+        },
+      );
     });
   });
 

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -3,6 +3,7 @@ import { BrowserConfig as IBrowserConfig } from '@amplitude/analytics-types';
 import { BrowserJoinedConfigGenerator, createBrowserJoinedConfigGenerator } from '../../src/config/joined-config';
 import { createConfigurationMock } from '../helpers/mock';
 import { BrowserRemoteConfig } from '../../lib/scripts/config/types';
+import { RequestMetadata } from '@amplitude/analytics-core';
 
 jest.mock('@amplitude/analytics-remote-config', () => ({
   createRemoteConfigFetch: jest.fn(),
@@ -80,16 +81,13 @@ describe('joined-config', () => {
         expect(joinedConfig).toEqual(localConfig);
       });
 
-      test.each([undefined, { sdk: { metrics: { histogram: { remote_config_fetch_time: 0 } } } }])(
-        'should set requestMetadata',
-        async (requestMetadata) => {
-          await generator.initialize();
-          generator.config.requestMetadata = requestMetadata;
-          const joinedConfig = await generator.generateJoinedConfig();
-          expect(joinedConfig.requestMetadata).not.toBeUndefined();
-          expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time).toBe(fetchTime);
-        },
-      );
+      test.each([undefined, new RequestMetadata()])('should set requestMetadata', async (requestMetadata) => {
+        await generator.initialize();
+        generator.config.requestMetadata = requestMetadata;
+        const joinedConfig = await generator.generateJoinedConfig();
+        expect(joinedConfig.requestMetadata).not.toBeUndefined();
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time).toBe(fetchTime);
+      });
     });
   });
 

--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -115,17 +115,15 @@ export class RequestMetadata implements IRequestMetadata {
   sdk: {
     metrics: {
       histogram: {
-        remote_config_fetch_time: number;
+        remote_config_fetch_time?: number;
       };
     };
   };
 
-  constructor(remoteConfigFetchTime: number) {
+  constructor() {
     this.sdk = {
       metrics: {
-        histogram: {
-          remote_config_fetch_time: remoteConfigFetchTime,
-        },
+        histogram: {},
       },
     };
   }

--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -11,6 +11,8 @@ import {
   ServerZoneType,
   OfflineDisabled,
   RequestMetadata as IRequestMetadata,
+  HistogramOptions as IHistogramOptions,
+  HistogramKey,
 } from '@amplitude/analytics-types';
 import {
   AMPLITUDE_SERVER_URL,
@@ -114,17 +116,23 @@ export const createServerConfig = (
 export class RequestMetadata implements IRequestMetadata {
   sdk: {
     metrics: {
-      histogram: {
-        remote_config_fetch_time?: number;
-      };
+      histogram: HistogramOptions;
     };
   };
 
   constructor() {
     this.sdk = {
       metrics: {
-        histogram: {},
+        histogram: new HistogramOptions(),
       },
     };
   }
+
+  recordHistogram<T extends HistogramKey>(key: T, value: HistogramOptions[T]) {
+    this.sdk.metrics.histogram[key] = value;
+  }
+}
+
+class HistogramOptions implements IHistogramOptions {
+  remote_config_fetch_time?: number;
 }

--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -10,7 +10,7 @@ import {
   Options,
   ServerZoneType,
   OfflineDisabled,
-  RequestMetadata,
+  RequestMetadata as IRequestMetadata,
 } from '@amplitude/analytics-types';
 import {
   AMPLITUDE_SERVER_URL,
@@ -52,7 +52,7 @@ export class Config implements IConfig {
   transportProvider: Transport;
   storageProvider?: Storage<Event[]>;
   useBatch: boolean;
-  request_metadata?: RequestMetadata;
+  requestMetadata?: RequestMetadata;
 
   protected _optOut = false;
   get optOut() {
@@ -110,3 +110,23 @@ export const createServerConfig = (
     serverUrl: getServerUrl(_serverZone, useBatch),
   };
 };
+
+export class RequestMetadata implements IRequestMetadata {
+  sdk: {
+    metrics: {
+      histogram: {
+        remote_config_fetch_time: number;
+      };
+    };
+  };
+
+  constructor(remoteConfigFetchTime: number) {
+    this.sdk = {
+      metrics: {
+        histogram: {
+          remote_config_fetch_time: remoteConfigFetchTime,
+        },
+      },
+    };
+  }
+}

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -2,7 +2,7 @@ export { AmplitudeCore } from './core-client';
 export { Identify } from './identify';
 export { Revenue } from './revenue';
 export { Destination } from './plugins/destination';
-export { Config } from './config';
+export { Config, RequestMetadata } from './config';
 export { Logger } from './logger';
 export { AMPLITUDE_PREFIX, STORAGE_PREFIX } from './constants';
 export { returnWrapper } from './utils/return-wrapper';

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -21,7 +21,7 @@ import {
 import { STORAGE_PREFIX } from '../constants';
 import { chunk } from '../utils/chunk';
 import { buildResult } from '../utils/result-builder';
-import { createServerConfig } from '../config';
+import { createServerConfig, RequestMetadata } from '../config';
 import { UUID } from '../utils/uuid';
 
 function getErrorMessage(error: unknown) {
@@ -161,8 +161,6 @@ export class Destination implements DestinationPlugin {
       return this.fulfillRequest(list, 400, MISSING_API_KEY_MESSAGE);
     }
 
-    const requestMetadata = this.config.requestMetadata;
-    delete this.config.requestMetadata;
     const payload = {
       api_key: this.config.apiKey,
       events: list.map((context) => {
@@ -174,8 +172,9 @@ export class Destination implements DestinationPlugin {
         min_id_length: this.config.minIdLength,
       },
       client_upload_time: new Date().toISOString(),
-      request_metadata: requestMetadata,
+      request_metadata: this.config.requestMetadata,
     };
+    this.config.requestMetadata = new RequestMetadata();
 
     try {
       const { serverUrl } = createServerConfig(this.config.serverUrl, this.config.serverZone, this.config.useBatch);

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -161,8 +161,8 @@ export class Destination implements DestinationPlugin {
       return this.fulfillRequest(list, 400, MISSING_API_KEY_MESSAGE);
     }
 
-    const request_metadata = this.config.request_metadata;
-    delete this.config.request_metadata;
+    const requestMetadata = this.config.requestMetadata;
+    delete this.config.requestMetadata;
     const payload = {
       api_key: this.config.apiKey,
       events: list.map((context) => {
@@ -174,7 +174,7 @@ export class Destination implements DestinationPlugin {
         min_id_length: this.config.minIdLength,
       },
       client_upload_time: new Date().toISOString(),
-      request_metadata: request_metadata,
+      request_metadata: requestMetadata,
     };
 
     try {

--- a/packages/analytics-core/test/config.test.ts
+++ b/packages/analytics-core/test/config.test.ts
@@ -130,14 +130,11 @@ describe('config', () => {
 
 describe('RequestMetadata', () => {
   test('constructor', () => {
-    const fetchTime = 100;
-    const requestMetadata = new RequestMetadata(fetchTime);
+    const requestMetadata = new RequestMetadata();
     expect(requestMetadata).toEqual({
       sdk: {
         metrics: {
-          histogram: {
-            remote_config_fetch_time: fetchTime,
-          },
+          histogram: {},
         },
       },
     });

--- a/packages/analytics-core/test/config.test.ts
+++ b/packages/analytics-core/test/config.test.ts
@@ -5,7 +5,7 @@ import {
   EU_AMPLITUDE_BATCH_SERVER_URL,
   EU_AMPLITUDE_SERVER_URL,
 } from '../src/constants';
-import { Config, createServerConfig, getServerUrl } from '../src/config';
+import { Config, createServerConfig, getServerUrl, RequestMetadata } from '../src/config';
 import { Logger } from '../src/logger';
 import { API_KEY, useDefaultConfig } from './helpers/default';
 
@@ -36,6 +36,7 @@ describe('config', () => {
       storageProvider: defaultConfig.storageProvider,
       transportProvider: defaultConfig.transportProvider,
       useBatch: false,
+      requestMetadata: undefined,
     });
     expect(config.optOut).toBe(false);
   });
@@ -124,5 +125,21 @@ describe('config', () => {
       flushIntervalMillis: 0,
     });
     expect(config.flushIntervalMillis).toEqual(0);
+  });
+});
+
+describe('RequestMetadata', () => {
+  test('constructor', () => {
+    const fetchTime = 100;
+    const requestMetadata = new RequestMetadata(fetchTime);
+    expect(requestMetadata).toEqual({
+      sdk: {
+        metrics: {
+          histogram: {
+            remote_config_fetch_time: fetchTime,
+          },
+        },
+      },
+    });
   });
 });

--- a/packages/analytics-core/test/index.test.ts
+++ b/packages/analytics-core/test/index.test.ts
@@ -14,6 +14,7 @@ import {
   UUID,
   MemoryStorage,
   createIdentifyEvent,
+  RequestMetadata,
 } from '../src/index';
 
 describe('index', () => {
@@ -32,6 +33,7 @@ describe('index', () => {
     expect(typeof BaseTransport).toBe('function');
     expect(typeof Destination).toBe('function');
     expect(typeof Config).toBe('function');
+    expect(typeof RequestMetadata).toEqual('function');
     expect(typeof Logger).toBe('function');
     expect(typeof returnWrapper).toBe('function');
     expect(typeof debugWrapper).toBe('function');

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -8,6 +8,7 @@ import {
   UNEXPECTED_ERROR_MESSAGE,
 } from '../../src/messages';
 import { uuidPattern } from '../helpers/util';
+import { RequestMetadata } from '../../src';
 
 const jsons = (obj: any) => JSON.stringify(obj, null, 2);
 
@@ -410,7 +411,8 @@ describe('destination', () => {
         requestMetadata: request_metadata,
       });
       await destination.send([context]);
-      expect(destination.config.requestMetadata).toBeUndefined();
+      // request metadata should be reset after sending
+      expect(destination.config.requestMetadata).toEqual(new RequestMetadata());
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -407,10 +407,10 @@ describe('destination', () => {
         ...useDefaultConfig(),
         transportProvider,
         apiKey: API_KEY,
-        request_metadata: request_metadata,
+        requestMetadata: request_metadata,
       });
       await destination.send([context]);
-      expect(destination.config.request_metadata).toBeUndefined();
+      expect(destination.config.requestMetadata).toBeUndefined();
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
         event,

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -380,15 +380,8 @@ describe('destination', () => {
         event,
         timeout: 0,
       };
-      const request_metadata = {
-        sdk: {
-          metrics: {
-            histogram: {
-              remote_config_fetch_time: 0,
-            },
-          },
-        },
-      };
+      const request_metadata = new RequestMetadata();
+      request_metadata.recordHistogram('remote_config_fetch_time', 100);
 
       const transportProvider = {
         send: jest.fn().mockImplementationOnce((_url: string, payload: Payload) => {

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -169,7 +169,7 @@ export interface CookieOptions {
   upgrade?: boolean;
 }
 
-type HiddenOptions = 'apiKey' | 'transportProvider';
+type HiddenOptions = 'apiKey' | 'transportProvider' | 'requestMetadata';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface BrowserOptions extends Omit<Partial<ExternalBrowserConfig>, HiddenOptions> {}

--- a/packages/analytics-types/src/config/core.ts
+++ b/packages/analytics-types/src/config/core.ts
@@ -95,7 +95,15 @@ export interface RequestMetadata {
       };
     };
   };
+
+  recordHistogram<T extends HistogramKey>(key: T, value: HistogramOptions[T]): void;
 }
+
+export interface HistogramOptions {
+  remote_config_fetch_time?: number;
+}
+
+export type HistogramKey = keyof HistogramOptions;
 
 export interface Options extends Partial<Config> {
   apiKey: string;

--- a/packages/analytics-types/src/config/core.ts
+++ b/packages/analytics-types/src/config/core.ts
@@ -91,7 +91,7 @@ export interface RequestMetadata {
   sdk: {
     metrics: {
       histogram: {
-        remote_config_fetch_time: number;
+        remote_config_fetch_time?: number;
       };
     };
   };

--- a/packages/analytics-types/src/config/core.ts
+++ b/packages/analytics-types/src/config/core.ts
@@ -84,7 +84,7 @@ export interface Config {
   /**
    * Metrics of the SDK.
    */
-  request_metadata?: RequestMetadata;
+  requestMetadata?: RequestMetadata;
 }
 
 export interface RequestMetadata {

--- a/packages/analytics-types/src/config/index.ts
+++ b/packages/analytics-types/src/config/index.ts
@@ -1,4 +1,4 @@
-export { Config, Options, RequestMetadata } from './core';
+export { Config, Options, RequestMetadata, HistogramOptions, HistogramKey } from './core';
 export { BrowserConfig, DefaultTrackingOptions, TrackingOptions, AttributionOptions, BrowserOptions } from './browser';
 export { NodeConfig, NodeOptions } from './node';
 export {

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -25,6 +25,8 @@ export {
   ReactNativeTrackingOptions,
   TrackingOptions,
   RequestMetadata,
+  HistogramOptions,
+  HistogramKey,
 } from './config';
 export { CoreClient } from './client/core-client';
 export { DestinationContext } from './destination-context';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
   integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
 
-"@amplitude/analytics-remote-config@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.2.1.tgz#0a80867521736bac12f74e1f500e93633a835249"
-  integrity sha512-mt+qAEkKv9LEnth0lk+RnqCk6L+sminXGUEvqpnSDZZkeWPFkKebiokcDRFlNb9x2v4wJ6Cs1IY7VtlfZyFHrA==
+"@amplitude/analytics-remote-config@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.3.0.tgz#6413761d17b25f3cb0c69c3caacab8c7d1653206"
+  integrity sha512-hfq4O+q1vj9St/VKb0WaHMpbJ6AVTWsVfZJbiu7ADfYqAEnEKihtReGvlwyU6Uim8n1xOBmES3JmWVJKAEOIWQ==
   dependencies:
     "@amplitude/analytics-client-common" ">=1 <3"
     "@amplitude/analytics-core" ">=1 <3"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add remote config fetch time to the payload. Example payload:
```
{
    "api_key": "xxx",
    "events": [
        {
            "user_id": "playground.user@amplitude.com",
            "device_id": "657b8364-e231-421f-8f2d-42103c0fcc92",
            "session_id": 1718215002924,
            "time": 1718215008416,
            "platform": "Web",
            "language": "en-US",
            "ip": "$remote",
            "insert_id": "81bd3a1a-aadf-4f01-8375-76de4fd3fa9b",
            "event_type": "[Amplitude] Page Viewed",
            "event_properties": {
                "[Amplitude] Page Domain": "127.0.0.1",
                "[Amplitude] Page Location": "http://127.0.0.1:8080/",
                "[Amplitude] Page Path": "/",
                "[Amplitude] Page Title": "Amplitude SDK Playground",
                "[Amplitude] Page URL": "http://127.0.0.1:8080/",
                "[Amplitude] Page Counter": 2
            },
            "event_id": 115,
            "library": "amplitude-ts/2.8.1",
            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
        }
    ],
    "options": {},
    "client_upload_time": "2024-06-12T17:56:49.418Z",
    "request_metadata": {
        "sdk": {
            "metrics": {
                "histogram": {
                    "remote_config_fetch_time": 76
                }
            }
        }
    }
}
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
