### PR TITLE
fix(session replay): set targeting match to false when session id is changed

### DIFF
--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -27,11 +27,7 @@ const createInstance: () => AmplitudeSessionReplay = () => {
       'setSessionId',
       getLogConfig(sessionReplay),
     ),
-    getSessionId: debugWrapper(
-      sessionReplay.getSessionId.bind(sessionReplay),
-      'getSessionId',
-      getLogConfig(sessionReplay),
-    ),
+    getSessionId: sessionReplay.getSessionId.bind(sessionReplay),
     getSessionReplayProperties: debugWrapper(
       sessionReplay.getSessionReplayProperties.bind(sessionReplay),
       'getSessionReplayProperties',

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -20,6 +20,7 @@ import { SessionReplayOptions } from '../src/typings/session-replay';
 import * as JoinedConfigGenerator from '../src/config/joined-config';
 import { SessionReplayJoinedConfigGenerator } from '../src/config/joined-config';
 import { flagConfig } from './flag-config-data';
+import { IDBPDatabase } from 'idb';
 
 jest.mock('@amplitude/rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
@@ -336,6 +337,13 @@ describe('SessionReplay', () => {
       sessionReplay.setSessionId(456);
       expect(recordCancelCallbackMock).toHaveBeenCalled();
     });
+    test('should set sessionTargetingMatch to false', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      sessionReplay.sessionTargetingMatch = true;
+
+      sessionReplay.setSessionId(456);
+      expect(sessionReplay.sessionTargetingMatch).toBe(false);
+    });
 
     test('should update the session id and start recording', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
@@ -498,7 +506,7 @@ describe('SessionReplay', () => {
     test('should add a custom rrweb event', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
       sessionReplay.addCustomRRWebEvent = jest.fn();
-      sessionReplay.getShouldRecord = () => true;
+      sessionReplay.getShouldCapture = () => true;
 
       const result = sessionReplay.getSessionReplayProperties();
       expect(sessionReplay.addCustomRRWebEvent).toHaveBeenCalledWith(
@@ -520,7 +528,7 @@ describe('SessionReplay', () => {
     test('should add a custom rrweb event with storage info if event count is 10, then reset event count', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, debugMode: true }).promise;
       sessionReplay.addCustomRRWebEvent = jest.fn();
-      sessionReplay.getShouldRecord = () => true;
+      sessionReplay.getShouldCapture = () => true;
       sessionReplay.eventCount = 10;
 
       const result = sessionReplay.getSessionReplayProperties();


### PR DESCRIPTION
### Summary
We need to reset the targeting match state when the session id turns over. The unfortunate aspect about this change is it highlights the fact that we are keeping the state of targeting match in two places - both in component state and in IDB (within the targeting manager class). This is necessary because we need to be able to access the value of sessionTargetingMatch synchronously, as it's used by synchronous fns (getShouldCapture, which is used by captureEvents and getSessionReplayProperties), and accessing a value from IDB is an asynchronous action. The downside here is that it's possible for the component state to be out of sync with the IDB state if we're not careful to update it.


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
