### PR TITLE
fix(session-replay-browser): add scroll to click event

### DIFF
--- a/packages/session-replay-browser/src/hooks/click.ts
+++ b/packages/session-replay-browser/src/hooks/click.ts
@@ -1,5 +1,5 @@
 import { mouseInteractionCallBack, MouseInteractions } from '@amplitude/rrweb-types';
-import { record } from '@amplitude/rrweb';
+import { record, utils } from '@amplitude/rrweb';
 import { SessionReplayEventsManager as AmplitudeSessionReplayEventsManager } from '../typings/session-replay';
 import { PayloadBatcher } from 'src/track-destination';
 import { finder } from '@medv/finder';
@@ -81,9 +81,11 @@ export const clickHook: (options: Options) => mouseInteractionCallBack =
       selector = finder(node as Element);
     }
 
+    const { left: scrollX, top: scrollY } = utils.getWindowScroll(globalScope as unknown as Window);
+
     const event: ClickEvent = {
-      x,
-      y,
+      x: x + scrollX,
+      y: y + scrollY,
       selector,
 
       viewportHeight: innerHeight,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds scroll to click events, using RRweb's window scroll method.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
