### PR TITLE
fix(session replay): restart recording on focus

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -86,7 +86,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const globalScope = getGlobalScope();
     if (globalScope) {
       globalScope.removeEventListener('blur', this.blurListener);
+      globalScope.removeEventListener('focus', this.focusListener);
       !teardown && globalScope.addEventListener('blur', this.blurListener);
+      !teardown && globalScope.addEventListener('focus', this.focusListener);
       // prefer pagehide to unload events, this is the standard going forward. it is not
       // 100% reliable, but is bfcache-compatible.
       if (globalScope.self && 'onpagehide' in globalScope.self) {
@@ -216,6 +218,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   blurListener = () => {
     this.sendEvents();
+  };
+
+  focusListener = () => {
+    // Restart recording on focus to ensure that when user
+    // switches tabs, we take a full snapshot
+    this.recordEvents();
   };
 
   /**


### PR DESCRIPTION
### Summary

Jackson pointed out that we will attribute incremental snapshots incorrectly if we don't take a full snapshot on a tab change. This updates the SDK to restart recording on focus (which will cause a full snapshot to be taken).

Example incorrect replay capture without this change: https://app.amplitude.com/analytics/amplitude/project/408823/search/amplitude_id%3D951490210053

Example correct replay capture with this change:
https://app.amplitude.com/analytics/amplitude/project/408823/search/amplitude_id%3D951502713658

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
