### PR TITLE
fix(session replay): ensure api key is obfuscated in local logs

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -7,6 +7,7 @@ import {
   SessionReplayJoinedConfig,
   SessionReplayRemoteConfig,
 } from './types';
+import { getDebugConfig } from '../helpers';
 
 export class SessionReplayJoinedConfigGenerator {
   localConfig: ISessionReplayLocalConfig;
@@ -157,7 +158,7 @@ export class SessionReplayJoinedConfigGenerator {
     }
 
     this.localConfig.loggerProvider.debug(
-      JSON.stringify({ name: 'session replay joined config', config: config }, null, 2),
+      JSON.stringify({ name: 'session replay joined config', config: getDebugConfig(config) }, null, 2),
     );
 
     return config;

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
 import { KB_SIZE, MASK_TEXT_CLASS, UNMASK_TEXT_CLASS } from './constants';
-import { DEFAULT_MASK_LEVEL, MaskLevel, PrivacyConfig } from './config/types';
+import { DEFAULT_MASK_LEVEL, MaskLevel, PrivacyConfig, SessionReplayJoinedConfig } from './config/types';
 import { getInputType } from '@amplitude/rrweb-snapshot';
 import { ServerZone } from '@amplitude/analytics-types';
 import {
@@ -147,4 +147,13 @@ export const getStorageSize = async (): Promise<StorageData> => {
     return { totalStorageSize, percentOfQuota, usageDetails: JSON.stringify(usageDetails) };
   }
   return { totalStorageSize: 0, percentOfQuota: 0, usageDetails: '' };
+};
+
+export const getDebugConfig = (config: SessionReplayJoinedConfig) => {
+  const debugConfig = {
+    ...config,
+  };
+  const { apiKey } = debugConfig;
+  debugConfig.apiKey = `****${apiKey.substring(apiKey.length - 4)}`;
+  return debugConfig;
 };

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -15,7 +15,7 @@ import {
 } from './constants';
 import { createEventsManager } from './events/events-manager';
 import { MultiEventManager } from './events/multi-manager';
-import { generateHashCode, getStorageSize, isSessionInSample, maskFn } from './helpers';
+import { generateHashCode, getDebugConfig, getStorageSize, isSessionInSample, maskFn } from './helpers';
 import { clickBatcher, clickHook } from './hooks/click';
 import { ScrollWatcher } from './hooks/scroll';
 import { SessionIdentifiers } from './identifiers';
@@ -399,17 +399,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (!this.config) {
       return;
     }
-    const config = {
-      ...this.config,
-    };
-    const { apiKey } = config;
-    config.apiKey = `****${apiKey.substring(apiKey.length - 4)}`;
-
     const storageSizeData = await getStorageSize();
 
     return {
       ...storageSizeData,
-      config,
+      config: getDebugConfig(this.config),
       version: VERSION,
     };
   };


### PR DESCRIPTION
### Summary

Ensure API Key is obfuscated when config is printed locally as well as sent as custom rrweb event

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
