### PR TITLE
fix(session replay): set sample rate if it is 0 as well

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -83,7 +83,7 @@ export class SessionReplayJoinedConfigGenerator {
         config.captureEnabled = false;
       }
 
-      if (samplingConfig.sample_rate) {
+      if (Object.prototype.hasOwnProperty.call(samplingConfig, 'sample_rate')) {
         config.sampleRate = samplingConfig.sample_rate;
       }
     } else {


### PR DESCRIPTION
### Summary
I just observed that a sample rate of 0 wasn't being respected when sent via remote config, due to an improper falsy check. This is quite an edge case but figured I'd fix it upon observation anyways.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
