### PR TITLE
fix(remote config): prevent extra fetches of remote config

### DIFF
--- a/packages/analytics-remote-config/src/remote-config-idb-store.ts
+++ b/packages/analytics-remote-config/src/remote-config-idb-store.ts
@@ -95,9 +95,20 @@ export const createRemoteConfigIDBStore = async <RemoteConfig extends { [key: st
     return undefined;
   };
 
+  const remoteConfigHasValues = async <K extends keyof RemoteConfig>(configNamespace: string): Promise<boolean> => {
+    try {
+      const config = (await remoteConfigDB.getAll(configNamespace)) as RemoteConfig[K][];
+      return !!config.length;
+    } catch (e) {
+      loggerProvider.warn(`Failed to fetch remote config: ${e as string}`);
+    }
+    return false;
+  };
+
   return {
     storeRemoteConfig,
     getRemoteConfig,
     getLastFetchedSessionId,
+    remoteConfigHasValues,
   };
 };

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -22,6 +22,7 @@ export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: obje
   extends BaseRemoteConfigFetch<RemoteConfig> {
   storeRemoteConfig: (remoteConfig: RemoteConfigAPIResponse<RemoteConfig>, sessionId?: number) => Promise<void>;
   getLastFetchedSessionId: () => Promise<number | void>;
+  remoteConfigHasValues: (configNamespace: string) => Promise<boolean>;
 }
 
 export type CreateRemoteConfigFetch = <RemoteConfig extends { [key: string]: object }>({

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,2 +1,3 @@
 import sessionReplay from './session-replay-factory';
 export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
+export { SessionReplayOptions } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -233,7 +233,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   getShouldRecord(ignoreFocus = false) {
     if (!this.identifiers || !this.config || !this.identifiers.sessionId) {
-      this.loggerProvider.error(`Session is not being recorded due to lack of config, please call sessionReplay.init.`);
+      this.loggerProvider.warn(`Session is not being recorded due to lack of config, please call sessionReplay.init.`);
       return false;
     }
     if (!this.config.captureEnabled) {


### PR DESCRIPTION
### Summary

2 changes in this PR:
1. Prevent remote config package from making multiple requests if response has been returned without certain keys - for example, if config response has `sampling_config` but not `targeting_config`, we should not keep refetching when package tries to access `targeting_config`
2. Type export and log level change in session replay

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
