### PR TITLE
fix(analytics-browser): fall back to MemoryStorage when localStorage is disabled

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -252,7 +252,7 @@ export const useBrowserConfig = async (
   const pageCounter = previousCookies?.pageCounter;
   const debugLogsEnabled = previousCookies?.debugLogsEnabled;
 
-  return new BrowserConfig(
+  const browserConfig = new BrowserConfig(
     apiKey,
     options.appVersion,
     cookieStorage,
@@ -286,6 +286,15 @@ export const useBrowserConfig = async (
     pageCounter,
     debugLogsEnabled,
   );
+
+  if (!(await browserConfig.storageProvider.isEnabled())) {
+    browserConfig.loggerProvider.warn(
+      `Storage provider ${browserConfig.storageProvider.constructor.name} is not enabled. Falling back to MemoryStorage.`,
+    );
+    browserConfig.storageProvider = new MemoryStorage();
+  }
+
+  return browserConfig;
 };
 
 export const createCookieStorage = <T>(


### PR DESCRIPTION

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-103256]

This PR fixes https://github.com/amplitude/Amplitude-TypeScript/issues/788 by setting `config.storageProvider` to be `MemoryStorage` when `config.storageProvider` (by default `localStorage` is disabled) as `localStorage` can be disabled in private mode browsers. 


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-103256]: https://amplitude.atlassian.net/browse/AMP-103256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ