### PR TITLE
fix: rename userInteractions to elementInteractions

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -3,13 +3,13 @@ import {
   getAnalyticsConnector,
   getAttributionTrackingConfig,
   getPageViewTrackingConfig,
-  getUserInteractionsConfig,
+  getElementInteractionsConfig,
   IdentityEventSender,
   isAttributionTrackingEnabled,
   isSessionTrackingEnabled,
   isFileDownloadTrackingEnabled,
   isFormInteractionTrackingEnabled,
-  isUserInteractionsEnabled,
+  isElementInteractionsEnabled,
   setConnectorDeviceId,
   setConnectorUserId,
   isNewSession,
@@ -140,9 +140,9 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;
     }
 
-    if (isUserInteractionsEnabled(this.config.autocapture)) {
+    if (isElementInteractionsEnabled(this.config.autocapture)) {
       this.config.loggerProvider.debug('Adding user interactions plugin (autocapture plugin)');
-      await this.add(autocapturePlugin(getUserInteractionsConfig(this.config))).promise;
+      await this.add(autocapturePlugin(getElementInteractionsConfig(this.config))).promise;
     }
 
     this.initializing = false;

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -322,7 +322,7 @@ describe('browser-client', () => {
       expect(formInteractionTrackingPlugin).toHaveBeenCalledTimes(0);
     });
 
-    test.each([true, { userInteractions: true }])(
+    test.each([true, { elementInteractions: true }])(
       'should add autocapture plugin',
       async (option: boolean | AutocaptureOptions) => {
         const autocapturePlugin = jest.spyOn(autocapture, 'autocapturePlugin');
@@ -336,7 +336,7 @@ describe('browser-client', () => {
     test.each([
       undefined, // default
       false, // disabled
-      { userInteractions: false }, // disabled
+      { elementInteractions: false }, // disabled
     ])('should NOT add autocapture plugin', async (option: undefined | boolean | AutocaptureOptions) => {
       const autocapturePlugin = jest.spyOn(autocapture, 'autocapturePlugin');
       await client.init(apiKey, userId, {

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -59,7 +59,7 @@ describe('joined-config', () => {
     });
 
     describe('generateJoinedConfig', () => {
-      test('should disable userInteractions if remote config sets it to false', async () => {
+      test('should disable elementInteractions if remote config sets it to false', async () => {
         localConfig = createConfigurationMock(
           createConfigurationMock({
             autocapture: true,
@@ -68,7 +68,7 @@ describe('joined-config', () => {
         generator = new BrowserJoinedConfigGenerator(localConfig);
         const remoteConfig = {
           autocapture: {
-            userInteractions: false,
+            elementInteractions: false,
           },
         };
         mockRemoteConfigFetch = {

--- a/packages/analytics-client-common/src/default-tracking.ts
+++ b/packages/analytics-client-common/src/default-tracking.ts
@@ -5,7 +5,7 @@ import {
   PageTrackingHistoryChanges,
   PageTrackingOptions,
   PageTrackingTrackOn,
-  UserInteractionsOptions,
+  ElementInteractionsOptions,
 } from '@amplitude/analytics-types';
 
 /**
@@ -42,18 +42,18 @@ export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boole
 /**
  * Returns true if
  * 1. autocapture === true
- * 2. if autocapture.userInteractions === true
- * 3. if autocapture.userInteractions === object
+ * 2. if autocapture.elementInteractions === true
+ * 3. if autocapture.elementInteractions === object
  * otherwise returns false
  */
-export const isUserInteractionsEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
+export const isElementInteractionsEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
   if (typeof autocapture === 'boolean') {
     return autocapture;
   }
 
   if (
     typeof autocapture === 'object' &&
-    (autocapture.userInteractions === true || typeof autocapture.userInteractions === 'object')
+    (autocapture.elementInteractions === true || typeof autocapture.elementInteractions === 'object')
   ) {
     return true;
   }
@@ -61,13 +61,13 @@ export const isUserInteractionsEnabled = (autocapture: AutocaptureOptions | bool
   return false;
 };
 
-export const getUserInteractionsConfig = (config: BrowserOptions): UserInteractionsOptions | undefined => {
+export const getElementInteractionsConfig = (config: BrowserOptions): ElementInteractionsOptions | undefined => {
   if (
-    isUserInteractionsEnabled(config.autocapture) &&
+    isElementInteractionsEnabled(config.autocapture) &&
     typeof config.autocapture === 'object' &&
-    typeof config.autocapture.userInteractions === 'object'
+    typeof config.autocapture.elementInteractions === 'object'
   ) {
-    return config.autocapture.userInteractions;
+    return config.autocapture.elementInteractions;
   }
   return undefined;
 };

--- a/packages/analytics-client-common/src/index.ts
+++ b/packages/analytics-client-common/src/index.ts
@@ -22,11 +22,11 @@ export { getGlobalScope } from './global-scope';
 export {
   getPageViewTrackingConfig,
   getAttributionTrackingConfig,
-  getUserInteractionsConfig,
+  getElementInteractionsConfig,
   isAttributionTrackingEnabled,
   isFileDownloadTrackingEnabled,
   isFormInteractionTrackingEnabled,
   isPageViewTrackingEnabled,
   isSessionTrackingEnabled,
-  isUserInteractionsEnabled,
+  isElementInteractionsEnabled,
 } from './default-tracking';

--- a/packages/analytics-client-common/test/default-tracking.test.ts
+++ b/packages/analytics-client-common/test/default-tracking.test.ts
@@ -1,13 +1,13 @@
 import {
   getAttributionTrackingConfig,
   getPageViewTrackingConfig,
-  getUserInteractionsConfig,
+  getElementInteractionsConfig,
   isAttributionTrackingEnabled,
   isFileDownloadTrackingEnabled,
   isFormInteractionTrackingEnabled,
   isPageViewTrackingEnabled,
   isSessionTrackingEnabled,
-  isUserInteractionsEnabled,
+  isElementInteractionsEnabled,
 } from '../src/default-tracking';
 
 describe('isFileDownloadTrackingEnabled', () => {
@@ -168,39 +168,39 @@ describe('isAttributionTrackingEnabled', () => {
   });
 });
 
-describe('isUserInteractionsEnabled', () => {
+describe('isElementInteractionsEnabled', () => {
   test('should return true with true parameter', () => {
-    expect(isUserInteractionsEnabled(true)).toBe(true);
+    expect(isElementInteractionsEnabled(true)).toBe(true);
   });
 
   test('should return false with undefined parameter', () => {
-    expect(isUserInteractionsEnabled(undefined)).toBe(false);
+    expect(isElementInteractionsEnabled(undefined)).toBe(false);
   });
 
   test('should return false with false parameter', () => {
-    expect(isUserInteractionsEnabled(false)).toBe(false);
+    expect(isElementInteractionsEnabled(false)).toBe(false);
   });
 
   test('should return true with object parameter', () => {
     expect(
-      isUserInteractionsEnabled({
-        userInteractions: true,
+      isElementInteractionsEnabled({
+        elementInteractions: true,
       }),
     ).toBe(true);
   });
 
   test('should return false with object parameter', () => {
     expect(
-      isUserInteractionsEnabled({
-        userInteractions: false,
+      isElementInteractionsEnabled({
+        elementInteractions: false,
       }),
     ).toBe(false);
   });
 
   test('should return false with object parameter undefined', () => {
     expect(
-      isUserInteractionsEnabled({
-        userInteractions: undefined,
+      isElementInteractionsEnabled({
+        elementInteractions: undefined,
       }),
     ).toBe(false);
   });
@@ -293,9 +293,9 @@ describe('getAttributionTrackingConfig', () => {
   });
 });
 
-describe('getUserInteractionsConfig', () => {
+describe('getElementInteractionsConfig', () => {
   test('should return an empty object when autocapture is true', () => {
-    const config = getUserInteractionsConfig({
+    const config = getElementInteractionsConfig({
       autocapture: true,
     });
 
@@ -303,9 +303,9 @@ describe('getUserInteractionsConfig', () => {
   });
 
   test('should return an empty object when userInteraction is true', () => {
-    const config = getUserInteractionsConfig({
+    const config = getElementInteractionsConfig({
       autocapture: {
-        userInteractions: true,
+        elementInteractions: true,
       },
     });
 
@@ -317,9 +317,9 @@ describe('getUserInteractionsConfig', () => {
     const testPageUrlAllowlist = ['example.com'];
     const mockedShouldTrackEventResolver = jest.fn(() => true);
     const testDataAttributePrefix = 'data-amp-track';
-    const config = getUserInteractionsConfig({
+    const config = getElementInteractionsConfig({
       autocapture: {
-        userInteractions: {
+        elementInteractions: {
           cssSelectorAllowlist: testCssSelectorAllowlist,
           pageUrlAllowlist: testPageUrlAllowlist,
           shouldTrackEventResolver: mockedShouldTrackEventResolver,

--- a/packages/analytics-types/src/config/browser.ts
+++ b/packages/analytics-types/src/config/browser.ts
@@ -3,7 +3,7 @@ import { IdentityStorageType, Storage } from '../storage';
 import { Transport } from '../transport';
 import { Config } from './core';
 import { PageTrackingOptions } from '../page-view-tracking';
-import { UserInteractionsOptions } from '../userInteractions';
+import { ElementInteractionsOptions } from '../element-interactions';
 
 export interface BrowserConfig extends ExternalBrowserConfig, InternalBrowserConfig {}
 
@@ -150,7 +150,7 @@ export interface AutocaptureOptions {
    * Enables/disables user interactions tracking.
    * @defaultValue `false`
    */
-  userInteractions?: boolean | UserInteractionsOptions;
+  elementInteractions?: boolean | ElementInteractionsOptions;
 }
 
 export interface TrackingOptions {

--- a/packages/analytics-types/src/element-interactions.ts
+++ b/packages/analytics-types/src/element-interactions.ts
@@ -27,7 +27,7 @@ export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
  */
 export const DEFAULT_DATA_ATTRIBUTE_PREFIX = 'data-amp-track-';
 
-export interface UserInteractionsOptions {
+export interface ElementInteractionsOptions {
   /**
    * List of CSS selectors to allow auto tracking on.
    * When provided, allow elements matching any selector to be tracked.

--- a/packages/analytics-types/src/index.ts
+++ b/packages/analytics-types/src/index.ts
@@ -67,8 +67,8 @@ export { PageTrackingOptions, PageTrackingTrackOn, PageTrackingHistoryChanges } 
 export { OfflineDisabled } from './offline';
 export {
   Messenger,
-  UserInteractionsOptions,
+  ElementInteractionsOptions,
   ActionType,
   DEFAULT_CSS_SELECTOR_ALLOWLIST,
   DEFAULT_DATA_ATTRIBUTE_PREFIX,
-} from './userInteractions';
+} from './element-interactions';


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-105806](https://amplitude.atlassian.net/browse/AMP-105806)

Rename `config.autocapture.userInteractions` to `config.autocapture.elementInteractions` to algin with mobile interfaces and make the config name less general.



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-105806]: https://amplitude.atlassian.net/browse/AMP-105806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ