### PR TITLE
fix(analytics-remote-config): reset attempt count on success

### DIFF
--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -129,6 +129,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
       const parsedStatus = new BaseTransport().buildStatus(res.status);
       switch (parsedStatus) {
         case Status.Success:
+          this.attempts = 0;
           return this.parseAndStoreConfig(res, sessionId);
         case Status.Failed:
           return this.retryFetch(signal, sessionId);

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -187,7 +187,7 @@ describe('RemoteConfigFetch', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(mockLoggerProvider.log.mock.calls[0][0]).toEqual('Remote config successfully fetched');
         expect(remoteConfig).toEqual(mockRemoteConfig);
-        expect(remoteConfigFetch.attempts).toBe(1);
+        expect(remoteConfigFetch.attempts).toBe(0);
       });
     });
     test('should fetch and set config in indexedDB', async () => {
@@ -344,7 +344,7 @@ describe('RemoteConfigFetch', () => {
       await runScheduleTimers();
       return fetchPromise.then(() => {
         expect(fetch).toHaveBeenCalledTimes(2);
-        expect(remoteConfigFetch.attempts).toBe(2);
+        expect(remoteConfigFetch.attempts).toBe(0);
       });
     });
 
@@ -404,7 +404,7 @@ describe('RemoteConfigFetch', () => {
 
       return fetchPromiseNextSession.finally(() => {
         expect(fetch).toHaveBeenCalledTimes(2);
-        expect(remoteConfigFetch.attempts).toBe(1);
+        expect(remoteConfigFetch.attempts).toBe(0);
         expect(remoteConfigFetch.lastFetchedSessionId).toBe(456);
       });
     });
@@ -425,7 +425,7 @@ describe('RemoteConfigFetch', () => {
       await runScheduleTimers();
       return fetchPromise.then(() => {
         expect(fetch).toHaveBeenCalledTimes(2);
-        expect(remoteConfigFetch.attempts).toBe(2);
+        expect(remoteConfigFetch.attempts).toBe(0);
       });
     });
     test('should handle unexpected error where fetch response is null', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

There may be other required changes, but what I noticed is that when testing the SDK would check for the remote config often and succeed. However, after awhile it started to fail because of request exceeeded count. Resetting the attempt count after success helps a bit, but maybe there is a better solution later on.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
