### PR TITLE
fix: Reverse hierarchy order and use more accurate property size calculation

### DIFF
--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -3,7 +3,7 @@ import { finder } from './libs/finder';
 import * as constants from './constants';
 import { Logger } from '@amplitude/analytics-types';
 
-export type JSONValue = string | number | boolean | { [x: string]: JSONValue } | Array<JSONValue>;
+export type JSONValue = string | number | boolean | null | { [x: string]: JSONValue } | Array<JSONValue>;
 
 const SENSITIVE_TAGS = ['input', 'select', 'textarea'];
 

--- a/packages/plugin-autocapture-browser/src/hierarchy.ts
+++ b/packages/plugin-autocapture-browser/src/hierarchy.ts
@@ -1,4 +1,4 @@
-import { isNonSensitiveElement } from './helpers';
+import { isNonSensitiveElement, JSONValue } from './helpers';
 import { Hierarchy, HierarchyNode } from './typings/autocapture';
 
 const BLOCKED_ATTRIBUTES = [
@@ -110,26 +110,99 @@ export function getAncestors(targetEl: Element | null): Element[] {
 
 // Get the DOM hierarchy of the element, starting from the target element to the root element.
 export const getHierarchy = (element: Element | null): Hierarchy => {
-  let outChars = 2;
-  const hierarchy: Hierarchy = [];
+  let hierarchy: Hierarchy = [];
   if (!element) {
-    return hierarchy;
+    return [];
   }
 
   // Get list of ancestors including itself and get properties at each level in the hierarchy
   const ancestors = getAncestors(element);
-  for (let i = 0; i < ancestors.length; i++) {
-    const elProperties = getElementProperties(ancestors[i]);
-    const elPropertiesLength = JSON.stringify(elProperties).length;
+  hierarchy = ensureListUnderLimit(
+    ancestors.map((el) => getElementProperties(el)),
+    MAX_HIERARCHY_LENGTH,
+  ) as Hierarchy;
 
-    // If adding the next ancestor would exceed the max hierarchy length, stop
-    const commaLength = i > 0 ? 1 : 0;
-    if (outChars + elPropertiesLength + commaLength > MAX_HIERARCHY_LENGTH) {
-      break;
-    }
-
-    outChars += elPropertiesLength + commaLength;
-    hierarchy.unshift(elProperties);
-  }
   return hierarchy;
 };
+
+export function ensureListUnderLimit(list: Hierarchy | JSONValue[], bytesLimit: number): Hierarchy | JSONValue[] {
+  let numChars = 0;
+  for (let i = 0; i < list.length; i++) {
+    const node = list[i];
+    if (node === null) {
+      // simulate 'None' in python
+      numChars += 4;
+    } else {
+      const value = ensureUnicodePythonCompatible(node);
+      // Using Array.from(string).length instead of string.length
+      // to correctly count Unicode characters (including emojis)
+      numChars += value ? Array.from(value).length : 4;
+    }
+    if (numChars > bytesLimit) {
+      return list.slice(0, i);
+    }
+  }
+  return list;
+}
+
+/**
+ * Converts a JSON-compatible value to a Python-compatible string representation.
+ * This function handles various data types and ensures proper escaping and formatting.
+ *
+ * @param value - The value to be converted (can be any JSON-compatible type)
+ * @param nested - Indicates if the value is nested within another structure (default: false)
+ * @returns A string representation of the value compatible with Python, or null if conversion fails
+ */
+export function ensureUnicodePythonCompatible(value: HierarchyNode | JSONValue | null, nested = false): string | null {
+  try {
+    if (value == null) {
+      // Handle null values
+      if (nested) {
+        return 'None'; // Represent null as 'None' in Python when nested
+      }
+      return null; // Return null for top-level null values
+    } else if (typeof value === 'string') {
+      if (nested) {
+        // Escape special characters in nested strings
+        value = value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\r/g, '\\r');
+
+        // Handle quotes in the string
+        if (value.includes('"')) {
+          return `'${value}'`; // Wrap in single quotes if it contains double quotes
+        }
+        if (value.includes("'")) {
+          return `"${value.replace(/'/g, "\\'")}"`; // Wrap in double quotes and escape single quotes
+        }
+        return `'${value}'`; // Default to wrapping in single quotes
+      }
+      return value; // Return non-nested strings as-is
+    } else if (typeof value === 'boolean') {
+      // Convert boolean to Python-style capitalized string
+      return value ? 'True' : 'False';
+    } else if (Array.isArray(value)) {
+      // Handle arrays by recursively converting each element
+      const elements = value.map((o) => ensureUnicodePythonCompatible(o, true));
+      return `[${elements.join(', ')}]`;
+    } else if (typeof value === 'object') {
+      // Handle objects (dictionaries in Python)
+      const entries = Object.entries(value)
+        .filter(([key]) => key != null) // Filter out null keys
+        .map(
+          ([key, val]) =>
+            `${String(ensureUnicodePythonCompatible(key, true))}: ${String(ensureUnicodePythonCompatible(val, true))}`,
+        );
+      let result = `{${entries.join(', ')}}`;
+
+      // Handle single quotes in the resulting string
+      if (result.includes("\\'")) {
+        result = result.replace(/'/g, "'").replace(/'/g, "\\'");
+      }
+      return result;
+    }
+    // For any other types, return their string representation;
+    return value.toString();
+  } catch (e) {
+    // Return null if any error occurs during the conversion
+    return null;
+  }
+}

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -178,12 +178,6 @@ describe('autoTrackingPlugin', () => {
         '[Amplitude] Element Class': 'my-link-class',
         '[Amplitude] Element Hierarchy': [
           {
-            index: 1,
-            indexOfType: 0,
-            prevSib: 'head',
-            tag: 'body',
-          },
-          {
             attrs: {
               'aria-label': 'my-link',
               href: 'https://www.amplitude.com/click-link',
@@ -193,6 +187,12 @@ describe('autoTrackingPlugin', () => {
             index: 0,
             indexOfType: 0,
             tag: 'a',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
           },
         ],
         '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
@@ -247,12 +247,6 @@ describe('autoTrackingPlugin', () => {
         '[Amplitude] Element Class': 'my-button-class',
         '[Amplitude] Element Hierarchy': [
           {
-            index: 1,
-            indexOfType: 0,
-            prevSib: 'head',
-            tag: 'body',
-          },
-          {
             attrs: {
               'aria-label': 'my-button',
             },
@@ -262,6 +256,12 @@ describe('autoTrackingPlugin', () => {
             indexOfType: 0,
             prevSib: 'h2',
             tag: 'button',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
           },
         ],
 
@@ -324,12 +324,6 @@ describe('autoTrackingPlugin', () => {
         '[Amplitude] Element Class': 'my-button-class',
         '[Amplitude] Element Hierarchy': [
           {
-            index: 1,
-            indexOfType: 0,
-            prevSib: 'head',
-            tag: 'body',
-          },
-          {
             attrs: {
               'aria-label': 'my-button',
             },
@@ -339,6 +333,12 @@ describe('autoTrackingPlugin', () => {
             indexOfType: 0,
             prevSib: 'h2',
             tag: 'button',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
           },
         ],
         '[Amplitude] Element ID': 'my-button-id',
@@ -588,12 +588,6 @@ describe('autoTrackingPlugin', () => {
         '[Amplitude] Element Class': 'my-button-class',
         '[Amplitude] Element Hierarchy': [
           {
-            index: 1,
-            indexOfType: 0,
-            prevSib: 'head',
-            tag: 'body',
-          },
-          {
             attrs: {
               'data-amp-test-hello': 'world',
               'data-amp-test-test': '',
@@ -605,6 +599,12 @@ describe('autoTrackingPlugin', () => {
             indexOfType: 0,
             prevSib: 'h2',
             tag: 'button',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
           },
         ],
         '[Amplitude] Element ID': 'my-button-id',

--- a/packages/plugin-autocapture-browser/test/hierarchy.test.ts
+++ b/packages/plugin-autocapture-browser/test/hierarchy.test.ts
@@ -1,4 +1,4 @@
-import { getAncestors, getElementProperties, getHierarchy } from '../src/hierarchy';
+import * as HierarchyUtil from '../src/hierarchy';
 
 describe('autocapture-plugin hierarchy', () => {
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('autocapture-plugin hierarchy', () => {
       `;
 
       const nullElement = document.getElementById('null-element');
-      expect(getElementProperties(nullElement)).toEqual(null);
+      expect(HierarchyUtil.getElementProperties(nullElement)).toEqual(null);
     });
 
     test('should return tag and index information if element has siblings', () => {
@@ -41,7 +41,7 @@ describe('autocapture-plugin hierarchy', () => {
       `;
 
       const inner4 = document.getElementById('inner4');
-      expect(getElementProperties(inner4)).toEqual({
+      expect(HierarchyUtil.getElementProperties(inner4)).toEqual({
         id: 'inner4',
         index: 3,
         indexOfType: 1,
@@ -63,7 +63,7 @@ describe('autocapture-plugin hierarchy', () => {
       `;
 
       const inner = document.getElementById('inner');
-      expect(getElementProperties(inner)).toEqual({
+      expect(HierarchyUtil.getElementProperties(inner)).toEqual({
         id: 'inner',
         index: 0,
         indexOfType: 0,
@@ -81,7 +81,7 @@ describe('autocapture-plugin hierarchy', () => {
       `;
 
       const inner = document.getElementById('inner');
-      expect(getElementProperties(inner)).toEqual({
+      expect(HierarchyUtil.getElementProperties(inner)).toEqual({
         id: 'inner',
         index: 0,
         indexOfType: 0,
@@ -94,7 +94,7 @@ describe('autocapture-plugin hierarchy', () => {
   test('should not fail when parent element is null', () => {
     const parentlessElement = document.createElement('div');
 
-    expect(getElementProperties(parentlessElement)).toEqual({
+    expect(HierarchyUtil.getElementProperties(parentlessElement)).toEqual({
       tag: 'div',
     });
   });
@@ -106,7 +106,7 @@ describe('autocapture-plugin hierarchy', () => {
     `;
 
       const target = document.getElementById('target');
-      expect(getElementProperties(target)).toEqual({
+      expect(HierarchyUtil.getElementProperties(target)).toEqual({
         id: 'target',
         index: 0,
         indexOfType: 0,
@@ -123,7 +123,7 @@ describe('autocapture-plugin hierarchy', () => {
     `;
 
       const target = document.getElementById('target');
-      expect(getElementProperties(target)).toEqual({
+      expect(HierarchyUtil.getElementProperties(target)).toEqual({
         id: 'target',
         index: 0,
         indexOfType: 0,
@@ -140,7 +140,7 @@ describe('autocapture-plugin hierarchy', () => {
     `;
 
       const target = document.getElementById('target');
-      expect(getElementProperties(target)).toEqual({
+      expect(HierarchyUtil.getElementProperties(target)).toEqual({
         id: 'target',
         index: 0,
         indexOfType: 0,
@@ -155,7 +155,7 @@ describe('autocapture-plugin hierarchy', () => {
     `;
 
       const target = document.getElementById('target');
-      expect(getElementProperties(target)).toEqual({
+      expect(HierarchyUtil.getElementProperties(target)).toEqual({
         id: 'target',
         index: 0,
         indexOfType: 0,
@@ -179,7 +179,7 @@ describe('getAncestors', () => {
     `;
 
     const inner = document.getElementById('inner');
-    expect(getAncestors(inner)).toEqual([
+    expect(HierarchyUtil.getAncestors(inner)).toEqual([
       inner,
       document.getElementById('parent1'),
       document.getElementById('parent2'),
@@ -189,7 +189,7 @@ describe('getAncestors', () => {
 
   test('should not fail when element is null', () => {
     const nullElement = null;
-    expect(getAncestors(nullElement)).toEqual([]);
+    expect(HierarchyUtil.getAncestors(nullElement)).toEqual([]);
   });
 });
 
@@ -210,17 +210,12 @@ describe('getHierarchy', () => {
 
     const inner2 = document.getElementById('inner2');
 
-    expect(getHierarchy(inner2)).toEqual([
+    expect(HierarchyUtil.getHierarchy(inner2)).toEqual([
       {
+        id: 'inner2',
         index: 1,
-        indexOfType: 0,
-        prevSib: 'head',
-        tag: 'body',
-      },
-      {
-        id: 'parent2',
-        index: 0,
-        indexOfType: 0,
+        indexOfType: 1,
+        prevSib: 'div',
         tag: 'div',
       },
       {
@@ -230,22 +225,28 @@ describe('getHierarchy', () => {
         tag: 'div',
       },
       {
-        id: 'inner2',
-        index: 1,
-        indexOfType: 1,
-        prevSib: 'div',
+        id: 'parent2',
+        index: 0,
+        indexOfType: 0,
         tag: 'div',
+      },
+      {
+        index: 1,
+        indexOfType: 0,
+        prevSib: 'head',
+        tag: 'body',
       },
     ]);
   });
 
   test('should not fail when element is null', () => {
     const nullElement = null;
-    expect(getHierarchy(nullElement)).toEqual([]);
+    expect(HierarchyUtil.getHierarchy(nullElement)).toEqual([]);
   });
 
-  test('should cut off hierarchy output nodes to stay less than or equal to 1024 chars', () => {
-    document.getElementsByTagName('body')[0].innerHTML = `
+  describe('[Amplitude] Element Hierarchy property:', () => {
+    test('should cut off hierarchy output nodes to stay less than or equal to 1024 chars', () => {
+      document.getElementsByTagName('body')[0].innerHTML = `
       <div id="parent2">
         <div id="parent1"
           long-attribute="${'a'.repeat(2000)}end"
@@ -253,7 +254,7 @@ describe('getHierarchy', () => {
           long-attribute3="${'a'.repeat(128)}"
           long-attribute4="${'a'.repeat(128)}"
           long-attribute5="${'a'.repeat(128)}"
-          attribute6="${'a'.repeat(85)}"
+          attribute6="${'a'.repeat(8)}"
         >
           <div id="inner12345">
             xxx
@@ -262,37 +263,141 @@ describe('getHierarchy', () => {
       </div>
     `;
 
-    const inner12345 = document.getElementById('inner12345');
-    const innerHierarchy = getHierarchy(inner12345);
-    expect(innerHierarchy).toEqual([
-      {
-        id: 'parent2',
-        index: 0,
-        indexOfType: 0,
-        tag: 'div',
-      },
-      {
-        id: 'parent1',
-        index: 0,
-        indexOfType: 0,
-        tag: 'div',
-        attrs: {
-          'long-attribute': 'a'.repeat(128),
-          'long-attribute2': 'a'.repeat(128),
-          'long-attribute3': 'a'.repeat(128),
-          'long-attribute4': 'a'.repeat(128),
-          'long-attribute5': 'a'.repeat(128),
-          attribute6: 'a'.repeat(85),
+      const inner12345 = document.getElementById('inner12345');
+      const innerHierarchy = HierarchyUtil.getHierarchy(inner12345);
+      // expect innerHierarchy to not have body to stay under 1024 chars
+      expect(innerHierarchy).toEqual([
+        {
+          id: 'inner12345',
+          index: 0,
+          indexOfType: 0,
+          tag: 'div',
         },
-      },
-      {
-        id: 'inner12345',
-        index: 0,
-        indexOfType: 0,
-        tag: 'div',
-      },
-    ]);
+        {
+          id: 'parent1',
+          index: 0,
+          indexOfType: 0,
+          tag: 'div',
+          attrs: {
+            'long-attribute': 'a'.repeat(128),
+            'long-attribute2': 'a'.repeat(128),
+            'long-attribute3': 'a'.repeat(128),
+            'long-attribute4': 'a'.repeat(128),
+            'long-attribute5': 'a'.repeat(128),
+            attribute6: 'a'.repeat(8),
+          },
+        },
+        {
+          id: 'parent2',
+          index: 0,
+          indexOfType: 0,
+          tag: 'div',
+        },
+      ]);
+      const resultLength = JSON.stringify(innerHierarchy).length;
+      expect(resultLength).toBeLessThanOrEqual(1024);
+      expect(resultLength).toEqual(947);
+    });
+  });
 
-    expect(JSON.stringify(innerHierarchy).length).toEqual(1024);
+  describe('ensureUnicodePythonCompatible', () => {
+    // Test null values
+    test('handles null values', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible(null)).toBeNull();
+      expect(HierarchyUtil.ensureUnicodePythonCompatible(null, true)).toBe('None');
+    });
+
+    test('handles simple string', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible('abc')).toBe('abc');
+    });
+
+    test('handles string with double quote', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible('ab"c', true)).toBe(`'ab"c'`);
+    });
+
+    test('handles string with single quote', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible(`ab'c`, true)).toBe(`"ab\\'c"`);
+    });
+
+    test('handles number', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible(123)).toBe('123');
+    });
+
+    test('handles boolean values', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible(true)).toBe('True');
+      expect(HierarchyUtil.ensureUnicodePythonCompatible(false)).toBe('False');
+    });
+
+    test('handles array with mixed types', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible([123, 'abc'])).toBe("[123, 'abc']");
+    });
+
+    test('handles object with mixed types', () => {
+      const result = HierarchyUtil.ensureUnicodePythonCompatible({ abc: 123, def: 'what' });
+      expect(result === "{'abc': 123, 'def': 'what'}" || result === "{'def': 'what', 'abc': 123}").toBeTruthy();
+    });
+
+    test('handles object with value of string with single quote', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible({ key: `ab'c` }, true)).toBe(`{\\'key\\': "ab\\d\\'c"}`);
+    });
+
+    // Test edge cases
+    test('handles edge cases', () => {
+      expect(HierarchyUtil.ensureUnicodePythonCompatible('')).toBe('');
+      expect(HierarchyUtil.ensureUnicodePythonCompatible('', true)).toBe("''");
+      expect(HierarchyUtil.ensureUnicodePythonCompatible({})).toBe('{}');
+      expect(HierarchyUtil.ensureUnicodePythonCompatible([])).toBe('[]');
+    });
+
+    test('returns null when error is thrown', () => {
+      const replaceSpy = jest.spyOn(String.prototype, 'replace');
+      replaceSpy.mockImplementation(() => {
+        throw new Error('Invalid value');
+      });
+
+      expect(HierarchyUtil.ensureUnicodePythonCompatible('h"i', true)).toBe(null);
+      replaceSpy.mockRestore();
+    });
+  });
+
+  describe('ensureListUnderLimit', () => {
+    test('returns full list when under limit', () => {
+      expect(HierarchyUtil.ensureListUnderLimit([123, 'abc'], 100)).toEqual([123, 'abc']);
+    });
+
+    test('drops second element when over limit', () => {
+      expect(HierarchyUtil.ensureListUnderLimit([123, 'abc'], 5)).toEqual([123]);
+    });
+
+    test('returns empty list when all elements exceed limit', () => {
+      expect(HierarchyUtil.ensureListUnderLimit([123, 'abc'], 2)).toEqual([]);
+    });
+
+    test('handles null values correctly', () => {
+      const arr = [null, null, 12, null, 'hello'];
+      expect(HierarchyUtil.ensureListUnderLimit(arr, 15)).toEqual([null, null, 12, null]);
+    });
+
+    test('handles Unicode characters correctly', () => {
+      expect(HierarchyUtil.ensureListUnderLimit(['😊😊 .', '.', '💛', '😊'], 6)).toEqual(['😊😊 .', '.', '💛']);
+    });
+
+    test('handles surrogate pairs correctly', () => {
+      expect(HierarchyUtil.ensureListUnderLimit(['\uD83D', '\uDE0A', '\uD83D', '\uDE0A', '.'], 3)).toEqual([
+        '\uD83D',
+        '\uDE0A',
+        '\uD83D',
+      ]);
+    });
+
+    test('returns length 4 when error is thrown in ensureUnicodePythonCompatible', () => {
+      const replaceSpy = jest.spyOn(Object, 'entries');
+      // eslint-disable-next-line
+      // @ts-ignore
+      replaceSpy.mockReturnValue(null);
+
+      expect(HierarchyUtil.ensureListUnderLimit([{}], 3)).toEqual([]);
+      expect(HierarchyUtil.ensureListUnderLimit([{}], 4)).toEqual([{}]);
+    });
   });
 });

--- a/packages/plugin-autocapture-browser/test/hierarchy.test.ts
+++ b/packages/plugin-autocapture-browser/test/hierarchy.test.ts
@@ -338,7 +338,7 @@ describe('getHierarchy', () => {
     });
 
     test('handles object with value of string with single quote', () => {
-      expect(HierarchyUtil.ensureUnicodePythonCompatible({ key: `ab'c` }, true)).toBe(`{\\'key\\': "ab\\d\\'c"}`);
+      expect(HierarchyUtil.ensureUnicodePythonCompatible({ key: `ab'c` }, true)).toBe(`{\\'key\\': "ab\\\\'c"}`);
     });
 
     // Test edge cases


### PR DESCRIPTION
### Summary
- Reverse the hierarchy element ordering
  -  This is important as elements from the end of the array will get removed if the total size of the property 
    exceeds the projects limit. If only parents are removed, the selector functionality is more likely to still work, rather than if 
    the last target element is removed
  - Use better size approximation logic that allows the client to determine if the property is likely to be too long.