### PR TITLE
fix(autocapture): Remove click tracking buffer and duplicate action clicks

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -172,7 +172,7 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
 
   options.cssSelectorAllowlist = options.cssSelectorAllowlist ?? DEFAULT_CSS_SELECTOR_ALLOWLIST;
   options.actionClickAllowlist = options.actionClickAllowlist ?? DEFAULT_ACTION_CLICK_ALLOWLIST;
-  options.debounceTime = options.debounceTime ?? 1000;
+  options.debounceTime = options.debounceTime ?? 0;
 
   const name = constants.PLUGIN_NAME;
   const type = 'enrichment';

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -172,7 +172,7 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
 
   options.cssSelectorAllowlist = options.cssSelectorAllowlist ?? DEFAULT_CSS_SELECTOR_ALLOWLIST;
   options.actionClickAllowlist = options.actionClickAllowlist ?? DEFAULT_ACTION_CLICK_ALLOWLIST;
-  options.debounceTime = options.debounceTime ?? 0;
+  options.debounceTime = options.debounceTime ?? 0; // TODO: update this when rage clicks are added to 1000ms
 
   const name = constants.PLUGIN_NAME;
   const type = 'enrichment';

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -140,48 +140,53 @@ describe('action clicks:', () => {
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 503));
 
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
-        '[Amplitude] Element Hierarchy': [
-          {
-            id: 'addDivButton',
-            index: 0,
-            indexOfType: 0,
-            tag: 'div',
-          },
-          {
-            id: 'inner-left',
-            classes: ['column'],
-            index: 0,
-            indexOfType: 0,
-            tag: 'div',
-          },
-          {
-            attrs: {
-              'data-test-attr': 'test-attr',
+      expect(track).toHaveBeenNthCalledWith(
+        1,
+        '[Amplitude] Element Clicked',
+        {
+          '[Amplitude] Element Hierarchy': [
+            {
+              id: 'addDivButton',
+              index: 0,
+              indexOfType: 0,
+              tag: 'div',
             },
-            id: 'main',
-            classes: ['class1', 'class2'],
-            index: 0,
-            indexOfType: 0,
-            tag: 'div',
-          },
-          {
-            index: 1,
-            indexOfType: 0,
-            prevSib: 'head',
-            tag: 'body',
-          },
-        ],
-        '[Amplitude] Element ID': 'addDivButton',
-        '[Amplitude] Element Parent Label': 'Card Title',
-        '[Amplitude] Element Position Left': 0,
-        '[Amplitude] Element Position Top': 0,
-        '[Amplitude] Element Selector': '#addDivButton',
-        '[Amplitude] Element Tag': 'div',
-        '[Amplitude] Element Text': 'Add div',
-        '[Amplitude] Viewport Height': 768,
-        '[Amplitude] Viewport Width': 1024,
-      });
+            {
+              id: 'inner-left',
+              classes: ['column'],
+              index: 0,
+              indexOfType: 0,
+              tag: 'div',
+            },
+            {
+              attrs: {
+                'data-test-attr': 'test-attr',
+              },
+              id: 'main',
+              classes: ['class1', 'class2'],
+              index: 0,
+              indexOfType: 0,
+              tag: 'div',
+            },
+            {
+              index: 1,
+              indexOfType: 0,
+              prevSib: 'head',
+              tag: 'body',
+            },
+          ],
+          '[Amplitude] Element ID': 'addDivButton',
+          '[Amplitude] Element Parent Label': 'Card Title',
+          '[Amplitude] Element Position Left': 0,
+          '[Amplitude] Element Position Top': 0,
+          '[Amplitude] Element Selector': '#addDivButton',
+          '[Amplitude] Element Tag': 'div',
+          '[Amplitude] Element Text': 'Add div',
+          '[Amplitude] Viewport Height': 768,
+          '[Amplitude] Viewport Width': 1024,
+        },
+        { time: expect.any(Number) as number },
+      );
     });
 
     test('should not trigger duplicate events if the immediate click target is in the action click allowlist', async () => {
@@ -223,6 +228,7 @@ describe('action clicks:', () => {
           '[Amplitude] Element Parent Label': 'Add div',
           '[Amplitude] Element Tag': 'span',
         }),
+        { time: expect.any(Number) as number },
       );
     });
 
@@ -253,6 +259,7 @@ describe('action clicks:', () => {
             '[Amplitude] Element Parent Label': 'Card Title',
             '[Amplitude] Element Tag': 'h1',
           }),
+          { time: expect.any(Number) as number },
         );
         expect(document.querySelectorAll('.new-div').length).toBe(2);
       });

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -758,11 +758,7 @@ describe('autoTrackingPlugin', () => {
 
       // trigger click button
       document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
-      await new Promise((r) => setTimeout(r, 500));
-
-      expect(track).toHaveBeenCalledTimes(0);
-
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 0));
       expect(track).toHaveBeenCalledTimes(1);
 
       global.fetch = oldFetch;


### PR DESCRIPTION
### Summary

- Lower rage click buffer to 0
    - the buffer can have issues when the event triggers a navigate event, this causes the buffer to be lost and no event to be fired. There are work arounds for this, but since the rage click feature had not been turned on yet, disabling it will be sufficient for now
- Fix issue where action clicks fired for each mutation or navigate event, now, limit it to 1 so that the action click is triggered only once
- Fix issue where timestamp was not used for action clicks

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
