### PR TITLE
fix(session-replay-browser): remove @medv/finder as a dependency

### DIFF
--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -17,11 +17,10 @@
     "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
   },
   "scripts": {
-    "build": "yarn build:fix-finder && yarn bundle && yarn build:es5 && yarn build:esm",
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
     "bundle": "rollup --config rollup.config.js",
     "build:es5": "tsc -p ./tsconfig.es5.json",
     "build:esm": "tsc -p ./tsconfig.esm.json",
-    "build:fix-finder": "rimraf ../../node_modules/@medv/finder/finder.ts # This is required until the package is fixed upstream",
     "clean": "rimraf node_modules lib coverage",
     "fix": "yarn fix:eslint & yarn fix:prettier",
     "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
@@ -44,7 +43,6 @@
     "@amplitude/analytics-remote-config": "^0.3.0",
     "@amplitude/analytics-types": ">=1 <3",
     "@amplitude/rrweb": "^2.0.0-alpha.14",
-    "@medv/finder": "^3.2.0",
     "idb": "^8.0.0",
     "tslib": "^2.4.1"
   },

--- a/packages/session-replay-browser/src/hooks/click.ts
+++ b/packages/session-replay-browser/src/hooks/click.ts
@@ -2,7 +2,7 @@ import { mouseInteractionCallBack, MouseInteractions } from '@amplitude/rrweb-ty
 import { record, utils } from '@amplitude/rrweb';
 import { SessionReplayEventsManager as AmplitudeSessionReplayEventsManager } from '../typings/session-replay';
 import { PayloadBatcher } from 'src/track-destination';
-import { finder } from '@medv/finder';
+import { finder } from '../libs/finder';
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 
 // exported for testing

--- a/packages/session-replay-browser/src/libs/finder.ts
+++ b/packages/session-replay-browser/src/libs/finder.ts
@@ -1,0 +1,336 @@
+/* istanbul ignore file */
+
+// DO NOT EDIT (unless you know what you're doing)
+// Taken directly from git@github.com:antonmedv/finder.git@77d33158440dfffee4a300d2975b43a5283004ab
+
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable prefer-const */
+
+// License: MIT
+// Author: Anton Medvedev <anton@medv.io>
+// Source: https://github.com/antonmedv/finder
+
+type Knot = {
+  name: string;
+  penalty: number;
+  level?: number;
+};
+
+type Path = Knot[];
+
+export type Options = {
+  root: Element;
+  idName: (name: string) => boolean;
+  className: (name: string) => boolean;
+  tagName: (name: string) => boolean;
+  attr: (name: string, value: string) => boolean;
+  seedMinLength: number;
+  optimizedMinLength: number;
+  threshold: number;
+  maxNumberOfTries: number;
+  timeoutMs: number | undefined;
+};
+
+let config: Options;
+let rootDocument: Document | Element;
+let start: Date;
+
+export function finder(input: Element, options?: Partial<Options>): string {
+  start = new Date();
+  if (input.nodeType !== Node.ELEMENT_NODE) {
+    throw new Error(`Can't generate CSS selector for non-element node type.`);
+  }
+  if ('html' === input.tagName.toLowerCase()) {
+    return 'html';
+  }
+  const defaults: Options = {
+    root: document.body,
+    idName: (_name: string) => true,
+    className: (_name: string) => true,
+    tagName: (_name: string) => true,
+    attr: (_name: string, _value: string) => false,
+    seedMinLength: 1,
+    optimizedMinLength: 2,
+    threshold: 1000,
+    maxNumberOfTries: 10000,
+    timeoutMs: undefined,
+  };
+
+  config = { ...defaults, ...options };
+  rootDocument = findRootDocument(config.root, defaults);
+
+  let path = bottomUpSearch(input, 'all', () =>
+    bottomUpSearch(input, 'two', () => bottomUpSearch(input, 'one', () => bottomUpSearch(input, 'none'))),
+  );
+
+  if (path) {
+    const optimized = sort(optimize(path, input));
+    if (optimized.length > 0) {
+      path = optimized[0];
+    }
+    return selector(path);
+  } else {
+    throw new Error(`Selector was not found.`);
+  }
+}
+
+function findRootDocument(rootNode: Element | Document, defaults: Options) {
+  if (rootNode.nodeType === Node.DOCUMENT_NODE) {
+    return rootNode;
+  }
+  if (rootNode === defaults.root) {
+    return rootNode.ownerDocument as Document;
+  }
+  return rootNode;
+}
+
+function bottomUpSearch(
+  input: Element,
+  limit: 'all' | 'two' | 'one' | 'none',
+  fallback?: () => Path | null,
+): Path | null {
+  let path: Path | null = null;
+  let stack: Knot[][] = [];
+  let current: Element | null = input;
+  let i = 0;
+  while (current) {
+    const elapsedTime = new Date().getTime() - start.getTime();
+    if (config.timeoutMs !== undefined && elapsedTime > config.timeoutMs) {
+      throw new Error(`Timeout: Can't find a unique selector after ${elapsedTime}ms`);
+    }
+    let level: Knot[] = maybe(id(current)) ||
+      maybe(...attr(current)) ||
+      maybe(...classNames(current)) ||
+      maybe(tagName(current)) || [any()];
+    const nth = index(current);
+    if (limit == 'all') {
+      if (nth) {
+        level = level.concat(level.filter(dispensableNth).map((node) => nthChild(node, nth)));
+      }
+    } else if (limit == 'two') {
+      level = level.slice(0, 1);
+      if (nth) {
+        level = level.concat(level.filter(dispensableNth).map((node) => nthChild(node, nth)));
+      }
+    } else if (limit == 'one') {
+      const [node] = (level = level.slice(0, 1));
+      if (nth && dispensableNth(node)) {
+        level = [nthChild(node, nth)];
+      }
+    } else if (limit == 'none') {
+      level = [any()];
+      if (nth) {
+        level = [nthChild(level[0], nth)];
+      }
+    }
+    for (let node of level) {
+      node.level = i;
+    }
+    stack.push(level);
+    if (stack.length >= config.seedMinLength) {
+      path = findUniquePath(stack, fallback);
+      if (path) {
+        break;
+      }
+    }
+    current = current.parentElement;
+    i++;
+  }
+  if (!path) {
+    path = findUniquePath(stack, fallback);
+  }
+  if (!path && fallback) {
+    return fallback();
+  }
+  return path;
+}
+
+function findUniquePath(stack: Knot[][], fallback?: () => Path | null): Path | null {
+  const paths = sort(combinations(stack));
+  if (paths.length > config.threshold) {
+    return fallback ? fallback() : null;
+  }
+  for (let candidate of paths) {
+    if (unique(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function selector(path: Path): string {
+  let node = path[0];
+  let query = node.name;
+  for (let i = 1; i < path.length; i++) {
+    const level = path[i].level || 0;
+    if (node.level === level - 1) {
+      query = `${path[i].name} > ${query}`;
+    } else {
+      query = `${path[i].name} ${query}`;
+    }
+    node = path[i];
+  }
+  return query;
+}
+
+function penalty(path: Path): number {
+  return path.map((node) => node.penalty).reduce((acc, i) => acc + i, 0);
+}
+
+function unique(path: Path) {
+  const css = selector(path);
+  switch (rootDocument.querySelectorAll(css).length) {
+    case 0:
+      throw new Error(`Can't select any node with this selector: ${css}`);
+    case 1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function id(input: Element): Knot | null {
+  const elementId = input.getAttribute('id');
+  if (elementId && config.idName(elementId)) {
+    return {
+      name: '#' + CSS.escape(elementId),
+      penalty: 0,
+    };
+  }
+  return null;
+}
+
+function attr(input: Element): Knot[] {
+  const attrs = Array.from(input.attributes).filter((attr) => config.attr(attr.name, attr.value));
+  return attrs.map(
+    (attr): Knot => ({
+      name: `[${CSS.escape(attr.name)}="${CSS.escape(attr.value)}"]`,
+      penalty: 0.5,
+    }),
+  );
+}
+
+function classNames(input: Element): Knot[] {
+  const names = Array.from(input.classList).filter(config.className);
+  return names.map(
+    (name): Knot => ({
+      name: '.' + CSS.escape(name),
+      penalty: 1,
+    }),
+  );
+}
+
+function tagName(input: Element): Knot | null {
+  const name = input.tagName.toLowerCase();
+  if (config.tagName(name)) {
+    return {
+      name,
+      penalty: 2,
+    };
+  }
+  return null;
+}
+
+function any(): Knot {
+  return {
+    name: '*',
+    penalty: 3,
+  };
+}
+
+function index(input: Element): number | null {
+  const parent = input.parentNode;
+  if (!parent) {
+    return null;
+  }
+  let child = parent.firstChild;
+  if (!child) {
+    return null;
+  }
+  let i = 0;
+  while (child) {
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      i++;
+    }
+    if (child === input) {
+      break;
+    }
+    child = child.nextSibling;
+  }
+  return i;
+}
+
+function nthChild(node: Knot, i: number): Knot {
+  return {
+    name: node.name + `:nth-child(${i})`,
+    penalty: node.penalty + 1,
+  };
+}
+
+function dispensableNth(node: Knot) {
+  return node.name !== 'html' && !node.name.startsWith('#');
+}
+
+function maybe(...level: (Knot | null)[]): Knot[] | null {
+  const list = level.filter(notEmpty);
+  if (list.length > 0) {
+    return list;
+  }
+  return null;
+}
+
+function notEmpty<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function* combinations(stack: Knot[][], path: Knot[] = []): Generator<Knot[]> {
+  if (stack.length > 0) {
+    for (let node of stack[0]) {
+      yield* combinations(stack.slice(1, stack.length), path.concat(node));
+    }
+  } else {
+    yield path;
+  }
+}
+
+function sort(paths: Iterable<Path>): Path[] {
+  return [...paths].sort((a, b) => penalty(a) - penalty(b));
+}
+
+type Scope = {
+  counter: number;
+  visited: Map<string, boolean>;
+};
+
+function* optimize(
+  path: Path,
+  input: Element,
+  scope: Scope = {
+    counter: 0,
+    visited: new Map<string, boolean>(),
+  },
+): Generator<Knot[]> {
+  if (path.length > 2 && path.length > config.optimizedMinLength) {
+    for (let i = 1; i < path.length - 1; i++) {
+      if (scope.counter > config.maxNumberOfTries) {
+        return; // Okay At least I tried!
+      }
+      scope.counter += 1;
+      const newPath = [...path];
+      newPath.splice(i, 1);
+      const newPathKey = selector(newPath);
+      if (scope.visited.has(newPathKey)) {
+        return;
+      }
+      if (unique(newPath) && same(newPath, input)) {
+        yield newPath;
+        scope.visited.set(newPathKey, true);
+        yield* optimize(newPath, input, scope);
+      }
+    }
+  }
+}
+
+function same(path: Path, input: Element) {
+  return rootDocument.querySelector(selector(path)) === input;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3624,11 +3624,6 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@medv/finder@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@medv/finder/-/finder-3.2.0.tgz#dffeb5b04d754ca4e575bbbee89b24935277908e"
-  integrity sha512-JmU7JIBwyL8RAzefvzALT4sP2M0biGk8i2invAgpQmma/QgfsaqoHIvJ7S0YC8n9hUVG8X3Leul2nGa06PvhbQ==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

`@medv/finder` is not packaged to dual support ESM and CJS. We could own this repo or try to make things work upstream, but it doesn't seem like it's worth the effort of "vendoring" the file. Our build process will appropriately create ESM and CJS versions.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
