### PR TITLE
refactor(session replay plugin): collapse plugins into one

### DIFF
--- a/packages/plugin-session-replay-browser/test/integration/browser-sdk-integration.test.ts
+++ b/packages/plugin-session-replay-browser/test/integration/browser-sdk-integration.test.ts
@@ -7,9 +7,6 @@ import { server } from './mockAPIHandlers';
 import { matchRequestUrl } from 'msw';
 
 const apiKey = 'static_key';
-server.events.on('request:start', ({ request }) => {
-  console.log('request', request.url);
-});
 
 function waitForRequest(method: string, url: string, bodyMatchingFn: (body: any) => boolean = () => true) {
   return new Promise<Request>((resolve) => {


### PR DESCRIPTION
### Summary

The Mobile SR team converted our enrichment plugin into an enrichment and destination plugin for a previous spike, but they no longer need that functionality. This PR simplifies the plugin back into a single enrichment plugin

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
