### PR TITLE
feat(analytics-browser): integrate autocapture plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
       - v1.x
   pull_request:
     types: [opened, synchronize]
-    branches:
-      - main
-      - v1.x
 
 jobs:
   build:

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -26,10 +26,11 @@ import {
   TransportType,
   OfflineDisabled,
   Result,
+  AutocaptureOptions,
 } from '@amplitude/analytics-types';
 import { convertProxyObjectToRealObject, isInstanceProxy } from './utils/snippet-helper';
 import { Context } from './plugins/context';
-import { useBrowserConfig, createTransport } from './config';
+import { useBrowserConfig, createTransport, isAutocaptureEnabled } from './config';
 import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
 import { formInteractionTracking } from './plugins/form-interaction-tracking';
 import { fileDownloadTracking } from './plugins/file-download-tracking';
@@ -37,6 +38,7 @@ import { DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT } from './consta
 import { detNotify } from './det-notification';
 import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity-checker';
 import { createBrowserJoinedConfigGenerator } from './config/joined-config';
+import { autocapturePlugin } from '@amplitude/plugin-autocapture-browser';
 
 export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -133,6 +135,12 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
     if (isPageViewTrackingEnabled(this.config.defaultTracking)) {
       this.config.loggerProvider.debug('Adding page view tracking plugin');
       await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;
+    }
+
+    if (isAutocaptureEnabled(this.config.autocapture)) {
+      const autocaptureOptions: undefined | AutocaptureOptions =
+        typeof this.config.autocapture === 'boolean' ? undefined : this.config.autocapture;
+      await this.add(autocapturePlugin(autocaptureOptions)).promise;
     }
 
     this.initializing = false;

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -14,6 +14,7 @@ import {
   IdentityStorageType,
   ServerZoneType,
   OfflineDisabled,
+  AutocaptureOptions,
 } from '@amplitude/analytics-types';
 import { Config, Logger, MemoryStorage, UUID } from '@amplitude/analytics-core';
 import { CookieStorage, getCookieName, FetchTransport, getQueryParams } from '@amplitude/analytics-client-common';
@@ -50,6 +51,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
       upgrade: true,
     },
     public defaultTracking?: boolean | DefaultTrackingOptions,
+    public autocapture?: boolean | AutocaptureOptions,
     deviceId?: string,
     public flushIntervalMillis: number = 1000,
     public flushMaxRetries: number = 5,
@@ -258,6 +260,7 @@ export const useBrowserConfig = async (
     cookieStorage,
     cookieOptions,
     options.defaultTracking,
+    options.autocapture,
     deviceId,
     options.flushIntervalMillis,
     options.flushMaxRetries,
@@ -347,4 +350,9 @@ export const getTopLevelDomain = async (url?: string) => {
   }
 
   return '';
+};
+
+export const isAutocaptureEnabled = (autocapture?: AutocaptureOptions | boolean): boolean => {
+  // Disable autocapture plugin only when false
+  return autocapture !== false;
 };

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -31,6 +31,9 @@ export class BrowserJoinedConfigGenerator {
     if (remoteConfig && remoteConfig.defaultTracking) {
       this.config.defaultTracking = remoteConfig.defaultTracking;
     }
+    if (remoteConfig && remoteConfig.autocapture) {
+      this.config.autocapture = remoteConfig.autocapture;
+    }
     this.config.loggerProvider.debug('Joined configuration: ', JSON.stringify(remoteConfig, null, 2));
     this.config.requestMetadata ??= new RequestMetadata();
     this.config.requestMetadata.recordHistogram('remote_config_fetch_time', this.remoteConfigFetch?.fetchTime);

--- a/packages/analytics-browser/src/config/types.ts
+++ b/packages/analytics-browser/src/config/types.ts
@@ -1,9 +1,8 @@
-import { DefaultTrackingOptions } from '@amplitude/analytics-types';
-import { AutocaptureOptions } from '@amplitude/plugin-autocapture-browser';
+import { DefaultTrackingOptions, AutocaptureOptions } from '@amplitude/analytics-types';
 
 export type BrowserRemoteConfig = {
   browserSDK: {
-    autoCapture?: AutocaptureOptions;
-    defaultTracking?: DefaultTrackingOptions;
+    autocapture?: AutocaptureOptions | boolean;
+    defaultTracking?: DefaultTrackingOptions | boolean;
   };
 };

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -9,6 +9,7 @@ import { WebAttribution } from '@amplitude/analytics-client-common/src';
 import * as core from '@amplitude/analytics-core';
 import { LogLevel, OfflineDisabled, UserSession } from '@amplitude/analytics-types';
 import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
+import * as autocapture from '@amplitude/plugin-autocapture-browser';
 import { AmplitudeBrowser } from '../src/browser-client';
 import * as Config from '../src/config';
 import * as CookieMigration from '../src/cookie-migration';
@@ -289,6 +290,25 @@ describe('browser-client', () => {
         },
       }).promise;
       expect(pageViewTrackingPlugin).toHaveBeenCalledTimes(0);
+    });
+
+    test.each([
+      undefined, // default
+      true, // enabled
+    ])('should add autocapture plugin', async (option) => {
+      const autocapturePlugin = jest.spyOn(autocapture, 'autocapturePlugin');
+      await client.init(apiKey, userId, {
+        autocapture: option,
+      }).promise;
+      expect(autocapturePlugin).toHaveBeenCalledTimes(1);
+    });
+
+    test('should NOT add autocapture plugin when autocapture is disabled', async () => {
+      const autocapturePlugin = jest.spyOn(autocapture, 'autocapturePlugin');
+      await client.init(apiKey, userId, {
+        autocapture: false,
+      }).promise;
+      expect(autocapturePlugin).toHaveBeenCalledTimes(0);
     });
 
     test('should listen for network change to online', async () => {

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -16,11 +16,12 @@ describe('joined-config', () => {
   const fetchTime = 100;
 
   beforeEach(() => {
-    localConfig = { ...createConfigurationMock(), defaultTracking: false };
+    localConfig = { ...createConfigurationMock(), defaultTracking: false, autocapture: false };
 
     mockRemoteConfigFetch = {
       getRemoteConfig: jest.fn().mockResolvedValue({
         defaultTracking: true,
+        autocapture: true,
       }),
       fetchTime: fetchTime,
     };

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -23,7 +23,19 @@ export class Timeline {
   constructor(private client: CoreClient) {}
 
   async register(plugin: Plugin, config: Config) {
-    plugin.name = plugin.name ?? UUID();
+    if (this.plugins.some((existingPlugin) => existingPlugin.name === plugin.name)) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      config.loggerProvider.warn(`Plugin with name ${plugin.name} already exists, skipping registration`);
+      return;
+    }
+
+    if (plugin.name === undefined) {
+      plugin.name = UUID();
+      config.loggerProvider.warn(`Plugin name is undefined. 
+      Generating a random UUID for plugin name: ${plugin.name}. 
+      Set a name for the plugin to prevent it from being added multiple times.`);
+    }
+
     plugin.type = plugin.type ?? 'enrichment';
     await plugin.setup?.(config, this.client);
     this.plugins.push(plugin);

--- a/packages/analytics-core/tsconfig.json
+++ b/packages/analytics-core/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noEmit": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "lib": ["dom", "es6"],
   }
 }

--- a/packages/analytics-types/src/autocapture.ts
+++ b/packages/analytics-types/src/autocapture.ts
@@ -2,6 +2,31 @@ import { Logger } from './logger';
 
 export type ActionType = 'click' | 'change';
 
+/**
+ * Default CSS selectors to define which elements on the page to track.
+ * Extend this list to include additional elements to track. For example:
+ * ```
+ * autocapturePlugin({
+ *    cssSelectorAllowlist: [...DEFAULT_CSS_SELECTOR_ALLOWLIST, ".my-class"],
+ * })
+ * ```
+ */
+export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
+  'a',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'label',
+  '[data-amp-default-track]',
+  '.amp-default-track',
+];
+
+/**
+ * Default prefix to allo the plugin to capture data attributes as an event property.
+ */
+export const DEFAULT_DATA_ATTRIBUTE_PREFIX = 'data-amp-track-';
+
 export interface AutocaptureOptions {
   /**
    * List of CSS selectors to allow auto tracking on.

--- a/packages/analytics-types/src/autocapture.ts
+++ b/packages/analytics-types/src/autocapture.ts
@@ -1,0 +1,53 @@
+import { Logger } from './logger';
+
+export type ActionType = 'click' | 'change';
+
+export interface AutocaptureOptions {
+  /**
+   * List of CSS selectors to allow auto tracking on.
+   * When provided, allow elements matching any selector to be tracked.
+   * Default is ['a', 'button', 'input', 'select', 'textarea', 'label', '[data-amp-default-track]', '.amp-default-track'].
+   */
+  cssSelectorAllowlist?: string[];
+
+  /**
+   * List of page URLs to allow auto tracking on.
+   * When provided, only allow tracking on these URLs.
+   * Both full URLs and regex are supported.
+   */
+  pageUrlAllowlist?: (string | RegExp)[];
+
+  /**
+   * Function to determine whether an event should be tracked.
+   * When provided, this function overwrites all other allowlists and configurations.
+   * If the function returns true, the event will be tracked.
+   * If the function returns false, the event will not be tracked.
+   * @param actionType - The type of action that triggered the event.
+   * @param element - The [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) that triggered the event.
+   */
+  shouldTrackEventResolver?: (actionType: ActionType, element: Element) => boolean;
+
+  /**
+   * Prefix for data attributes to allow auto collecting.
+   * Default is 'data-amp-track-'.
+   */
+  dataAttributePrefix?: string;
+
+  /**
+   * Options for integrating visual tagging selector.
+   */
+  visualTaggingOptions?: {
+    enabled?: boolean;
+    messenger?: Messenger;
+  };
+}
+
+export interface Messenger {
+  logger?: Logger;
+  setup: () => void;
+}
+
+interface Element {
+  id: string;
+  className: string;
+}

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -3,6 +3,7 @@ import { IdentityStorageType, Storage } from '../storage';
 import { Transport } from '../transport';
 import { Config } from './core';
 import { PageTrackingOptions } from '../page-view-tracking';
+import { AutocaptureOptions } from '../autocapture';
 
 export interface BrowserConfig extends ExternalBrowserConfig, InternalBrowserConfig {}
 
@@ -18,6 +19,12 @@ export interface ExternalBrowserConfig extends Config {
    * @defaultValue `true`
    */
   defaultTracking?: boolean | DefaultTrackingOptions;
+  /**
+   * The configurations for autocapture plugin.
+   * See {@link https://www.docs.developers.amplitude.com/data/sdks/browser-2/autocapture/}.
+   * @defaultValue `true`
+   */
+  autocapture?: boolean | AutocaptureOptions;
   /**
    * The identifier for the device running your application.
    * @defaultValue `UUID()`

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -63,4 +63,10 @@ export { UserSession } from './user-session';
 export { UTMData } from './utm';
 export { PageTrackingOptions, PageTrackingTrackOn, PageTrackingHistoryChanges } from './page-view-tracking';
 export { OfflineDisabled } from './offline';
-export { Messenger, AutocaptureOptions, ActionType } from './autocapture';
+export {
+  Messenger,
+  AutocaptureOptions,
+  ActionType,
+  DEFAULT_CSS_SELECTOR_ALLOWLIST,
+  DEFAULT_DATA_ATTRIBUTE_PREFIX,
+} from './autocapture';

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -63,3 +63,4 @@ export { UserSession } from './user-session';
 export { UTMData } from './utm';
 export { PageTrackingOptions, PageTrackingTrackOn, PageTrackingHistoryChanges } from './page-view-tracking';
 export { OfflineDisabled } from './offline';
+export { Messenger, AutocaptureOptions, ActionType } from './autocapture';

--- a/packages/analytics-types/tsconfig.json
+++ b/packages/analytics-types/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": ".",
     "noEmit": true,
     "rootDir": ".",
-    "types": []
+    "types": [],
+    "lib": ["dom", "es6"],
   }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Add `config.autocapture` and install the autocapture plugin if `config.autocapture` is not `false`. 
- Copy `AutocaptureOptions` from `@amplitude/plugin-autocapture-browser` to export them from `@amplitude/analytics-types` so that it can be used in the `BrowserConfig` interface without circular reference
  - Will update `@amplitude/plugin-autocapture-browser`  to use `AutocaptureOptions` in `@amplitude/analytics-types` later in [AMP-102833]
- Timeline will NOT install a new plugin if it's name is the same as one of the existing plugins. 

Note:
Add `lib: dom, es6` to `tsconfig.json` of `analytics-types` and `analytics-core` for `Element` and `RegExp` in `AutocaptureOptions`. It will not affect existing customers using the packages. They don't need to add it to their `tsconfig.json`. And it will only throw compilation error if `Element` and `RegExp` is explicitly used in an unsupported environment. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-102833]: https://amplitude.atlassian.net/browse/AMP-102833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ