### PR TITLE
fix(remote config): return empty config from indexeddb

### DIFF
--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -52,11 +52,10 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     const fetchStartTime = Date.now();
     // First check IndexedDB for session
     if (this.remoteConfigIDBStore) {
-      const remoteConfigHasValues = await this.remoteConfigIDBStore.remoteConfigHasValues(configNamespace);
       const lastFetchedSessionId = await this.remoteConfigIDBStore.getLastFetchedSessionId();
 
       // Another option is to empty the db if current session doesn't match lastFetchedSessionId
-      if (remoteConfigHasValues && lastFetchedSessionId === sessionId) {
+      if (!!lastFetchedSessionId && !!sessionId && lastFetchedSessionId === sessionId) {
         const idbRemoteConfig = await this.remoteConfigIDBStore.getRemoteConfig(configNamespace, key);
         this.fetchTime = Date.now() - fetchStartTime;
         return idbRemoteConfig;

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -155,8 +155,16 @@ describe('RemoteConfigFetch', () => {
       expect(remoteConfig).toEqual(samplingConfig.sr_sampling_config);
       expect(fetchMock).toHaveBeenCalled();
     });
+    test('should return from indexeddb if lastSessionId is set in indexeddb', async () => {
+      mockConfigStore.getLastFetchedSessionId = jest.fn().mockResolvedValue(123);
+      jest.spyOn(RemoteConfigAPIStore, 'createRemoteConfigIDBStore').mockResolvedValue(mockConfigStore);
+      const remoteConfig = await remoteConfigFetch.getRemoteConfig('sessionReplay', 'sr_sampling_config', 123);
+      expect(remoteConfig).toEqual(samplingConfig.sr_sampling_config);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
     test('should call fetchWithTimeout if no config exists in memory or indexeddb', async () => {
       mockConfigStore.getRemoteConfig = jest.fn().mockResolvedValue(undefined);
+      mockConfigStore.getLastFetchedSessionId = jest.fn().mockResolvedValue(undefined);
       mockConfigStore.remoteConfigHasValues = jest.fn().mockResolvedValue(false);
       jest.spyOn(RemoteConfigAPIStore, 'createRemoteConfigIDBStore').mockResolvedValue(mockConfigStore);
       await initialize();


### PR DESCRIPTION
### Summary

It's a valid case for the remote config call to return no configs. In this case, we don't want to keep fetching the remote config, it should apply by the same rules as if configs were returned, and we should read from IndexedDB instead. We can leverage the lastFetchedSessionId matching the current to know if we've successfully fetched the config already.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
