### PR TITLE
fix(session replay): change log level of init warning

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -161,7 +161,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   getSessionReplayProperties() {
     if (!this.config || !this.identifiers) {
-      this.loggerProvider.error('Session replay init has not been called, cannot get session replay properties.');
+      this.loggerProvider.warn('Session replay init has not been called, cannot get session replay properties.');
       return {};
     }
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -414,7 +414,7 @@ describe('SessionReplay', () => {
       const result = sessionReplay.getSessionReplayProperties();
       expect(result).toEqual({});
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLoggerProvider.error).toHaveBeenCalled();
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
     });
 
     test('should return an empty object if shouldRecord is false', async () => {


### PR DESCRIPTION
### Summary

Reduce the init error to warn to be less noisy

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
