### PR TITLE
fix: ga events sent through fetch not captured

### DIFF
--- a/packages/plugin-ga-events-forwarder-browser/package.json
+++ b/packages/plugin-ga-events-forwarder-browser/package.json
@@ -47,6 +47,7 @@
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
+    "jest-fetch-mock": "^3.0.3",
     "rollup": "^2.79.1",
     "rollup-plugin-execute": "^1.1.1",
     "rollup-plugin-gzip": "^3.1.0",

--- a/packages/plugin-ga-events-forwarder-browser/test/constants.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/constants.ts
@@ -31,3 +31,52 @@ export const MOCK_GA_EVENT = {
   dt: 'Amplitude',
   uid: 'kevinp@amplitude.com',
 };
+
+export const MOCK_FETCH_URL =
+  'https://analytics.google.com/g/collect?v=2&tid=G-2FY44PPV92&gtm=45je4730v877985709z8893376489za200zb893376489&_p=1720047351081&_gaz=1&gcs=G111&gcd=13r3r3r3r5&npa=0&dma=0&tag_exp=0&cid=832723134.1720041784&ul=en-us&sr=1728x1117&uaa=arm&uab=64&uafvl=Google%2520Chrome%3B125.0.6422.142%7CChromium%3B125.0.6422.142%7CNot.A%252FBrand%3B24.0.0.0&uamb=0&uam=&uap=macOS&uapv=13.2.1&uaw=0&are=1&pae=1&frm=0&pscdl=&_s=1&sid=1720047352&sct=1&seg=0&dl=https%3A%2F%2Famplitude.com%2F&dr=https%3A%2F%2Famplitude.com%2Fdigital-analytics-platform&dt=Amplitude%20%7C%20Product%20Analytics%20%26%20Event%20Tracking%20Platform%20%7C%20Amplitude&en=page_view&_fv=1&_ss=1&tfd=1931&_z=fetch';
+
+export const MOCK_REGIONAL_FETCH_URL: string = (() => {
+  const regionalUrl = new URL(MOCK_FETCH_URL);
+  regionalUrl.hostname = 'region1.analytics.google.com';
+  return regionalUrl.toString();
+})();
+
+export const MOCK_FETCH_EVENT = {
+  v: 2,
+  tid: 'G-2FY44PPV92',
+  gtm: '45je4730v877985709z8893376489za200zb893376489',
+  _p: '1720047351081',
+  _gaz: '1',
+  gcs: 'G111',
+  gcd: '13r3r3r3r5',
+  npa: '0',
+  dma: '0',
+  tag_exp: '0',
+  cid: '832723134.1720041784',
+  ul: 'en-us',
+  sr: '1728x1117',
+  uaa: 'arm',
+  uab: '64',
+  uafvl: 'Google%20Chrome;125.0.6422.142|Chromium;125.0.6422.142|Not.A%2FBrand;24.0.0.0',
+  uamb: '0',
+  uam: '',
+  uap: 'macOS',
+  uapv: '13.2.1',
+  uaw: '0',
+  are: '1',
+  pae: '1',
+  frm: '0',
+  pscdl: '',
+  _s: '1',
+  sid: '1720047352',
+  sct: '1',
+  seg: '0',
+  dl: 'https://amplitude.com/',
+  dr: 'https://amplitude.com/digital-analytics-platform',
+  dt: 'Amplitude | Product Analytics & Event Tracking Platform | Amplitude',
+  en: 'page_view',
+  _fv: '1',
+  _ss: '1',
+  tfd: '1931',
+  _z: 'fetch',
+};

--- a/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
@@ -1,6 +1,7 @@
 import { BrowserClient, BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
+import fetchMock from 'jest-fetch-mock';
 import { gaEventsForwarderPlugin } from '../src/ga-events-forwarder';
-import { MOCK_REGIONAL_URL, MOCK_URL } from './constants';
+import { MOCK_REGIONAL_URL, MOCK_URL, MOCK_FETCH_URL, MOCK_REGIONAL_FETCH_URL, MOCK_FETCH_EVENT } from './constants';
 import { AMPLITUDE_EVENT_LIBRARY, AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID } from '../src/constants';
 
 describe('gaEventsForwarderPlugin', () => {
@@ -11,10 +12,12 @@ describe('gaEventsForwarderPlugin', () => {
 
   beforeAll(() => {
     window.navigator.sendBeacon = sendBeaconMock;
+    fetchMock.enableMocks();
   });
 
   beforeEach(() => {
     plugin = gaEventsForwarderPlugin();
+    fetchMock.resetMocks();
   });
 
   afterEach(() => {
@@ -23,6 +26,7 @@ describe('gaEventsForwarderPlugin', () => {
 
   afterAll(() => {
     window.navigator.sendBeacon = sendBeacon;
+    fetchMock.disableMocks();
   });
 
   describe('name', () => {
@@ -155,236 +159,530 @@ describe('gaEventsForwarderPlugin', () => {
   });
 
   describe('teardown', () => {
-    test('should reset state', () => {
+    test('should reset sendBeacon', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(window.navigator.sendBeacon).not.toBe(sendBeaconMock);
       void plugin?.teardown?.();
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(window.navigator.sendBeacon).toBe(sendBeaconMock);
     });
+
+    test('should reset fetch', () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(window.fetch).not.toBe(fetchMock);
+      void plugin?.teardown?.();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(window.fetch).toBe(fetchMock);
+    });
   });
 
   describe('integration', () => {
-    const requestPayload = 'en=page_view&_ee=1\\r\\en=custom_event&_ee=1&epn.1=1&ep.a=a&upn.2=2&up.b=b';
+    describe('sendBeacon', () => {
+      const requestPayload = 'en=page_view&_ee=1\\r\\en=custom_event&_ee=1&epn.1=1&ep.a=a&upn.2=2&up.b=b';
 
-    test('should send events to Amplitude tracked before Amplitude SDK is initialized', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        error: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      const amplitude: Partial<BrowserClient> = {
-        track: jest.fn(),
-        setUserId: jest.fn(),
-      };
+      test('should send events to Amplitude tracked before Amplitude SDK is initialized', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
 
-      // 1. Send event to Google Analytics
-      window.navigator.sendBeacon(MOCK_URL, requestPayload);
-      // 2. Setup is called when Amplitude SDK is initialized
-      await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 1. Send event to Google Analytics
+        window.navigator.sendBeacon(MOCK_URL, requestPayload);
+        // 2. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
 
-      expect(amplitude.track).toHaveBeenCalledTimes(2);
-      expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        event_properties: {
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'page_view',
-        user_properties: {},
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+        expect(amplitude.track).toHaveBeenCalledTimes(2);
+        expect(amplitude.track).toHaveBeenNthCalledWith(1, {
+          event_properties: {
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'page_view',
+          user_properties: {},
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
+        expect(amplitude.track).toHaveBeenNthCalledWith(2, {
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'custom_event',
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
       });
-      expect(amplitude.track).toHaveBeenNthCalledWith(2, {
-        event_properties: {
-          '1': 1,
-          a: 'a',
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'custom_event',
-        user_properties: {
-          '2': 2,
-          b: 'b',
-        },
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+
+      test('should send events to Amplitude tracked after Amplitude SDK is initialized', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        window.navigator.sendBeacon(MOCK_URL, requestPayload);
+
+        expect(amplitude.track).toHaveBeenCalledTimes(2);
+        expect(amplitude.track).toHaveBeenNthCalledWith(1, {
+          event_properties: {
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'page_view',
+          user_properties: {},
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
+        expect(amplitude.track).toHaveBeenNthCalledWith(2, {
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'custom_event',
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
+      });
+
+      test('should send events to Amplitude tracked on GA regional URL', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        window.navigator.sendBeacon(MOCK_REGIONAL_URL, requestPayload);
+
+        expect(amplitude.track).toHaveBeenCalledTimes(2);
+        expect(amplitude.track).toHaveBeenNthCalledWith(1, {
+          event_properties: {
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'page_view',
+          user_properties: {},
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
+        expect(amplitude.track).toHaveBeenNthCalledWith(2, {
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'custom_event',
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
+      });
+
+      test('should skip GA automatically collected events if DET is enabled', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: true,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        window.navigator.sendBeacon(MOCK_URL, requestPayload);
+
+        expect(amplitude.track).toHaveBeenCalledTimes(1);
+        expect(amplitude.track).toHaveBeenNthCalledWith(1, {
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
+          },
+          event_type: 'custom_event',
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
+      });
+
+      test('should ignore non-GA events', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        window.navigator.sendBeacon('https://api2.amplitude.com/2/httpapi');
+
+        expect(amplitude.track).toHaveBeenCalledTimes(0);
+      });
+
+      test('should catch invalid URL error', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        expect(() => window.navigator.sendBeacon('🤷‍♂️')).not.toThrow();
+
+        expect(amplitude.track).toHaveBeenCalledTimes(0);
       });
     });
 
-    test('should send events to Amplitude tracked after Amplitude SDK is initialized', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        error: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      const amplitude: Partial<BrowserClient> = {
-        track: jest.fn(),
-        setUserId: jest.fn(),
-      };
+    describe('fetch', () => {
+      test('should send events to Amplitude tracked before Amplitude SDK is initialized', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
 
-      // 1. Setup is called when Amplitude SDK is initialized
-      await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
-      // 2.Send event to Google Analytics
-      window.navigator.sendBeacon(MOCK_URL, requestPayload);
+        // 1. Send event to Google Analytics
+        await window.fetch(`${MOCK_FETCH_URL}&epn.1=1&ep.a=a&upn.2=2&up.b=b`);
+        // 2. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
 
-      expect(amplitude.track).toHaveBeenCalledTimes(2);
-      expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        event_properties: {
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'page_view',
-        user_properties: {},
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+        expect(amplitude.track).toHaveBeenCalledWith({
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: MOCK_FETCH_EVENT.tid,
+          },
+          event_type: MOCK_FETCH_EVENT.en,
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
       });
-      expect(amplitude.track).toHaveBeenNthCalledWith(2, {
-        event_properties: {
-          '1': 1,
-          a: 'a',
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'custom_event',
-        user_properties: {
-          '2': 2,
-          b: 'b',
-        },
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+
+      test('should send events to Amplitude tracked after Amplitude SDK is initialized', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 1. Send event to Google Analytics
+        await window.fetch(`${MOCK_FETCH_URL}&epn.1=1&ep.a=a&upn.2=2&up.b=b`);
+
+        expect(amplitude.track).toHaveBeenCalledWith({
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: MOCK_FETCH_EVENT.tid,
+          },
+          event_type: MOCK_FETCH_EVENT.en,
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
       });
-    });
 
-    test('should send events to Amplitude tracked on GA regional URL', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        error: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      const amplitude: Partial<BrowserClient> = {
-        track: jest.fn(),
-        setUserId: jest.fn(),
-      };
+      test('should send events to Amplitude tracked on GA regional URL', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
 
-      // 1. Setup is called when Amplitude SDK is initialized
-      await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
-      // 2.Send event to Google Analytics
-      window.navigator.sendBeacon(MOCK_REGIONAL_URL, requestPayload);
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 1. Send event to Google Analytics
+        await window.fetch(`${MOCK_REGIONAL_FETCH_URL}&epn.1=1&ep.a=a&upn.2=2&up.b=b`);
 
-      expect(amplitude.track).toHaveBeenCalledTimes(2);
-      expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        event_properties: {
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'page_view',
-        user_properties: {},
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+        expect(amplitude.track).toHaveBeenCalledWith({
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: MOCK_FETCH_EVENT.tid,
+          },
+          event_type: MOCK_FETCH_EVENT.en,
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
       });
-      expect(amplitude.track).toHaveBeenNthCalledWith(2, {
-        event_properties: {
-          '1': 1,
-          a: 'a',
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'custom_event',
-        user_properties: {
-          '2': 2,
-          b: 'b',
-        },
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+
+      test('should capture fetch events with stringifier', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        const request = new URL(`${MOCK_FETCH_URL}&epn.1=1&ep.a=a&upn.2=2&up.b=b`);
+
+        expect(() => {
+          // jest-fetch-mock does not support stringified args but is supported by fetch spec
+          // https://github.com/jefflau/jest-fetch-mock/pull/193
+          void window.fetch(request, { method: 'post' });
+        }).toThrow();
+
+        expect(amplitude.track).toHaveBeenCalledWith({
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: MOCK_FETCH_EVENT.tid,
+          },
+          event_type: MOCK_FETCH_EVENT.en,
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
       });
-    });
 
-    test('should skip GA automatically collected events if DET is enabled', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        error: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: true,
-        loggerProvider: loggerProvider as Logger,
-      };
-      const amplitude: Partial<BrowserClient> = {
-        track: jest.fn(),
-        setUserId: jest.fn(),
-      };
+      test('should capture fetch events with Request constructor', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
 
-      // 1. Setup is called when Amplitude SDK is initialized
-      await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
-      // 2.Send event to Google Analytics
-      window.navigator.sendBeacon(MOCK_URL, requestPayload);
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        const request = new window.Request(`${MOCK_FETCH_URL}&epn.1=1&ep.a=a&upn.2=2&up.b=b`);
+        await window.fetch(request, { method: 'post' });
 
-      expect(amplitude.track).toHaveBeenCalledTimes(1);
-      expect(amplitude.track).toHaveBeenNthCalledWith(1, {
-        event_properties: {
-          '1': 1,
-          a: 'a',
-          [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: 'G-DELYSDZ9Q3',
-        },
-        event_type: 'custom_event',
-        user_properties: {
-          '2': 2,
-          b: 'b',
-        },
-        extra: {
-          library: AMPLITUDE_EVENT_LIBRARY,
-        },
+        expect(amplitude.track).toHaveBeenCalledWith({
+          event_properties: {
+            '1': 1,
+            a: 'a',
+            [AMPLITUDE_EVENT_PROPERTY_MEASUREMENT_ID]: MOCK_FETCH_EVENT.tid,
+          },
+          event_type: MOCK_FETCH_EVENT.en,
+          user_properties: {
+            '2': 2,
+            b: 'b',
+          },
+          extra: {
+            library: AMPLITUDE_EVENT_LIBRARY,
+          },
+        });
       });
-    });
 
-    test('should ignore non-GA events', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        error: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      const amplitude: Partial<BrowserClient> = {
-        track: jest.fn(),
-      };
+      test('should ignore bad stringifier', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+        };
 
-      // 1. Setup is called when Amplitude SDK is initialized
-      await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
-      // 2.Send event to Google Analytics
-      window.navigator.sendBeacon('https://api2.amplitude.com/2/httpapi');
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        const request = {
+          toString() {
+            throw 'invalid tostring';
+            return '';
+          },
+        };
+        expect(() => {
+          // jest-fetch-mock does not support stringified args but is supported by fetch spec
+          // https://github.com/jefflau/jest-fetch-mock/pull/193
+          void window.fetch(request as RequestInfo, { method: 'post' });
+        }).toThrow();
 
-      expect(amplitude.track).toHaveBeenCalledTimes(0);
-    });
+        expect(amplitude.track).not.toHaveBeenCalled();
+      });
 
-    test('should catch invalid URL error', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        error: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      const amplitude: Partial<BrowserClient> = {
-        track: jest.fn(),
-      };
+      test('should skip GA automatically collected events if DET is enabled', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: true,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+          setUserId: jest.fn(),
+        };
 
-      // 1. Setup is called when Amplitude SDK is initialized
-      await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
-      // 2.Send event to Google Analytics
-      expect(() => window.navigator.sendBeacon('🤷‍♂️')).not.toThrow();
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        await window.fetch(`${MOCK_FETCH_URL}&epn.1=1&ep.a=a&upn.2=2&up.b=b`);
 
-      expect(amplitude.track).toHaveBeenCalledTimes(0);
+        expect(amplitude.track).not.toHaveBeenCalled();
+      });
+
+      test('should ignore non-GA events', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        await window.fetch('https://api2.amplitude.com/2/httpapi', { method: 'post' });
+
+        expect(amplitude.track).not.toHaveBeenCalled();
+      });
+
+      test('should catch invalid URL error', async () => {
+        const loggerProvider: Partial<Logger> = {
+          log: jest.fn(),
+          error: jest.fn(),
+        };
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider as Logger,
+        };
+        const amplitude: Partial<BrowserClient> = {
+          track: jest.fn(),
+        };
+
+        // 1. Setup is called when Amplitude SDK is initialized
+        await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
+        // 2.Send event to Google Analytics
+        expect(() => window.fetch('🤷‍♂️')).not.toThrow();
+
+        expect(amplitude.track).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6356,6 +6356,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -8534,6 +8541,14 @@ jest-environment-node@^29.3.1:
     jest-mock "^29.3.1"
     jest-util "^29.3.1"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -10154,6 +10169,13 @@ node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp-build@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
@@ -10940,6 +10962,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 promise-retry@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
### Summary

It appears that google analytics now can send events using `fetch` rather than using the `sendBeacon` api. The current GA plugin does not capture these events and thus some customers are not seeing their GA events in amplitude. This PR adds a Proxy for fetch to capture these events in the same way as those for `sendBeacon` were.

Jira: https://amplitude.atlassian.net/browse/AMP-103958

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
