### PR TITLE
fix(session replay): move removeInvalidSelectorsFromPrivacyConfig to joined config class

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -53,37 +53,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
     return returnWrapper(this._init(apiKey, options));
   }
 
-  removeInvalidSelectors() {
-    if (!this.config?.privacyConfig) {
-      return;
-    }
-
-    // This allows us to not search the DOM.
-    const fragment = document.createDocumentFragment();
-
-    const dropInvalidSelectors = (selectors: string[] | string = []): string[] | undefined => {
-      if (typeof selectors === 'string') {
-        selectors = [selectors];
-      }
-      selectors = selectors.filter((selector: string) => {
-        try {
-          fragment.querySelector(selector);
-        } catch {
-          this.loggerProvider.warn(`[session-replay-browser] omitting selector "${selector}" because it is invalid`);
-          return false;
-        }
-        return true;
-      });
-      if (selectors.length === 0) {
-        return undefined;
-      }
-      return selectors;
-    };
-    this.config.privacyConfig.blockSelector = dropInvalidSelectors(this.config.privacyConfig.blockSelector);
-    this.config.privacyConfig.maskSelector = dropInvalidSelectors(this.config.privacyConfig.maskSelector);
-    this.config.privacyConfig.unmaskSelector = dropInvalidSelectors(this.config.privacyConfig.unmaskSelector);
-  }
-
   private teardownEventListeners = (teardown: boolean) => {
     const globalScope = getGlobalScope();
     if (globalScope) {
@@ -124,8 +93,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.pageLeaveFns = [scrollWatcher.send(this.getDeviceId.bind(this))];
       this.scrollHook = scrollWatcher.hook.bind(scrollWatcher);
     }
-
-    this.removeInvalidSelectors();
 
     const managers: EventsManagerWithType<EventType, string>[] = [];
     const rrwebEventManager = await createEventsManager<'replay'>({

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -124,10 +124,6 @@ describe('SessionReplay', () => {
     jest.useRealTimers();
   });
   describe('init', () => {
-    test('should do nothing if config is undefined for removeInvalidSelectors', async () => {
-      expect(sessionReplay.removeInvalidSelectors()).toBeUndefined();
-    });
-
     test('should remove invalid selectors', async () => {
       await sessionReplay.init(apiKey, {
         ...mockOptions,
@@ -1032,23 +1028,6 @@ describe('SessionReplay', () => {
     test('null config', () => {
       sessionReplay.config = undefined;
       expect(sessionReplay.getSessionReplayDebugPropertyValue()).toBe('{"appHash":""}');
-    });
-  });
-
-  describe('removeInvalidSelectors', () => {
-    test('should handle string block selector correctly', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      if (sessionReplay.config) {
-        sessionReplay.config.privacyConfig = {
-          blockSelector: 'FASE<:F>!@<?#>!#<',
-        };
-      }
-      sessionReplay.removeInvalidSelectors();
-      expect(sessionReplay.config?.privacyConfig).toStrictEqual({
-        blockSelector: undefined,
-        maskSelector: undefined,
-        unmaskSelector: undefined,
-      });
     });
   });
 


### PR DESCRIPTION
### Summary

Move removeInvalidSelectorsFromPrivacyConfig to joined config class so that it can be run on session id change as well

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
