### PR TITLE
feat(session replay): add logging to SR SDK

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -156,6 +156,10 @@ export class SessionReplayJoinedConfigGenerator {
       config.privacyConfig = joinedPrivacyConfig;
     }
 
+    this.localConfig.loggerProvider.debug(
+      JSON.stringify({ name: 'session replay joined config', config: config }, null, 2),
+    );
+
     return config;
   }
 }

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -24,3 +24,4 @@ export const INTERACTION_MAX_INTERVAL = 60_000; // 1 minute
 export const MIN_INTERVAL = 500; // 500 ms
 export const MAX_INTERVAL = 10 * 1000; // 10 seconds
 export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 3; // 3 days
+export const KB_SIZE = Math.pow(1024, 1);

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -24,4 +24,4 @@ export const INTERACTION_MAX_INTERVAL = 60_000; // 1 minute
 export const MIN_INTERVAL = 500; // 500 ms
 export const MAX_INTERVAL = 10 * 1000; // 10 seconds
 export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 3; // 3 days
-export const KB_SIZE = Math.pow(1024, 1);
+export const KB_SIZE = 1024;

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -96,7 +96,6 @@ export const createStore = async (dbName: string) => {
     upgrade: defineObjectStores,
   });
 };
-
 export class SessionReplayEventsIDBStore implements AmplitudeSessionReplayEventsIDBStore {
   apiKey: string;
   db: IDBPDatabase<SessionReplayDB> | undefined;

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -141,13 +141,10 @@ export const getServerUrl = (serverZone?: keyof typeof ServerZone): string => {
 export const getStorageSize = async (): Promise<StorageData> => {
   const globalScope = getGlobalScope();
   if (globalScope) {
-    const storeEstimate: ChromeStorageEstimate = await globalScope.navigator.storage.estimate();
-    const totalStorageSize = storeEstimate.usage ? Math.round(storeEstimate.usage / KB_SIZE) : 0;
-    const percentOfQuota =
-      storeEstimate.usage && storeEstimate.quota
-        ? Math.round((storeEstimate.usage / storeEstimate.quota + Number.EPSILON) * 1000) / 1000
-        : 0;
-    return { totalStorageSize, percentOfQuota, usageDetails: JSON.stringify(storeEstimate.usageDetails) };
+    const { usage, quota, usageDetails }: ChromeStorageEstimate = await globalScope.navigator.storage.estimate();
+    const totalStorageSize = usage ? Math.round(usage / KB_SIZE) : 0;
+    const percentOfQuota = usage && quota ? Math.round((usage / quota + Number.EPSILON) * 1000) / 1000 : 0;
+    return { totalStorageSize, percentOfQuota, usageDetails: JSON.stringify(usageDetails) };
   }
   return { totalStorageSize: 0, percentOfQuota: 0, usageDetails: '' };
 };

--- a/packages/session-replay-browser/src/messages.ts
+++ b/packages/session-replay-browser/src/messages.ts
@@ -1,5 +1,3 @@
-export const getSuccessMessage = (sessionId: number) =>
-  `Session replay event batch tracked successfully for session id ${sessionId}`;
 export const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred';
 export const UNEXPECTED_NETWORK_ERROR_MESSAGE = 'Network error occurred, event batch rejected';
 export const MAX_RETRIES_EXCEEDED_MESSAGE = 'Session replay event batch rejected due to exceeded retry count';

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -408,9 +408,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const storageSizeData = await getStorageSize();
 
     return {
+      ...storageSizeData,
       config,
       version: VERSION,
-      ...storageSizeData,
     };
   };
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -112,13 +112,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
-    this.loggerProvider.debug(
-      JSON.stringify(
-        { name: 'session replay joined privacy config', privacyConfig: this.config.privacyConfig },
-        null,
-        2,
-      ),
-    );
 
     if (options.sessionId && this.config.interactionConfig?.enabled) {
       const scrollWatcher = ScrollWatcher.default(
@@ -199,7 +192,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   getSessionReplayProperties() {
     if (!this.config || !this.identifiers) {
-      this.loggerProvider.error('Session replay init has not been called, cannot get session recording properties.');
+      this.loggerProvider.error('Session replay init has not been called, cannot get session replay properties.');
       return {};
     }
 
@@ -331,6 +324,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.stopRecordingEvents();
     const privacyConfig = this.config.privacyConfig;
 
+    this.loggerProvider.log('Session Replay capture beginning.');
     this.recordCancelCallback = record({
       emit: (event) => {
         if (this.shouldOptOut()) {
@@ -382,7 +376,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
           throw typedError;
         }
 
-        this.loggerProvider.warn('Error while recording: ', typedError.toString());
+        this.loggerProvider.warn('Error while capturing replay: ', typedError.toString());
         // Return true so that we don't clutter user's consoles with internal rrweb errors
         return true;
       },
@@ -414,11 +408,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   stopRecordingEvents = () => {
     try {
+      this.loggerProvider.log('Session Replay capture stopping.');
       this.recordCancelCallback && this.recordCancelCallback();
       this.recordCancelCallback = null;
     } catch (error) {
       const typedError = error as Error;
-      this.loggerProvider.warn(`Error occurred while stopping recording: ${typedError.toString()}`);
+      this.loggerProvider.warn(`Error occurred while stopping replay capture: ${typedError.toString()}`);
     }
   };
 

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -7,7 +7,6 @@ import {
   MISSING_DEVICE_ID_MESSAGE,
   UNEXPECTED_ERROR_MESSAGE,
   UNEXPECTED_NETWORK_ERROR_MESSAGE,
-  getSuccessMessage,
 } from './messages';
 import {
   SessionReplayTrackDestination as AmplitudeSessionReplayTrackDestination,
@@ -15,6 +14,7 @@ import {
   SessionReplayDestinationContext,
 } from './typings/session-replay';
 import { VERSION } from './version';
+import { KB_SIZE } from './constants';
 
 export type PayloadBatcher = ({ version, events }: { version: number; events: string[] }) => {
   version: number;
@@ -172,7 +172,11 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   }
 
   handleSuccessResponse(context: SessionReplayDestinationContext) {
-    this.completeRequest({ context, success: getSuccessMessage(context.sessionId) });
+    const sizeOfEventsList = Math.round(new Blob(context.events).size / KB_SIZE);
+    this.completeRequest({
+      context,
+      success: `Session replay event batch with seq id ${context.sequenceId} tracked successfully for session id ${context.sessionId}, size of events: ${sizeOfEventsList} KB`,
+    });
   }
 
   handleOtherResponse(context: SessionReplayDestinationContext) {

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,10 +1,16 @@
 import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-types';
 import { SessionReplayJoinedConfig, SessionReplayLocalConfig } from '../config/types';
 
-export type DebugInfo = {
+export type StorageData = {
+  totalStorageSize: number;
+  percentOfQuota: number;
+  usageDetails: string;
+};
+
+export interface DebugInfo extends StorageData {
   config: SessionReplayJoinedConfig;
   version: string;
-};
+}
 
 export type Events = string[];
 

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -11,7 +11,6 @@ import * as SessionReplayIDB from '../../src/events/events-idb-store';
 
 import { DEFAULT_SAMPLE_RATE, DEFAULT_SESSION_REPLAY_PROPERTY, SESSION_REPLAY_SERVER_URL } from '../../src/constants';
 import * as Helpers from '../../src/helpers';
-import { getSuccessMessage } from '../../src/messages';
 import { SessionReplay } from '../../src/session-replay';
 import { SESSION_ID_IN_20_SAMPLE } from '../test-data';
 
@@ -148,7 +147,9 @@ describe('module level integration', () => {
           `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&seq_number=1&type=replay`,
           expect.anything(),
         );
-        expect(mockLoggerProvider.log).toHaveBeenCalledWith(getSuccessMessage(SESSION_ID_IN_20_SAMPLE));
+        expect(mockLoggerProvider.log).toHaveBeenLastCalledWith(
+          'Session replay event batch with seq id 1 tracked successfully for session id 1719847315000, size of events: 0 KB',
+        );
       });
 
       test('should use sampleRate from sdk options', async () => {
@@ -184,7 +185,9 @@ describe('module level integration', () => {
           expect.anything(),
         );
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockLoggerProvider.log).toHaveBeenCalledWith(getSuccessMessage(SESSION_ID_IN_20_SAMPLE));
+        expect(mockLoggerProvider.log).toHaveBeenLastCalledWith(
+          'Session replay event batch with seq id 1 tracked successfully for session id 1719847315000, size of events: 0 KB',
+        );
       });
 
       test('should use sampleRate from remote config', async () => {
@@ -235,7 +238,9 @@ describe('module level integration', () => {
           expect.anything(),
         );
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(mockLoggerProvider.log).toHaveBeenCalledWith(getSuccessMessage(SESSION_ID_IN_20_SAMPLE));
+        expect(mockLoggerProvider.log).toHaveBeenLastCalledWith(
+          'Session replay event batch with seq id 1 tracked successfully for session id 1719847315000, size of events: 0 KB',
+        );
       });
     });
     describe('without a sample rate', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -56,6 +56,19 @@ describe('SessionReplay', () => {
       href: 'http://localhost',
     },
     indexedDB: new IDBFactory(),
+    navigator: {
+      storage: {
+        estimate: () => {
+          return {
+            usage: 1000,
+            quota: 100000,
+            usageDetails: {
+              indexedDB: 10,
+            },
+          };
+        },
+      },
+    },
   } as unknown as typeof globalThis;
   const apiKey = 'static_key';
   const mockOptions: SessionReplayOptions = {
@@ -1040,17 +1053,24 @@ describe('SessionReplay', () => {
   });
 
   describe('getDebugInfo', () => {
-    test('null config', () => {
+    test('null config', async () => {
       sessionReplay.config = undefined;
-      expect(sessionReplay.getDebugInfo()).toBeUndefined();
+      expect(await sessionReplay.getDebugInfo()).toBeUndefined();
     });
 
     test('get config', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
-      const debugInfo = sessionReplay.getDebugInfo();
+      const debugInfo = await sessionReplay.getDebugInfo();
       expect(debugInfo).toBeDefined();
       expect(debugInfo?.config.apiKey).toStrictEqual('****_key');
       expect(debugInfo?.version).toMatch(/\d+.\d+.\d+/);
+      expect(debugInfo?.percentOfQuota).toEqual(0.01);
+      expect(debugInfo?.totalStorageSize).toEqual(1);
+      expect(debugInfo?.usageDetails).toEqual(
+        JSON.stringify({
+          indexedDB: 10,
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
### Summary

This PR adds extra logs to the SR SDK lifecycle, as well as adds storage size data to the custom event we are sending along with our rrweb events.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
