### PR TITLE
feat: support remote config for each autocapture field

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@amplitude/analytics-client-common": "^2.3.0",
     "@amplitude/analytics-core": "^2.4.0",
-    "@amplitude/analytics-remote-config": "^0.3.0",
+    "@amplitude/analytics-remote-config": "^0.3.5",
     "@amplitude/analytics-types": "^2.7.0",
     "@amplitude/plugin-autocapture-browser": "^1.0.0",
     "@amplitude/plugin-page-view-tracking-browser": "^2.2.18",

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -69,7 +69,24 @@ export class BrowserJoinedConfigGenerator {
 
       this.config.loggerProvider.debug('Joined configuration: ', JSON.stringify(this.config, null, 2));
       this.config.requestMetadata ??= new RequestMetadata();
-      this.config.requestMetadata.recordHistogram('remote_config_fetch_time', this.remoteConfigFetch?.fetchTime);
+      if (this.remoteConfigFetch?.metrics.fetchTimeIDB) {
+        this.config.requestMetadata.recordHistogram(
+          'remote_config_fetch_time_IDB',
+          this.remoteConfigFetch.metrics.fetchTimeIDB,
+        );
+      }
+      if (this.remoteConfigFetch?.metrics.fetchTimeAPISuccess) {
+        this.config.requestMetadata.recordHistogram(
+          'remote_config_fetch_time_API_success',
+          this.remoteConfigFetch.metrics.fetchTimeAPISuccess,
+        );
+      }
+      if (this.remoteConfigFetch?.metrics.fetchTimeAPIFail) {
+        this.config.requestMetadata.recordHistogram(
+          'remote_config_fetch_time_API_fail',
+          this.remoteConfigFetch.metrics.fetchTimeAPIFail,
+        );
+      }
     } catch (e) {
       this.config.loggerProvider.error('Failed to fetch remote configuration because of error: ', e);
     }

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -29,10 +29,11 @@ export class BrowserJoinedConfigGenerator {
         this.remoteConfigFetch &&
         (await this.remoteConfigFetch.getRemoteConfig('analyticsSDK', 'browserSDK', this.config.sessionId));
       this.config.loggerProvider.debug('Remote configuration:', JSON.stringify(remoteConfig, null, 2));
+
+      // merge remoteConfig.autocapture and this.config.autocapture
+      // if a field is in remoteConfig.autocapture, use that value
+      // if a field is not in remoteConfig.autocapture, use the value from this.config.autocapture
       if (remoteConfig && 'autocapture' in remoteConfig) {
-        // merge remoteConfig.autocapture and this.config.autocapture
-        // if a field is in remoteConfig.autocapture, use that value
-        // if a field is not in remoteConfig.autocapture, use the value from this.config.autocapture
         if (typeof remoteConfig.autocapture === 'boolean') {
           this.config.autocapture = remoteConfig.autocapture;
         }

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -12,7 +12,9 @@ describe('joined-config', () => {
   let localConfig: IBrowserConfig;
   let mockRemoteConfigFetch: RemoteConfigFetch<BrowserRemoteConfig>;
   let generator: BrowserJoinedConfigGenerator;
-  const fetchTime = 100;
+  const metrics = {
+    fetchTimeAPISuccess: 100,
+  };
 
   beforeEach(() => {
     localConfig = { ...createConfigurationMock(), defaultTracking: false, autocapture: false };
@@ -22,7 +24,7 @@ describe('joined-config', () => {
         defaultTracking: true,
         autocapture: true,
       }),
-      fetchTime: fetchTime,
+      metrics: metrics,
     };
 
     // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
@@ -73,7 +75,7 @@ describe('joined-config', () => {
         };
         mockRemoteConfigFetch = {
           getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
-          fetchTime: fetchTime,
+          metrics: metrics,
         };
         // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
         (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
@@ -115,7 +117,7 @@ describe('joined-config', () => {
         };
         mockRemoteConfigFetch = {
           getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
-          fetchTime: fetchTime,
+          metrics: metrics,
         };
         // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
         (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
@@ -162,7 +164,7 @@ describe('joined-config', () => {
         };
         mockRemoteConfigFetch = {
           getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
-          fetchTime: fetchTime,
+          metrics: metrics,
         };
         // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
         (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
@@ -195,7 +197,7 @@ describe('joined-config', () => {
         };
         mockRemoteConfigFetch = {
           getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
-          fetchTime: fetchTime,
+          metrics: metrics,
         };
         // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
         (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
@@ -248,7 +250,79 @@ describe('joined-config', () => {
         generator.config.requestMetadata = requestMetadata;
         const joinedConfig = await generator.generateJoinedConfig();
         expect(joinedConfig.requestMetadata).not.toBeUndefined();
-        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time).toBe(fetchTime);
+      });
+
+      test('should set remote config fetch time API success', async () => {
+        mockRemoteConfigFetch = {
+          getRemoteConfig: jest.fn().mockResolvedValue({
+            defaultTracking: true,
+            autocapture: true,
+          }),
+          metrics: {
+            fetchTimeAPISuccess: 100,
+          },
+        };
+
+        // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
+        (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
+          mockRemoteConfigFetch,
+        );
+
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_success).toBe(100);
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_fail).toBe(undefined);
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_IDB).toBe(undefined);
+      });
+
+      test('should set remote config fetch time API fail', async () => {
+        mockRemoteConfigFetch = {
+          getRemoteConfig: jest.fn().mockResolvedValue({
+            defaultTracking: true,
+            autocapture: true,
+          }),
+          metrics: {
+            fetchTimeAPIFail: 100,
+          },
+        };
+
+        // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
+        (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
+          mockRemoteConfigFetch,
+        );
+
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_success).toBe(
+          undefined,
+        );
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_fail).toBe(100);
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_IDB).toBe(undefined);
+      });
+
+      test('should set remote config fetch time IDB', async () => {
+        mockRemoteConfigFetch = {
+          getRemoteConfig: jest.fn().mockResolvedValue({
+            defaultTracking: true,
+            autocapture: true,
+          }),
+          metrics: {
+            fetchTimeIDB: 100,
+          },
+        };
+
+        // Mock the createRemoteConfigFetch to return the mockRemoteConfigFetch
+        (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
+          mockRemoteConfigFetch,
+        );
+
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_success).toBe(
+          undefined,
+        );
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_fail).toBe(undefined);
+        expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_IDB).toBe(100);
       });
     });
   });

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -159,7 +159,7 @@ describe('joined-config', () => {
         generator = new BrowserJoinedConfigGenerator(localConfig);
         const remoteConfig = {
           autocapture: {
-            elementInteractions: false,
+            elementInteractions: true,
           },
         };
         mockRemoteConfigFetch = {
@@ -177,7 +177,7 @@ describe('joined-config', () => {
           formInteractions: false,
           attribution: false,
           pageViews: false,
-          elementInteractions: false,
+          elementInteractions: true,
         };
 
         await generator.initialize();

--- a/packages/analytics-core/src/config.ts
+++ b/packages/analytics-core/src/config.ts
@@ -123,7 +123,7 @@ export class RequestMetadata implements IRequestMetadata {
   constructor() {
     this.sdk = {
       metrics: {
-        histogram: new HistogramOptions(),
+        histogram: {},
       },
     };
   }
@@ -134,5 +134,7 @@ export class RequestMetadata implements IRequestMetadata {
 }
 
 class HistogramOptions implements IHistogramOptions {
-  remote_config_fetch_time?: number;
+  remote_config_fetch_time_IDB?: number;
+  remote_config_fetch_time_API_success?: number;
+  remote_config_fetch_time_API_fail?: number;
 }

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -381,7 +381,7 @@ describe('destination', () => {
         timeout: 0,
       };
       const request_metadata = new RequestMetadata();
-      request_metadata.recordHistogram('remote_config_fetch_time', 100);
+      request_metadata.recordHistogram('remote_config_fetch_time_API_success', 100);
 
       const transportProvider = {
         send: jest.fn().mockImplementationOnce((_url: string, payload: Payload) => {

--- a/packages/analytics-types/src/config/core.ts
+++ b/packages/analytics-types/src/config/core.ts
@@ -90,9 +90,7 @@ export interface Config {
 export interface RequestMetadata {
   sdk: {
     metrics: {
-      histogram: {
-        remote_config_fetch_time?: number;
-      };
+      histogram: HistogramOptions;
     };
   };
 
@@ -100,7 +98,9 @@ export interface RequestMetadata {
 }
 
 export interface HistogramOptions {
-  remote_config_fetch_time?: number;
+  remote_config_fetch_time_IDB?: number;
+  remote_config_fetch_time_API_success?: number;
+  remote_config_fetch_time_API_fail?: number;
 }
 
 export type HistogramKey = keyof HistogramOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
   integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
 
-"@amplitude/analytics-remote-config@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.3.0.tgz#6413761d17b25f3cb0c69c3caacab8c7d1653206"
-  integrity sha512-hfq4O+q1vj9St/VKb0WaHMpbJ6AVTWsVfZJbiu7ADfYqAEnEKihtReGvlwyU6Uim8n1xOBmES3JmWVJKAEOIWQ==
+"@amplitude/analytics-remote-config@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.3.5.tgz#b3b9ca15f183a0399c451b9395d9c8281d310e7d"
+  integrity sha512-jnm/w+/NFSLnjcHSP/MYvdy6RQ7lVqWyAiIw/cTs+iL6cJaoauHuB0gbUnqGTPUhvbUlKa7faz1iiXGwt6HSjA==
   dependencies:
     "@amplitude/analytics-client-common" ">=1 <3"
     "@amplitude/analytics-core" ">=1 <3"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR contains two changes

### Support enable remote config for each autocapture field by merging remote and local config. 
[AMP-106699]
Merging logic:
   - `options.autocapture` should override `options.defaultTracking` if it’s set. This happens at `useBrowserConfig()` when creating browser config based on options customers passed in 
   - In `joined-config.ts`, `remoteConfig.autocapture` should merge with `localConfig.autocapture` which means that if a field exists in `remoteConfig.autocapture`, it should add to mergedConfig, however, if a filed doesn’t exist, we should check the value in `localConfig.autocapture`

Examples
```
client.init(apiKey, userId, {
  autocapture: false
}).promise;

// remote config is enabled only for clicks
{
  autocapture: {
    elementInteractions: true
  }
}

// result
{
  fileDownloads: false,
  formInteractions: false,
  pageViews: false,
  attribution: false,
  sessions: false,
  elementInteractions: true
}
```
```
client.init(apiKey);

// remote config is enabled only for clicks
{
  autocapture: {
    elementInteractions: true
  }
}

// result
{
  elementInteractions: true
}

all of the other fields in autocapture will be default value
```

### Separate fetch time into 3 at a finer granularity
[AMP-106700]
   - fetch from indexedDB
   - fetch from API and succeed
   - fetch from API but fail

Below is an example of tracking the time of successful fetching from API 
<img width="969" alt="Screenshot 2024-08-12 at 12 48 16" src="https://github.com/user-attachments/assets/89c22ecb-a792-433d-97dd-a0a54a4ebe56">
<img width="951" alt="Screenshot 2024-08-12 at 12 48 29" src="https://github.com/user-attachments/assets/730a7540-b0a8-43b8-8c35-5250587354dc">


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-106699]: https://amplitude.atlassian.net/browse/AMP-106699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMP-106700]: https://amplitude.atlassian.net/browse/AMP-106700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ