### PR TITLE
fix: add metrics field to remote config fetcher

### DIFF
--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -29,7 +29,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   lastFetchedSessionId: number | undefined;
   sessionTargetingMatch = false;
   configKeys: string[];
-  metrics: Map<RemoteConfigMetric, number> = new Map<RemoteConfigMetric, number>();
+  metrics: RemoteConfigMetric = {};
 
   constructor({ localConfig, configKeys }: { localConfig: Config; configKeys: string[] }) {
     this.localConfig = localConfig;
@@ -57,7 +57,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
       // Another option is to empty the db if current session doesn't match lastFetchedSessionId
       if (!!lastFetchedSessionId && !!sessionId && lastFetchedSessionId === sessionId) {
         const idbRemoteConfig = await this.remoteConfigIDBStore.getRemoteConfig(configNamespace, key);
-        this.metrics.set(RemoteConfigMetric.FetchTimeIDB, Date.now() - fetchStartTime);
+        this.metrics.fetchTimeIDB = Date.now() - fetchStartTime;
         return idbRemoteConfig;
       }
     }
@@ -66,11 +66,11 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     if (configAPIResponse) {
       const remoteConfig = configAPIResponse.configs && configAPIResponse.configs[configNamespace];
       if (remoteConfig) {
-        this.metrics.set(RemoteConfigMetric.FetchTimeAPI, Date.now() - fetchStartTime);
+        this.metrics.fetchTimeAPISuccess = Date.now() - fetchStartTime;
         return remoteConfig[key];
       }
     }
-    this.metrics.set(RemoteConfigMetric.FetchTimeAPI, Date.now() - fetchStartTime);
+    this.metrics.fetchTimeAPIFail = Date.now() - fetchStartTime;
     return undefined;
   };
 

--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -29,7 +29,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   lastFetchedSessionId: number | undefined;
   sessionTargetingMatch = false;
   configKeys: string[];
-  metrics: Map<RemoteConfigMetric, string | number> = new Map<RemoteConfigMetric, string | number>();
+  metrics: Map<RemoteConfigMetric, number> = new Map<RemoteConfigMetric, number>();
 
   constructor({ localConfig, configKeys }: { localConfig: Config; configKeys: string[] }) {
     this.localConfig = localConfig;

--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -29,7 +29,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   sessionTargetingMatch = false;
   configKeys: string[];
   // Time used to fetch remote config in milliseconds
-  fetchTime = 0;
+  metrics: Map<string, string | number> = new Map<string, string | number>();
 
   constructor({ localConfig, configKeys }: { localConfig: Config; configKeys: string[] }) {
     this.localConfig = localConfig;
@@ -57,7 +57,7 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
       // Another option is to empty the db if current session doesn't match lastFetchedSessionId
       if (!!lastFetchedSessionId && !!sessionId && lastFetchedSessionId === sessionId) {
         const idbRemoteConfig = await this.remoteConfigIDBStore.getRemoteConfig(configNamespace, key);
-        this.fetchTime = Date.now() - fetchStartTime;
+        this.metrics.set('remote_config_fetch_time_IDB', Date.now() - fetchStartTime);
         return idbRemoteConfig;
       }
     }
@@ -66,11 +66,11 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     if (configAPIResponse) {
       const remoteConfig = configAPIResponse.configs && configAPIResponse.configs[configNamespace];
       if (remoteConfig) {
-        this.fetchTime = Date.now() - fetchStartTime;
+        this.metrics.set('remote_config_fetch_time_API', Date.now() - fetchStartTime);
         return remoteConfig[key];
       }
     }
-    this.fetchTime = Date.now() - fetchStartTime;
+    this.metrics.set('remote_config_fetch_time_API', Date.now() - fetchStartTime);
     return undefined;
   };
 

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -16,16 +16,20 @@ export interface BaseRemoteConfigFetch<T> {
 
 export interface RemoteConfigFetch<T> extends BaseRemoteConfigFetch<T> {
   // Each metric is independent. See RemoteConfigMetric for more information.
-  metrics: Map<RemoteConfigMetric, number>;
+  metrics: RemoteConfigMetric;
 }
 
-export enum RemoteConfigMetric {
+export interface RemoteConfigMetric {
   // The time, in milliseconds, taken to fetch the last remote config via getRemoteConfig() from IndexedDB.
   // If multiple remote config fetches occur, this value will be updated to reflect the time of the most recent fetch.
-  FetchTimeIDB = 'remote_config_fetch_time_IDB',
+  fetchTimeIDB?: number;
   // The time, in milliseconds, taken to fetch the last remote config via getRemoteConfig() from API.
   // If multiple remote config fetches occur, this value will be updated to reflect the time of the most recent fetch.
-  FetchTimeAPI = 'remote_config_fetch_time_API',
+  fetchTimeAPISuccess?: number;
+  // The time, in milliseconds, taken to fetch the last remote config via getRemoteConfig() from API
+  // but failed because of exceeding max retry or an error.
+  // If multiple remote config fetches occur, this value will be updated to reflect the time of the most recent fetch.
+  fetchTimeAPIFail?: number;
 }
 
 export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: object }>

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -18,6 +18,15 @@ export interface RemoteConfigFetch<T> extends BaseRemoteConfigFetch<T> {
   metrics: Map<string, string | number>;
 }
 
+export enum RemoteConfigMetric {
+  // The time, in milliseconds, taken to fetch the last remote config via getRemoteConfig() from IndexedDB.
+  // If multiple remote config fetches occur, this value will be updated to reflect the time of the most recent fetch.
+  FetchTimeIDB = 'remote_config_fetch_time_IDB',
+  // The time, in milliseconds, taken to fetch the last remote config via getRemoteConfig() from API.
+  // If multiple remote config fetches occur, this value will be updated to reflect the time of the most recent fetch.
+  FetchTimeAPI = 'remote_config_fetch_time_API',
+}
+
 export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: object }>
   extends BaseRemoteConfigFetch<RemoteConfig> {
   storeRemoteConfig: (remoteConfig: RemoteConfigAPIResponse<RemoteConfig>, sessionId?: number) => Promise<void>;

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -15,7 +15,8 @@ export interface BaseRemoteConfigFetch<T> {
 }
 
 export interface RemoteConfigFetch<T> extends BaseRemoteConfigFetch<T> {
-  metrics: Map<string, string | number>;
+  // Each metric is independent. See RemoteConfigMetric for more information.
+  metrics: Map<RemoteConfigMetric, number>;
 }
 
 export enum RemoteConfigMetric {

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -15,7 +15,7 @@ export interface BaseRemoteConfigFetch<T> {
 }
 
 export interface RemoteConfigFetch<T> extends BaseRemoteConfigFetch<T> {
-  fetchTime: number;
+  metrics: Map<string, string | number>;
 }
 
 export interface RemoteConfigIDBStore<RemoteConfig extends { [key: string]: object }>

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -505,13 +505,13 @@ describe('RemoteConfigFetch', () => {
       expect(remoteConfigFetch).toBeDefined();
     });
 
-    test('should set fetchTime to 0 when initialization', async () => {
+    test('should set metrics to an empty map when initialization', async () => {
       const remoteConfigFetch = await createRemoteConfigFetch({ localConfig, configKeys: ['sessionReplay'] });
-      expect(remoteConfigFetch.fetchTime).toEqual(0);
+      expect(remoteConfigFetch.metrics).toEqual(new Map());
     });
   });
 
-  test('should calculate fetchTime', async () => {
+  test('should calculate API fetch time', async () => {
     const mockDateNow = jest.spyOn(global.Date, 'now');
     const startTimestamp = 1000;
     const endTimestamp = 2000;
@@ -520,7 +520,25 @@ describe('RemoteConfigFetch', () => {
 
     await initialize();
     await remoteConfigFetch.getRemoteConfig('sessionReplay', 'sr_sampling_config', 456);
-    expect(remoteConfigFetch.fetchTime).toEqual(endTimestamp - startTimestamp);
+    expect(remoteConfigFetch.metrics).toEqual(
+      new Map([['remote_config_fetch_time_API', endTimestamp - startTimestamp]]),
+    );
+
+    mockDateNow.mockRestore();
+  });
+
+  test('should calculate IDB fetch time', async () => {
+    const mockDateNow = jest.spyOn(global.Date, 'now');
+    const startTimestamp = 1000;
+    const endTimestamp = 2000;
+    mockDateNow.mockImplementationOnce(() => startTimestamp);
+    mockDateNow.mockImplementationOnce(() => endTimestamp);
+
+    await initialize();
+    await remoteConfigFetch.getRemoteConfig('sessionReplay', 'sr_sampling_config', 123);
+    expect(remoteConfigFetch.metrics).toEqual(
+      new Map([['remote_config_fetch_time_IDB', endTimestamp - startTimestamp]]),
+    );
 
     mockDateNow.mockRestore();
   });

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -8,7 +8,7 @@ import {
   createRemoteConfigFetch,
 } from '../src/remote-config';
 import * as RemoteConfigAPIStore from '../src/remote-config-idb-store';
-import { RemoteConfigAPIResponse, RemoteConfigIDBStore } from '../src/types';
+import { RemoteConfigAPIResponse, RemoteConfigIDBStore, RemoteConfigMetric } from '../src/types';
 
 type MockedLogger = jest.Mocked<Logger>;
 
@@ -521,7 +521,7 @@ describe('RemoteConfigFetch', () => {
     await initialize();
     await remoteConfigFetch.getRemoteConfig('sessionReplay', 'sr_sampling_config', 456);
     expect(remoteConfigFetch.metrics).toEqual(
-      new Map([['remote_config_fetch_time_API', endTimestamp - startTimestamp]]),
+      new Map([[RemoteConfigMetric.FetchTimeAPI, endTimestamp - startTimestamp]]),
     );
 
     mockDateNow.mockRestore();
@@ -537,7 +537,7 @@ describe('RemoteConfigFetch', () => {
     await initialize();
     await remoteConfigFetch.getRemoteConfig('sessionReplay', 'sr_sampling_config', 123);
     expect(remoteConfigFetch.metrics).toEqual(
-      new Map([['remote_config_fetch_time_IDB', endTimestamp - startTimestamp]]),
+      new Map([[RemoteConfigMetric.FetchTimeIDB, endTimestamp - startTimestamp]]),
     );
 
     mockDateNow.mockRestore();

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -71,7 +71,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      metrics: new Map(),
+      metrics: {},
     });
     jest.useFakeTimers();
   });

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -71,7 +71,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      fetchTime: 0,
+      metrics: new Map(),
     });
     jest.useFakeTimers();
   });

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -71,7 +71,7 @@ describe('module level integration', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      fetchTime: 0,
+      metrics: new Map(),
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     jest.useFakeTimers();

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -71,7 +71,7 @@ describe('module level integration', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      metrics: new Map(),
+      metrics: {},
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     jest.useFakeTimers();

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -82,7 +82,7 @@ describe('module level integration', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      fetchTime: 0,
+      metrics: new Map(),
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     jest.useFakeTimers({ doNotFake: ['nextTick'] });

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -82,7 +82,7 @@ describe('module level integration', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      metrics: new Map(),
+      metrics: {},
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     jest.useFakeTimers({ doNotFake: ['nextTick'] });

--- a/packages/session-replay-browser/test/session-replay-factory.test.ts
+++ b/packages/session-replay-browser/test/session-replay-factory.test.ts
@@ -8,7 +8,7 @@ describe('session replay factory', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      fetchTime: 0,
+      metrics: new Map(),
     });
   });
   describe('getLogConfig', () => {

--- a/packages/session-replay-browser/test/session-replay-factory.test.ts
+++ b/packages/session-replay-browser/test/session-replay-factory.test.ts
@@ -8,7 +8,7 @@ describe('session replay factory', () => {
     getRemoteConfigMock = jest.fn();
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      metrics: new Map(),
+      metrics: {},
     });
   });
   describe('getLogConfig', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -104,7 +104,7 @@ describe('SessionReplay', () => {
     getRemoteConfigMock = jest.fn().mockResolvedValue(samplingConfig);
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      metrics: new Map(),
+      metrics: {},
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     sessionReplay = new SessionReplay();
@@ -239,7 +239,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
-        metrics: new Map(),
+        metrics: {},
       });
       await sessionReplay.init(apiKey, {
         ...mockOptions,
@@ -589,7 +589,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
-        metrics: new Map(),
+        metrics: {},
       });
       await sessionReplay.init(apiKey, {
         ...mockOptions,

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -104,7 +104,7 @@ describe('SessionReplay', () => {
     getRemoteConfigMock = jest.fn().mockResolvedValue(samplingConfig);
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
-      fetchTime: 0,
+      metrics: new Map(),
     });
     jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
     sessionReplay = new SessionReplay();
@@ -239,7 +239,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
-        fetchTime: 0,
+        metrics: new Map(),
       });
       await sessionReplay.init(apiKey, {
         ...mockOptions,
@@ -589,7 +589,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
-        fetchTime: 0,
+        metrics: new Map(),
       });
       await sessionReplay.init(apiKey, {
         ...mockOptions,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Add a "metrics" filed with type `Map<string, string|number>` to remote config fetcher 
- Collect two metrics
   - fetch time from IndexedDB
   - fetch time from API

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
