### PR TITLE
chore(core): bump node versions for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.15.x]
+        node-version: [18.15.x, 20x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.15.x, 20x]
+        node-version: [18.15.x, 20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -34,7 +34,7 @@ jobs:
       RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.15.x]
 
     steps:
       - name: Check out git repository

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -34,7 +34,7 @@ jobs:
       RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.15.x]
 
     steps:
       - name: Check out git repository


### PR DESCRIPTION
### Summary

Node 16 is end of life: https://endoflife.date/nodejs

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
