### PR TITLE
fix(uuid): set UUID's using crypto libraries instead of Math.random

### DIFF
--- a/packages/analytics-core/src/utils/uuid.ts
+++ b/packages/analytics-core/src/utils/uuid.ts
@@ -1,32 +1,19 @@
 /**
- * Source: [jed's gist]{@link https://gist.github.com/982883}.
+ * Source: [jed's gist's comment]{@link https://gist.github.com/jed/982883?permalink_comment_id=3223002#gistcomment-3223002}.
  * Returns a random v4 UUID of the form xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx,
  * where each x is replaced with a random hexadecimal digit from 0 to f, and
  * y is replaced with a random hexadecimal digit from 8 to b.
  * Used to generate UUIDs for deviceIds.
  * @private
  */
-export const UUID = function (a?: any): string {
-  return a // if the placeholder was passed, return
-    ? // a random number from 0 to 15
-      (
-        a ^ // unless b is 8,
-        ((Math.random() * // in which case
-          16) >> // a random number from
-          (a / 4))
-      ) // 8 to 11
-        .toString(16) // in hexadecimal
-    : // or otherwise a concatenated string:
-      (
-        String(1e7) + // 10000000 +
-        String(-1e3) + // -1000 +
-        String(-4e3) + // -4000 +
-        String(-8e3) + // -80000000 +
-        String(-1e11)
-      ) // -100000000000,
-        .replace(
-          // replacing
-          /[018]/g, // zeroes, ones, and eights with
-          UUID, // random hex digits
-        );
+
+const hex: string[] = [...Array(256).keys()].map((index) => index.toString(16).padStart(2, '0'));
+
+export const UUID = (): string => {
+  const r = crypto.getRandomValues(new Uint8Array(16));
+
+  r[6] = (r[6] & 0x0f) | 0x40;
+  r[8] = (r[8] & 0x3f) | 0x80;
+
+  return [...r.entries()].map(([index, int]) => ([4, 6, 8, 10].includes(index) ? `-${hex[int]}` : hex[int])).join('');
 };

--- a/packages/analytics-core/src/utils/uuid.ts
+++ b/packages/analytics-core/src/utils/uuid.ts
@@ -7,9 +7,20 @@
  * @private
  */
 
+import { getGlobalScope } from '../global-scope';
+
 const hex: string[] = [...Array(256).keys()].map((index) => index.toString(16).padStart(2, '0'));
 
 export const UUID = (): string => {
+  const global = getGlobalScope();
+  let crypto: Crypto;
+  if (global?.crypto?.getRandomValues) {
+    crypto = global.crypto;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    crypto = require('crypto') as Crypto;
+  }
+
   const r = crypto.getRandomValues(new Uint8Array(16));
 
   r[6] = (r[6] & 0x0f) | 0x40;

--- a/packages/analytics-core/src/utils/uuid.ts
+++ b/packages/analytics-core/src/utils/uuid.ts
@@ -9,8 +9,6 @@
 
 import { getGlobalScope } from '../global-scope';
 
-const hex: string[] = [...Array(256).keys()].map((index) => index.toString(16).padStart(2, '0'));
-
 const legacyUUID = function (a?: any): string {
   return a // if the placeholder was passed, return
     ? // a random number from 0 to 15
@@ -36,16 +34,18 @@ const legacyUUID = function (a?: any): string {
         );
 };
 
-export const UUID = (a?: any): string => {
-  const global = getGlobalScope();
+const hex: string[] = [...Array(256).keys()].map((index) => index.toString(16).padStart(2, '0'));
 
+export const UUID = (a?: any): string => {
+  const globalScope = getGlobalScope();
+  
   /* istanbul ignore next */
-  if (!global?.crypto?.getRandomValues) {
+  if (!globalScope?.crypto?.getRandomValues) {
     // Fallback to legacy UUID generation if crypto is not available
     return legacyUUID(a);
   }
 
-  const r = global.crypto.getRandomValues(new Uint8Array(16));
+  const r = globalScope.crypto.getRandomValues(new Uint8Array(16));
 
   r[6] = (r[6] & 0x0f) | 0x40;
   r[8] = (r[8] & 0x3f) | 0x80;

--- a/packages/analytics-core/src/utils/uuid.ts
+++ b/packages/analytics-core/src/utils/uuid.ts
@@ -11,10 +11,6 @@ import { getGlobalScope } from '../global-scope';
 
 const hex: string[] = [...Array(256).keys()].map((index) => index.toString(16).padStart(2, '0'));
 
-interface Crypto {
-  getRandomValues: (array: Uint8Array) => Uint8Array;
-}
-
 const legacyUUID = function (a?: any): string {
   return a // if the placeholder was passed, return
     ? // a random number from 0 to 15
@@ -42,14 +38,14 @@ const legacyUUID = function (a?: any): string {
 
 export const UUID = (a?: any): string => {
   const global = getGlobalScope();
-  let crypto: Crypto | undefined = global?.crypto;
 
-  if (!crypto?.getRandomValues) {
+  /* istanbul ignore next */
+  if (!global?.crypto?.getRandomValues) {
     // Fallback to legacy UUID generation if crypto is not available
     return legacyUUID(a);
   }
 
-  const r = crypto.getRandomValues(new Uint8Array(16));
+  const r = global.crypto.getRandomValues(new Uint8Array(16));
 
   r[6] = (r[6] & 0x0f) | 0x40;
   r[8] = (r[8] & 0x3f) | 0x80;

--- a/packages/analytics-core/src/utils/uuid.ts
+++ b/packages/analytics-core/src/utils/uuid.ts
@@ -38,7 +38,7 @@ const hex: string[] = [...Array(256).keys()].map((index) => index.toString(16).p
 
 export const UUID = (a?: any): string => {
   const globalScope = getGlobalScope();
-  
+
   /* istanbul ignore next */
   if (!globalScope?.crypto?.getRandomValues) {
     // Fallback to legacy UUID generation if crypto is not available

--- a/packages/analytics-core/src/utils/uuid.ts
+++ b/packages/analytics-core/src/utils/uuid.ts
@@ -44,7 +44,7 @@ export const UUID = (a?: any): string => {
   const global = getGlobalScope();
   let crypto: Crypto | undefined = global?.crypto;
 
-  if (!crypto) {
+  if (!crypto?.getRandomValues) {
     // Fallback to legacy UUID generation if crypto is not available
     return legacyUUID(a);
   }

--- a/packages/analytics-core/test/utils/uuid.test.ts
+++ b/packages/analytics-core/test/utils/uuid.test.ts
@@ -8,23 +8,16 @@ describe('UUID', () => {
   });
   
   test('should generate a valid UUID-4 (no native Crypto)', () => {
-    const backupCrypto = global.crypto;
-    Object.defineProperties(global, {
-      crypto: {
-        value: null,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-    });
-
+    const backupCrypto = (global as any).crypto;
+    (global as any).crypto = null;
+    
     try {
       const uuid = UUID();
       expect(uuid.length).toEqual(36);
       expect(uuid.substring(14, 15)).toEqual('4');
     } finally {
       // Restore the original crypto object
-      global.crypto = backupCrypto;
+      (global as any).crypto = backupCrypto;
     }
   });
 });

--- a/packages/analytics-core/test/utils/uuid.test.ts
+++ b/packages/analytics-core/test/utils/uuid.test.ts
@@ -1,16 +1,31 @@
 import { UUID } from '../../src/utils/uuid';
 
 describe('UUID', () => {
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  /* eslint-disable @typescript-eslint/no-unsafe-call */
   test('should generate a valid UUID-4', () => {
+    // hack to make sure that the test runs in nodejs v18.x
+    // this is never reached in Node >= 20
+    if (!globalThis.crypto?.getRandomValues) {
+      (globalThis as any).crypto = {
+        getRandomValues: (arr: Uint8Array) => {
+          for (let i = 0; i < arr.length; i++) {
+            arr[i] = Math.floor(Math.random() * 256);
+          }
+          return arr;
+        },
+      };
+    }
     const uuid = UUID();
     expect(uuid.length).toEqual(36);
     expect(uuid.substring(14, 15)).toEqual('4');
   });
-  
+
   test('should generate a valid UUID-4 (no native Crypto)', () => {
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     const backupCrypto = (global as any).crypto;
     (global as any).crypto = null;
-    
+
     try {
       const uuid = UUID();
       expect(uuid.length).toEqual(36);

--- a/packages/analytics-core/test/utils/uuid.test.ts
+++ b/packages/analytics-core/test/utils/uuid.test.ts
@@ -1,9 +1,29 @@
 import { UUID } from '../../src/utils/uuid';
 
 describe('UUID', () => {
-  test('should generate a valid UUID-4', () => {
+  test('should generate a valid UUID-4 (web)', () => {
     const uuid = UUID();
     expect(uuid.length).toEqual(36);
     expect(uuid.substring(14, 15)).toEqual('4');
+  });
+  test('should generate a valid UUID-4 (nodejs)', () => {
+    const backupCrypto = global.crypto;
+    Object.defineProperties(global, {
+      crypto: {
+        value: {
+          getRandomValues: undefined,
+        },
+        writable: true,
+      },
+    });
+
+    try {
+      const uuid = UUID();
+      expect(uuid.length).toEqual(36);
+      expect(uuid.substring(14, 15)).toEqual('4');
+    } finally {
+      // Restore the original crypto object
+      global.crypto = backupCrypto;
+    }
   });
 });

--- a/packages/analytics-core/test/utils/uuid.test.ts
+++ b/packages/analytics-core/test/utils/uuid.test.ts
@@ -1,13 +1,13 @@
 import { UUID } from '../../src/utils/uuid';
 
 describe('UUID', () => {
-  test('should generate a valid UUID-4 (web)', () => {
+  test('should generate a valid UUID-4', () => {
     const uuid = UUID();
     expect(uuid.length).toEqual(36);
     expect(uuid.substring(14, 15)).toEqual('4');
   });
   
-  test('should generate a valid UUID-4 (nodejs)', () => {
+  test('should generate a valid UUID-4 (no native Crypto)', () => {
     const backupCrypto = global.crypto;
     Object.defineProperties(global, {
       crypto: {

--- a/packages/analytics-core/test/utils/uuid.test.ts
+++ b/packages/analytics-core/test/utils/uuid.test.ts
@@ -24,7 +24,10 @@ describe('UUID', () => {
   test('should generate a valid UUID-4 (no native Crypto)', () => {
     /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     const backupCrypto = (global as any).crypto;
-    (global as any).crypto = null;
+    Object.defineProperty(global, 'crypto', {
+      value: null,
+      writable: true,
+    });
 
     try {
       const uuid = UUID();

--- a/packages/analytics-core/test/utils/uuid.test.ts
+++ b/packages/analytics-core/test/utils/uuid.test.ts
@@ -6,14 +6,15 @@ describe('UUID', () => {
     expect(uuid.length).toEqual(36);
     expect(uuid.substring(14, 15)).toEqual('4');
   });
+  
   test('should generate a valid UUID-4 (nodejs)', () => {
     const backupCrypto = global.crypto;
     Object.defineProperties(global, {
       crypto: {
-        value: {
-          getRandomValues: undefined,
-        },
+        value: null,
         writable: true,
+        enumerable: true,
+        configurable: true,
       },
     });
 


### PR DESCRIPTION
### Summary

Hi, this is Jake from the Technical Support team.

There was an issue of user properties being mapped incorrectly due to colliding UUIDs set by the Amplitude TS SDK[due to math.random function]. 

There was a fix in JS SDK but not carried over to TS SDK
- https://github.com/amplitude/Amplitude-JavaScript/blob/v8.x/src/uuid.js

The issue has been stale, so I am making PR for the issue!


### Checklist

* [v] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
