### PR TITLE
chore(session replay): add custom rrweb event method and fire on getSessionReplayProperties

### DIFF
--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -25,3 +25,8 @@ export const MIN_INTERVAL = 500; // 500 ms
 export const MAX_INTERVAL = 10 * 1000; // 10 seconds
 export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 3; // 3 days
 export const KB_SIZE = 1024;
+
+export enum CustomRRwebEvent {
+  GET_SR_PROPS = 'get-sr-props',
+  DEBUG_INFO = 'debug-info',
+}

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -139,12 +139,16 @@ export const getServerUrl = (serverZone?: keyof typeof ServerZone): string => {
 };
 
 export const getStorageSize = async (): Promise<StorageData> => {
-  const globalScope = getGlobalScope();
-  if (globalScope) {
-    const { usage, quota, usageDetails }: ChromeStorageEstimate = await globalScope.navigator.storage.estimate();
-    const totalStorageSize = usage ? Math.round(usage / KB_SIZE) : 0;
-    const percentOfQuota = usage && quota ? Math.round((usage / quota + Number.EPSILON) * 1000) / 1000 : 0;
-    return { totalStorageSize, percentOfQuota, usageDetails: JSON.stringify(usageDetails) };
+  try {
+    const globalScope = getGlobalScope();
+    if (globalScope) {
+      const { usage, quota, usageDetails }: ChromeStorageEstimate = await globalScope.navigator.storage.estimate();
+      const totalStorageSize = usage ? Math.round(usage / KB_SIZE) : 0;
+      const percentOfQuota = usage && quota ? Math.round((usage / quota + Number.EPSILON) * 1000) / 1000 : 0;
+      return { totalStorageSize, percentOfQuota, usageDetails: JSON.stringify(usageDetails) };
+    }
+  } catch (e) {
+    // swallow
   }
   return { totalStorageSize: 0, percentOfQuota: 0, usageDetails: '' };
 };

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -188,6 +188,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (this.eventCount === 10) {
       this.eventCount = 0;
     }
+    this.eventCount++;
 
     return eventProperties;
   }

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -7,7 +7,7 @@ export type StorageData = {
   usageDetails: string;
 };
 
-export interface DebugInfo extends StorageData {
+export interface DebugInfo extends Partial<StorageData> {
   config: SessionReplayJoinedConfig;
   version: string;
 }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -490,6 +490,13 @@ describe('SessionReplay', () => {
         false,
       );
     });
+    test('should increment the event count', async () => {
+      await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
+      expect(sessionReplay.eventCount).toBe(0);
+
+      sessionReplay.getSessionReplayProperties();
+      expect(sessionReplay.eventCount).toBe(1);
+    });
     test('should add a custom rrweb event with storage info if event count is 10, then reset event count', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
       sessionReplay.addCustomRRWebEvent = jest.fn();
@@ -505,7 +512,7 @@ describe('SessionReplay', () => {
         },
         true,
       );
-      expect(sessionReplay.eventCount).toEqual(0);
+      expect(sessionReplay.eventCount).toEqual(1);
     });
   });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -9,7 +10,7 @@ import { SessionReplayLocalConfig } from '../src/config/local-config';
 
 import { IDBFactory } from 'fake-indexeddb';
 import { InteractionConfig, SessionReplayJoinedConfig, SessionReplayRemoteConfig } from '../src/config/types';
-import { DEFAULT_SAMPLE_RATE } from '../src/constants';
+import { CustomRRwebEvent, DEFAULT_SAMPLE_RATE } from '../src/constants';
 import * as SessionReplayIDB from '../src/events/events-idb-store';
 import * as Helpers from '../src/helpers';
 import { SessionReplay } from '../src/session-replay';
@@ -1031,25 +1032,56 @@ describe('SessionReplay', () => {
     });
   });
 
-  describe('getDebugInfo', () => {
-    test('null config', async () => {
+  describe('addCustomRRWebEvent', () => {
+    test('should add custom event if null config', async () => {
       sessionReplay.config = undefined;
-      expect(await sessionReplay.getDebugInfo()).toBeUndefined();
+      sessionReplay.recordCancelCallback = () => {
+        return;
+      };
+      record.addCustomEvent = jest.fn();
+      await sessionReplay.addCustomRRWebEvent(CustomRRwebEvent.GET_SR_PROPS, { myKey: 'data' });
+      expect(record.addCustomEvent).toHaveBeenCalledWith(CustomRRwebEvent.GET_SR_PROPS, { myKey: 'data' });
     });
 
-    test('get config', async () => {
+    test('should add custom event with config and storage data', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
-      const debugInfo = await sessionReplay.getDebugInfo();
-      expect(debugInfo).toBeDefined();
-      expect(debugInfo?.config.apiKey).toStrictEqual('****_key');
-      expect(debugInfo?.version).toMatch(/\d+.\d+.\d+/);
-      expect(debugInfo?.percentOfQuota).toEqual(0.01);
-      expect(debugInfo?.totalStorageSize).toEqual(1);
-      expect(debugInfo?.usageDetails).toEqual(
-        JSON.stringify({
-          indexedDB: 10,
+      sessionReplay.recordCancelCallback = () => {
+        return;
+      };
+      record.addCustomEvent = jest.fn();
+      await sessionReplay.addCustomRRWebEvent(CustomRRwebEvent.GET_SR_PROPS, { myKey: 'data' });
+      expect(record.addCustomEvent).toHaveBeenCalledWith(
+        CustomRRwebEvent.GET_SR_PROPS,
+        expect.objectContaining({
+          myKey: 'data',
+          config: expect.objectContaining({
+            apiKey: '****_key',
+          }),
+          version: expect.stringMatching(/\d+.\d+.\d+/),
+          percentOfQuota: 0.01,
+          totalStorageSize: 1,
+          usageDetails: JSON.stringify({
+            indexedDB: 10,
+          }),
         }),
       );
+    });
+    test('should not add custom event if not recording', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.recordCancelCallback = undefined;
+      record.addCustomEvent = jest.fn();
+      await sessionReplay.addCustomRRWebEvent(CustomRRwebEvent.GET_SR_PROPS, { myKey: 'data' });
+      expect(record.addCustomEvent).not.toHaveBeenCalled();
+    });
+    test('should handle an error', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      jest.spyOn(Helpers, 'getStorageSize').mockImplementation(() => {
+        throw new Error();
+      });
+      record.addCustomEvent = jest.fn();
+      await sessionReplay.addCustomRRWebEvent(CustomRRwebEvent.GET_SR_PROPS, { myKey: 'data' });
+      expect(record.addCustomEvent).not.toHaveBeenCalled();
+      expect(mockLoggerProvider.debug).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### Summary

Add a tool to fire custom rrweb events when recording, and add an event when getSessionReplayProperties is called.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
