### PR TITLE
fix(session-replay-browser): send proper interaction response

### DIFF
--- a/packages/session-replay-browser/src/hooks/click.ts
+++ b/packages/session-replay-browser/src/hooks/click.ts
@@ -28,6 +28,18 @@ type Options = {
 
 const HOUR_IN_MILLISECONDS = 3_600_000;
 
+export const clickNonBatcher: PayloadBatcher = ({ version, events }) => {
+  const clickEvents: ClickEvent[] = [];
+  events.forEach((evt: string) => {
+    const record = JSON.parse(evt) as Record<string, unknown>;
+    record.count = 1;
+    if (record.type === 'click') {
+      clickEvents.push(record as ClickEvent);
+    }
+  });
+  return { version, events: clickEvents };
+};
+
 export const clickBatcher: PayloadBatcher = ({ version, events }) => {
   const clickEvents: ClickEvent[] = [];
   events.forEach((evt: string) => {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -17,7 +17,7 @@ import {
 import { createEventsManager } from './events/events-manager';
 import { MultiEventManager } from './events/multi-manager';
 import { generateHashCode, getDebugConfig, getStorageSize, isSessionInSample, maskFn } from './helpers';
-import { clickBatcher, clickHook } from './hooks/click';
+import { clickBatcher, clickHook, clickNonBatcher } from './hooks/click';
 import { ScrollWatcher } from './hooks/scroll';
 import { SessionIdentifiers } from './identifiers';
 import {
@@ -105,7 +105,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     managers.push({ name: 'replay', manager: rrwebEventManager });
 
     if (this.config.interactionConfig?.enabled) {
-      const payloadBatcher = this.config.interactionConfig.batch ? clickBatcher : undefined;
+      const payloadBatcher = this.config.interactionConfig.batch ? clickBatcher : clickNonBatcher;
       const interactionEventManager = await createEventsManager<'interaction'>({
         config: this.config,
         sessionId: this.identifiers.sessionId,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We were sending a payload of strings rather than objects, which is incorrect. This fixes it.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
