### PR TITLE
fix(session-replay-browser): remote config failure handling

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -33,6 +33,7 @@ export class SessionReplayJoinedConfigGenerator {
     let remoteConfig: SessionReplayRemoteConfig | undefined;
     try {
       if (!this.remoteConfigFetch) {
+        config.captureEnabled = false;
         return config;
       }
 
@@ -67,7 +68,7 @@ export class SessionReplayJoinedConfigGenerator {
     } catch (err: unknown) {
       const knownError = err as Error;
       this.localConfig.loggerProvider.warn(knownError.message);
-      config.captureEnabled = true;
+      config.captureEnabled = false;
     }
 
     if (!remoteConfig) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -110,13 +110,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
-    this.loggerProvider.debug(
-      JSON.stringify(
-        { name: 'session replay joined privacy config', privacyConfig: this.config.privacyConfig },
-        null,
-        2,
-      ),
-    );
+    this.loggerProvider.debug(JSON.stringify({ name: 'session replay joined config', config: this.config }, null, 2));
 
     if (options.sessionId && this.config.interactionConfig?.enabled) {
       const scrollWatcher = ScrollWatcher.default(
@@ -184,6 +178,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // and config was just fetched in initialization, so no need to fetch it a second time
     if (this.joinedConfigGenerator && previousSessionId) {
       this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
+      this.loggerProvider.debug(JSON.stringify({ name: 'session replay joined config', config: this.config }, null, 2));
     }
     this.recordEvents();
   }
@@ -284,7 +279,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
     if (!this.config.captureEnabled) {
       this.loggerProvider.log(
-        `Session ${this.identifiers.sessionId} not being captured due to capture being disabled for project.`,
+        `Session ${this.identifiers.sessionId} not being captured due to capture being disabled for project or because the remote config could not be fetched.`,
       );
       return false;
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -110,7 +110,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
-    this.loggerProvider.debug(JSON.stringify({ name: 'session replay joined config', config: this.config }, null, 2));
+    this.loggerProvider.debug(
+      JSON.stringify(
+        { name: 'session replay joined privacy config', privacyConfig: this.config.privacyConfig },
+        null,
+        2,
+      ),
+    );
 
     if (options.sessionId && this.config.interactionConfig?.enabled) {
       const scrollWatcher = ScrollWatcher.default(
@@ -178,7 +184,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // and config was just fetched in initialization, so no need to fetch it a second time
     if (this.joinedConfigGenerator && previousSessionId) {
       this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
-      this.loggerProvider.debug(JSON.stringify({ name: 'session replay joined config', config: this.config }, null, 2));
     }
     this.recordEvents();
   }

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -133,7 +133,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
-          captureEnabled: true,
+          captureEnabled: false,
         });
       });
     });
@@ -144,7 +144,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
-          captureEnabled: true,
+          captureEnabled: false,
         });
       });
     });

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -106,7 +106,7 @@ describe('module level integration', () => {
       beforeEach(() => {
         getRemoteConfigMock.mockImplementation(() => Promise.reject('error'));
       });
-      test('should capture replays and use options sampleRate', async () => {
+      test('should not capture replays and use options sampleRate', async () => {
         const sessionReplay = new SessionReplay();
         const initPromise = sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 0 }).promise;
         // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -117,10 +117,8 @@ describe('module level integration', () => {
           // Ensure that sample rate matches what's passed in the options
           expect(sampleRate).toBe(1);
           const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
-          expect(sessionRecordingProperties).toMatchObject({
-            [DEFAULT_SESSION_REPLAY_PROPERTY]: `1a2b3c/${SESSION_ID_IN_20_SAMPLE}`,
-          });
-          expect(record).toHaveBeenCalled();
+          expect(sessionRecordingProperties).toMatchObject({});
+          expect(record).not.toHaveBeenCalled();
         });
       });
     });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We used to record on remote config fetch failure, however with privacy config added it's important that if we fail to fetch any config that we do not record. Otherwise, we risk exposing unwanted text.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
