### PR TITLE
fix(analytics-client-common): adding ampIntegrationsContext to getGlobalScope

### DIFF
--- a/packages/analytics-client-common/src/global-scope.ts
+++ b/packages/analytics-client-common/src/global-scope.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-restricted-globals */
 /* Only file allowed to access to globalThis, window, self */
 
-import { ampIntegrationContext } from './types/global';
-
 export const getGlobalScope = (): typeof globalThis | undefined => {
-  if (typeof ampIntegrationContext !== 'undefined') {
-    return ampIntegrationContext;
+  // This should only be used for integrations with Amplitude that are not running in a browser environment
+  //   We need to specify the name of the global variable as a string to prevent it from being minified
+  const ampIntegrationContextName = 'ampIntegrationContext' as keyof typeof globalThis;
+  if (typeof globalThis[ampIntegrationContextName] !== 'undefined') {
+    return globalThis[ampIntegrationContextName] as typeof globalThis;
   }
   if (typeof globalThis !== 'undefined') {
     return globalThis;

--- a/packages/analytics-client-common/src/global-scope.ts
+++ b/packages/analytics-client-common/src/global-scope.ts
@@ -2,6 +2,9 @@
 /* Only file allowed to access to globalThis, window, self */
 
 export const getGlobalScope = (): typeof globalThis | undefined => {
+  if (typeof ampIntegrationContext !== 'undefined') {
+    return ampIntegrationContext;
+  }
   if (typeof globalThis !== 'undefined') {
     return globalThis;
   }

--- a/packages/analytics-client-common/src/global-scope.ts
+++ b/packages/analytics-client-common/src/global-scope.ts
@@ -5,7 +5,7 @@ export const getGlobalScope = (): typeof globalThis | undefined => {
   // This should only be used for integrations with Amplitude that are not running in a browser environment
   //   We need to specify the name of the global variable as a string to prevent it from being minified
   const ampIntegrationContextName = 'ampIntegrationContext' as keyof typeof globalThis;
-  if (typeof globalThis[ampIntegrationContextName] !== 'undefined') {
+  if (typeof globalThis !== 'undefined' && typeof globalThis[ampIntegrationContextName] !== 'undefined') {
     return globalThis[ampIntegrationContextName] as typeof globalThis;
   }
   if (typeof globalThis !== 'undefined') {

--- a/packages/analytics-client-common/src/global-scope.ts
+++ b/packages/analytics-client-common/src/global-scope.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-restricted-globals */
 /* Only file allowed to access to globalThis, window, self */
 
+import { ampIntegrationContext } from './types/global';
+
 export const getGlobalScope = (): typeof globalThis | undefined => {
   if (typeof ampIntegrationContext !== 'undefined') {
     return ampIntegrationContext;

--- a/packages/analytics-client-common/src/types/global.d.ts
+++ b/packages/analytics-client-common/src/types/global.d.ts
@@ -1,2 +1,0 @@
-/* eslint-disable no-restricted-globals */
-declare let ampIntegrationContext: typeof globalThis;

--- a/packages/analytics-client-common/src/types/global.d.ts
+++ b/packages/analytics-client-common/src/types/global.d.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-globals */
+declare let ampIntegrationContext: typeof globalThis;

--- a/packages/analytics-client-common/src/types/global.ts
+++ b/packages/analytics-client-common/src/types/global.ts
@@ -1,0 +1,3 @@
+/* eslint-disable no-restricted-globals */
+// eslint-disable-next-line no-var
+export var ampIntegrationContext: typeof globalThis;

--- a/packages/analytics-client-common/test/global-scope.test.ts
+++ b/packages/analytics-client-common/test/global-scope.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { getGlobalScope } from '../src/global-scope';
+
+describe('getGlobalScope', () => {
+  let originalGlobalThis: any;
+
+  beforeEach(() => {
+    originalGlobalThis = globalThis;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    globalThis = originalGlobalThis;
+    delete (globalThis as any).ampIntegrationContext;
+  });
+
+  test('returns ampIntegrationContext if it exists', () => {
+    (globalThis as any).ampIntegrationContext = { someKey: 'someValue' };
+    expect(getGlobalScope()).toBe((globalThis as any).ampIntegrationContext);
+  });
+
+  test('returns globalThis if ampIntegrationContext does not exist', () => {
+    const scope = getGlobalScope();
+    // Need to use Object.is because expect(scope).toBe(globalThis) will throw an error
+    expect(Object.is(scope, globalThis)).toBeTruthy();
+  });
+
+  test('should return window if globalThis is undefined and window is defined', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    globalThis = undefined;
+
+    const scope = getGlobalScope();
+
+    // Note: We NEED to reassign globalThis to its original state because the jest expect function requires it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    globalThis = originalGlobalThis;
+    // Need to use Object.is because expect(scope).toBe(globalThis) will throw an error
+    expect(Object.is(scope, window)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Summary

Adding another option to get the getGlobalScope function to assist with our integration

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  NO
