### PR TITLE
fix(session-replay-browser): support disabling batching for interaction events

### DIFF
--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -8,6 +8,7 @@ export interface SamplingConfig {
 export interface InteractionConfig {
   trackEveryNms?: number;
   enabled: boolean; // defaults to false
+  batch: boolean; // defaults to false
 }
 
 export type SessionReplayRemoteConfig = {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -105,13 +105,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
     managers.push({ name: 'replay', manager: rrwebEventManager });
 
     if (this.config.interactionConfig?.enabled) {
+      const payloadBatcher = this.config.interactionConfig.batch ? clickBatcher : undefined;
       const interactionEventManager = await createEventsManager<'interaction'>({
         config: this.config,
         sessionId: this.identifiers.sessionId,
         type: 'interaction',
         minInterval: this.config.interactionConfig.trackEveryNms ?? INTERACTION_MIN_INTERVAL,
         maxInterval: INTERACTION_MAX_INTERVAL,
-        payloadBatcher: clickBatcher,
+        payloadBatcher,
       });
       managers.push({ name: 'interaction', manager: interactionEventManager });
     }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -201,6 +201,7 @@ describe('SessionReplay', () => {
         },
         async (config: SessionReplayJoinedConfig) => {
           expect(config.interactionConfig?.enabled).toBe(true);
+          expect(config.interactionConfig?.batch).toBeUndefined();
           expect(config.interactionConfig?.trackEveryNms).toBe(500);
         },
       ],
@@ -210,6 +211,7 @@ describe('SessionReplay', () => {
         },
         async (config: SessionReplayJoinedConfig) => {
           expect(config.interactionConfig?.enabled).toBe(true);
+          expect(config.interactionConfig?.batch).toBeUndefined();
           expect(config.interactionConfig?.trackEveryNms).toBeUndefined();
         },
       ],
@@ -220,6 +222,7 @@ describe('SessionReplay', () => {
         },
         async (config: SessionReplayJoinedConfig) => {
           expect(config.interactionConfig?.enabled).toBe(false);
+          expect(config.interactionConfig?.batch).toBeUndefined();
           expect(config.interactionConfig?.trackEveryNms).toBe(1_000);
         },
       ],
@@ -227,6 +230,29 @@ describe('SessionReplay', () => {
         undefined,
         async (config: SessionReplayJoinedConfig) => {
           expect(config.interactionConfig?.enabled).toBeUndefined();
+          expect(config.interactionConfig?.batch).toBeUndefined();
+          expect(config.interactionConfig?.trackEveryNms).toBeUndefined();
+        },
+      ],
+      [
+        {
+          enabled: true,
+          batch: true,
+        },
+        async (config: SessionReplayJoinedConfig) => {
+          expect(config.interactionConfig?.enabled).toBe(true);
+          expect(config.interactionConfig?.batch).toBe(true);
+          expect(config.interactionConfig?.trackEveryNms).toBeUndefined();
+        },
+      ],
+      [
+        {
+          enabled: true,
+          batch: false,
+        },
+        async (config: SessionReplayJoinedConfig) => {
+          expect(config.interactionConfig?.enabled).toBe(true);
+          expect(config.interactionConfig?.batch).toBe(false);
           expect(config.interactionConfig?.trackEveryNms).toBeUndefined();
         },
       ],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Supports disabling batching for interaction events to eventually support attribution.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
