### PR TITLE
fix(session replay): remove focus/blur handling

### DIFF
--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -124,7 +124,7 @@ describe('module level integration', () => {
         event: { type: 'unknown' as EventType, data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).not.toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
@@ -180,7 +180,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
@@ -216,7 +216,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
@@ -253,7 +253,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(2);
@@ -286,7 +286,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(2);
@@ -318,7 +318,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(2);
@@ -341,7 +341,7 @@ describe('module level integration', () => {
         event: { type: 'replay', data: mockEventString },
         deviceId: '1a2b3c',
       });
-      sessionReplay.stopRecordingAndSendEvents();
+      sessionReplay.sendEvents();
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -140,7 +140,7 @@ describe('module level integration', () => {
         expect(record).toHaveBeenCalled();
         const recordArg = record.mock.calls[0][0];
         recordArg?.emit && recordArg?.emit(mockEvent);
-        sessionReplay.stopRecordingAndSendEvents();
+        sessionReplay.sendEvents();
         await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
 
         await runScheduleTimers();
@@ -176,7 +176,7 @@ describe('module level integration', () => {
         expect(record).toHaveBeenCalled();
         const recordArg = record.mock.calls[0][0];
         recordArg?.emit && recordArg?.emit(mockEvent);
-        sessionReplay.stopRecordingAndSendEvents();
+        sessionReplay.sendEvents();
         await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(
@@ -227,7 +227,7 @@ describe('module level integration', () => {
         expect(record).toHaveBeenCalled();
         const recordArg = record.mock.calls[0][0];
         recordArg?.emit && recordArg?.emit(mockEvent);
-        sessionReplay.stopRecordingAndSendEvents();
+        sessionReplay.sendEvents();
         await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(


### PR DESCRIPTION
### Summary
I believe we can now remove our focus/blur handling to stop/start recording when moving between tabs. Many customers have run into issues around this part of our logic, so much that we've had to add a `debugMode` option to our sdk to ease their pain. Reflecting on this recently, I realized that we no longer need this logic for the following reasons:

- Because of the IndexedDB refactor I did a few months ago, we now use IndexedDB as our source of truth for event lists. So the cross tab communication already works seamlessly without doing needing to sync the IndexedDB state to memory (this can be observed by looking at the sequenceId numbers in the track calls when switching back and forth between tabs, the sequenceIds automatically jump ahead to match the state from the previous tab)
- RRweb likely won't emit any events when the user is not on the tab (RRweb is powered via MutationObserver, mutations likely won't occur when a user is not on the tab). This is the riskier part to me, in that if RRweb is emitting events simultaneously in two tabs, the replay could have a choppy/confusing experience. However I've reviewed a few of our competitor's implementations of RRweb and noticed none of them have tab handling logic, which makes me think this is not a large scale issue.

Here is an example replay taken without the focus/blur handler: https://app.amplitude.com/analytics/org/36958/project/408823/search/amplitude_id%3D950783228955?collapsed=true&sessionHandle=ZDmIW0Y_ZDmIW0Y_N1fGLwb_Bjz3_c77fdc1a-3ee5-4f57-82c8-f105f61dee3a&sessionReplayEventId=63af4c88-11bf-496a-ac8e-ede8df0fb820

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
