### PR TITLE
feat(session replay): support targeting via passing user properties

### DIFF
--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -1,0 +1,11 @@
+import { IdentifyOperation } from '@amplitude/analytics-types';
+
+export const PROPERTY_ADD_OPERATIONS = [
+  IdentifyOperation.SET,
+  IdentifyOperation.SET_ONCE,
+  IdentifyOperation.ADD,
+  IdentifyOperation.APPEND,
+  IdentifyOperation.PREPEND,
+  IdentifyOperation.POSTINSERT,
+  IdentifyOperation.POSTINSERT,
+];

--- a/packages/plugin-session-replay-browser/src/helpers.ts
+++ b/packages/plugin-session-replay-browser/src/helpers.ts
@@ -9,10 +9,7 @@ export const parseUserProperties = (event: Event) => {
   const userPropertyKeys = Object.keys(event.user_properties);
 
   userPropertyKeys.forEach((identifyKey) => {
-    if (
-      Object.values(IdentifyOperation).includes(identifyKey as IdentifyOperation) &&
-      PROPERTY_ADD_OPERATIONS.includes(identifyKey as IdentifyOperation)
-    ) {
+    if (PROPERTY_ADD_OPERATIONS.includes(identifyKey as IdentifyOperation)) {
       const typedUserPropertiesOperation =
         event.user_properties && (event.user_properties[identifyKey as IdentifyOperation] as Record<string, any>);
       userPropertiesObj = {

--- a/packages/plugin-session-replay-browser/src/helpers.ts
+++ b/packages/plugin-session-replay-browser/src/helpers.ts
@@ -1,0 +1,25 @@
+import { Event, IdentifyOperation } from '@amplitude/analytics-types';
+import { PROPERTY_ADD_OPERATIONS } from './constants';
+
+export const parseUserProperties = (event: Event) => {
+  if (!event.user_properties) {
+    return;
+  }
+  let userPropertiesObj = {};
+  const userPropertyKeys = Object.keys(event.user_properties);
+
+  userPropertyKeys.forEach((identifyKey) => {
+    if (
+      Object.values(IdentifyOperation).includes(identifyKey as IdentifyOperation) &&
+      PROPERTY_ADD_OPERATIONS.includes(identifyKey as IdentifyOperation)
+    ) {
+      const typedUserPropertiesOperation =
+        event.user_properties && (event.user_properties[identifyKey as IdentifyOperation] as Record<string, any>);
+      userPropertiesObj = {
+        ...userPropertiesObj,
+        ...typedUserPropertiesOperation,
+      };
+    }
+  });
+  return userPropertiesObj;
+};

--- a/packages/plugin-session-replay-browser/test/helpers.test.ts
+++ b/packages/plugin-session-replay-browser/test/helpers.test.ts
@@ -1,0 +1,40 @@
+import { SpecialEventType } from '@amplitude/analytics-types';
+import { parseUserProperties } from '../src/helpers';
+
+describe('helpers', () => {
+  test('should return undefined if no user properties', () => {
+    const userProperties = parseUserProperties({
+      event_type: SpecialEventType.IDENTIFY,
+      session_id: 123,
+    });
+    expect(userProperties).toEqual(undefined);
+  });
+
+  test('should parse properties from their operation', () => {
+    const userProperties = parseUserProperties({
+      event_type: SpecialEventType.IDENTIFY,
+      user_properties: {
+        $set: {
+          plan_id: 'free',
+        },
+      },
+      session_id: 123,
+    });
+    expect(userProperties).toEqual({
+      plan_id: 'free',
+    });
+  });
+
+  test('should return an empty object if operations are not additive', () => {
+    const userProperties = parseUserProperties({
+      event_type: SpecialEventType.IDENTIFY,
+      user_properties: {
+        $remove: {
+          plan_id: 'free',
+        },
+      },
+      session_id: 123,
+    });
+    expect(userProperties).toEqual({});
+  });
+});

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -50,6 +50,7 @@ export interface SessionReplayLocalConfig extends Config {
   debugMode?: boolean;
   configEndpointUrl?: string;
   shouldInlineStylesheet?: boolean;
+  userProperties?: { [key: string]: any };
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -1,8 +1,9 @@
 import { getAnalyticsConnector, getGlobalScope } from '@amplitude/analytics-client-common';
 import { Logger, returnWrapper } from '@amplitude/analytics-core';
-import { Event, Logger as ILogger, LogLevel, SpecialEventType } from '@amplitude/analytics-types';
+import { Logger as ILogger, LogLevel, SpecialEventType } from '@amplitude/analytics-types';
 import { pack, record } from '@amplitude/rrweb';
 import { scrollCallback } from '@amplitude/rrweb-types';
+import { TargetingParameters } from '@amplitude/targeting';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import { SessionReplayJoinedConfig, SessionReplayJoinedConfigGenerator } from './config/types';
 import {
@@ -167,15 +168,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     const globalScope = getGlobalScope();
     if (globalScope && globalScope.document && globalScope.document.hasFocus()) {
-      await this.evaluateTargetingAndRecord();
+      await this.evaluateTargetingAndRecord({ userProperties: options.userProperties });
     }
   }
 
-  setSessionId(sessionId: number, deviceId?: string) {
-    return returnWrapper(this.asyncSetSessionId(sessionId, deviceId));
+  setSessionId(sessionId: number, deviceId?: string, options?: { userProperties?: { [key: string]: any } }) {
+    return returnWrapper(this.asyncSetSessionId(sessionId, deviceId, options));
   }
 
-  async asyncSetSessionId(sessionId: number, deviceId?: string) {
+  async asyncSetSessionId(sessionId: number, deviceId?: string, options?: { userProperties?: { [key: string]: any } }) {
     const previousSessionId = this.identifiers && this.identifiers.sessionId;
     if (previousSessionId) {
       this.stopRecordingAndSendEvents(previousSessionId);
@@ -192,7 +193,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (this.joinedConfigGenerator && previousSessionId) {
       this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
     }
-    await this.evaluateTargetingAndRecord();
+    await this.evaluateTargetingAndRecord({ userProperties: options?.userProperties });
   }
 
   getSessionReplayDebugPropertyValue() {
@@ -249,7 +250,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     });
   };
 
-  evaluateTargetingAndRecord = async (options?: { event?: Event }) => {
+  evaluateTargetingAndRecord = async (targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>) => {
     if (!this.identifiers || !this.identifiers.sessionId || !this.config) {
       this.loggerProvider.error('Session replay init has not been called, cannot evaluate targeting.');
       return false;
@@ -257,12 +258,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // Return early if a targeting match has already been made
     if (this.sessionTargetingMatch) {
       if (!this.recordCancelCallback) {
+        this.loggerProvider.log('Session replay capture beginning due to targeting match.');
         this.recordEvents();
       }
       return this.sessionTargetingMatch;
     }
 
-    let eventForTargeting = options?.event;
+    let eventForTargeting = targetingParams?.event;
     if (
       eventForTargeting &&
       Object.values(SpecialEventType).includes(eventForTargeting.event_type as SpecialEventType)
@@ -270,18 +272,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
       eventForTargeting = undefined;
     }
 
-    let userProperties;
-    if (this.config.instanceName) {
-      const identityStore = getAnalyticsConnector(this.config.instanceName).identityStore;
-      userProperties = identityStore.getIdentity().userProperties;
-    }
     this.sessionTargetingMatch = await evaluateTargetingAndStore({
       sessionId: this.identifiers.sessionId,
       config: this.config,
-      targetingParams: { userProperties, event: eventForTargeting },
+      targetingParams: { userProperties: targetingParams?.userProperties, event: eventForTargeting },
     });
 
     if (this.sessionTargetingMatch) {
+      this.loggerProvider.log('Session replay capture beginning due to targeting match.');
       this.recordEvents();
     }
 

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -39,6 +39,7 @@ export const evaluateTargetingAndStore = async ({
         apiKey: config.apiKey,
         loggerProvider: config.loggerProvider,
       });
+
       sessionTargetingMatch = targetingResult.sr_targeting_config.key === 'on';
     }
     void targetingIDBStore.storeTargetingMatchForSession({

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,4 +1,5 @@
-import { AmplitudeReturn, Event, ServerZone } from '@amplitude/analytics-types';
+import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-types';
+import { TargetingParameters } from '@amplitude/targeting';
 import { SessionReplayLocalConfig } from '../config/types';
 
 export type Events = string[];
@@ -59,10 +60,16 @@ export type SessionReplayOptions = Omit<Partial<SessionReplayLocalConfig & Sessi
 
 export interface AmplitudeSessionReplay {
   init: (apiKey: string, options: SessionReplayOptions) => AmplitudeReturn<void>;
-  setSessionId: (sessionId: number, deviceId?: string) => AmplitudeReturn<void>;
+  setSessionId: (
+    sessionId: number,
+    deviceId?: string,
+    options?: { userProperties?: { [key: string]: any } },
+  ) => AmplitudeReturn<void>;
   getSessionId: () => number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
-  evaluateTargetingAndRecord: (options?: { event?: Event }) => Promise<boolean>;
+  evaluateTargetingAndRecord: (
+    targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>,
+  ) => Promise<boolean>;
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;
 }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -376,6 +376,16 @@ describe('SessionReplay', () => {
       expect(sessionReplay.identifiers?.deviceId).toEqual('9l8m7n');
       expect(sessionReplay.getDeviceId()).toEqual('9l8m7n');
     });
+
+    test('should pass userProperties to evaluateTargetingAndRecord', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.loggerProvider = mockLoggerProvider;
+      const evaluateMock = jest.fn();
+      sessionReplay.evaluateTargetingAndRecord = evaluateMock;
+      return sessionReplay.setSessionId(456, '9l8m7n', { userProperties: { plan_id: 'free' } }).promise.then(() => {
+        expect(evaluateMock).toHaveBeenCalledWith({ userProperties: { plan_id: 'free' } });
+      });
+    });
   });
 
   describe('getSessionId', () => {
@@ -880,7 +890,21 @@ describe('SessionReplay', () => {
       return evaluateTargetingAndStorePromise.then(() => {
         expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
           expect.objectContaining({
-            targetingParams: { event: { event_type: 'Purchase' }, userProperties: {} },
+            targetingParams: { event: { event_type: 'Purchase' }, userProperties: undefined },
+          }),
+        );
+      });
+    });
+
+    test('should pass user properties to evaluateTargetingAndStore', async () => {
+      await sessionReplay.evaluateTargetingAndRecord({
+        event: { event_type: 'Purchase' },
+        userProperties: { plan_id: 'free' },
+      });
+      return evaluateTargetingAndStorePromise.then(() => {
+        expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
+          expect.objectContaining({
+            targetingParams: { event: { event_type: 'Purchase' }, userProperties: { plan_id: 'free' } },
           }),
         );
       });
@@ -890,7 +914,7 @@ describe('SessionReplay', () => {
       await sessionReplay.evaluateTargetingAndRecord({ event: { event_type: '$identify' } });
       expect(TargetingManager.evaluateTargetingAndStore).toHaveBeenCalledWith(
         expect.objectContaining({
-          targetingParams: { event: undefined, userProperties: {} },
+          targetingParams: { event: undefined, userProperties: undefined },
         }),
       );
     });


### PR DESCRIPTION
### Summary

(Reattempting #808)
The current implementation of targeting via user properties relied on a Browser SDK instance being present (it used the analytics connector functionality). This PR updates the logic in the standalone to accept user properties as config and arguments to setSessionId and to evaluateTargetingAndRecord, and updates the plugin to pass user properties when appropriate.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
