### PR TITLE
fix(analytics-browser): handle double URL encoded cookie values for R…

### DIFF
--- a/packages/analytics-client-common/src/storage/cookie.ts
+++ b/packages/analytics-client-common/src/storage/cookie.ts
@@ -36,7 +36,7 @@ export class CookieStorage<T> implements Storage<T> {
       return undefined;
     }
     try {
-      const decodedValue = decodeCookiesAsDefault(value) ?? decodeCookiesForRuby(value);
+      const decodedValue = decodeCookiesAsDefault(value) ?? decodeCookiesWithDoubleUrlEncoding(value);
       if (decodedValue === undefined) {
         console.error(`Amplitude Logger [Error]: Failed to decode cookie value for key: ${key}, value: ${value}`);
         return undefined;
@@ -110,7 +110,7 @@ const decodeCookiesAsDefault = (value: string): string | undefined => {
   }
 };
 
-const decodeCookiesForRuby = (value: string): string | undefined => {
+const decodeCookiesWithDoubleUrlEncoding = (value: string): string | undefined => {
   // Modern Ruby (v7+) automatically encodes cookies with URL encoding by
   // https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html
   try {

--- a/packages/analytics-client-common/test/storage/cookies.test.ts
+++ b/packages/analytics-client-common/test/storage/cookies.test.ts
@@ -22,11 +22,28 @@ describe('cookies', () => {
       await cookies.remove('world');
     });
 
+    test('should handle double url encoded value for Ruby Rails', async () => {
+      const cookies = new CookieStorage();
+      const value = { a: 1 };
+      const cookieValue = encodeURIComponent(btoa(encodeURIComponent(JSON.stringify(value))));
+      document.cookie = `hello=${cookieValue}`;
+      expect(await cookies.get('hello')).toEqual(value);
+      await cookies.remove('world');
+    });
+
     test('should return cookie object value', async () => {
       const cookies = new CookieStorage<Record<string, number>>();
       await cookies.set('hello', { a: 1 });
       expect(await cookies.get('hello')).toEqual({ a: 1 });
       await cookies.remove('hello');
+    });
+
+    test('should catch non-json format value', async () => {
+      const cookies = new CookieStorage();
+      const value = '{"a":1';
+      const encodedValue = btoa(encodeURIComponent(value));
+      document.cookie = `hello=${encodedValue}`;
+      expect(await cookies.get('hello')).toBe(undefined);
     });
 
     test('should return cookie array value', async () => {


### PR DESCRIPTION
…uby Rails

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-101996]

Make up https://github.com/amplitude/Amplitude-TypeScript/pull/686.

This PR supports getting cookie values which are encoded by the following order: URL encoding, base64, URL encoding for Ruby on Rails. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-101996]: https://amplitude.atlassian.net/browse/AMP-101996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ