### PR TITLE
feat(autocapture-browser): Adding async request/response pattern to Autocapture messenger

### DIFF
--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -223,6 +223,7 @@ export const asyncLoadScript = (url: string) => {
   });
 };
 
-export function generateUniqueId() {
-  return Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+export function generateUniqueId(): string {
+  //write below with template literal
+  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -224,6 +224,5 @@ export const asyncLoadScript = (url: string) => {
 };
 
 export function generateUniqueId(): string {
-  //write below with template literal
   return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -222,3 +222,7 @@ export const asyncLoadScript = (url: string) => {
     }
   });
 };
+
+export function generateUniqueId() {
+  return Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+}

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -169,7 +169,7 @@ export class WindowMessenger implements Messenger {
         return;
       }
 
-      // If id exists, andle responses to previous requests
+      // If id exists, handle responses to previous requests
       if ('id' in eventData) {
         this.logger?.debug?.('Received Response to previous request: ', JSON.stringify(event));
         this.handleResponse(eventData);

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -97,7 +97,7 @@ export class WindowMessenger implements Messenger {
   }
 
   // Send an async request to the parent window
-  public sendRequest(action, args, options = { timeout: 15_000 }): Promise<any> {
+  public sendRequest(action: string, args: Record<string, any>, options = { timeout: 15_000 }): Promise<any> {
     // Create Request ID
     const id = generateUniqueId();
     const request = {

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -191,6 +191,7 @@ export class WindowMessenger implements Messenger {
                   }
                   return true;
                 },
+                onSelect: this.onSelect,
                 onTrack: this.onTrack,
                 visualHighlightClass: AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
                 messenger: this,
@@ -210,6 +211,10 @@ export class WindowMessenger implements Messenger {
     // Notify the parent window that the page has loaded
     this.notify({ action: 'page-loaded' });
   }
+
+  private onSelect = (data: ElementSelectedData) => {
+    this.notify({ action: 'element-selected', data });
+  };
 
   private onTrack = (type: string, properties: { [key: string]: string | null }) => {
     if (type === 'selector-mode-changed') {

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -13,6 +13,7 @@ import {
   getClosestElement,
   getEventTagProps,
   asyncLoadScript,
+  generateUniqueId,
 } from '../src/helpers';
 import { mockWindowLocationFromURL } from './utils';
 import { Logger } from '@amplitude/analytics-types';
@@ -559,6 +560,19 @@ describe('autocapture-plugin helpers', () => {
       expect(document.getElementsByTagName('script')[0].src).toEqual('https://test-url.amplitude/');
 
       script.dispatchEvent(new Event('error'));
+    });
+  });
+
+  describe('generateUniqueId', () => {
+    test('should return a unique id', () => {
+      const id1 = generateUniqueId();
+      const id2 = generateUniqueId();
+      expect(id1).not.toEqual(id2);
+
+      // Test random characters in second part of the id
+      const randomChar1 = id1.split('-')[1];
+      const randomChar2 = id2.split('-')[1];
+      expect(randomChar1).not.toEqual(randomChar2);
     });
   });
 });


### PR DESCRIPTION
### Summary

Use unique IDs and a callback map to allow clients to use a request/response pattern for communication to the opener window
