### PR TITLE
feat(session-replay-browser): support debug info in session replay SDK

### DIFF
--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -31,7 +31,7 @@
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\" @amplitude/analytics-core@\">=1 <3\"",
+    "version": "yarn version-file && GENERATE_SNIPPET=true yarn build",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -396,7 +396,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
    * Used to send a debug RRWeb event. Typing is included for ease of debugging later on, but probably not
    * used at compile/run time.
    */
-  private getDebugInfo = (): DebugInfo | undefined => {
+  getDebugInfo = (): DebugInfo | undefined => {
     if (!this.config) {
       return;
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -22,11 +22,13 @@ import { SessionIdentifiers } from './identifiers';
 import {
   AmplitudeSessionReplay,
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
+  DebugInfo,
   EventType,
   EventsManagerWithType,
   SessionIdentifiers as ISessionIdentifiers,
   SessionReplayOptions,
 } from './typings/session-replay';
+import { VERSION } from './version';
 
 type PageLeaveFn = (e: PageTransitionEvent | Event) => void;
 
@@ -385,7 +387,30 @@ export class SessionReplay implements AmplitudeSessionReplay {
         return true;
       },
     });
+
+    const debugInfo = this.getDebugInfo();
+    debugInfo && record.addCustomEvent('debug-info', debugInfo);
   }
+
+  /**
+   * Used to send a debug RRWeb event. Typing is included for ease of debugging later on, but probably not
+   * used at compile/run time.
+   */
+  private getDebugInfo = (): DebugInfo | undefined => {
+    if (!this.config) {
+      return;
+    }
+    const config = {
+      ...this.config,
+    };
+    const { apiKey } = config;
+    config.apiKey = `****${apiKey.substring(apiKey.length - 4)}`;
+
+    return {
+      config,
+      version: VERSION,
+    };
+  };
 
   stopRecordingEvents = () => {
     try {

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,5 +1,10 @@
 import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-types';
-import { SessionReplayLocalConfig } from '../config/types';
+import { SessionReplayJoinedConfig, SessionReplayLocalConfig } from '../config/types';
+
+export type DebugInfo = {
+  config: SessionReplayJoinedConfig;
+  version: string;
+};
 
 export type Events = string[];
 

--- a/packages/session-replay-browser/src/version.ts
+++ b/packages/session-replay-browser/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.2.5';
+export const VERSION = '1.11.5';

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1038,4 +1038,19 @@ describe('SessionReplay', () => {
       });
     });
   });
+
+  describe('getDebugInfo', () => {
+    test('null config', () => {
+      sessionReplay.config = undefined;
+      expect(sessionReplay.getDebugInfo()).toBeUndefined();
+    });
+
+    test('get config', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const debugInfo = sessionReplay.getDebugInfo();
+      expect(debugInfo).toBeDefined();
+      expect(debugInfo?.config.apiKey).toStrictEqual('****_key');
+      expect(debugInfo?.version).toMatch(/\d+.\d+.\d+/);
+    });
+  });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

* This sends RRweb events that include the config for internal debugging purposes.
* I also fixed the version being incorrect in the SDK.

Tested this locally.

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
