### PR TITLE
fix(session-replay-browser): update rrweb version to 2.0.0-alpha.19 to fix duplicate text

### DIFF
--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -42,7 +42,7 @@
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-remote-config": "^0.3.3",
     "@amplitude/analytics-types": ">=1 <3",
-    "@amplitude/rrweb": "^2.0.0-alpha.14",
+    "@amplitude/rrweb": "2.0.0-alpha.19",
     "idb": "^8.0.0",
     "tslib": "^2.4.1"
   },


### PR DESCRIPTION
### Summary

The description should cover it. An [example replay with the fix](https://app.amplitude.com/analytics/junjie-amplitude/session-replay/project/626341/search/amplitude_id%3D956859617383?sessionHandle=ZEQU/3P_ZEQU/3P_N7JRxBn_CY6l_b428b501-6223-4dcc-934b-9a9b250d6cf5&sessionReplayId=b428b501-6223-4dcc-934b-9a9b250d6cf5/1722555825615&sessionLength=199&sessionStartTime=1722555825615&deviceType=Windows&user_id=&country=United%20States).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
