### PR TITLE
feat(session-replay-browser): support higher granularity sample rate

### DIFF
--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -100,8 +100,8 @@ export const isSessionInSample = function (sessionId: number, sampleRate: number
   const hashNumber = generateHashCode(sessionId.toString());
   const absHash = Math.abs(hashNumber);
   const absHashMultiply = absHash * 31;
-  const mod = absHashMultiply % 100;
-  return mod / 100 < sampleRate;
+  const mod = absHashMultiply % 1000000;
+  return mod / 1000000 < sampleRate;
 };
 
 export const getCurrentUrl = () => {

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -189,11 +189,11 @@ describe('SessionReplayPlugin helpers', () => {
 
   describe('isSessionInSample', () => {
     test('should deterministically return true if calculation puts session id below sample rate', () => {
-      const result = isSessionInSample(1691092433788, 0.5);
+      const result = isSessionInSample(1691092433788, 0.56);
       expect(result).toEqual(true);
     });
     test('should deterministically return false if calculation puts session id above sample rate', () => {
-      const result = isSessionInSample(1691092416403, 0.5);
+      const result = isSessionInSample(1691092416403, 0.13);
       expect(result).toEqual(false);
     });
   });

--- a/packages/session-replay-browser/test/test-data.ts
+++ b/packages/session-replay-browser/test/test-data.ts
@@ -1,2 +1,2 @@
 // This session id will be included in a 20% sample rate or higher
-export const SESSION_ID_IN_20_SAMPLE = 1691092433788;
+export const SESSION_ID_IN_20_SAMPLE = 1719847315000;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Supports higher granularity sample rate, up from 2 to 6 decimal places. Performance impact here should be negligible: https://jsperf.app/xeditu/2

This would give different results for the same session, but because sessions are short lived it should be OK.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
