### PR TITLE
ci: stop publishing preleases to CDN

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -83,12 +83,6 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}" > ~/.npmrc
           npm whoami
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
-          aws-region: us-west-2
-
       # Converted to all lowercase and stripped of non-letter characters
       - name: Transform feature branch name
         run: |
@@ -109,6 +103,5 @@ jobs:
       - name: Publish Release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y
-        env:
-          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- from-git -y --ignore-scripts
+


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR stops the CI "Prerelease feature branch" publishing prereleases to CDN. It will only publish to NPM with a tag based on the branch name by selecting the feature branch. For example, the screenshot will release `2.x.x-featureremoteconfig.0`.

<img width="330" alt="image" src="https://github.com/amplitude/Amplitude-TypeScript/assets/31029607/6c1e69ea-b3c6-49ae-9395-b5d032a628ac">

I added [--ignore-scripts](https://www.npmjs.com/package/@lerna/publish/v/3.14.1#--ignore-scripts) so that lerna will not run `build' commands of subpackages, for example, [uploading-to-s3](https://github.com/amplitude/Amplitude-TypeScript/blob/d00981e3d7d2572d479d49511b96282a44d81de7/packages/analytics-browser/package.json#L38) in analytics-browser.


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
