### PR TITLE
fix(analytics-browser): should catch error from getRemoteConfig

### DIFF
--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -42,7 +42,7 @@ export class BrowserJoinedConfigGenerator {
     } catch (e) {
       this.config.loggerProvider.error('Failed to fetch remote configuration because of error: ', e);
     }
-    
+
     return this.config;
   }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-102552]
Catch the error returned by `remoteConfigFetch.getRemoteConfig()` at https://github.com/amplitude/Amplitude-TypeScript/blob/0525097f4002f44349fc01c4a17486bf0ef5fbae/packages/analytics-remote-config/src/remote-config.ts#L163

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-102552]: https://amplitude.atlassian.net/browse/AMP-102552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ