### PR TITLE
feat(autocapture): add more elements to the default cssSelectorAllowlist

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -61,7 +61,7 @@ export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
   'label',
   'video',
   'audio',
-  '[contenteditable="true"]',
+  '[contenteditable="true" i]',
   '[data-amp-default-track]',
   '.amp-default-track',
 ];

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -59,6 +59,9 @@ export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
   'select',
   'textarea',
   'label',
+  'video',
+  'audio',
+  '[contenteditable="true"]',
   '[data-amp-default-track]',
   '.amp-default-track',
 ];


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add more elements to the default `cssSelectorAllowlist`
- `video`
- `audio`
- `[contenteditable="true" i]`


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
