### PR TITLE
feat(session-replay-browser): scroll events support

### DIFF
--- a/packages/session-replay-browser/src/beacon-transport.ts
+++ b/packages/session-replay-browser/src/beacon-transport.ts
@@ -1,7 +1,7 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { SessionReplayJoinedConfig } from '../config/types';
-import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';
-import { getServerUrl } from '../helpers';
+import { SessionReplayJoinedConfig } from './config/types';
+import { SessionReplayDestinationSessionMetadata } from './typings/session-replay';
+import { getServerUrl } from './helpers';
 
 type BeaconSendFn<T> = (pageUrl: string, payload: T) => boolean;
 

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -2,6 +2,12 @@ import { getGlobalScope } from '@amplitude/analytics-client-common';
 import { MASK_TEXT_CLASS, UNMASK_TEXT_CLASS } from './constants';
 import { DEFAULT_MASK_LEVEL, MaskLevel, PrivacyConfig } from './config/types';
 import { getInputType } from '@amplitude/rrweb-snapshot';
+import { ServerZone } from '@amplitude/analytics-types';
+import {
+  SESSION_REPLAY_EU_URL as SESSION_REPLAY_EU_SERVER_URL,
+  SESSION_REPLAY_SERVER_URL,
+  SESSION_REPLAY_STAGING_URL as SESSION_REPLAY_STAGING_SERVER_URL,
+} from './constants';
 
 /**
  * Light: Subset of inputs
@@ -111,4 +117,20 @@ export const getCurrentUrl = () => {
 
 export const generateSessionReplayId = (sessionId: number, deviceId: string): string => {
   return `${deviceId}/${sessionId}`;
+};
+
+export const getServerUrl = (serverZone?: keyof typeof ServerZone): string => {
+  if (serverZone) {
+    return 'http://localhost:3000/test';
+  }
+
+  if (serverZone === ServerZone.STAGING) {
+    return SESSION_REPLAY_STAGING_SERVER_URL;
+  }
+
+  if (serverZone === ServerZone.EU) {
+    return SESSION_REPLAY_EU_SERVER_URL;
+  }
+
+  return SESSION_REPLAY_SERVER_URL;
 };

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -120,10 +120,6 @@ export const generateSessionReplayId = (sessionId: number, deviceId: string): st
 };
 
 export const getServerUrl = (serverZone?: keyof typeof ServerZone): string => {
-  if (serverZone) {
-    return 'http://localhost:3000/test';
-  }
-
   if (serverZone === ServerZone.STAGING) {
     return SESSION_REPLAY_STAGING_SERVER_URL;
   }

--- a/packages/session-replay-browser/src/hooks/beacon.ts
+++ b/packages/session-replay-browser/src/hooks/beacon.ts
@@ -20,19 +20,11 @@ export class BeaconTransport<T> {
 
   constructor(context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>, config: SessionReplayJoinedConfig) {
     const globalScope = getGlobalScope();
-    if (
-      globalScope &&
-      globalScope.navigator &&
-      typeof globalScope.navigator.sendBeacon === 'function' &&
-      typeof globalScope.Blob === 'function'
-    ) {
-      this.sendBeacon = (pageUrl, payload, contentType) => {
-        const blobData = new globalScope.Blob([JSON.stringify(payload)], {
-          type: contentType,
-        });
-
+    if (globalScope && globalScope.navigator && typeof globalScope.navigator.sendBeacon === 'function') {
+      this.sendBeacon = (pageUrl, payload, _) => {
         try {
-          if (globalScope.navigator.sendBeacon(pageUrl, blobData)) {
+          // something seems to be broken if we try to send the content type header in chrome
+          if (globalScope.navigator.sendBeacon(pageUrl, JSON.stringify(payload))) {
             return true;
           }
         } catch (e) {

--- a/packages/session-replay-browser/src/hooks/beacon.ts
+++ b/packages/session-replay-browser/src/hooks/beacon.ts
@@ -54,10 +54,7 @@ export class BeaconTransport<T> {
       type: String(type),
     });
 
-    void urlParams;
-
     this.pageUrl = `${pageUrl}?${urlParams.toString()}`;
-    // this.pageUrl = pageUrl;
   }
 
   send(payload: T) {

--- a/packages/session-replay-browser/src/hooks/beacon.ts
+++ b/packages/session-replay-browser/src/hooks/beacon.ts
@@ -3,27 +3,35 @@ import { SessionReplayJoinedConfig } from '../config/types';
 import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';
 import { getServerUrl } from '../helpers';
 
-type BeaconSendFn<T> = (pageUrl: string, payload: T, contentType: 'application/json') => boolean;
+type BeaconSendFn<T> = (pageUrl: string, payload: T) => boolean;
 
 /**
  * For very small payloads it's preferable to use the [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API).
  * While it doesn't provide 100% guarantees on sends, it greatly helps with overall reliability and page load performance. As
  * the Beacon API has a potential to fail due to size constraints we want to fall back to XHR if need be. This is mostly to
  * be used with 'pagehide' or 'beforeunload' events.
+ *
+ * Note there are only 3 CORS safelisted Content-Types you can send:
+ *
+ * - application/x-www-form-urlencoded
+ * - multipart/form-data
+ * - text/plain
+ *
+ * If we do not send one of these, some browsers like Chrome may not send this at all. Also we incur the overhead of a preflight
+ * request. In our case we will add no additional content-type header. If you are trying to ping a server that requires this
+ * header, you may want to use the regular fetch API or a different mechanism.
  */
 export class BeaconTransport<T> {
   private sendBeacon: BeaconSendFn<T>;
   private sendXhr: BeaconSendFn<T>;
   private readonly basePageUrl: string;
   private readonly context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>;
-  private static readonly contentType = 'application/json';
 
   constructor(context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>, config: SessionReplayJoinedConfig) {
     const globalScope = getGlobalScope();
     if (globalScope && globalScope.navigator && typeof globalScope.navigator.sendBeacon === 'function') {
-      this.sendBeacon = (pageUrl, payload, _) => {
+      this.sendBeacon = (pageUrl, payload) => {
         try {
-          // something seems to be broken if we try to send the content type header in chrome
           if (globalScope.navigator.sendBeacon(pageUrl, JSON.stringify(payload))) {
             return true;
           }
@@ -36,10 +44,9 @@ export class BeaconTransport<T> {
       this.sendBeacon = () => false;
     }
 
-    this.sendXhr = (pageUrl, payload, contentType) => {
+    this.sendXhr = (pageUrl, payload) => {
       const xhr = new XMLHttpRequest();
       xhr.open('POST', pageUrl, true);
-      xhr.setRequestHeader('Content-Type', contentType);
       xhr.setRequestHeader('Accept', '*/*');
       xhr.send(JSON.stringify(payload));
       return true;
@@ -61,7 +68,6 @@ export class BeaconTransport<T> {
 
     // ideally send using the beacon API, but there is a chance it may fail, possibly due to a payload
     // size limit. in this case, try best effort to send using xhr.
-    this.sendBeacon(pageUrl, payload, BeaconTransport.contentType) ||
-      this.sendXhr(pageUrl, payload, BeaconTransport.contentType);
+    this.sendBeacon(pageUrl, payload) || this.sendXhr(pageUrl, payload);
   }
 }

--- a/packages/session-replay-browser/src/hooks/beacon.ts
+++ b/packages/session-replay-browser/src/hooks/beacon.ts
@@ -1,0 +1,75 @@
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { SessionReplayJoinedConfig } from '../config/types';
+import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';
+import { getServerUrl } from '../helpers';
+
+type BeaconSendFn<T> = (pageUrl: string, payload: T, contentType: 'application/json') => boolean;
+
+export class BeaconTransport<T> {
+  private sendBeacon: BeaconSendFn<T>;
+  private sendXhr: BeaconSendFn<T>;
+  private readonly pageUrl: string;
+  private static readonly contentType = 'application/json';
+
+  constructor(context: SessionReplayDestinationSessionMetadata, config: SessionReplayJoinedConfig) {
+    const globalScope = getGlobalScope();
+    if (
+      globalScope &&
+      globalScope.navigator &&
+      typeof globalScope.navigator.sendBeacon === 'function' &&
+      typeof globalScope.Blob === 'function'
+    ) {
+      this.sendBeacon = (pageUrl, payload, contentType) => {
+        const blobData = new globalScope.Blob([JSON.stringify(payload)], {
+          type: contentType,
+        });
+
+        try {
+          return globalScope.navigator.sendBeacon(pageUrl, blobData);
+        } catch (e) {
+          // not logging error, since it would be hard to view and just adds overhead.
+        }
+        return false;
+      };
+    } else {
+      this.sendBeacon = () => false;
+    }
+
+    if (typeof XMLHttpRequest === 'undefined') {
+      this.sendXhr = () => false;
+    } else {
+      this.sendXhr = (pageUrl, payload, contentType) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', pageUrl, true);
+        xhr.setRequestHeader('Content-Type', contentType);
+        xhr.setRequestHeader('Accept', '*/*');
+        xhr.send(JSON.stringify(payload));
+        return true;
+      };
+    }
+
+    const pageUrl = getServerUrl(config.serverZone);
+    const { deviceId, sessionId, type } = context;
+    if (deviceId) {
+      const urlParams = new URLSearchParams({
+        device_id: deviceId,
+        session_id: String(sessionId),
+        type: String(type),
+      });
+
+      void urlParams;
+
+      this.pageUrl = `${pageUrl}?${urlParams.toString()}`;
+      // this.pageUrl = pageUrl;
+    } else {
+      this.pageUrl = pageUrl;
+    }
+  }
+
+  send(payload: T) {
+    // ideally send using the beacon API, but there is a chance it may fail, possibly due to a payload
+    // size limit. in this case, try best effort to send using xhr.
+    this.sendBeacon(this.pageUrl, payload, BeaconTransport.contentType) ||
+      this.sendXhr(this.pageUrl, payload, BeaconTransport.contentType);
+  }
+}

--- a/packages/session-replay-browser/src/hooks/beacon.ts
+++ b/packages/session-replay-browser/src/hooks/beacon.ts
@@ -5,6 +5,12 @@ import { getServerUrl } from '../helpers';
 
 type BeaconSendFn<T> = (pageUrl: string, payload: T, contentType: 'application/json') => boolean;
 
+/**
+ * For very small payloads it's preferable to use the [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API).
+ * While it doesn't provide 100% guarantees on sends, it greatly helps with overall reliability and page load performance. As
+ * the Beacon API has a potential to fail due to size constraints we want to fall back to XHR if need be. This is mostly to
+ * be used with 'pagehide' or 'beforeunload' events.
+ */
 export class BeaconTransport<T> {
   private sendBeacon: BeaconSendFn<T>;
   private sendXhr: BeaconSendFn<T>;

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -2,6 +2,8 @@ import { utils } from '@amplitude/rrweb';
 import { scrollCallback, scrollPosition } from '@amplitude/rrweb-types';
 import { BeaconTransport } from './beacon';
 import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { SessionReplayJoinedConfig } from '../config/types';
+import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';
 
 const { getWindowHeight, getWindowWidth } = utils;
 
@@ -31,6 +33,13 @@ export class ScrollWatcher {
   private _maxScrollWidth: number;
   private _maxScrollHeight: number;
   private readonly transport: BeaconTransport<ScrollEvent>;
+
+  static default(
+    context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>,
+    config: SessionReplayJoinedConfig,
+  ): ScrollWatcher {
+    return new ScrollWatcher(new BeaconTransport<ScrollEvent>(context, config));
+  }
 
   constructor(transport: BeaconTransport<ScrollEvent>) {
     this._maxScrollX = 0;

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -18,37 +18,53 @@ export type ScrollEvent = {
 };
 
 export class ScrollWatcher {
-  private maxScrollX: number;
-  private maxScrollY: number;
-  private maxScrollWidth: number;
-  private maxScrollHeight: number;
+  private _maxScrollX: number;
+  private _maxScrollY: number;
+  private _maxScrollWidth: number;
+  private _maxScrollHeight: number;
   private readonly transport: BeaconTransport<ScrollEvent>;
 
   constructor(transport: BeaconTransport<ScrollEvent>) {
-    this.maxScrollX = 0;
-    this.maxScrollY = 0;
-    this.maxScrollWidth = getWindowWidth();
-    this.maxScrollHeight = getWindowHeight();
+    this._maxScrollX = 0;
+    this._maxScrollY = 0;
+    this._maxScrollWidth = getWindowWidth();
+    this._maxScrollHeight = getWindowHeight();
 
     this.transport = transport;
   }
 
+  public get maxScrollX(): number {
+    return this._maxScrollX;
+  }
+
+  public get maxScrollY(): number {
+    return this._maxScrollY;
+  }
+
+  public get maxScrollWidth(): number {
+    return this._maxScrollWidth;
+  }
+
+  public get maxScrollHeight(): number {
+    return this._maxScrollHeight;
+  }
+
   update(e: scrollPosition) {
-    if (e.x > this.maxScrollX) {
+    if (e.x > this._maxScrollX) {
       const width = getWindowWidth();
-      this.maxScrollX = e.x;
+      this._maxScrollX = e.x;
       const maxScrollWidth = e.x + width;
-      if (maxScrollWidth > this.maxScrollWidth) {
-        this.maxScrollWidth = maxScrollWidth;
+      if (maxScrollWidth > this._maxScrollWidth) {
+        this._maxScrollWidth = maxScrollWidth;
       }
     }
 
-    if (e.y > this.maxScrollY) {
+    if (e.y > this._maxScrollY) {
       const height = getWindowHeight();
-      this.maxScrollY = e.y;
+      this._maxScrollY = e.y;
       const maxScrollHeight = e.y + height;
-      if (maxScrollHeight > this.maxScrollHeight) {
-        this.maxScrollHeight = maxScrollHeight;
+      if (maxScrollHeight > this._maxScrollHeight) {
+        this._maxScrollHeight = maxScrollHeight;
       }
     }
   }
@@ -61,10 +77,10 @@ export class ScrollWatcher {
     const globalScope = getGlobalScope();
     globalScope &&
       this.transport.send({
-        maxScrollX: this.maxScrollX,
-        maxScrollY: this.maxScrollY,
-        maxScrollWidth: this.maxScrollWidth,
-        maxScrollHeight: this.maxScrollHeight,
+        maxScrollX: this._maxScrollX,
+        maxScrollY: this._maxScrollY,
+        maxScrollWidth: this._maxScrollWidth,
+        maxScrollHeight: this._maxScrollHeight,
 
         viewportHeight: getWindowHeight(),
         viewportWidth: getWindowWidth(),

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -1,6 +1,6 @@
 import { utils } from '@amplitude/rrweb';
 import { scrollCallback, scrollPosition } from '@amplitude/rrweb-types';
-import { BeaconTransport } from './beacon';
+import { BeaconTransport } from '../beacon-transport';
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import { SessionReplayJoinedConfig } from '../config/types';
 import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -1,7 +1,7 @@
+import { utils } from '@amplitude/rrweb';
 import { scrollCallback, scrollPosition } from '@amplitude/rrweb-types';
 import { BeaconTransport } from './beacon';
 import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { utils } from '@amplitude/rrweb';
 
 const { getWindowHeight, getWindowWidth } = utils;
 
@@ -73,10 +73,11 @@ export class ScrollWatcher {
     this.update(e);
   };
 
-  send: (_: PageTransitionEvent | Event) => void = (_) => {
+  send: (deviceIdFn: () => string | undefined) => (_: PageTransitionEvent | Event) => void = (deviceIdFn) => (_) => {
+    const deviceId = deviceIdFn();
     const globalScope = getGlobalScope();
-    globalScope &&
-      this.transport.send({
+    if (globalScope && deviceId) {
+      this.transport.send(deviceId, {
         maxScrollX: this._maxScrollX,
         maxScrollY: this._maxScrollY,
         maxScrollWidth: this._maxScrollWidth,
@@ -84,9 +85,10 @@ export class ScrollWatcher {
 
         viewportHeight: getWindowHeight(),
         viewportWidth: getWindowWidth(),
-        pageUrl: globalScope.location.href,
+        pageUrl: location.href,
         timestamp: Date.now(),
         type: 'scroll',
       });
+    }
   };
 }

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -1,0 +1,76 @@
+import { scrollCallback, scrollPosition } from '@amplitude/rrweb-types';
+import { BeaconTransport } from './beacon';
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { utils } from '@amplitude/rrweb';
+
+const { getWindowHeight, getWindowWidth } = utils;
+
+export type ScrollEvent = {
+  timestamp: number; // Timestamp the event occurred
+  maxScrollX: number; // Max window scroll X on a page
+  maxScrollY: number; // Max window scroll Y on a page
+  maxScrollHeight: number; // Max window scroll Y + window height on a page
+  maxScrollWidth: number; // Max window scroll X + window width on a page
+  viewportWidth: number;
+  viewportHeight: number;
+  pageUrl: string;
+  type: 'scroll';
+};
+
+export class ScrollWatcher {
+  private maxScrollX: number;
+  private maxScrollY: number;
+  private maxScrollWidth: number;
+  private maxScrollHeight: number;
+  private readonly transport: BeaconTransport<ScrollEvent>;
+
+  constructor(transport: BeaconTransport<ScrollEvent>) {
+    this.maxScrollX = 0;
+    this.maxScrollY = 0;
+    this.maxScrollWidth = getWindowWidth();
+    this.maxScrollHeight = getWindowHeight();
+
+    this.transport = transport;
+  }
+
+  update(e: scrollPosition) {
+    if (e.x > this.maxScrollX) {
+      const width = getWindowWidth();
+      this.maxScrollX = e.x;
+      const maxScrollWidth = e.x + width;
+      if (maxScrollWidth > this.maxScrollWidth) {
+        this.maxScrollWidth = maxScrollWidth;
+      }
+    }
+
+    if (e.y > this.maxScrollY) {
+      const height = getWindowHeight();
+      this.maxScrollY = e.y;
+      const maxScrollHeight = e.y + height;
+      if (maxScrollHeight > this.maxScrollHeight) {
+        this.maxScrollHeight = maxScrollHeight;
+      }
+    }
+  }
+
+  hook: scrollCallback = (e: scrollPosition) => {
+    this.update(e);
+  };
+
+  send: (_: PageTransitionEvent | Event) => void = (_) => {
+    const globalScope = getGlobalScope();
+    globalScope &&
+      this.transport.send({
+        maxScrollX: this.maxScrollX,
+        maxScrollY: this.maxScrollY,
+        maxScrollWidth: this.maxScrollWidth,
+        maxScrollHeight: this.maxScrollHeight,
+
+        viewportHeight: getWindowHeight(),
+        viewportWidth: getWindowWidth(),
+        pageUrl: globalScope.location.href,
+        timestamp: Date.now(),
+        type: 'scroll',
+      });
+  };
+}

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -17,7 +17,15 @@ export type ScrollEvent = {
   type: 'scroll';
 };
 
+/**
+ * This is intended to watch and update max scroll activity when loaded for a particular page.
+ * A new instance should be created if the page URL changes, since by default it does not reset
+ * it's max scroll state. It is intended to send very few and very small events utilizing the
+ * Beacon API.
+ * @see {@link BeaconTransport} for more details on Beacon API usage.
+ */
 export class ScrollWatcher {
+  private timestamp = Date.now();
   private _maxScrollX: number;
   private _maxScrollY: number;
   private _maxScrollWidth: number;
@@ -50,6 +58,7 @@ export class ScrollWatcher {
   }
 
   update(e: scrollPosition) {
+    const now = Date.now();
     if (e.x > this._maxScrollX) {
       const width = getWindowWidth();
       this._maxScrollX = e.x;
@@ -57,6 +66,7 @@ export class ScrollWatcher {
       if (maxScrollWidth > this._maxScrollWidth) {
         this._maxScrollWidth = maxScrollWidth;
       }
+      this.timestamp = now;
     }
 
     if (e.y > this._maxScrollY) {
@@ -66,6 +76,7 @@ export class ScrollWatcher {
       if (maxScrollHeight > this._maxScrollHeight) {
         this._maxScrollHeight = maxScrollHeight;
       }
+      this.timestamp = now;
     }
   }
 
@@ -85,8 +96,8 @@ export class ScrollWatcher {
 
         viewportHeight: getWindowHeight(),
         viewportWidth: getWindowWidth(),
-        pageUrl: location.href,
-        timestamp: Date.now(),
+        pageUrl: globalScope.location.href,
+        timestamp: this.timestamp,
         type: 'scroll',
       });
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -143,7 +143,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       globalScope.addEventListener('focus', this.focusListener);
       // prefer pagehide to unload events, this is the standard going forward. it is not
       // 100% reliable, but is bfcache-compatible.
-      if ('onpagehide' in globalScope.self) {
+      if (globalScope.self && 'onpagehide' in globalScope.self) {
         globalScope.removeEventListener('pagehide', this.pageLeaveListener);
         globalScope.addEventListener('pagehide', this.pageLeaveListener);
       } else {
@@ -152,9 +152,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
         globalScope.removeEventListener('beforeunload', this.pageLeaveListener, { capture: true });
         globalScope.addEventListener('beforeunload', this.pageLeaveListener, { capture: true });
       }
-
-      globalScope.removeEventListener('visibilitychange', this.pageLeaveListener);
-      globalScope.addEventListener('visibilitychange', this.pageLeaveListener);
     }
 
     if (globalScope && globalScope.document && globalScope.document.hasFocus()) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -119,7 +119,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       ),
     );
 
-    if (options.sessionId) {
+    if (options.sessionId && this.config.interactionConfig?.enabled) {
       const transport = new BeaconTransport<ScrollEvent>(
         {
           sessionId: options.sessionId,
@@ -129,10 +129,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       );
       const scrollWatcher = new ScrollWatcher(transport);
       this.pageLeaveFns = [scrollWatcher.send(this.getDeviceId.bind(this))];
-      const { interactionConfig } = this.config;
-      if (interactionConfig?.enabled) {
-        this.scrollHook = scrollWatcher.hook.bind(scrollWatcher);
-      }
+      this.scrollHook = scrollWatcher.hook.bind(scrollWatcher);
     }
 
     this.removeInvalidSelectors();

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -118,7 +118,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       ),
     );
 
-    if (options.sessionId) {
+    if (options.sessionId && options.deviceId) {
       const transport = new BeaconTransport<ScrollEvent>(
         {
           deviceId: options.deviceId,

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -121,14 +121,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (options.sessionId && options.deviceId) {
       const transport = new BeaconTransport<ScrollEvent>(
         {
-          deviceId: options.deviceId,
           sessionId: options.sessionId,
           type: 'interaction',
         },
         this.config,
       );
       this.scrollWatcher = new ScrollWatcher(transport);
-      this.pageLeaveFns = [this.scrollWatcher.send];
+      this.pageLeaveFns = [this.scrollWatcher.send(this.getDeviceId.bind(this))];
     }
 
     this.removeInvalidSelectors();

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -1,11 +1,6 @@
 import { BaseTransport } from '@amplitude/analytics-core';
-import { Logger as ILogger, ServerZone, Status } from '@amplitude/analytics-types';
-import {
-  SESSION_REPLAY_EU_URL as SESSION_REPLAY_EU_SERVER_URL,
-  SESSION_REPLAY_SERVER_URL,
-  SESSION_REPLAY_STAGING_URL as SESSION_REPLAY_STAGING_SERVER_URL,
-} from './constants';
-import { getCurrentUrl } from './helpers';
+import { Logger as ILogger, Status } from '@amplitude/analytics-types';
+import { getCurrentUrl, getServerUrl } from './helpers';
 import {
   MAX_RETRIES_EXCEEDED_MESSAGE,
   MISSING_API_KEY_MESSAGE,
@@ -45,18 +40,6 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       attempts: 0,
       timeout: 0,
     });
-  }
-
-  getServerUrl(serverZone?: keyof typeof ServerZone) {
-    if (serverZone === ServerZone.STAGING) {
-      return SESSION_REPLAY_STAGING_SERVER_URL;
-    }
-
-    if (serverZone === ServerZone.EU) {
-      return SESSION_REPLAY_EU_SERVER_URL;
-    }
-
-    return SESSION_REPLAY_SERVER_URL;
   }
 
   addToQueue(...list: SessionReplayDestinationContext[]) {
@@ -152,7 +135,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         body: JSON.stringify(payload),
         method: 'POST',
       };
-      const server_url = `${this.getServerUrl(context.serverZone)}?${urlParams.toString()}`;
+      const server_url = `${getServerUrl(context.serverZone)}?${urlParams.toString()}`;
       const res = await fetch(server_url, options);
       if (res === null) {
         this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE });

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -4,18 +4,22 @@ import { SessionReplayLocalConfig } from '../config/types';
 export type Events = string[];
 
 export type EventType = 'replay' | 'interaction';
-export interface SessionReplayDestination {
-  events: Events;
-  sequenceId: number;
+
+export interface SessionReplayDestinationSessionMetadata {
   type: EventType;
   sessionId: number;
+  deviceId?: string;
+}
+
+export type SessionReplayDestination = {
+  events: Events;
+  sequenceId: number;
   flushMaxRetries?: number;
   apiKey?: string;
-  deviceId?: string;
   sampleRate: number;
   serverZone?: keyof typeof ServerZone;
   onComplete: (sequenceId: number) => Promise<void>;
-}
+} & SessionReplayDestinationSessionMetadata;
 
 export interface SessionReplayDestinationContext extends SessionReplayDestination {
   attempts: number;

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -1,6 +1,13 @@
 import { PrivacyConfig } from '../src/config/types';
-import { MASK_TEXT_CLASS, UNMASK_TEXT_CLASS } from '../src/constants';
-import { generateHashCode, isSessionInSample, maskFn } from '../src/helpers';
+import {
+  MASK_TEXT_CLASS,
+  SESSION_REPLAY_EU_URL,
+  SESSION_REPLAY_SERVER_URL,
+  SESSION_REPLAY_STAGING_URL,
+  UNMASK_TEXT_CLASS,
+} from '../src/constants';
+import { ServerZone } from '@amplitude/analytics-types';
+import { generateHashCode, getServerUrl, isSessionInSample, maskFn } from '../src/helpers';
 
 describe('SessionReplayPlugin helpers', () => {
   describe('maskFn -- input', () => {
@@ -195,6 +202,20 @@ describe('SessionReplayPlugin helpers', () => {
     test('should deterministically return false if calculation puts session id above sample rate', () => {
       const result = isSessionInSample(1691092416403, 0.5);
       expect(result).toEqual(false);
+    });
+  });
+
+  describe('getServerUrl', () => {
+    test('should return us server url if no config set', () => {
+      expect(getServerUrl()).toEqual(SESSION_REPLAY_SERVER_URL);
+    });
+
+    test('should return staging server url if staging config set', async () => {
+      expect(getServerUrl(ServerZone.STAGING)).toEqual(SESSION_REPLAY_STAGING_URL);
+    });
+
+    test('should return eu server url if eu config set', async () => {
+      expect(getServerUrl(ServerZone.EU)).toEqual(SESSION_REPLAY_EU_URL);
     });
   });
 });

--- a/packages/session-replay-browser/test/hooks/beacon.test.ts
+++ b/packages/session-replay-browser/test/hooks/beacon.test.ts
@@ -38,7 +38,6 @@ describe('beacon', () => {
       transport = new BeaconTransport<TestEvent>(
         {
           sessionId,
-          deviceId,
           type: 'interaction',
         },
         {} as SessionReplayJoinedConfig,
@@ -62,12 +61,11 @@ describe('beacon', () => {
         transport = new BeaconTransport<TestEvent>(
           {
             sessionId,
-            deviceId,
             type: 'interaction',
           },
           {} as SessionReplayJoinedConfig,
         );
-        transport.send({
+        transport.send(deviceId, {
           Field1: 'foo',
           Field2: 1234,
         });
@@ -85,12 +83,11 @@ describe('beacon', () => {
         transport = new BeaconTransport<TestEvent>(
           {
             sessionId,
-            deviceId,
             type: 'interaction',
           },
           {} as SessionReplayJoinedConfig,
         );
-        transport.send({
+        transport.send(deviceId, {
           Field1: 'foo',
           Field2: 1234,
         });
@@ -101,7 +98,7 @@ describe('beacon', () => {
         );
       });
       test('sends with xhr', () => {
-        transport.send({
+        transport.send(deviceId, {
           Field1: 'foo',
           Field2: 1234,
         });

--- a/packages/session-replay-browser/test/hooks/beacon.test.ts
+++ b/packages/session-replay-browser/test/hooks/beacon.test.ts
@@ -1,0 +1,116 @@
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import { SessionReplayJoinedConfig } from 'src/config/types';
+import { BeaconTransport } from '../../src/hooks/beacon';
+import { randomUUID } from 'crypto';
+
+type TestEvent = {
+  Field1: string;
+  Field2: number;
+};
+
+jest.mock('@amplitude/analytics-client-common');
+
+describe('beacon', () => {
+  const mockGlobalScope = (globalScope?: Partial<typeof globalThis>) => {
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+  };
+
+  describe('BeaconTransport', () => {
+    let transport: BeaconTransport<TestEvent>;
+    let deviceId: string;
+    let sessionId: number;
+
+    const xmlMockFns = {
+      open: jest.fn(),
+      send: jest.fn(),
+      setRequestHeader: jest.fn(),
+    };
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      window.XMLHttpRequest = jest.fn().mockImplementation(() => {
+        return xmlMockFns;
+      }) as any;
+
+      sessionId = Date.now();
+      deviceId = randomUUID();
+
+      transport = new BeaconTransport<TestEvent>(
+        {
+          sessionId,
+          deviceId,
+          type: 'interaction',
+        },
+        {} as SessionReplayJoinedConfig,
+      );
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    describe('#send', () => {
+      test('sends with beacon', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        mockGlobalScope({
+          navigator: {
+            sendBeacon: jest.fn().mockImplementation(() => true),
+          },
+          Blob: jest.fn(),
+        } as any);
+
+        transport = new BeaconTransport<TestEvent>(
+          {
+            sessionId,
+            deviceId,
+            type: 'interaction',
+          },
+          {} as SessionReplayJoinedConfig,
+        );
+        transport.send({
+          Field1: 'foo',
+          Field2: 1234,
+        });
+        expect(xmlMockFns.open).not.toHaveBeenCalled();
+      });
+      test('falls back to xhr', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        mockGlobalScope({
+          navigator: {
+            sendBeacon: jest.fn().mockImplementation(() => false),
+          },
+          Blob: jest.fn(),
+        } as any);
+
+        transport = new BeaconTransport<TestEvent>(
+          {
+            sessionId,
+            deviceId,
+            type: 'interaction',
+          },
+          {} as SessionReplayJoinedConfig,
+        );
+        transport.send({
+          Field1: 'foo',
+          Field2: 1234,
+        });
+        expect(xmlMockFns.open).toHaveBeenCalledWith(
+          'POST',
+          `https://api-sr.amplitude.com/sessions/v2/track?device_id=${deviceId}&session_id=${sessionId}&type=interaction`,
+          true,
+        );
+      });
+      test('sends with xhr', () => {
+        transport.send({
+          Field1: 'foo',
+          Field2: 1234,
+        });
+        expect(xmlMockFns.open).toHaveBeenCalledWith(
+          'POST',
+          `https://api-sr.amplitude.com/sessions/v2/track?device_id=${deviceId}&session_id=${sessionId}&type=interaction`,
+          true,
+        );
+      });
+    });
+  });
+});

--- a/packages/session-replay-browser/test/hooks/beacon.test.ts
+++ b/packages/session-replay-browser/test/hooks/beacon.test.ts
@@ -1,6 +1,6 @@
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { SessionReplayJoinedConfig } from 'src/config/types';
-import { BeaconTransport } from '../../src/hooks/beacon';
+import { BeaconTransport } from '../../src/beacon-transport';
 import { randomUUID } from 'crypto';
 
 type TestEvent = {

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectMaxScrolls"] }] */
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
-import { BeaconTransport } from '../../src/hooks/beacon';
+import { BeaconTransport } from '../../src/beacon-transport';
 import { ScrollEvent, ScrollWatcher } from '../../src/hooks/scroll';
 import { utils } from '@amplitude/rrweb';
 import { randomUUID } from 'crypto';
 
 jest.mock('@amplitude/rrweb');
-jest.mock('../../src/hooks/beacon');
+jest.mock('../../src/beacon-transport');
 
 describe('scroll', () => {
   const mockGlobalScope = (globalScope?: Partial<typeof globalThis>) => {

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -91,7 +91,7 @@ describe('scroll', () => {
 
           viewportHeight: 0,
           viewportWidth: 0,
-          pageUrl: 'http://localhost/',
+          pageUrl: 'http://localhost',
           timestamp: expect.any(Number),
           type: 'scroll',
         });

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -1,0 +1,153 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectMaxScrolls"] }] */
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import { BeaconTransport } from '../../src/hooks/beacon';
+import { ScrollEvent, ScrollWatcher } from '../../src/hooks/scroll';
+import { utils } from '@amplitude/rrweb';
+
+jest.mock('@amplitude/rrweb');
+jest.mock('../../src/hooks/beacon');
+
+describe('scroll', () => {
+  const mockGlobalScope = (globalScope?: Partial<typeof globalThis>) => {
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+  };
+
+  const mockWindowScroll = (left = 0, top = 0) => {
+    (utils.getWindowScroll as jest.Mock).mockImplementation(() => {
+      return { left, top };
+    }) as any;
+  };
+
+  const mockWindowWidth = (width = 0) => {
+    (utils.getWindowWidth as jest.Mock).mockImplementation(() => {
+      return width;
+    }) as any;
+  };
+
+  const mockWindowHeight = (height = 0) => {
+    (utils.getWindowHeight as jest.Mock).mockImplementation(() => {
+      return height;
+    }) as any;
+  };
+
+  describe('ScrollWatcher', () => {
+    const mockTransport = BeaconTransport<ScrollEvent> as jest.MockedClass<typeof BeaconTransport<ScrollEvent>>;
+
+    let mockTransportInstance: BeaconTransport<ScrollEvent>;
+    let scrollWatcher: ScrollWatcher;
+
+    beforeEach(() => {
+      mockWindowScroll();
+      mockWindowWidth();
+      mockWindowHeight();
+      mockGlobalScope({
+        location: {
+          href: 'http://localhost',
+        } as any,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockTransportInstance = new mockTransport({} as any, {} as any);
+      scrollWatcher = new ScrollWatcher(mockTransportInstance);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.resetAllMocks();
+    });
+
+    const expectMaxScrolls = (scrolls: {
+      maxScrollX?: number;
+      maxScrollY?: number;
+      maxScrollWidth?: number;
+      maxScrollHeight?: number;
+    }) => {
+      expect({
+        maxScrollX: scrolls.maxScrollX && scrollWatcher.maxScrollX,
+        maxScrollY: scrolls.maxScrollY && scrollWatcher.maxScrollY,
+        maxScrollWidth: scrolls.maxScrollWidth && scrollWatcher.maxScrollWidth,
+        maxScrollHeight: scrolls.maxScrollHeight && scrollWatcher.maxScrollHeight,
+      }).toStrictEqual({
+        maxScrollX: scrolls.maxScrollX,
+        maxScrollY: scrolls.maxScrollY,
+        maxScrollWidth: scrolls.maxScrollWidth,
+        maxScrollHeight: scrolls.maxScrollHeight,
+      });
+    };
+
+    describe('#send', () => {
+      test('sends scroll event', () => {
+        scrollWatcher.hook({ id: 1, x: 3, y: 5 });
+        scrollWatcher.send({} as Event);
+
+        expect(mockTransport.prototype.send.mock.calls[0][0]).toStrictEqual({
+          maxScrollX: 3,
+          maxScrollY: 5,
+          maxScrollWidth: 3,
+          maxScrollHeight: 5,
+
+          viewportHeight: 0,
+          viewportWidth: 0,
+          pageUrl: 'http://localhost',
+          timestamp: expect.any(Number),
+          type: 'scroll',
+        });
+      });
+    });
+
+    describe('#hook', () => {
+      // Most of the tests are covered in #update
+      test('updates correctly', () => {
+        scrollWatcher.hook({ id: 1, x: 3, y: 5 });
+        expectMaxScrolls({ maxScrollX: 3, maxScrollY: 5, maxScrollHeight: 5, maxScrollWidth: 3 });
+      });
+    });
+
+    describe('#update', () => {
+      test('initial update', () => {
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        expectMaxScrolls({ maxScrollX: 3, maxScrollY: 4, maxScrollHeight: 4, maxScrollWidth: 3 });
+      });
+
+      test('new max scroll x', () => {
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        scrollWatcher.update({ id: 1, x: 5, y: 4 });
+        expectMaxScrolls({ maxScrollX: 5, maxScrollWidth: 5 });
+      });
+
+      test('does not update max scroll x', () => {
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        scrollWatcher.update({ id: 1, x: 2, y: 4 });
+        expectMaxScrolls({ maxScrollX: 3, maxScrollWidth: 3 });
+      });
+
+      test('new max scroll y', () => {
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        scrollWatcher.update({ id: 1, x: 3, y: 6 });
+        expectMaxScrolls({ maxScrollY: 6, maxScrollHeight: 6 });
+      });
+
+      test('does not update max scroll y', () => {
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        scrollWatcher.update({ id: 1, x: 2, y: 1 });
+        expectMaxScrolls({ maxScrollY: 4, maxScrollHeight: 4 });
+      });
+
+      test('new max scroll width', () => {
+        mockWindowWidth(42);
+        scrollWatcher = new ScrollWatcher(mockTransportInstance);
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        scrollWatcher.update({ id: 1, x: 5, y: 4 });
+        expectMaxScrolls({ maxScrollX: 5, maxScrollWidth: 42 + 5 });
+      });
+
+      test('new max scroll height', () => {
+        mockWindowHeight(24);
+        scrollWatcher = new ScrollWatcher(mockTransportInstance);
+        scrollWatcher.update({ id: 1, x: 3, y: 4 });
+        scrollWatcher.update({ id: 1, x: 5, y: 6 });
+        expectMaxScrolls({ maxScrollY: 6, maxScrollHeight: 24 + 6 });
+      });
+    });
+  });
+});

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -4,6 +4,7 @@ import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { BeaconTransport } from '../../src/hooks/beacon';
 import { ScrollEvent, ScrollWatcher } from '../../src/hooks/scroll';
 import { utils } from '@amplitude/rrweb';
+import { randomUUID } from 'crypto';
 
 jest.mock('@amplitude/rrweb');
 jest.mock('../../src/hooks/beacon');
@@ -78,9 +79,11 @@ describe('scroll', () => {
     describe('#send', () => {
       test('sends scroll event', () => {
         scrollWatcher.hook({ id: 1, x: 3, y: 5 });
-        scrollWatcher.send({} as Event);
+        const deviceId = randomUUID().toString();
+        scrollWatcher.send(() => deviceId)({} as Event);
 
-        expect(mockTransport.prototype.send.mock.calls[0][0]).toStrictEqual({
+        expect(mockTransport.prototype.send.mock.calls[0][0]).toStrictEqual(deviceId);
+        expect(mockTransport.prototype.send.mock.calls[0][1]).toStrictEqual({
           maxScrollX: 3,
           maxScrollY: 5,
           maxScrollWidth: 3,
@@ -88,7 +91,7 @@ describe('scroll', () => {
 
           viewportHeight: 0,
           viewportWidth: 0,
-          pageUrl: 'http://localhost',
+          pageUrl: 'http://localhost/',
           timestamp: expect.any(Number),
           type: 'scroll',
         });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -235,7 +235,7 @@ describe('SessionReplay', () => {
       const initialize = jest.spyOn(sessionReplay, 'initialize');
       await sessionReplay.init(apiKey, mockOptions).promise;
       initialize.mockReset();
-      expect(addEventListenerMock).toHaveBeenCalledTimes(2);
+      expect(addEventListenerMock).toHaveBeenCalledTimes(3);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(addEventListenerMock.mock.calls[0][0]).toEqual('blur');
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -13,7 +13,7 @@ const mockEvent = {
 const mockEventString = JSON.stringify(mockEvent);
 
 async function runScheduleTimers() {
-  // exhause first setTimeout∏
+  // exhause first setTimeout
   jest.runAllTimers();
   // wait for next tick to call nested setTimeout
   await Promise.resolve();

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1,9 +1,8 @@
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import { Logger, ServerZone } from '@amplitude/analytics-types';
-import { SESSION_REPLAY_EU_URL, SESSION_REPLAY_SERVER_URL, SESSION_REPLAY_STAGING_URL } from '../src/constants';
+import { SessionReplayDestinationContext } from 'src/typings/session-replay';
 import { SessionReplayTrackDestination } from '../src/track-destination';
 import { VERSION } from '../src/version';
-import { SessionReplayDestinationContext } from 'src/typings/session-replay';
 
 type MockedLogger = jest.Mocked<Logger>;
 const mockEvent = {
@@ -14,7 +13,7 @@ const mockEvent = {
 const mockEventString = JSON.stringify(mockEvent);
 
 async function runScheduleTimers() {
-  // exhause first setTimeout
+  // exhause first setTimeout∏
   jest.runAllTimers();
   // wait for next tick to call nested setTimeout
   await Promise.resolve();
@@ -216,24 +215,6 @@ describe('SessionReplayTrackDestination', () => {
       expect(trackDestination.queue).toEqual([context]);
       expect(result).toBe(undefined);
       expect(send).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('getServerUrl', () => {
-    test('should return us server url if no config set', () => {
-      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
-      expect(trackDestination.getServerUrl()).toEqual(SESSION_REPLAY_SERVER_URL);
-    });
-
-    test('should return staging server url if staging config set', async () => {
-      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
-      expect(trackDestination.getServerUrl(ServerZone.STAGING)).toEqual(SESSION_REPLAY_STAGING_URL);
-    });
-
-    test('should return eu server url if eu config set', async () => {
-      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
-
-      expect(trackDestination.getServerUrl(ServerZone.EU)).toEqual(SESSION_REPLAY_EU_URL);
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds scroll event support. This tries its best to send scroll events which should be small on a page leave. It uses the Beacon API for reliability and performance with a fallback to XHR. I decided to add a few new classes:

1. ScrollWatcher -- Watches for max page scrolls and updates its state. It includes a hook for RRweb to trigger it to update its state and a BeaconTracker to send a Beacon API event for either 'pagehide' or 'beforeunload', whichever is supported by the browser.
2. BeaconTracker -- Wraps the Beacon API and provides an automatic fallback to XHR on failure.

There was a slight refactor to pull out common functions and make testing easier.

#### Testing

I tested this using the tasks-app in Chrome and Firefox though I may need to do a bit more testing. I'll especially need to do end to end testing once we are ready to ingest events.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
