### PR TITLE
ci: bump node version to match release jobs

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -10,7 +10,6 @@ on:
         options:
           - dry-run
           - prerelease
-        
 
 jobs:
   authorize:
@@ -33,7 +32,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.15.x]
 
     steps:
       - name: Get branch name


### PR DESCRIPTION
### Summary

Need to use node 18+ in our jobs

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
