### PR TITLE
feat(autocapture): track DOM mutations and navigation events to capture action clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   },
   "dependencies": {
     "tslib": "^2.4.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/plugin-autocapture-browser/package.json
+++ b/packages/plugin-autocapture-browser/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@amplitude/analytics-client-common": ">=1 <3",
     "@amplitude/analytics-types": ">=1 <3",
+    "rxjs": "^7.8.1",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -137,6 +137,7 @@ type BaseTimestampedEvent<T> = {
 };
 
 // Specific types for events with targetElementProperties
+export type ElementBasedEvent = MouseEvent | Event;
 export type ElementBasedTimestampedEvent<T> = BaseTimestampedEvent<T> & {
   event: MouseEvent | Event;
   type: 'click' | 'change';
@@ -301,6 +302,7 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
       return;
     }
 
+    // Create should track event functions the different allowlists
     const shouldTrackEvent = createShouldTrackEvent(
       options,
       (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
@@ -310,7 +312,10 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
       (options as AutoCaptureOptionsWithDefaults).actionClickAllowlist,
     );
 
+    // Create observables for events on the window
     const allObservables = createObservables();
+
+    // Create subscriptions
     const clickTrackingSubscription = trackClicks({
       allObservables,
       options: options as AutoCaptureOptionsWithDefaults,

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -194,8 +194,7 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
       map((error) => addAdditionalEventProperties(error, 'error')),
     );
 
-    // add observable for URL changes
-
+    // Create observable for URL changes
     let navigateObservable;
     if (window.navigation) {
       navigateObservable = fromEvent<NavigateEvent>(window.navigation, 'navigate').pipe(

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -124,7 +124,7 @@ export type AutoCaptureOptionsWithDefaults = Required<
 export enum ObservablesEnum {
   ClickObservable = 'clickObservable',
   ChangeObservable = 'changeObservable',
-  ErrorObservable = 'errorObservable',
+  // ErrorObservable = 'errorObservable',
   NavigateObservable = 'navigateObservable',
   MutationObservable = 'mutationObservable',
 }
@@ -151,7 +151,7 @@ export type TimestampedEvent<T> = BaseTimestampedEvent<T> | ElementBasedTimestam
 export interface AllWindowObservables {
   [ObservablesEnum.ClickObservable]: Observable<ElementBasedTimestampedEvent<MouseEvent>>;
   [ObservablesEnum.ChangeObservable]: Observable<ElementBasedTimestampedEvent<Event>>;
-  [ObservablesEnum.ErrorObservable]: Observable<TimestampedEvent<ErrorEvent>>;
+  // [ObservablesEnum.ErrorObservable]: Observable<TimestampedEvent<ErrorEvent>>;
   [ObservablesEnum.NavigateObservable]: Observable<TimestampedEvent<NavigateEvent>> | undefined;
   [ObservablesEnum.MutationObservable]: Observable<TimestampedEvent<MutationRecord[]>>;
 }
@@ -191,12 +191,13 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
     );
 
     // Create Observable from unhandled errors
-    const errorObservable = fromEvent<ErrorEvent>(window, 'error').pipe(
-      map((error) => addAdditionalEventProperties(error, 'error')),
-    );
+    // const errorObservable = fromEvent<ErrorEvent>(window, 'error').pipe(
+    //   map((error) => addAdditionalEventProperties(error, 'error')),
+    // );
 
     // Create observable for URL changes
     let navigateObservable;
+    /* istanbul ignore next */
     if (window.navigation) {
       navigateObservable = fromEvent<NavigateEvent>(window.navigation, 'navigate').pipe(
         map((navigate) => addAdditionalEventProperties(navigate, 'navigate')),
@@ -220,7 +221,7 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
     return {
       [ObservablesEnum.ClickObservable]: clickObservable as Observable<ElementBasedTimestampedEvent<MouseEvent>>,
       [ObservablesEnum.ChangeObservable]: changeObservable as Observable<ElementBasedTimestampedEvent<Event>>,
-      [ObservablesEnum.ErrorObservable]: errorObservable,
+      // [ObservablesEnum.ErrorObservable]: errorObservable,
       [ObservablesEnum.NavigateObservable]: navigateObservable,
       [ObservablesEnum.MutationObservable]: mutationObservable,
     };

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -348,14 +348,16 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
 
     // Setup visual tagging selector
     if (window.opener && visualTaggingOptions.enabled) {
+      const allowlist = (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist;
+      const actionClickAllowlist = (options as AutoCaptureOptionsWithDefaults).actionClickAllowlist;
+
       /* istanbul ignore next */
       visualTaggingOptions.messenger?.setup({
         logger: config?.loggerProvider,
         ...(config?.serverZone && { endpoint: constants.AMPLITUDE_ORIGINS_MAP[config.serverZone] }),
-        isElementSelectable: createShouldTrackEvent(
-          options,
-          (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
-        ),
+        isElementSelectable: createShouldTrackEvent(options, [...allowlist, ...actionClickAllowlist]),
+        cssSelectorAllowlist: allowlist,
+        actionClickAllowlist: actionClickAllowlist,
       });
     }
   };

--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -25,7 +25,6 @@ export function trackActionClick({
   shouldTrackActionClick: shouldTrackEvent;
   shouldTrackEvent: shouldTrackEvent;
 }) {
-  options;
   const { clickObservable, mutationObservable, navigateObservable } = allObservables;
 
   const filteredClickObservable = clickObservable.pipe(

--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -1,0 +1,91 @@
+import {
+  AllWindowObservables,
+  AutoCaptureOptionsWithDefaults,
+  ElementBasedTimestampedEvent,
+  ObservablesEnum,
+} from 'src/autocapture-plugin';
+import { filter, map, switchMap, takeUntil, timer, take, merge } from 'rxjs';
+import { ActionType } from 'src/typings/autocapture';
+import { BrowserClient } from '@amplitude/analytics-types';
+import { getClosestElement, shouldTrackEvent } from '../helpers';
+import { AMPLITUDE_ELEMENT_CLICKED_EVENT } from '../constants';
+
+export function trackActionClick({
+  amplitude,
+  allObservables,
+  options,
+  getEventProperties,
+  shouldTrackEvent,
+  shouldTrackActionClick,
+}: {
+  amplitude: BrowserClient;
+  allObservables: AllWindowObservables;
+  options: AutoCaptureOptionsWithDefaults;
+  getEventProperties: (actionType: ActionType, element: Element) => Record<string, any>;
+  shouldTrackActionClick: shouldTrackEvent;
+  shouldTrackEvent: shouldTrackEvent;
+}) {
+  options;
+  const { clickObservable, mutationObservable, navigateObservable } = allObservables;
+
+  const filteredClickObservable = clickObservable.pipe(
+    filter((click) => {
+      // Filter out clickEvent events with no target
+      // no event target could happen when change events are triggered programmatically
+      if (!click.event.target) {
+        return false;
+      }
+
+      // Filter out regularly tracked click events that are already handled in trackClicks
+      return !shouldTrackEvent('click', click.event.target as Element);
+    }),
+    map((click) => {
+      // overwrite the closestTrackedAncestor with the closest element that is on the actionClickAllowlist
+      const closestActionClickEl = getClosestElement(click.event.target as Element, options.actionClickAllowlist);
+      click.closestTrackedAncestor = closestActionClickEl as Element;
+
+      // overwrite the targetElementProperties with the properties of the closestActionClickEl
+      if (click.closestTrackedAncestor !== null) {
+        click.targetElementProperties = getEventProperties(click.type, click.closestTrackedAncestor);
+      }
+      return click;
+    }),
+    filter((clickEvent) => {
+      // Filter out clicks with no closestTrackedAncestor according to actionClickAllowlist
+      if (!clickEvent.closestTrackedAncestor) {
+        return false;
+      }
+
+      // Only track change on elements that should be tracked,
+      return shouldTrackActionClick('click', clickEvent.closestTrackedAncestor);
+    }),
+  );
+
+  const changeObservables: Array<
+    AllWindowObservables[ObservablesEnum.MutationObservable] | AllWindowObservables[ObservablesEnum.NavigateObservable]
+  > = [mutationObservable];
+  if (navigateObservable) {
+    changeObservables.push(navigateObservable);
+  }
+  const mutationOrNavigate = merge(...changeObservables);
+
+  const actionClicks = filteredClickObservable.pipe(
+    // If a mutation occurs within 1 second (takeUntil(timer(1000))), it emits the original first click event.
+    switchMap((click) =>
+      mutationOrNavigate.pipe(
+        takeUntil(timer(500)),
+        map(() => click),
+        take(1),
+      ),
+    ),
+  );
+
+  return actionClicks.subscribe((actionClick) => {
+    console.log('actionClick', actionClick);
+
+    amplitude?.track(
+      AMPLITUDE_ELEMENT_CLICKED_EVENT,
+      getEventProperties('click', (actionClick as ElementBasedTimestampedEvent<MouseEvent>).closestTrackedAncestor),
+    );
+  });
+}

--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -7,7 +7,7 @@ import {
 import { filter, map, switchMap, takeUntil, timer, take, merge } from 'rxjs';
 import { ActionType } from 'src/typings/autocapture';
 import { BrowserClient } from '@amplitude/analytics-types';
-import { getClosestElement, shouldTrackEvent } from '../helpers';
+import { filterOutNonTrackableEvents, getClosestElement, shouldTrackEvent } from '../helpers';
 import { AMPLITUDE_ELEMENT_CLICKED_EVENT } from '../constants';
 
 export function trackActionClick({
@@ -49,12 +49,8 @@ export function trackActionClick({
       }
       return click;
     }),
+    filter(filterOutNonTrackableEvents),
     filter((clickEvent) => {
-      // Filter out clicks with no closestTrackedAncestor according to actionClickAllowlist
-      if (!clickEvent.closestTrackedAncestor) {
-        return false;
-      }
-
       // Only track change on elements that should be tracked,
       return shouldTrackActionClick('click', clickEvent.closestTrackedAncestor);
     }),

--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -53,6 +53,7 @@ export function trackActionClick({
   const changeObservables: Array<
     AllWindowObservables[ObservablesEnum.MutationObservable] | AllWindowObservables[ObservablesEnum.NavigateObservable]
   > = [mutationObservable];
+  /* istanbul ignore next */
   if (navigateObservable) {
     changeObservables.push(navigateObservable);
   }
@@ -69,6 +70,7 @@ export function trackActionClick({
   );
 
   return actionClicks.subscribe((actionClick) => {
+    /* istanbul ignore next */
     amplitude?.track(
       AMPLITUDE_ELEMENT_CLICKED_EVENT,
       getEventProperties('click', (actionClick as ElementBasedTimestampedEvent<MouseEvent>).closestTrackedAncestor),

--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -81,8 +81,6 @@ export function trackActionClick({
   );
 
   return actionClicks.subscribe((actionClick) => {
-    console.log('actionClick', actionClick);
-
     amplitude?.track(
       AMPLITUDE_ELEMENT_CLICKED_EVENT,
       getEventProperties('click', (actionClick as ElementBasedTimestampedEvent<MouseEvent>).closestTrackedAncestor),

--- a/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
@@ -27,6 +27,7 @@ export function trackChange({
   );
 
   return filteredChangeObservable.subscribe((changeEvent) => {
+    /* istanbul ignore next */
     amplitude?.track(AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', changeEvent.closestTrackedAncestor));
   });
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
@@ -1,24 +1,21 @@
-import { AllWindowObservables, AutoCaptureOptionsWithDefaults } from 'src/autocapture-plugin';
+import { AllWindowObservables } from 'src/autocapture-plugin';
 import { filter } from 'rxjs';
 import { ActionType } from 'src/typings/autocapture';
 import { BrowserClient } from '@amplitude/analytics-types';
-import { getClosestElement, shouldTrackEvent } from '../helpers';
+import { shouldTrackEvent } from '../helpers';
 import { AMPLITUDE_ELEMENT_CHANGED_EVENT } from '../constants';
 
 export function trackChange({
   amplitude,
   allObservables,
-  options,
   getEventProperties,
   shouldTrackEvent,
 }: {
   amplitude: BrowserClient;
   allObservables: AllWindowObservables;
-  options: AutoCaptureOptionsWithDefaults;
   getEventProperties: (actionType: ActionType, element: Element) => Record<string, any>;
   shouldTrackEvent: shouldTrackEvent;
 }) {
-  const { cssSelectorAllowlist } = options;
   const { changeObservable } = allObservables;
 
   const filteredChangeObservable = changeObservable.pipe(
@@ -29,20 +26,16 @@ export function trackChange({
         return false;
       }
 
-      const closestTrackedAncestor = getClosestElement(changeEvent.event.target as HTMLElement, cssSelectorAllowlist);
-
-      if (!closestTrackedAncestor) {
+      if (!changeEvent.closestTrackedAncestor) {
         return false;
       }
 
       // Only track change on elements that should be tracked,
-      return shouldTrackEvent('change', closestTrackedAncestor);
+      return shouldTrackEvent('change', changeEvent.closestTrackedAncestor);
     }),
   );
 
   return filteredChangeObservable.subscribe((changeEvent) => {
-    const closestTrackedAncestor = getClosestElement(changeEvent.event.target as HTMLElement, cssSelectorAllowlist);
-
-    amplitude?.track(AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', closestTrackedAncestor as Element));
+    amplitude?.track(AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', changeEvent.closestTrackedAncestor));
   });
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
@@ -2,7 +2,7 @@ import { AllWindowObservables } from 'src/autocapture-plugin';
 import { filter } from 'rxjs';
 import { ActionType } from 'src/typings/autocapture';
 import { BrowserClient } from '@amplitude/analytics-types';
-import { shouldTrackEvent } from '../helpers';
+import { filterOutNonTrackableEvents, shouldTrackEvent } from '../helpers';
 import { AMPLITUDE_ELEMENT_CHANGED_EVENT } from '../constants';
 
 export function trackChange({
@@ -19,17 +19,8 @@ export function trackChange({
   const { changeObservable } = allObservables;
 
   const filteredChangeObservable = changeObservable.pipe(
+    filter(filterOutNonTrackableEvents),
     filter((changeEvent) => {
-      // Filter out changeEvent events with no target
-      // This could happen when change events are triggered programmatically
-      if (changeEvent.event.target === null) {
-        return false;
-      }
-
-      if (!changeEvent.closestTrackedAncestor) {
-        return false;
-      }
-
       // Only track change on elements that should be tracked,
       return shouldTrackEvent('change', changeEvent.closestTrackedAncestor);
     }),

--- a/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
@@ -1,0 +1,48 @@
+import { AllWindowObservables, AutoCaptureOptionsWithDefaults } from 'src/autocapture-plugin';
+import { filter } from 'rxjs';
+import { ActionType } from 'src/typings/autocapture';
+import { BrowserClient } from '@amplitude/analytics-types';
+import { getClosestElement, shouldTrackEvent } from '../helpers';
+import { AMPLITUDE_ELEMENT_CHANGED_EVENT } from '../constants';
+
+export function trackChange({
+  amplitude,
+  allObservables,
+  options,
+  getEventProperties,
+  shouldTrackEvent,
+}: {
+  amplitude: BrowserClient;
+  allObservables: AllWindowObservables;
+  options: AutoCaptureOptionsWithDefaults;
+  getEventProperties: (actionType: ActionType, element: Element) => Record<string, any>;
+  shouldTrackEvent: shouldTrackEvent;
+}) {
+  const { cssSelectorAllowlist } = options;
+  const { changeObservable } = allObservables;
+
+  const filteredChangeObservable = changeObservable.pipe(
+    filter((changeEvent) => {
+      // Filter out changeEvent events with no target
+      // This could happen when change events are triggered programmatically
+      if (changeEvent.event.target === null) {
+        return false;
+      }
+
+      const closestTrackedAncestor = getClosestElement(changeEvent.event.target as HTMLElement, cssSelectorAllowlist);
+
+      if (!closestTrackedAncestor) {
+        return false;
+      }
+
+      // Only track change on elements that should be tracked,
+      return shouldTrackEvent('change', closestTrackedAncestor);
+    }),
+  );
+
+  return filteredChangeObservable.subscribe((changeEvent) => {
+    const closestTrackedAncestor = getClosestElement(changeEvent.event.target as HTMLElement, cssSelectorAllowlist);
+
+    amplitude?.track(AMPLITUDE_ELEMENT_CHANGED_EVENT, getEventProperties('change', closestTrackedAncestor as Element));
+  });
+}

--- a/packages/plugin-autocapture-browser/src/autocapture/track-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-click.ts
@@ -1,0 +1,78 @@
+import { AllWindowObservables, AutoCaptureOptionsWithDefaults } from 'src/autocapture-plugin';
+import { buffer, filter, map, debounceTime, merge, pairwise, delay } from 'rxjs';
+import { ActionType } from 'src/typings/autocapture';
+import { BrowserClient } from '@amplitude/analytics-types';
+import { getClosestElement, shouldTrackEvent } from '../helpers';
+import { AMPLITUDE_ELEMENT_CLICKED_EVENT } from '../constants';
+
+const RAGE_CLICK_THRESHOLD = 5;
+
+export function trackClicks({
+  amplitude,
+  allObservables,
+  options,
+  getEventProperties,
+  shouldTrackEvent,
+}: {
+  amplitude: BrowserClient;
+  allObservables: AllWindowObservables;
+  options: AutoCaptureOptionsWithDefaults;
+  getEventProperties: (actionType: ActionType, element: Element) => Record<string, any>;
+  shouldTrackEvent: shouldTrackEvent;
+}) {
+  const { cssSelectorAllowlist } = options;
+  const { clickObservable } = allObservables;
+
+  // Trigger if the target of the click event has changed
+  const comparisonTrigger = clickObservable.pipe(
+    pairwise(),
+    filter(([prev, current]) => {
+      return prev.event.target !== current.event.target;
+    }),
+  );
+
+  // Trigger if there is no click event within 1 second
+  const timeoutTrigger = clickObservable.pipe(
+    debounceTime(options.debounceTime),
+    map(() => 'timeout' as const),
+  );
+
+  const triggers = merge(comparisonTrigger, timeoutTrigger);
+
+  // Get buffers of clicks, if the buffer length is over 5, it is rage click
+
+  const bufferedClicks = clickObservable.pipe(
+    delay(0),
+    filter((click) => {
+      // Filter out click events with no target
+      // This could happen when click events are triggered programmatically
+      if (click.event.target === null) {
+        return false;
+      }
+
+      const closestTrackedAncestor = getClosestElement(click.event.target as HTMLElement, cssSelectorAllowlist);
+
+      if (!closestTrackedAncestor) {
+        return false;
+      }
+
+      // Only track clicks on elements that should be tracked,
+      // Later this will be changed when mutation events are used
+      return shouldTrackEvent('click', closestTrackedAncestor);
+    }),
+    buffer(triggers),
+  );
+
+  return bufferedClicks.subscribe((clicks) => {
+    // TODO: update this when rage clicks are added
+    const clickType =
+      clicks.length >= RAGE_CLICK_THRESHOLD ? AMPLITUDE_ELEMENT_CLICKED_EVENT : AMPLITUDE_ELEMENT_CLICKED_EVENT;
+
+    for (const click of clicks) {
+      const closestTrackedAncestor = getClosestElement(click.event.target as HTMLElement, cssSelectorAllowlist);
+      amplitude?.track(clickType, getEventProperties('click', closestTrackedAncestor as Element), {
+        time: click.timestamp,
+      });
+    }
+  });
+}

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -2,7 +2,7 @@
 import { finder } from './libs/finder';
 import * as constants from './constants';
 import { Logger } from '@amplitude/analytics-types';
-import { AutocaptureOptions } from './autocapture-plugin';
+import { AutocaptureOptions, ElementBasedEvent, ElementBasedTimestampedEvent } from './autocapture-plugin';
 import { ActionType } from './typings/autocapture';
 
 export type JSONValue = string | number | boolean | { [x: string]: JSONValue } | Array<JSONValue>;
@@ -298,3 +298,13 @@ export const asyncLoadScript = (url: string) => {
 export function generateUniqueId(): string {
   return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }
+
+export const filterOutNonTrackableEvents = (event: ElementBasedTimestampedEvent<ElementBasedEvent>): boolean => {
+  // Filter out changeEvent events with no target
+  // This could happen when change events are triggered programmatically
+  if (event.event.target === null || !event.closestTrackedAncestor) {
+    return false;
+  }
+
+  return true;
+};

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -11,9 +11,12 @@ const SENSITIVE_TAGS = ['input', 'select', 'textarea'];
 
 export type shouldTrackEvent = (actionType: ActionType, element: Element) => boolean;
 
-export const createShouldTrackEvent = (autocaptureOptions: AutocaptureOptions): shouldTrackEvent => {
+export const createShouldTrackEvent = (
+  autocaptureOptions: AutocaptureOptions,
+  allowlist: string[], // this can be any type of css selector allow list
+): shouldTrackEvent => {
   return (actionType: ActionType, element: Element) => {
-    const { cssSelectorAllowlist, pageUrlAllowlist, shouldTrackEventResolver } = autocaptureOptions;
+    const { pageUrlAllowlist, shouldTrackEventResolver } = autocaptureOptions;
     /* istanbul ignore if */
     if (!element) {
       return false;
@@ -46,8 +49,8 @@ export const createShouldTrackEvent = (autocaptureOptions: AutocaptureOptions): 
     }
 
     /* istanbul ignore if */
-    if (cssSelectorAllowlist) {
-      const hasMatchAnyAllowedSelector = cssSelectorAllowlist.some((selector) => !!element?.matches?.(selector));
+    if (allowlist) {
+      const hasMatchAnyAllowedSelector = allowlist.some((selector) => !!element?.matches?.(selector));
       if (!hasMatchAnyAllowedSelector) {
         return false;
       }
@@ -96,7 +99,7 @@ export const isTextNode = (node: Node) => {
 export const isNonSensitiveElement = (element: Element) => {
   /* istanbul ignore next */
   const tag = element?.tagName?.toLowerCase?.();
-  const isContentEditable = element.getAttribute('contenteditable') === 'true';
+  const isContentEditable = element?.getAttribute?.('contenteditable') === 'true';
   return !SENSITIVE_TAGS.includes(tag) && !isContentEditable;
 };
 

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -15,16 +15,12 @@ export const createShouldTrackEvent = (
   autocaptureOptions: AutocaptureOptions,
   allowlist: string[], // this can be any type of css selector allow list
 ): shouldTrackEvent => {
-  return (actionType: ActionType, element: Element | null | undefined) => {
+  return (actionType: ActionType, element: Element) => {
     const { pageUrlAllowlist, shouldTrackEventResolver } = autocaptureOptions;
-    /* istanbul ignore if */
-    if (!element) {
-      return false;
-    }
 
     /* istanbul ignore next */
     const tag = element?.tagName?.toLowerCase?.();
-    // Text nodes have no tag
+    // window, document, and Text nodes have no tag
     if (!tag) {
       return false;
     }
@@ -99,7 +95,7 @@ export const isTextNode = (node: Node) => {
 export const isNonSensitiveElement = (element: Element) => {
   /* istanbul ignore next */
   const tag = element?.tagName?.toLowerCase?.();
-  const isContentEditable = element?.getAttribute?.('contenteditable') === 'true';
+  const isContentEditable = element instanceof HTMLElement ? element.isContentEditable : false;
   return !SENSITIVE_TAGS.includes(tag) && !isContentEditable;
 };
 

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -95,7 +95,9 @@ export const isTextNode = (node: Node) => {
 export const isNonSensitiveElement = (element: Element) => {
   /* istanbul ignore next */
   const tag = element?.tagName?.toLowerCase?.();
-  const isContentEditable = element instanceof HTMLElement ? element.isContentEditable : false;
+  const isContentEditable =
+    element instanceof HTMLElement ? element.getAttribute('contenteditable')?.toLowerCase() === 'true' : false;
+
   return !SENSITIVE_TAGS.includes(tag) && !isContentEditable;
 };
 

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -15,7 +15,7 @@ export const createShouldTrackEvent = (
   autocaptureOptions: AutocaptureOptions,
   allowlist: string[], // this can be any type of css selector allow list
 ): shouldTrackEvent => {
-  return (actionType: ActionType, element: Element) => {
+  return (actionType: ActionType, element: Element | null | undefined) => {
     const { pageUrlAllowlist, shouldTrackEventResolver } = autocaptureOptions;
     /* istanbul ignore if */
     if (!element) {

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -141,10 +141,14 @@ export class WindowMessenger implements Messenger {
     logger,
     endpoint,
     isElementSelectable,
+    cssSelectorAllowlist,
+    actionClickAllowlist,
   }: {
     logger?: Logger;
     endpoint?: string;
     isElementSelectable?: (action: InitializeVisualTaggingSelectorData['actionType'], element: Element) => boolean;
+    cssSelectorAllowlist?: string[];
+    actionClickAllowlist?: string[];
   } = {}) {
     this.logger = logger;
     // If endpoint is customized, don't override it.
@@ -196,6 +200,8 @@ export class WindowMessenger implements Messenger {
                 onSelect: this.onSelect,
                 visualHighlightClass: AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
                 messenger: this,
+                cssSelectorAllowlist,
+                actionClickAllowlist,
               });
               this.notify({ action: 'selector-loaded' });
             })

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -94,8 +94,6 @@ describe('action clicks:', () => {
 
       const goBackButton = document.getElementById('go-back-button');
       const goBack = () => {
-        console.log('gooooo', global.window.location, history);
-
         history.pushState(null, '', '#new-hash');
       };
       goBackButton?.addEventListener('click', goBack);

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -1,0 +1,159 @@
+import { autocapturePlugin } from '../../src/autocapture-plugin';
+import { BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
+import { createInstance } from '@amplitude/analytics-browser';
+
+describe('autoTrackingPlugin', () => {
+  let plugin: EnrichmentPlugin | undefined;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: '',
+        href: '',
+        pathname: '',
+        search: '',
+      },
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    (window.location as any) = {
+      hostname: '',
+      href: '',
+      pathname: '',
+      search: '',
+    };
+    plugin = autocapturePlugin();
+  });
+
+  afterEach(() => {
+    void plugin?.teardown?.();
+    document.getElementsByTagName('body')[0].innerHTML = '';
+    jest.clearAllMocks();
+  });
+
+  // ********** START TESTS **********
+
+  describe('auto-tracked events', () => {
+    const API_KEY = 'API_KEY';
+    const USER_ID = 'USER_ID';
+
+    let instance = createInstance();
+    let track: jest.SpyInstance;
+
+    beforeEach(async () => {
+      plugin = autocapturePlugin();
+      instance = createInstance();
+      await instance.init(API_KEY, USER_ID).promise;
+      track = jest.spyOn(instance, 'track');
+
+      const content = `
+        <div id="main" className="class1 class2" data-test-attr="test-attr">
+          <div id="inner-left" className="column">
+            <div id="addDivButton">Add div</div>
+            <button id="real-button">Click me</button>
+          </div>
+          <div id="inner-right" className="column">
+            <div className="card">
+              <h1>Card Title</h1>
+              <a href="https://google.com">Go to Google</a>
+              <a href="#">Dead Link</a>
+            </div>
+          </div>
+          <span data-testid="test-element">inner</span>
+        </div>
+      `;
+
+      document.body.innerHTML = content;
+
+      // Add event listener to div
+      const addDivButton = document.getElementById('addDivButton');
+      let divCount = 0;
+      const addDiv = () => {
+        divCount++;
+        const newDiv = document.createElement('div');
+        newDiv.className = 'new-div';
+        newDiv.textContent = `This is div number ${divCount}`;
+        document.body.appendChild(newDiv);
+      };
+      addDivButton?.addEventListener('click', addDiv);
+
+      // mockWindowLocationFromURL(new URL('https://www.amplitude.com/unit-test?query=param'));
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    test('should track button click even if there is no DOM change', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger 2 click events on button
+      const realButton = document.getElementById('real-button');
+      realButton?.dispatchEvent(new Event('click'));
+      realButton?.dispatchEvent(new Event('click'));
+
+      expect(track).toHaveBeenCalledTimes(2);
+    });
+
+    test('should track div click if it causes a DOM change', async () => {
+      const loggerProvider: Partial<Logger> = {
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider as Logger,
+      };
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      // trigger click event
+      document.getElementById('addDivButton')?.dispatchEvent(new Event('click'));
+
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-link-class',
+        '[Amplitude] Element Hierarchy': [
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+          {
+            attrs: {
+              'aria-label': 'my-link',
+              href: 'https://www.amplitude.com/click-link',
+            },
+            classes: ['my-link-class'],
+            id: 'my-link-id',
+            index: 0,
+            indexOfType: 0,
+            tag: 'a',
+          },
+        ],
+        '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
+        '[Amplitude] Element ID': 'my-link-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'a',
+        '[Amplitude] Element Text': 'my-link-text',
+        '[Amplitude] Element Aria Label': 'my-link',
+        '[Amplitude] Element Selector': '#my-link-id',
+        '[Amplitude] Element Parent Label': 'my-h2-text',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
+    });
+  });
+});

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -258,6 +258,27 @@ describe('action clicks:', () => {
       });
     });
 
+    test('should not track when element type is hidden', async () => {
+      // Use only div in allowlist
+      plugin = autocapturePlugin({ actionClickAllowlist: ['input'], debounceTime: TESTING_DEBOUNCE_TIME });
+      await plugin?.setup(config as BrowserConfig, instance);
+
+      const input = document.createElement('input');
+      input.setAttribute('id', 'my-input-id');
+      input.setAttribute('class', 'my-input-class');
+      input.type = 'hidden';
+      document.body.appendChild(input);
+
+      // trigger click input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
+      await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 503));
+      expect(track).toHaveBeenCalledTimes(0);
+
+      // trigger change input
+      document.getElementById('my-input-id')?.dispatchEvent(new Event('change'));
+      expect(track).toHaveBeenCalledTimes(0);
+    });
+
     // Readd when jsdom has support for navigate events
     // test('should track div click if it causes a navigation (popstate) change', async () => {
     //   await plugin?.setup(config as BrowserConfig, instance);

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -2,9 +2,9 @@ import { autocapturePlugin } from '../../src/autocapture-plugin';
 import { BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
 import { createInstance } from '@amplitude/analytics-browser';
 
-const TESTING_DEBOUNCE_TIME = 9;
+const TESTING_DEBOUNCE_TIME = 4;
 
-describe('autoTrackingPlugin', () => {
+describe('action clicks:', () => {
   let plugin: EnrichmentPlugin | undefined;
 
   beforeAll(() => {
@@ -37,7 +37,7 @@ describe('autoTrackingPlugin', () => {
 
   // ********** START TESTS **********
 
-  describe('auto-tracked events', () => {
+  describe('autotrack clicks that cause a change:', () => {
     const API_KEY = 'API_KEY';
     const USER_ID = 'USER_ID';
 
@@ -104,7 +104,7 @@ describe('autoTrackingPlugin', () => {
       const realButton = document.getElementById('real-button');
       realButton?.dispatchEvent(new Event('click'));
       realButton?.dispatchEvent(new Event('click'));
-      await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 1));
+      await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
       expect(track).toHaveBeenCalledTimes(2);
     });
@@ -114,7 +114,7 @@ describe('autoTrackingPlugin', () => {
 
       // trigger click event on div which is acting as a button
       document.getElementById('addDivButton')?.dispatchEvent(new Event('click'));
-      await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 1));
+      await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
       expect(track).toHaveBeenCalledTimes(1);
       expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -372,7 +372,6 @@ describe('autoTrackingPlugin', () => {
       // assert no additional event was tracked
       expect(track).toHaveBeenCalledTimes(1);
     });
-
     test('should track clicks to elements added after initial load', async () => {
       const body = document.body;
       const bodyParent = body?.parentNode;
@@ -444,7 +443,6 @@ describe('autoTrackingPlugin', () => {
       // stop observer and listeners
       await plugin?.teardown?.();
     });
-
     test('should not track disallowed tag', async () => {
       const div = document.createElement('div');
       div.setAttribute('id', 'my-div-id');
@@ -480,7 +478,10 @@ describe('autoTrackingPlugin', () => {
         button.appendChild(buttonText);
         document.body.appendChild(button);
 
-        plugin = autocapturePlugin({ cssSelectorAllowlist: ['.my-button-class'], debounceTime: TESTING_DEBOUNCE_TIME });
+        plugin = autocapturePlugin({
+          cssSelectorAllowlist: ['.my-button-class'],
+          debounceTime: TESTING_DEBOUNCE_TIME,
+        });
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
@@ -732,8 +733,16 @@ describe('autoTrackingPlugin', () => {
         { time: expect.any(Number) as number },
       );
     });
-
     test('should follow default debounceTime configuration', async () => {
+      const oldFetch = global.fetch;
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              code: 200,
+            }),
+        }),
+      ) as jest.Mock;
       const button = document.createElement('button');
       const buttonText = document.createTextNode('submit');
       button.setAttribute('id', 'my-button-id');
@@ -756,6 +765,8 @@ describe('autoTrackingPlugin', () => {
 
       await new Promise((r) => setTimeout(r, 500));
       expect(track).toHaveBeenCalledTimes(1);
+
+      global.fetch = oldFetch;
     });
 
     test('should track change event', async () => {
@@ -913,7 +924,7 @@ describe('autoTrackingPlugin', () => {
 
         // trigger click inner
         document.getElementById('inner')?.dispatchEvent(new Event('click', { bubbles: true }));
-        await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3000));
+        await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
         expect(track).toHaveBeenCalledTimes(1);
         expect(track).toHaveBeenNthCalledWith(

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -70,7 +70,6 @@ describe('autoTrackingPlugin', () => {
       expect(loggerProvider.warn).toHaveBeenCalledTimes(0);
       expect(loggerProvider.log).toHaveBeenCalledTimes(1);
       expect(loggerProvider.log).toHaveBeenNthCalledWith(1, `${plugin?.name as string} has been successfully added.`);
-      expect(loggerProvider.error).toHaveBeenCalledTimes(0);
     });
 
     test('should handle incompatible Amplitude SDK version', async () => {

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -1118,6 +1118,64 @@ describe('autoTrackingPlugin', () => {
         );
       });
     });
+
+    test('should not track click for an event fired without a target', async () => {
+      const event = new Event('click', {
+        bubbles: true,
+        cancelable: true,
+      });
+
+      window.dispatchEvent(event);
+
+      await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
+
+      expect(track).toHaveBeenCalledTimes(0);
+    });
+
+    describe('rage click detection:', () => {
+      test('clicking on the same element 4 times should track 4 clicks separately', async () => {
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider,
+        };
+        await plugin?.setup(config as BrowserConfig, instance);
+
+        const button = document.createElement('button');
+        document.body.appendChild(button);
+
+        // trigger click event
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+
+        await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
+        expect(track).toHaveBeenCalledTimes(4);
+      });
+
+      // TODO: this will change in the future
+      test('clicking on the same element 5 times should track 6 clicks separately', async () => {
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider,
+        };
+        await plugin?.setup(config as BrowserConfig, instance);
+
+        const button = document.createElement('button');
+        document.body.appendChild(button);
+
+        // trigger click event
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+        button.dispatchEvent(new Event('click'));
+
+        await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
+        expect(track).toHaveBeenCalledTimes(6);
+      });
+    });
   });
 
   describe('teardown', () => {

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -14,6 +14,7 @@ import {
   getEventTagProps,
   asyncLoadScript,
   generateUniqueId,
+  createShouldTrackEvent,
 } from '../src/helpers';
 import { mockWindowLocationFromURL } from './utils';
 import { Logger } from '@amplitude/analytics-types';
@@ -83,10 +84,25 @@ describe('autocapture-plugin helpers', () => {
       expect(result).toEqual(false);
     });
 
-    test('should return false when element is a sensitive tag', () => {
+    test('should return true when element is a sensitive tag', () => {
       const element = document.createElement('a');
       const result = isNonSensitiveElement(element);
       expect(result).toEqual(true);
+    });
+
+    test('should detect contenteditable as a sensitive tag', () => {
+      // Create the SVG element
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('width', '200');
+      svg.setAttribute('height', '200');
+      svg.setAttribute('viewBox', '0 0 200 200');
+
+      expect(isNonSensitiveElement(svg)).toEqual(true);
+      const element = document.createElement('div');
+      expect(isNonSensitiveElement(element)).toEqual(true);
+
+      element.setAttribute('contenteditable', 'true');
+      expect(isNonSensitiveElement(element)).toEqual(true);
     });
   });
 
@@ -573,6 +589,15 @@ describe('autocapture-plugin helpers', () => {
       const randomChar1 = id1.split('-')[1];
       const randomChar2 = id2.split('-')[1];
       expect(randomChar1).not.toEqual(randomChar2);
+    });
+  });
+
+  describe('createShouldTrackEvent', () => {
+    test('should not fail when given window as element', () => {
+      const shouldTrackEvent = createShouldTrackEvent({}, ['div']);
+
+      expect(shouldTrackEvent('click', window as unknown as Element)).toEqual(false);
+      expect(shouldTrackEvent('click', document as unknown as Element)).toEqual(false);
     });
   });
 });

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -78,13 +78,13 @@ describe('autocapture-plugin helpers', () => {
   });
 
   describe('isNonSensitiveElement', () => {
-    test('should return false when element is not a sensitive tag', () => {
+    test('should return false when element is a sensitive tag', () => {
       const element = document.createElement('textarea');
       const result = isNonSensitiveElement(element);
       expect(result).toEqual(false);
     });
 
-    test('should return true when element is a sensitive tag', () => {
+    test('should return true when element is a non-sensitive tag', () => {
       const element = document.createElement('a');
       const result = isNonSensitiveElement(element);
       expect(result).toEqual(true);
@@ -101,8 +101,8 @@ describe('autocapture-plugin helpers', () => {
       const element = document.createElement('div');
       expect(isNonSensitiveElement(element)).toEqual(true);
 
-      element.setAttribute('contenteditable', 'true');
-      expect(isNonSensitiveElement(element)).toEqual(true);
+      element.setAttribute('contenteditable', 'True');
+      expect(isNonSensitiveElement(element)).toEqual(false);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11611,6 +11611,13 @@ rxjs@^7.5.5, rxjs@^7.5.7:
   dependencies:
     tslib "^2.1.0"
 
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
### Summary
This PR introduces significant enhancements to the autocapture plugin. Most notably, clicks that result in either a DOM mutation or a navigation event:

1. Implementation with RxJS for multiple event stream handling
2. Addition of action click tracking for elements not in the default selector list
3. Enhanced configurability with new options like `debounceTime` and `actionClickAllowlist`
4. Refactoring of event tracking logic into separate modules for better maintainability
5. Update the default `isElementSelectable` function that is passed to Visual Labeling to also include
    elements from `actionClickAllowlist` 

Note on navigation events:
Currently this is not fully implemented in all browsers, the fallback will be beforeunload

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
