### PR TITLE
fix(remote config): recreate remote config store with correct name

### DIFF
--- a/packages/analytics-remote-config/src/remote-config-idb-store.ts
+++ b/packages/analytics-remote-config/src/remote-config-idb-store.ts
@@ -51,7 +51,7 @@ export const createRemoteConfigIDBStore = async <RemoteConfig extends { [key: st
     if (lastFetchedSessionId && Date.now() - lastFetchedSessionId >= MAX_IDB_STORAGE_TIME) {
       remoteConfigDB.close();
       await deleteDB(remoteConfigDBName);
-      remoteConfigDB = await openOrCreateRemoteConfigStore(apiKey, configKeys);
+      remoteConfigDB = await openOrCreateRemoteConfigStore(remoteConfigDBName, configKeys);
     }
   } catch (e) {
     loggerProvider.warn(`Failed to reset store: ${e as string}`);

--- a/packages/analytics-remote-config/test/remote-config-idb-store.test.ts
+++ b/packages/analytics-remote-config/test/remote-config-idb-store.test.ts
@@ -73,7 +73,8 @@ describe('RemoteConfigIDBStore', () => {
         configKeys: ['sessionReplay'],
       });
       expect(IDB.deleteDB).toHaveBeenCalledWith('static_key_amp_config');
-      expect(RemoteConfigAPIStore.openOrCreateRemoteConfigStore).toHaveBeenCalledWith('static_key_amp_config', [
+      expect(RemoteConfigAPIStore.openOrCreateRemoteConfigStore).toHaveBeenCalledTimes(2);
+      expect(RemoteConfigAPIStore.openOrCreateRemoteConfigStore).toHaveBeenLastCalledWith('static_key_amp_config', [
         'sessionReplay',
       ]);
     });


### PR DESCRIPTION
### Summary

Noticed when trying to debug an issue for a customer that we were creating the store with the incorrect store name here!

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
