### PR TITLE
feat(targeting and session replay): Add support for targeting by single event and multiple events

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -33,6 +33,7 @@ class SessionReplayEnrichmentPlugin implements EnrichmentPlugin {
     // Treating config.sessionId as source of truth, if the event's session id doesn't match, the
     // event is not of the current session (offline/late events). In that case, don't tag the events
     if (this.config.sessionId && this.config.sessionId === event.session_id) {
+      await sessionReplay.evaluateTargetingAndRecord({ event: event });
       const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
       event.event_properties = {
         ...event.event_properties,

--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -47,13 +47,19 @@ sessionReplay.init(API_KEY, {
 });
 ```
 
-### 3. Evaluate targeting and get session replay event properties
-Any event that occurs within the span of a session replay must be passed to the SDK to evaluate against targeting conditions. It must also be tagged with properties that signal to Amplitude to include it in the scope of the replay. The following shows an example of how to use the properties
+### 3. Evaluate targeting (optional)
+Any event that occurs within the span of a session replay must be passed to the SDK to evaluate against targeting conditions. This should be done *before* step 4, getting the event properties. If you are not using the targeting condition logic provided via the Amplitude UI, this step is not required.
 ```typescript
 const sessionTargetingMatch = sessionReplay.evaluateTargetingAndRecord({ event: {
   event_type: EVENT_NAME,
+  time: EVENT_TIMESTAMP,
   event_properties: eventProperties
 } });
+```
+
+### 4. Get session replay event properties
+Any event must be tagged with properties that signal to Amplitude to include it in the scope of the replay. The following shows an example of how to use the properties.
+```typescript
 const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
 track(EVENT_NAME, {
   ...eventProperties,
@@ -61,7 +67,7 @@ track(EVENT_NAME, {
 })
 ```
 
-### 4. Update session id
+### 5. Update session id
 Any time that the session id for the user changes, the session replay SDK must be notified of that change. Update the session id via the following method:
 ```typescript
 sessionReplay.setSessionId(UNIX_TIMESTAMP)
@@ -71,7 +77,7 @@ You can optionally pass a new device id as a second argument as well:
 sessionReplay.setSessionId(UNIX_TIMESTAMP, deviceId)
 ```
 
-### 5. Shutdown (optional)
+### 6. Shutdown (optional)
 If at any point you would like to discontinue collection of session replays, for example in a part of your application where you would not like sessions to be collected, you can use the following method to stop collection and remove collection event listeners.
 ```typescript
 sessionReplay.shutdown()

--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -47,9 +47,13 @@ sessionReplay.init(API_KEY, {
 });
 ```
 
-### 3. Get session replay event properties
-Any event that occurs within the span of a session replay must be tagged with properties that signal to Amplitude to include it in the scope of the replay. The following shows an example of how to use the properties
+### 3. Evaluate targeting and get session replay event properties
+Any event that occurs within the span of a session replay must be passed to the SDK to evaluate against targeting conditions. It must also be tagged with properties that signal to Amplitude to include it in the scope of the replay. The following shows an example of how to use the properties
 ```typescript
+const sessionTargetingMatch = sessionReplay.evaluateTargetingAndRecord({ event: {
+  event_type: EVENT_NAME,
+  event_properties: eventProperties
+} });
 const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
 track(EVENT_NAME, {
   ...eventProperties,

--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -43,7 +43,7 @@
     "@amplitude/analytics-remote-config": "^0.3.0",
     "@amplitude/analytics-types": ">=1 <3",
     "@amplitude/rrweb": "^2.0.0-alpha.14",
-    "@amplitude/targeting": "0.1.0",
+    "@amplitude/targeting": "0.1.1",
     "idb": "^8.0.0",
     "tslib": "^2.4.1"
   },

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,2 +1,10 @@
 import sessionReplay from './session-replay-factory';
-export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
+export const {
+  init,
+  setSessionId,
+  getSessionId,
+  evaluateTargetingAndRecord,
+  getSessionReplayProperties,
+  flush,
+  shutdown,
+} = sessionReplay;

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -17,6 +17,11 @@ const createInstance: () => AmplitudeSessionReplay = () => {
   const sessionReplay = new SessionReplay();
   return {
     init: debugWrapper(sessionReplay.init.bind(sessionReplay), 'init', getLogConfig(sessionReplay)),
+    evaluateTargetingAndRecord: debugWrapper(
+      sessionReplay.evaluateTargetingAndRecord.bind(sessionReplay),
+      'evaluateTargetingAndRecord',
+      getLogConfig(sessionReplay),
+    ),
     setSessionId: debugWrapper(
       sessionReplay.setSessionId.bind(sessionReplay),
       'setSessionId',

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -1,6 +1,6 @@
 import { getAnalyticsConnector, getGlobalScope } from '@amplitude/analytics-client-common';
 import { Logger, returnWrapper } from '@amplitude/analytics-core';
-import { Logger as ILogger } from '@amplitude/analytics-types';
+import { Event, Logger as ILogger } from '@amplitude/analytics-types';
 import { pack, record } from '@amplitude/rrweb';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import { SessionReplayJoinedConfig, SessionReplayJoinedConfigGenerator } from './config/types';
@@ -171,7 +171,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     void this.initialize();
   };
 
-  evaluateTargetingAndRecord = async () => {
+  evaluateTargetingAndRecord = async (options?: { event?: Event }) => {
     if (!this.identifiers || !this.identifiers.sessionId || !this.config) {
       this.loggerProvider.error('Session replay init has not been called, cannot evaluate targeting.');
       return;
@@ -182,13 +182,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
       const identityStore = getAnalyticsConnector(this.config.instanceName).identityStore;
       userProperties = identityStore.getIdentity().userProperties;
     }
-    const sessionTargetingMatch = await evaluateTargetingAndStore({
+    this.sessionTargetingMatch = await evaluateTargetingAndStore({
       sessionId: this.identifiers.sessionId,
       config: this.config,
-      targetingParams: { userProperties },
+      targetingParams: { userProperties, event: options?.event },
     });
 
-    if (sessionTargetingMatch) {
+    if (this.sessionTargetingMatch) {
       this.recordEvents();
     }
   };
@@ -235,7 +235,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     return identityStoreOptOut !== undefined ? identityStoreOptOut : this.config?.optOut;
   }
 
-  getShouldRecord(ignoreFocus = false) {
+  getShouldRecord = (ignoreFocus = false) => {
     if (!this.identifiers || !this.config || !this.identifiers.sessionId) {
       this.loggerProvider.error(`Session is not being recorded due to lack of config, please call sessionReplay.init.`);
       return false;
@@ -243,6 +243,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (!this.config.captureEnabled) {
       this.loggerProvider.log(
         `Session ${this.identifiers.sessionId} not being captured due to capture being disabled for project.`,
+      );
+      return false;
+    }
+
+    if (!this.sessionTargetingMatch) {
+      this.loggerProvider.log(
+        `Session ${this.identifiers.sessionId} not recording due to not matching targeting conditions.`,
       );
       return false;
     }
@@ -263,9 +270,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const isInSample = isSessionInSample(this.identifiers.sessionId, this.config.sampleRate);
     if (!isInSample) {
       this.loggerProvider.log(`Opting session ${this.identifiers.sessionId} out of recording due to sample rate.`);
+      return false;
     }
-    return isInSample;
-  }
+
+    return true;
+  };
 
   getBlockSelectors(): string | string[] | undefined {
     // For some reason, this defaults to empty array ([]) if undefined in the compiled script.

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -1,6 +1,6 @@
 import { getAnalyticsConnector, getGlobalScope } from '@amplitude/analytics-client-common';
 import { Logger, returnWrapper } from '@amplitude/analytics-core';
-import { Event, Logger as ILogger } from '@amplitude/analytics-types';
+import { Event, Logger as ILogger, SpecialEventType } from '@amplitude/analytics-types';
 import { pack, record } from '@amplitude/rrweb';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import { SessionReplayJoinedConfig, SessionReplayJoinedConfigGenerator } from './config/types';
@@ -174,7 +174,16 @@ export class SessionReplay implements AmplitudeSessionReplay {
   evaluateTargetingAndRecord = async (options?: { event?: Event }) => {
     if (!this.identifiers || !this.identifiers.sessionId || !this.config) {
       this.loggerProvider.error('Session replay init has not been called, cannot evaluate targeting.');
-      return;
+      return false;
+    }
+    let eventForTargeting = options?.event;
+
+    if (
+      [SpecialEventType.GROUP_IDENTIFY, SpecialEventType.IDENTIFY, SpecialEventType.REVENUE].includes(
+        eventForTargeting?.event_type as SpecialEventType,
+      )
+    ) {
+      eventForTargeting = undefined;
     }
 
     let userProperties;
@@ -185,12 +194,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.sessionTargetingMatch = await evaluateTargetingAndStore({
       sessionId: this.identifiers.sessionId,
       config: this.config,
-      targetingParams: { userProperties, event: options?.event },
+      targetingParams: { userProperties, event: eventForTargeting },
     });
 
     if (this.sessionTargetingMatch) {
       this.recordEvents();
     }
+
+    return this.sessionTargetingMatch;
   };
 
   stopRecordingAndSendEvents(sessionId?: number) {

--- a/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
@@ -1,6 +1,7 @@
 import { Logger as ILogger } from '@amplitude/analytics-types';
 import { DBSchema, IDBPDatabase, openDB } from 'idb';
 
+export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 2; // 2 days
 export interface SessionReplayTargetingDB extends DBSchema {
   sessionTargetingMatch: {
     key: number;
@@ -71,4 +72,30 @@ export const storeTargetingMatchForSession = async ({
     loggerProvider.warn(`Failed to store targeting match for session id ${sessionId}: ${e as string}`);
   }
   return undefined;
+};
+
+export const clearStoreOfOldSessions = async ({
+  loggerProvider,
+  apiKey,
+  currentSessionId,
+}: {
+  loggerProvider: ILogger;
+  apiKey: string;
+  currentSessionId: number;
+}) => {
+  try {
+    const db = await openOrCreateDB(apiKey);
+    const tx = db.transaction<'sessionTargetingMatch', 'readwrite'>('sessionTargetingMatch', 'readwrite');
+    const allTargetingMatchObjs = await tx.store.getAll();
+    for (let i = 0; i < allTargetingMatchObjs.length; i++) {
+      const targetingMatchObj = allTargetingMatchObjs[i];
+      const amountOfTimeSinceSession = Date.now() - targetingMatchObj.sessionId;
+      if (targetingMatchObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
+        await tx.store.delete(targetingMatchObj.sessionId);
+      }
+    }
+    await tx.done;
+  } catch (e) {
+    loggerProvider.warn(`Failed to clear old targeting matches for sessions: ${e as string}`);
+  }
 };

--- a/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
@@ -12,90 +12,103 @@ export interface SessionReplayTargetingDB extends DBSchema {
   };
 }
 
-export const createStore = async (dbName: string) => {
-  return await openDB<SessionReplayTargetingDB>(dbName, 1, {
-    upgrade: (db: IDBPDatabase<SessionReplayTargetingDB>) => {
-      if (!db.objectStoreNames.contains('sessionTargetingMatch')) {
-        db.createObjectStore('sessionTargetingMatch', {
-          keyPath: 'sessionId',
-        });
-      }
-    },
-  });
-};
+export class TargetingIDBStore {
+  dbs: { [apiKey: string]: IDBPDatabase<SessionReplayTargetingDB> } | undefined;
 
-const openOrCreateDB = async (apiKey: string) => {
-  const dbName = `${apiKey.substring(0, 10)}_amp_session_replay_targeting`;
-  return await createStore(dbName);
-};
-
-export const getTargetingMatchForSession = async ({
-  loggerProvider,
-  apiKey,
-  sessionId,
-}: {
-  loggerProvider: ILogger;
-  apiKey: string;
-  sessionId: number;
-}) => {
-  try {
-    const db = await openOrCreateDB(apiKey);
-    const targetingMatchForSession = await db.get<'sessionTargetingMatch'>('sessionTargetingMatch', sessionId);
-
-    return targetingMatchForSession?.targetingMatch;
-  } catch (e) {
-    loggerProvider.warn(`Failed to get targeting match for session id ${sessionId}: ${e as string}`);
-  }
-  return undefined;
-};
-
-export const storeTargetingMatchForSession = async ({
-  loggerProvider,
-  apiKey,
-  sessionId,
-  targetingMatch,
-}: {
-  loggerProvider: ILogger;
-  apiKey: string;
-  sessionId: number;
-  targetingMatch: boolean;
-}) => {
-  try {
-    const db = await openOrCreateDB(apiKey);
-    const targetingMatchForSession = await db.put<'sessionTargetingMatch'>('sessionTargetingMatch', {
-      targetingMatch,
-      sessionId,
+  createStore = async (dbName: string) => {
+    return await openDB<SessionReplayTargetingDB>(dbName, 1, {
+      upgrade: (db: IDBPDatabase<SessionReplayTargetingDB>) => {
+        if (!db.objectStoreNames.contains('sessionTargetingMatch')) {
+          db.createObjectStore('sessionTargetingMatch', {
+            keyPath: 'sessionId',
+          });
+        }
+      },
     });
+  };
 
-    return targetingMatchForSession;
-  } catch (e) {
-    loggerProvider.warn(`Failed to store targeting match for session id ${sessionId}: ${e as string}`);
-  }
-  return undefined;
-};
-
-export const clearStoreOfOldSessions = async ({
-  loggerProvider,
-  apiKey,
-  currentSessionId,
-}: {
-  loggerProvider: ILogger;
-  apiKey: string;
-  currentSessionId: number;
-}) => {
-  try {
-    const db = await openOrCreateDB(apiKey);
-    const tx = db.transaction<'sessionTargetingMatch', 'readwrite'>('sessionTargetingMatch', 'readwrite');
-    const allTargetingMatchObjs = await tx.store.getAll();
-    for (let i = 0; i < allTargetingMatchObjs.length; i++) {
-      const targetingMatchObj = allTargetingMatchObjs[i];
-      const amountOfTimeSinceSession = Date.now() - targetingMatchObj.sessionId;
-      if (targetingMatchObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
-        await tx.store.delete(targetingMatchObj.sessionId);
-      }
+  openOrCreateDB = async (apiKey: string) => {
+    if (this.dbs && this.dbs[apiKey]) {
+      return this.dbs[apiKey];
     }
-    await tx.done;
-  } catch (e) {
-    loggerProvider.warn(`Failed to clear old targeting matches for sessions: ${e as string}`);
-  }
-};
+    const dbName = `${apiKey.substring(0, 10)}_amp_session_replay_targeting`;
+    const db = await this.createStore(dbName);
+    this.dbs = {
+      ...this.dbs,
+      [apiKey]: db,
+    };
+    return db;
+  };
+
+  getTargetingMatchForSession = async ({
+    loggerProvider,
+    apiKey,
+    sessionId,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    sessionId: number;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+      const targetingMatchForSession = await db.get<'sessionTargetingMatch'>('sessionTargetingMatch', sessionId);
+
+      return targetingMatchForSession?.targetingMatch;
+    } catch (e) {
+      loggerProvider.warn(`Failed to get targeting match for session id ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  storeTargetingMatchForSession = async ({
+    loggerProvider,
+    apiKey,
+    sessionId,
+    targetingMatch,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    sessionId: number;
+    targetingMatch: boolean;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+      const targetingMatchForSession = await db.put<'sessionTargetingMatch'>('sessionTargetingMatch', {
+        targetingMatch,
+        sessionId,
+      });
+
+      return targetingMatchForSession;
+    } catch (e) {
+      loggerProvider.warn(`Failed to store targeting match for session id ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  clearStoreOfOldSessions = async ({
+    loggerProvider,
+    apiKey,
+    currentSessionId,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    currentSessionId: number;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+      const tx = db.transaction<'sessionTargetingMatch', 'readwrite'>('sessionTargetingMatch', 'readwrite');
+      const allTargetingMatchObjs = await tx.store.getAll();
+      for (let i = 0; i < allTargetingMatchObjs.length; i++) {
+        const targetingMatchObj = allTargetingMatchObjs[i];
+        const amountOfTimeSinceSession = Date.now() - targetingMatchObj.sessionId;
+        if (targetingMatchObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
+          await tx.store.delete(targetingMatchObj.sessionId);
+        }
+      }
+      await tx.done;
+    } catch (e) {
+      loggerProvider.warn(`Failed to clear old targeting matches for sessions: ${e as string}`);
+    }
+  };
+}
+export const targetingIDBStore = new TargetingIDBStore();

--- a/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
@@ -13,7 +13,7 @@ export interface SessionReplayTargetingDB extends DBSchema {
 }
 
 export class TargetingIDBStore {
-  dbs: { [apiKey: string]: IDBPDatabase<SessionReplayTargetingDB> } | undefined;
+  dbs: { [apiKey: string]: IDBPDatabase<SessionReplayTargetingDB> } = {};
 
   createStore = async (dbName: string) => {
     return await openDB<SessionReplayTargetingDB>(dbName, 1, {
@@ -33,10 +33,7 @@ export class TargetingIDBStore {
     }
     const dbName = `${apiKey.substring(0, 10)}_amp_session_replay_targeting`;
     const db = await this.createStore(dbName);
-    this.dbs = {
-      ...this.dbs,
-      [apiKey]: db,
-    };
+    this.dbs[apiKey] = db;
     return db;
   };
 

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -11,6 +11,12 @@ export const evaluateTargetingAndStore = async ({
   config: SessionReplayJoinedConfig;
   targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>;
 }) => {
+  await TargetingIDBStore.clearStoreOfOldSessions({
+    loggerProvider: config.loggerProvider,
+    apiKey: config.apiKey,
+    currentSessionId: sessionId,
+  });
+
   const idbTargetingMatch = await TargetingIDBStore.getTargetingMatchForSession({
     loggerProvider: config.loggerProvider,
     apiKey: config.apiKey,
@@ -26,10 +32,12 @@ export const evaluateTargetingAndStore = async ({
   let sessionTargetingMatch = true;
   try {
     if (config.targetingConfig && Object.keys(config.targetingConfig).length) {
-      const targetingResult = evaluateTargetingPackage({
+      const targetingResult = await evaluateTargetingPackage({
         ...targetingParams,
         flag: config.targetingConfig,
         sessionId: sessionId,
+        apiKey: config.apiKey,
+        loggerProvider: config.loggerProvider,
       });
       sessionTargetingMatch = targetingResult.sr_targeting_config.key === 'on';
     }

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -1,6 +1,6 @@
 import { TargetingParameters, evaluateTargeting as evaluateTargetingPackage } from '@amplitude/targeting';
 import { SessionReplayJoinedConfig } from 'src/config/types';
-import * as TargetingIDBStore from './targeting-idb-store';
+import { targetingIDBStore } from './targeting-idb-store';
 
 export const evaluateTargetingAndStore = async ({
   sessionId,
@@ -11,13 +11,13 @@ export const evaluateTargetingAndStore = async ({
   config: SessionReplayJoinedConfig;
   targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>;
 }) => {
-  await TargetingIDBStore.clearStoreOfOldSessions({
+  await targetingIDBStore.clearStoreOfOldSessions({
     loggerProvider: config.loggerProvider,
     apiKey: config.apiKey,
     currentSessionId: sessionId,
   });
 
-  const idbTargetingMatch = await TargetingIDBStore.getTargetingMatchForSession({
+  const idbTargetingMatch = await targetingIDBStore.getTargetingMatchForSession({
     loggerProvider: config.loggerProvider,
     apiKey: config.apiKey,
     sessionId: sessionId,
@@ -41,7 +41,7 @@ export const evaluateTargetingAndStore = async ({
       });
       sessionTargetingMatch = targetingResult.sr_targeting_config.key === 'on';
     }
-    void TargetingIDBStore.storeTargetingMatchForSession({
+    void targetingIDBStore.storeTargetingMatchForSession({
       loggerProvider: config.loggerProvider,
       apiKey: config.apiKey,
       sessionId: sessionId,

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -49,7 +49,7 @@ export interface AmplitudeSessionReplay {
   setSessionId: (sessionId: number, deviceId?: string) => AmplitudeReturn<void>;
   getSessionId: () => number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
-  evaluateTargetingAndRecord: (options?: { event?: Event }) => Promise<void>;
+  evaluateTargetingAndRecord: (options?: { event?: Event }) => Promise<boolean>;
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;
 }

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,4 +1,4 @@
-import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-types';
+import { AmplitudeReturn, Event, ServerZone } from '@amplitude/analytics-types';
 import { SessionReplayLocalConfig } from '../config/types';
 
 export type Events = string[];
@@ -49,6 +49,7 @@ export interface AmplitudeSessionReplay {
   setSessionId: (sessionId: number, deviceId?: string) => AmplitudeReturn<void>;
   getSessionId: () => number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
+  evaluateTargetingAndRecord: (options?: { event?: Event }) => Promise<void>;
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;
 }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -352,6 +352,7 @@ describe('SessionReplay', () => {
         },
       } as typeof globalThis);
       await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const result = sessionReplay.getSessionReplayProperties();
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(result).toEqual({
@@ -519,6 +520,7 @@ describe('SessionReplay', () => {
       // Mock as if remote config call fails
       getRemoteConfigMock.mockImplementation(() => Promise.reject('error'));
       await sessionReplay.init(apiKey, mockEmptyOptions).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const sampleRate = sessionReplay.config?.sampleRate;
       expect(sampleRate).toBe(DEFAULT_SAMPLE_RATE);
       const shouldRecord = sessionReplay.getShouldRecord();
@@ -531,6 +533,7 @@ describe('SessionReplay', () => {
       });
 
       await sessionReplay.init(apiKey, { ...mockOptions }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(false);
     });
@@ -540,6 +543,7 @@ describe('SessionReplay', () => {
       jest.spyOn(Helpers, 'isSessionInSample').mockImplementationOnce(() => false);
 
       await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.2 }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const sampleRate = sessionReplay.config?.sampleRate;
       expect(sampleRate).toBe(0.2);
       const shouldRecord = sessionReplay.getShouldRecord();
@@ -547,23 +551,33 @@ describe('SessionReplay', () => {
     });
     test('should set record as true if session is included in sample rate', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.2 }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       jest.spyOn(Helpers, 'isSessionInSample').mockImplementationOnce(() => true);
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(true);
     });
+    test('should set record as false if sessionTargetingMatch is false', async () => {
+      await sessionReplay.init(apiKey, { ...mockOptions, optOut: true }).promise;
+      sessionReplay.sessionTargetingMatch = false;
+      const shouldRecord = sessionReplay.getShouldRecord();
+      expect(shouldRecord).toBe(false);
+    });
     test('should set record as false if opt out in config', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, optOut: true }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(false);
     });
     test('should set record as false if no session id', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, sessionId: undefined }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(false);
     });
     test('opt out in config should override the sample rate', async () => {
       jest.spyOn(Math, 'random').mockImplementationOnce(() => 0.7);
       await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.8, optOut: true }).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const shouldRecord = sessionReplay.getShouldRecord();
       expect(shouldRecord).toBe(false);
     });
@@ -575,6 +589,7 @@ describe('SessionReplay', () => {
         },
       } as typeof globalThis);
       await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.sessionTargetingMatch = true;
       const shouldRecord = sessionReplay.getShouldRecord();
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.log).toHaveBeenCalled();
@@ -834,6 +849,24 @@ describe('SessionReplay', () => {
       return evaluateTargetingAndStorePromise.then(() => {
         expect(record).toHaveBeenCalled();
       });
+    });
+
+    test('should pass event to evaluateTargetingAndStore', async () => {
+      await sessionReplay.evaluateTargetingAndRecord({ event: { event_type: 'Purchase' } });
+      expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetingParams: { event: { event_type: 'Purchase' }, userProperties: {} },
+        }),
+      );
+    });
+
+    test('should not pass event to evaluateTargetingAndStore if it is one of the SpecialEvents', async () => {
+      await sessionReplay.evaluateTargetingAndRecord({ event: { event_type: '$identify' } });
+      expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetingParams: { event: undefined, userProperties: {} },
+        }),
+      );
     });
   });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -9,10 +9,12 @@ import * as RRWeb from '@amplitude/rrweb';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
 
 import { IDBFactory } from 'fake-indexeddb';
+import { IDBPDatabase } from 'idb';
 import { DEFAULT_SAMPLE_RATE } from '../src/constants';
 import * as SessionReplayIDB from '../src/events/events-idb-store';
 import * as Helpers from '../src/helpers';
 import { SessionReplay } from '../src/session-replay';
+import { SessionReplayTargetingDB, targetingIDBStore } from '../src/targeting/targeting-idb-store';
 import * as TargetingManager from '../src/targeting/targeting-manager';
 import { SessionReplayOptions } from '../src/typings/session-replay';
 
@@ -83,7 +85,6 @@ describe('SessionReplay', () => {
   };
   let sessionReplay: SessionReplay;
   let getRemoteConfigMock: jest.Mock;
-  let initialize: jest.SpyInstance;
   const evaluateTargetingAndStorePromise = Promise.resolve(true);
   beforeEach(() => {
     getRemoteConfigMock = jest.fn().mockResolvedValue(samplingConfig);
@@ -94,7 +95,6 @@ describe('SessionReplay', () => {
     jest.spyOn(TargetingManager, 'evaluateTargetingAndStore').mockReturnValue(evaluateTargetingAndStorePromise);
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     sessionReplay = new SessionReplay();
-    initialize = jest.spyOn(sessionReplay, 'initialize');
     jest.useFakeTimers();
     originalFetch = global.fetch;
     (global.fetch as jest.Mock) = jest.fn(() => {
@@ -159,20 +159,12 @@ describe('SessionReplay', () => {
       expect(sessionReplay.config?.privacyConfig?.blockSelector).toEqual(['.class', '#id']);
       expect(sessionReplay.loggerProvider).toBeDefined();
     });
-
-    test('should call initialize with shouldSendStoredEvents=true', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-
-      expect(initialize).toHaveBeenCalledTimes(1);
-
-      expect(initialize.mock.calls[0]).toEqual([true]);
-    });
     test('should set up blur and focus event listeners', async () => {
       const stopRecordingMock = jest.fn();
       sessionReplay.recordCancelCallback = stopRecordingMock;
-      const initialize = jest.spyOn(sessionReplay, 'initialize');
+      const evaluateTargetingAndRecord = jest.spyOn(sessionReplay, 'evaluateTargetingAndRecord');
+      sessionReplay.sessionTargetingMatch = true;
       await sessionReplay.init(apiKey, mockOptions).promise;
-      initialize.mockReset();
       expect(addEventListenerMock).toHaveBeenCalledTimes(2);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(addEventListenerMock.mock.calls[0][0]).toEqual('blur');
@@ -189,18 +181,16 @@ describe('SessionReplay', () => {
       const focusCallback = addEventListenerMock.mock.calls[1][1];
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       focusCallback();
-      expect(initialize).toHaveBeenCalled();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(initialize.mock.calls[0]).toEqual([]);
+      expect(evaluateTargetingAndRecord).toHaveBeenCalled();
     });
-    test('it should not call initialize if the document does not have focus', () => {
-      const initialize = jest.spyOn(sessionReplay, 'initialize');
+    test('it should not call recordEvents if the document does not have focus', () => {
+      const recordEvents = jest.spyOn(sessionReplay, 'recordEvents');
       jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
         document: {
           hasFocus: () => false,
         },
       } as typeof globalThis);
-      expect(initialize).not.toHaveBeenCalled();
+      expect(recordEvents).not.toHaveBeenCalled();
     });
 
     describe('flushMaxRetries config', () => {
@@ -383,92 +373,6 @@ describe('SessionReplay', () => {
         '[Amplitude] Session Replay ID': '1a2b3c/123',
         '[Amplitude] Session Replay Debug': '{"appHash":"-109988594"}',
       });
-    });
-  });
-
-  describe('initialize', () => {
-    test('should return early if session id not set', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      if (!sessionReplay.eventsManager || !sessionReplay.identifiers) {
-        throw new Error('Did not call init');
-      }
-      sessionReplay.identifiers.sessionId = undefined;
-      const sendStoredEventsSpy = jest.spyOn(sessionReplay.eventsManager, 'sendStoredEvents');
-      await sessionReplay.initialize();
-      expect(sendStoredEventsSpy).not.toHaveBeenCalled();
-    });
-    test('should return early if no identifiers', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      sessionReplay.identifiers = undefined;
-      if (!sessionReplay.eventsManager) {
-        throw new Error('Did not call init');
-      }
-      const sendStoredEventsSpy = jest.spyOn(sessionReplay.eventsManager, 'sendStoredEvents');
-      await sessionReplay.initialize();
-      expect(sendStoredEventsSpy).not.toHaveBeenCalled();
-    });
-    test('should return early if no device id', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      sessionReplay.getDeviceId = jest.fn().mockReturnValue(undefined);
-      if (!sessionReplay.eventsManager) {
-        throw new Error('Did not call init');
-      }
-      const sendStoredEventsSpy = jest.spyOn(sessionReplay.eventsManager, 'sendStoredEvents');
-      await sessionReplay.initialize();
-      expect(sendStoredEventsSpy).not.toHaveBeenCalled();
-    });
-    test('should send stored events and record events', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      record.mockReset();
-      if (!sessionReplay.eventsManager) {
-        throw new Error('Did not call init');
-      }
-      const eventsManagerInitSpy = jest.spyOn(sessionReplay.eventsManager, 'sendStoredEvents');
-
-      await sessionReplay.initialize(true);
-      expect(eventsManagerInitSpy).toHaveBeenCalledWith({
-        deviceId: mockOptions.deviceId,
-      });
-      expect(record).toHaveBeenCalledTimes(1);
-    });
-    test('should not send stored events if shouldSendStoredEvents is false', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      record.mockReset();
-      if (!sessionReplay.eventsManager) {
-        throw new Error('Did not call init');
-      }
-      const eventsManagerInitSpy = jest.spyOn(sessionReplay.eventsManager, 'sendStoredEvents');
-
-      await sessionReplay.initialize(false);
-      expect(eventsManagerInitSpy).not.toHaveBeenCalled();
-      expect(record).toHaveBeenCalledTimes(1);
-    });
-    test('should evaluate targeting based on existing user properties', async () => {
-      const sessionReplay = new SessionReplay();
-      await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
-      const mockUserProperties = {
-        country: 'US',
-        city: 'San Francisco',
-      };
-      jest.spyOn(AnalyticsClientCommon, 'getAnalyticsConnector').mockReturnValue({
-        identityStore: {
-          getIdentity: () => {
-            return {
-              userProperties: mockUserProperties,
-            };
-          },
-        },
-      } as unknown as ReturnType<typeof AnalyticsClientCommon.getAnalyticsConnector>);
-      const evaluateTargetingSpy = jest.spyOn(TargetingManager, 'evaluateTargetingAndStore').mockResolvedValue(true);
-
-      await sessionReplay.initialize(true);
-      expect(evaluateTargetingSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          targetingParams: {
-            userProperties: mockUserProperties,
-          },
-        }),
-      );
     });
   });
 
@@ -819,11 +723,16 @@ describe('SessionReplay', () => {
   describe('evaluateTargetingAndRecord', () => {
     let sessionReplay: SessionReplay;
     let evaluateTargetingMock: jest.SpyInstance;
+    let db: IDBPDatabase<SessionReplayTargetingDB>;
     beforeEach(async () => {
+      db = await targetingIDBStore.openOrCreateDB('static_key');
+      await db.clear('sessionTargetingMatch');
       sessionReplay = new SessionReplay();
-      sessionReplay.initialize = jest.fn(); // Mock out the initialize method as it calls evaluateTargeting, creates testing conflicts
       await sessionReplay.init(apiKey, { ...mockOptions }).promise;
-
+      // Reset this to false, it is set in init
+      sessionReplay.sessionTargetingMatch = false;
+      record.mockClear();
+      evaluateTargetingMock.mockClear();
       evaluateTargetingMock = jest.spyOn(TargetingManager, 'evaluateTargetingAndStore').mockResolvedValue(true);
     });
     test('should return undefined if no identifiers set', async () => {
@@ -853,11 +762,13 @@ describe('SessionReplay', () => {
 
     test('should pass event to evaluateTargetingAndStore', async () => {
       await sessionReplay.evaluateTargetingAndRecord({ event: { event_type: 'Purchase' } });
-      expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
-        expect.objectContaining({
-          targetingParams: { event: { event_type: 'Purchase' }, userProperties: {} },
-        }),
-      );
+      return evaluateTargetingAndStorePromise.then(() => {
+        expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
+          expect.objectContaining({
+            targetingParams: { event: { event_type: 'Purchase' }, userProperties: {} },
+          }),
+        );
+      });
     });
 
     test('should not pass event to evaluateTargetingAndStore if it is one of the SpecialEvents', async () => {

--- a/packages/session-replay-browser/test/targeting/targeting-idb-store.test.ts
+++ b/packages/session-replay-browser/test/targeting/targeting-idb-store.test.ts
@@ -90,4 +90,81 @@ describe('TargetingIDBStore', () => {
       );
     });
   });
+
+  describe('clearStoreOfOldSessions', () => {
+    test('should delete object stores with sessions older than 2 days', async () => {
+      // Set current time to 08:30
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      // Current session from one hour before, 07:30
+      const currentSessionId = new Date('2023-07-31 07:30:00').getTime();
+      await TargetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        sessionId: currentSessionId,
+        targetingMatch: true,
+      });
+      // Add session from the same day
+      await TargetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        sessionId: new Date('2023-07-31 05:30:00').getTime(),
+        targetingMatch: true,
+      });
+      // Add session from one month ago
+      await TargetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        sessionId: new Date('2023-06-31 10:30:00').getTime(),
+        targetingMatch: true,
+      });
+      const store = await TargetingIDBStore.createStore('static_key_amp_session_replay_targeting');
+      const allEntries = await store.getAll('sessionTargetingMatch');
+      expect(allEntries).toEqual([
+        {
+          sessionId: new Date('2023-06-31 10:30:00').getTime(),
+          targetingMatch: true,
+        },
+        {
+          sessionId: new Date('2023-07-31 05:30:00').getTime(),
+          targetingMatch: true,
+        },
+        {
+          sessionId: currentSessionId,
+          targetingMatch: true,
+        },
+      ]);
+
+      await TargetingIDBStore.clearStoreOfOldSessions({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        currentSessionId,
+      });
+
+      const allEntriesUpdated = await store.getAll('sessionTargetingMatch');
+      // Only one month old entry should be deleted
+      expect(allEntriesUpdated).toEqual([
+        {
+          sessionId: new Date('2023-07-31 05:30:00').getTime(),
+          targetingMatch: true,
+        },
+        {
+          sessionId: currentSessionId,
+          targetingMatch: true,
+        },
+      ]);
+    });
+    test('should catch errors', async () => {
+      jest.spyOn(TargetingIDBStore, 'createStore').mockRejectedValueOnce('error');
+      await TargetingIDBStore.clearStoreOfOldSessions({
+        loggerProvider: mockLoggerProvider,
+        currentSessionId: 123,
+        apiKey,
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to clear old targeting matches for sessions: error',
+      );
+    });
+  });
 });

--- a/packages/session-replay-browser/test/targeting/targeting-manager.test.ts
+++ b/packages/session-replay-browser/test/targeting/targeting-manager.test.ts
@@ -60,7 +60,7 @@ describe('Targeting Manager', () => {
 
     test('should use remote config to determine targeting match', async () => {
       jest.spyOn(TargetingIDBStore, 'getTargetingMatchForSession').mockResolvedValueOnce(false);
-      evaluateTargeting.mockReturnValueOnce({
+      evaluateTargeting.mockResolvedValueOnce({
         sr_targeting_config: {
           key: 'on',
         },
@@ -77,6 +77,8 @@ describe('Targeting Manager', () => {
         },
       });
       expect(evaluateTargeting).toHaveBeenCalledWith({
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
         flag: flagConfig,
         sessionId: 123,
         userProperties: mockUserProperties,
@@ -102,7 +104,7 @@ describe('Targeting Manager', () => {
       expect(sessionTargetingMatch).toBe(true);
     });
     test('should store sessionTargetingMatch', async () => {
-      evaluateTargeting.mockReturnValueOnce({
+      evaluateTargeting.mockResolvedValueOnce({
         sr_targeting_config: {
           key: 'on',
         },

--- a/packages/targeting/jest.config.js
+++ b/packages/targeting/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   rootDir: '.',
   testEnvironment: 'jsdom',
   coveragePathIgnorePatterns: ['index.ts'],
+  setupFilesAfterEnv: ['./test/jest-setup.js'],
 };

--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -49,6 +49,7 @@
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
+    "fake-indexeddb": "4.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-execute": "^1.1.1",
     "rollup-plugin-gzip": "^3.1.0",

--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -42,6 +42,7 @@
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-types": ">=1 <3",
     "@amplitude/experiment-core": "0.7.2",
+    "idb": "^8.0.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/targeting/src/targeting-idb-store.ts
+++ b/packages/targeting/src/targeting-idb-store.ts
@@ -21,7 +21,7 @@ export interface TargetingDB extends DBSchema {
 }
 
 export class TargetingIDBStore {
-  dbs: { [apiKey: string]: IDBPDatabase<TargetingDB> } | undefined;
+  dbs: { [apiKey: string]: IDBPDatabase<TargetingDB> } = {};
 
   createStore = async (dbName: string) => {
     return await openDB<TargetingDB>(dbName, 1, {
@@ -41,10 +41,8 @@ export class TargetingIDBStore {
     }
     const dbName = `${apiKey.substring(0, 10)}_amp_targeting`;
     const db = await this.createStore(dbName);
-    this.dbs = {
-      ...this.dbs,
-      [apiKey]: db,
-    };
+    this.dbs[apiKey] = db;
+
     return db;
   };
 

--- a/packages/targeting/src/targeting-idb-store.ts
+++ b/packages/targeting/src/targeting-idb-store.ts
@@ -3,110 +3,148 @@ import { DBSchema, IDBPDatabase, IDBPTransaction, openDB } from 'idb';
 
 export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 2; // 2 days
 
+// This type is constructed to allow for future proofing - in the future we may want
+// to track how many of each event is fired, and we may want to track event properties
+// Any further fields, like event properties, can be added to this type without causing
+// a breaking change
+type EventData = { event_type: string };
+
+type EventTypeStore = { [event_type: string]: { [timestamp: number]: EventData } };
 export interface TargetingDB extends DBSchema {
   eventTypesForSession: {
     key: number;
     value: {
       sessionId: number;
-      eventTypes: Array<{ event_type: string }>;
+      eventTypes: EventTypeStore;
     };
   };
 }
 
-export const createStore = async (dbName: string) => {
-  return await openDB<TargetingDB>(dbName, 1, {
-    upgrade: (db: IDBPDatabase<TargetingDB>) => {
-      if (!db.objectStoreNames.contains('eventTypesForSession')) {
-        db.createObjectStore('eventTypesForSession', {
-          keyPath: 'sessionId',
-        });
-      }
-    },
-  });
-};
+export class TargetingIDBStore {
+  dbs: { [apiKey: string]: IDBPDatabase<TargetingDB> } | undefined;
 
-const openOrCreateDB = async (apiKey: string) => {
-  const dbName = `${apiKey.substring(0, 10)}_amp_targeting`;
-  return await createStore(dbName);
-};
+  createStore = async (dbName: string) => {
+    return await openDB<TargetingDB>(dbName, 1, {
+      upgrade: (db: IDBPDatabase<TargetingDB>) => {
+        if (!db.objectStoreNames.contains('eventTypesForSession')) {
+          db.createObjectStore('eventTypesForSession', {
+            keyPath: 'sessionId',
+          });
+        }
+      },
+    });
+  };
 
-export const updateEventListForSession = async ({
-  sessionId,
-  eventType,
-  loggerProvider,
-  tx,
-}: {
-  sessionId: number;
-  eventType: string;
-  loggerProvider: ILogger;
-  tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
-}) => {
-  try {
-    const eventTypesForSessionStorage = await tx.store.get(sessionId);
-    const eventTypesForSession = eventTypesForSessionStorage ? eventTypesForSessionStorage.eventTypes : [];
-
-    const updatedEventTypes = eventTypesForSession.concat({ event_type: eventType });
-    await tx.store.put({ sessionId, eventTypes: updatedEventTypes });
-    return updatedEventTypes;
-  } catch (e) {
-    loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
-  }
-  return undefined;
-};
-
-export const deleteOldSessionEventTypes = async ({
-  currentSessionId,
-  loggerProvider,
-  tx,
-}: {
-  currentSessionId: number;
-  loggerProvider: ILogger;
-  tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
-}) => {
-  try {
-    const allEventTypeObjs = await tx.store.getAll();
-    for (let i = 0; i < allEventTypeObjs.length; i++) {
-      const eventTypeObj = allEventTypeObjs[i];
-      const amountOfTimeSinceSession = Date.now() - eventTypeObj.sessionId;
-      if (eventTypeObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
-        await tx.store.delete(eventTypeObj.sessionId);
-      }
+  openOrCreateDB = async (apiKey: string) => {
+    if (this.dbs && this.dbs[apiKey]) {
+      return this.dbs[apiKey];
     }
-  } catch (e) {
-    loggerProvider.warn(`Failed to clear old session events for targeting: ${e as string}`);
-  }
-};
+    const dbName = `${apiKey.substring(0, 10)}_amp_targeting`;
+    const db = await this.createStore(dbName);
+    this.dbs = {
+      ...this.dbs,
+      [apiKey]: db,
+    };
+    return db;
+  };
 
-export const storeEventTypeForSession = async ({
-  loggerProvider,
-  sessionId,
-  eventType,
-  apiKey,
-}: {
-  loggerProvider: ILogger;
-  apiKey: string;
-  eventType: string;
-  sessionId: number;
-}) => {
-  try {
-    const db = await openOrCreateDB(apiKey);
+  updateEventListForSession = async ({
+    sessionId,
+    eventType,
+    eventTime,
+    loggerProvider,
+    tx,
+  }: {
+    sessionId: number;
+    eventType: string;
+    eventTime: number;
+    loggerProvider: ILogger;
+    tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
+  }) => {
+    try {
+      const eventTypesForSessionStorage = await tx.store.get(sessionId);
+      const eventTypesForSession = eventTypesForSessionStorage ? eventTypesForSessionStorage.eventTypes : {};
+      const eventTypeStore = eventTypesForSession[eventType] || {};
 
-    const tx = db.transaction<'eventTypesForSession', 'readwrite'>('eventTypesForSession', 'readwrite');
-    if (!tx) {
-      return;
+      const updatedEventTypes: EventTypeStore = {
+        ...eventTypesForSession,
+        [eventType]: {
+          ...eventTypeStore,
+          [eventTime]: { event_type: eventType },
+        },
+      };
+      await tx.store.put({ sessionId, eventTypes: updatedEventTypes });
+      return updatedEventTypes;
+    } catch (e) {
+      loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
     }
+    return undefined;
+  };
 
-    // Update the list of events for the session
-    const updatedEventTypes = await updateEventListForSession({ sessionId, tx, loggerProvider, eventType });
+  deleteOldSessionEventTypes = async ({
+    currentSessionId,
+    loggerProvider,
+    tx,
+  }: {
+    currentSessionId: number;
+    loggerProvider: ILogger;
+    tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
+  }) => {
+    try {
+      const allEventTypeObjs = await tx.store.getAll();
+      for (let i = 0; i < allEventTypeObjs.length; i++) {
+        const eventTypeObj = allEventTypeObjs[i];
+        const amountOfTimeSinceSession = Date.now() - eventTypeObj.sessionId;
+        if (eventTypeObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
+          await tx.store.delete(eventTypeObj.sessionId);
+        }
+      }
+    } catch (e) {
+      loggerProvider.warn(`Failed to clear old session events for targeting: ${e as string}`);
+    }
+  };
 
-    // Clear out sessions older than 2 days
-    await deleteOldSessionEventTypes({ currentSessionId: sessionId, tx, loggerProvider });
+  storeEventTypeForSession = async ({
+    loggerProvider,
+    sessionId,
+    eventType,
+    eventTime,
+    apiKey,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    eventType: string;
+    eventTime: number;
+    sessionId: number;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
 
-    await tx.done;
+      const tx = db.transaction<'eventTypesForSession', 'readwrite'>('eventTypesForSession', 'readwrite');
+      if (!tx) {
+        return;
+      }
 
-    return updatedEventTypes;
-  } catch (e) {
-    loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
-  }
-  return undefined;
-};
+      // Update the list of events for the session
+      const updatedEventTypes = await this.updateEventListForSession({
+        sessionId,
+        tx,
+        loggerProvider,
+        eventType,
+        eventTime,
+      });
+
+      // Clear out sessions older than 2 days
+      await this.deleteOldSessionEventTypes({ currentSessionId: sessionId, tx, loggerProvider });
+
+      await tx.done;
+
+      return updatedEventTypes;
+    } catch (e) {
+      loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+}
+
+export const targetingIDBStore = new TargetingIDBStore();

--- a/packages/targeting/src/targeting-idb-store.ts
+++ b/packages/targeting/src/targeting-idb-store.ts
@@ -1,0 +1,120 @@
+import { Logger as ILogger, SpecialEventType } from '@amplitude/analytics-types';
+import { DBSchema, IDBPDatabase, IDBPTransaction, openDB } from 'idb';
+
+export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 2; // 2 days
+
+export interface TargetingDB extends DBSchema {
+  eventTypesForSession: {
+    key: number;
+    value: {
+      sessionId: number;
+      eventTypes: Set<string>;
+    };
+  };
+}
+
+export const createStore = async (dbName: string) => {
+  return await openDB<TargetingDB>(dbName, 1, {
+    upgrade: (db: IDBPDatabase<TargetingDB>) => {
+      if (!db.objectStoreNames.contains('eventTypesForSession')) {
+        db.createObjectStore('eventTypesForSession', {
+          keyPath: 'sessionId',
+        });
+      }
+    },
+  });
+};
+
+const openOrCreateDB = async (apiKey: string) => {
+  const dbName = `${apiKey.substring(0, 10)}_amp_targeting`;
+  return await createStore(dbName);
+};
+
+export const updateEventListForSession = async ({
+  sessionId,
+  eventType,
+  loggerProvider,
+  tx,
+}: {
+  sessionId: number;
+  eventType: string;
+  loggerProvider: ILogger;
+  tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
+}) => {
+  try {
+    const eventTypesForSessionStorage = await tx.store.get(sessionId);
+    const eventTypesForSession = eventTypesForSessionStorage ? eventTypesForSessionStorage.eventTypes : new Set([]);
+
+    const updatedEventTypes = eventTypesForSession.add(eventType);
+    updatedEventTypes && (await tx.store.put({ sessionId, eventTypes: updatedEventTypes }));
+    return updatedEventTypes;
+  } catch (e) {
+    loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
+  }
+  return undefined;
+};
+
+export const deleteOldSessionEventTypes = async ({
+  currentSessionId,
+  loggerProvider,
+  tx,
+}: {
+  currentSessionId: number;
+  loggerProvider: ILogger;
+  tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
+}) => {
+  try {
+    const allEventTypeObjs = await tx.store.getAll();
+    for (let i = 0; i < allEventTypeObjs.length; i++) {
+      const eventTypeObj = allEventTypeObjs[i];
+      const amountOfTimeSinceSession = Date.now() - eventTypeObj.sessionId;
+      if (eventTypeObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
+        await tx.store.delete(eventTypeObj.sessionId);
+      }
+    }
+  } catch (e) {
+    loggerProvider.warn(`Failed to clear old session events for targeting: ${e as string}`);
+  }
+};
+
+export const storeEventTypeForSession = async ({
+  loggerProvider,
+  sessionId,
+  eventType,
+  apiKey,
+}: {
+  loggerProvider: ILogger;
+  apiKey: string;
+  eventType: string;
+  sessionId: number;
+}) => {
+  if (
+    [SpecialEventType.GROUP_IDENTIFY, SpecialEventType.IDENTIFY, SpecialEventType.REVENUE].includes(
+      eventType as SpecialEventType,
+    )
+  ) {
+    return;
+  }
+
+  try {
+    const db = await openOrCreateDB(apiKey);
+
+    const tx = db.transaction<'eventTypesForSession', 'readwrite'>('eventTypesForSession', 'readwrite');
+    if (!tx) {
+      return;
+    }
+
+    // Update the list of events for the session
+    const updatedEventTypes = await updateEventListForSession({ sessionId, tx, loggerProvider, eventType });
+
+    // Clear out sessions older than 2 days
+    await deleteOldSessionEventTypes({ currentSessionId: sessionId, tx, loggerProvider });
+
+    await tx.done;
+
+    return updatedEventTypes;
+  } catch (e) {
+    loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
+  }
+  return undefined;
+};

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -1,4 +1,5 @@
 import { EvaluationEngine } from '@amplitude/experiment-core';
+import { storeEventTypeForSession } from './targeting-idb-store';
 import { Targeting as AmplitudeTargeting, TargetingParameters } from './typings/targeting';
 
 export class Targeting implements AmplitudeTargeting {
@@ -8,10 +9,27 @@ export class Targeting implements AmplitudeTargeting {
     this.evaluationEngine = new EvaluationEngine();
   }
 
-  evaluateTargeting = ({ event, sessionId, userProperties, deviceId, flag }: TargetingParameters) => {
+  evaluateTargeting = async ({
+    apiKey,
+    loggerProvider,
+    event,
+    sessionId,
+    userProperties,
+    deviceId,
+    flag,
+  }: TargetingParameters) => {
+    const eventTypes =
+      event &&
+      (await storeEventTypeForSession({
+        loggerProvider: loggerProvider,
+        apiKey: apiKey,
+        sessionId,
+        eventType: event.event_type,
+      }));
     const context = {
       session_id: sessionId,
       event,
+      event_types: eventTypes && Array.from(eventTypes),
       user: {
         device_id: deviceId,
         user_properties: userProperties,

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -26,10 +26,13 @@ export class Targeting implements AmplitudeTargeting {
         sessionId,
         eventType: event.event_type,
       }));
+
+    const eventStrings = eventTypes && new Set(eventTypes.map((eventTypeObj) => eventTypeObj.event_type));
+
     const context = {
       session_id: sessionId,
       event,
-      event_types: eventTypes && Array.from(eventTypes),
+      event_types: eventStrings && Array.from(eventStrings),
       user: {
         device_id: deviceId,
         user_properties: userProperties,

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -1,5 +1,5 @@
 import { EvaluationEngine } from '@amplitude/experiment-core';
-import { storeEventTypeForSession } from './targeting-idb-store';
+import { targetingIDBStore } from './targeting-idb-store';
 import { Targeting as AmplitudeTargeting, TargetingParameters } from './typings/targeting';
 
 export class Targeting implements AmplitudeTargeting {
@@ -19,15 +19,17 @@ export class Targeting implements AmplitudeTargeting {
     flag,
   }: TargetingParameters) => {
     const eventTypes =
-      event &&
-      (await storeEventTypeForSession({
-        loggerProvider: loggerProvider,
-        apiKey: apiKey,
-        sessionId,
-        eventType: event.event_type,
-      }));
+      event && event.time
+        ? await targetingIDBStore.storeEventTypeForSession({
+            loggerProvider: loggerProvider,
+            apiKey: apiKey,
+            sessionId,
+            eventType: event.event_type,
+            eventTime: event.time,
+          })
+        : undefined;
 
-    const eventStrings = eventTypes && new Set(eventTypes.map((eventTypeObj) => eventTypeObj.event_type));
+    const eventStrings = eventTypes && new Set(Object.keys(eventTypes));
 
     const context = {
       session_id: sessionId,

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -1,4 +1,4 @@
-import { Event } from '@amplitude/analytics-types';
+import { Event, Logger } from '@amplitude/analytics-types';
 import { EvaluationFlag, EvaluationVariant } from '@amplitude/experiment-core';
 
 export type TargetingFlag = EvaluationFlag;
@@ -8,8 +8,10 @@ export interface TargetingParameters {
   deviceId?: string;
   flag: EvaluationFlag;
   sessionId: number;
+  apiKey: string;
+  loggerProvider: Logger;
 }
 
 export interface Targeting {
-  evaluateTargeting: (args: TargetingParameters) => Record<string, EvaluationVariant>;
+  evaluateTargeting: (args: TargetingParameters) => Promise<Record<string, EvaluationVariant>>;
 }

--- a/packages/targeting/test/flag-config-data.ts
+++ b/packages/targeting/test/flag-config-data.ts
@@ -33,6 +33,33 @@ export const flagConfig = {
       ],
     },
     {
+      metadata: { segmentName: 'multiple event trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 19], // Selects 20% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event_types'],
+            op: 'set contains',
+            values: ['Add to Cart', 'Purchase'],
+          },
+        ],
+      ],
+    },
+    {
       metadata: { segmentName: 'user property' },
       bucket: {
         selector: ['context', 'session_id'],

--- a/packages/targeting/test/jest-setup.js
+++ b/packages/targeting/test/jest-setup.js
@@ -1,0 +1,8 @@
+require('fake-indexeddb/auto');
+const { IDBFactory } = require('fake-indexeddb');
+const structuredClone = require('@ungap/structured-clone');
+
+global.structuredClone = structuredClone.default;
+global.beforeEach(() => {
+  global.indexedDB = new IDBFactory();
+});

--- a/packages/targeting/test/targeting-idb-store.test.ts
+++ b/packages/targeting/test/targeting-idb-store.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Logger } from '@amplitude/analytics-types';
+import { IDBPDatabase } from 'idb';
+import * as TargetingIDBStore from '../src/targeting-idb-store';
+import { TargetingDB } from '../src/targeting-idb-store';
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const mockLoggerProvider: MockedLogger = {
+  error: jest.fn(),
+  log: jest.fn(),
+  disable: jest.fn(),
+  enable: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('targeting idb store', () => {
+  describe('storeEventTypeForSession', () => {
+    test('should add event to stored event list', async () => {
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Purchase',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const db = await TargetingIDBStore.createStore('static_key_amp_targeting');
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        { eventTypes: [{ event_type: 'Add to Cart' }, { event_type: 'Purchase' }], sessionId: 123 },
+      ]);
+    });
+
+    test('should return updated list', async () => {
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const updatedList = await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Purchase',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(updatedList).toEqual([{ event_type: 'Add to Cart' }, { event_type: 'Purchase' }]);
+    });
+
+    test('should handle errors', async () => {
+      jest.spyOn(TargetingIDBStore, 'updateEventListForSession').mockRejectedValueOnce('error');
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    });
+
+    test('should handle errors on updating event list', async () => {
+      const mockDB: IDBPDatabase<TargetingDB> = {
+        transaction: jest.fn().mockImplementation(() => {
+          return {
+            store: {
+              put: jest.fn().mockImplementation(() => Promise.reject('put error')),
+            },
+          };
+        }),
+      } as unknown as IDBPDatabase<TargetingDB>;
+      jest.spyOn(TargetingIDBStore, 'createStore').mockResolvedValue(mockDB);
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    });
+
+    test('should handle undefinted transaction', async () => {
+      const mockDB: IDBPDatabase<TargetingDB> = {
+        transaction: jest.fn().mockImplementation(() => undefined),
+      } as unknown as IDBPDatabase<TargetingDB>;
+      jest.spyOn(TargetingIDBStore, 'createStore').mockResolvedValue(mockDB);
+      const updatedEventTypes = await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(updatedEventTypes).toBeUndefined();
+    });
+
+    test('should delete old sessions', async () => {
+      // Set current time to 08:30
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      // Insert older session
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Add to Cart',
+        sessionId: new Date('2023-07-25 08:30:00').getTime(),
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const db = await TargetingIDBStore.createStore('static_key_amp_targeting');
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        { eventTypes: [{ event_type: 'Add to Cart' }], sessionId: new Date('2023-07-25 08:30:00').getTime() },
+      ]);
+      await TargetingIDBStore.storeEventTypeForSession({
+        eventType: 'Purchase',
+        sessionId: new Date('2023-07-31 07:30:00').getTime(),
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntriesUpdated = await db.getAll('eventTypesForSession');
+      expect(allEntriesUpdated).toEqual([
+        { eventTypes: [{ event_type: 'Purchase' }], sessionId: new Date('2023-07-31 07:30:00').getTime() },
+      ]);
+    });
+  });
+});

--- a/packages/targeting/test/targeting-idb-store.test.ts
+++ b/packages/targeting/test/targeting-idb-store.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from '@amplitude/analytics-types';
 import { IDBPDatabase } from 'idb';
-import * as TargetingIDBStore from '../src/targeting-idb-store';
-import { TargetingDB } from '../src/targeting-idb-store';
+import { TargetingDB, targetingIDBStore } from '../src/targeting-idb-store';
 
 type MockedLogger = jest.Mocked<Logger>;
 
@@ -16,46 +15,116 @@ const mockLoggerProvider: MockedLogger = {
 };
 
 describe('targeting idb store', () => {
+  let db: IDBPDatabase<TargetingDB>;
+  beforeEach(async () => {
+    db = await targetingIDBStore.openOrCreateDB('static_key');
+    await db.clear('eventTypesForSession');
+  });
   describe('storeEventTypeForSession', () => {
     test('should add event to stored event list', async () => {
-      await TargetingIDBStore.storeEventTypeForSession({
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Add to Cart',
         sessionId: 123,
         apiKey: 'static_key',
         loggerProvider: mockLoggerProvider,
       });
-      await TargetingIDBStore.storeEventTypeForSession({
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Purchase',
         sessionId: 123,
         apiKey: 'static_key',
         loggerProvider: mockLoggerProvider,
       });
-      const db = await TargetingIDBStore.createStore('static_key_amp_targeting');
       const allEntries = await db.getAll('eventTypesForSession');
       expect(allEntries).toEqual([
-        { eventTypes: [{ event_type: 'Add to Cart' }, { event_type: 'Purchase' }], sessionId: 123 },
+        {
+          eventTypes: {
+            'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+            Purchase: { 123: { event_type: 'Purchase' } },
+          },
+          sessionId: 123,
+        },
+      ]);
+    });
+
+    test('should handle adding the same event twice correctly', async () => {
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        {
+          eventTypes: {
+            'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+          },
+          sessionId: 123,
+        },
+      ]);
+    });
+
+    test('should add the same event with different timestamps', async () => {
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 456,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        {
+          eventTypes: {
+            'Add to Cart': { 123: { event_type: 'Add to Cart' }, 456: { event_type: 'Add to Cart' } },
+          },
+          sessionId: 123,
+        },
       ]);
     });
 
     test('should return updated list', async () => {
-      await TargetingIDBStore.storeEventTypeForSession({
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Add to Cart',
         sessionId: 123,
         apiKey: 'static_key',
         loggerProvider: mockLoggerProvider,
       });
-      const updatedList = await TargetingIDBStore.storeEventTypeForSession({
+      const updatedList = await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Purchase',
         sessionId: 123,
         apiKey: 'static_key',
         loggerProvider: mockLoggerProvider,
       });
-      expect(updatedList).toEqual([{ event_type: 'Add to Cart' }, { event_type: 'Purchase' }]);
+      expect(updatedList).toEqual({
+        'Add to Cart': { '123': { event_type: 'Add to Cart' } },
+        Purchase: { '123': { event_type: 'Purchase' } },
+      });
     });
 
     test('should handle errors', async () => {
-      jest.spyOn(TargetingIDBStore, 'updateEventListForSession').mockRejectedValueOnce('error');
-      await TargetingIDBStore.storeEventTypeForSession({
+      jest.spyOn(targetingIDBStore, 'updateEventListForSession').mockRejectedValueOnce('error');
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Add to Cart',
         sessionId: 123,
         apiKey: 'static_key',
@@ -74,8 +143,9 @@ describe('targeting idb store', () => {
           };
         }),
       } as unknown as IDBPDatabase<TargetingDB>;
-      jest.spyOn(TargetingIDBStore, 'createStore').mockResolvedValue(mockDB);
-      await TargetingIDBStore.storeEventTypeForSession({
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Add to Cart',
         sessionId: 123,
         apiKey: 'static_key',
@@ -84,12 +154,13 @@ describe('targeting idb store', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalled();
     });
 
-    test('should handle undefinted transaction', async () => {
+    test('should handle undefined transaction', async () => {
       const mockDB: IDBPDatabase<TargetingDB> = {
         transaction: jest.fn().mockImplementation(() => undefined),
       } as unknown as IDBPDatabase<TargetingDB>;
-      jest.spyOn(TargetingIDBStore, 'createStore').mockResolvedValue(mockDB);
-      const updatedEventTypes = await TargetingIDBStore.storeEventTypeForSession({
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+      const updatedEventTypes = await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Add to Cart',
         sessionId: 123,
         apiKey: 'static_key',
@@ -102,18 +173,22 @@ describe('targeting idb store', () => {
       // Set current time to 08:30
       jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
       // Insert older session
-      await TargetingIDBStore.storeEventTypeForSession({
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Add to Cart',
         sessionId: new Date('2023-07-25 08:30:00').getTime(),
         apiKey: 'static_key',
         loggerProvider: mockLoggerProvider,
       });
-      const db = await TargetingIDBStore.createStore('static_key_amp_targeting');
       const allEntries = await db.getAll('eventTypesForSession');
       expect(allEntries).toEqual([
-        { eventTypes: [{ event_type: 'Add to Cart' }], sessionId: new Date('2023-07-25 08:30:00').getTime() },
+        {
+          eventTypes: { 'Add to Cart': { 123: { event_type: 'Add to Cart' } } },
+          sessionId: new Date('2023-07-25 08:30:00').getTime(),
+        },
       ]);
-      await TargetingIDBStore.storeEventTypeForSession({
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
         eventType: 'Purchase',
         sessionId: new Date('2023-07-31 07:30:00').getTime(),
         apiKey: 'static_key',
@@ -121,7 +196,10 @@ describe('targeting idb store', () => {
       });
       const allEntriesUpdated = await db.getAll('eventTypesForSession');
       expect(allEntriesUpdated).toEqual([
-        { eventTypes: [{ event_type: 'Purchase' }], sessionId: new Date('2023-07-31 07:30:00').getTime() },
+        {
+          eventTypes: { Purchase: { 123: { event_type: 'Purchase' } } },
+          sessionId: new Date('2023-07-31 07:30:00').getTime(),
+        },
       ]);
     });
   });

--- a/packages/targeting/test/targeting.test.ts
+++ b/packages/targeting/test/targeting.test.ts
@@ -1,22 +1,63 @@
+import { Logger } from '@amplitude/analytics-types';
 import { Targeting } from '../src/targeting';
+import * as TargetingIDBStore from '../src/targeting-idb-store';
 import { flagConfig } from './flag-config-data';
 
+type MockedLogger = jest.Mocked<Logger>;
 const mockEvent = {
   event_type: 'sign_in',
 };
 const mockUserProperties = {};
 
+const mockLoggerProvider: MockedLogger = {
+  error: jest.fn(),
+  log: jest.fn(),
+  disable: jest.fn(),
+  enable: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
 describe('targeting', () => {
   describe('evaluateTargeting', () => {
-    test('should call evaluation engine evaluate', () => {
+    test('should call evaluation engine evaluate', async () => {
       const targeting = new Targeting();
       const mockEngineEvaluate = jest.fn();
       targeting.evaluationEngine.evaluate = mockEngineEvaluate;
-      targeting.evaluateTargeting({
+      await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: mockUserProperties,
+        flag: flagConfig,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockEngineEvaluate).toHaveBeenCalledWith(
+        {
+          user: {
+            device_id: '1a2b3c',
+            user_properties: mockUserProperties,
+          },
+          session_id: 123,
+          event_types: undefined,
+        },
+        [flagConfig],
+      );
+    });
+    test('should pass a list of event types to the evaluation engine evaluate', async () => {
+      jest
+        .spyOn(TargetingIDBStore, 'storeEventTypeForSession')
+        .mockResolvedValueOnce([{ event_type: 'Add to Cart' }, { event_type: 'Purchase' }]);
+      const targeting = new Targeting();
+      const mockEngineEvaluate = jest.fn();
+      targeting.evaluationEngine.evaluate = mockEngineEvaluate;
+      await targeting.evaluateTargeting({
         deviceId: '1a2b3c',
         event: mockEvent,
         userProperties: mockUserProperties,
         flag: flagConfig,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
       });
       expect(mockEngineEvaluate).toHaveBeenCalledWith(
         {
@@ -25,6 +66,8 @@ describe('targeting', () => {
             device_id: '1a2b3c',
             user_properties: mockUserProperties,
           },
+          session_id: 123,
+          event_types: ['Add to Cart', 'Purchase'],
         },
         [flagConfig],
       );

--- a/packages/targeting/test/targeting.test.ts
+++ b/packages/targeting/test/targeting.test.ts
@@ -1,11 +1,12 @@
 import { Logger } from '@amplitude/analytics-types';
 import { Targeting } from '../src/targeting';
-import * as TargetingIDBStore from '../src/targeting-idb-store';
+import { targetingIDBStore } from '../src/targeting-idb-store';
 import { flagConfig } from './flag-config-data';
 
 type MockedLogger = jest.Mocked<Logger>;
 const mockEvent = {
   event_type: 'sign_in',
+  time: 123,
 };
 const mockUserProperties = {};
 
@@ -44,9 +45,10 @@ describe('targeting', () => {
       );
     });
     test('should pass a list of event types to the evaluation engine evaluate', async () => {
-      jest
-        .spyOn(TargetingIDBStore, 'storeEventTypeForSession')
-        .mockResolvedValueOnce([{ event_type: 'Add to Cart' }, { event_type: 'Purchase' }]);
+      jest.spyOn(targetingIDBStore, 'storeEventTypeForSession').mockResolvedValueOnce({
+        'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+        Purchase: { 123: { event_type: 'Purchase' } },
+      });
       const targeting = new Targeting();
       const mockEngineEvaluate = jest.fn();
       targeting.evaluationEngine.evaluate = mockEngineEvaluate;


### PR DESCRIPTION
### Summary

This PR adds support for targeting via single or multiple event conditions. A new method is exposed, evaluateTargetingAndRecord, which accepts an event as a parameter. That event is passed to the targeting package, which updates an internal IDB store of events for the current session. The single event and the list of stored events are passed to the evaluation package to be compared against the targeting flag config.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
