### PR TITLE
fix(session-replay-browser): always get device id from the current session identifiers

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -416,13 +416,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   };
 
   getDeviceId() {
-    let identityStoreDeviceId: string | undefined;
-    if (this.config?.instanceName) {
-      const identityStore = getAnalyticsConnector(this.config.instanceName).identityStore;
-      identityStoreDeviceId = identityStore.getIdentity().deviceId;
-    }
-
-    return identityStoreDeviceId || this.identifiers?.deviceId;
+    return this.identifiers?.deviceId;
   }
 
   getSessionId() {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -925,23 +925,14 @@ describe('SessionReplay', () => {
     test('should return undefined if no config set', () => {
       expect(sessionReplay.getDeviceId()).toEqual(undefined);
     });
-    test('should return device id from identity store if set', async () => {
-      const storedDeviceId = '6t7y8u';
-      jest.spyOn(AnalyticsClientCommon, 'getAnalyticsConnector').mockReturnValue({
-        identityStore: {
-          getIdentity: () => {
-            return {
-              deviceId: storedDeviceId,
-            };
-          },
-        },
-      } as unknown as ReturnType<typeof AnalyticsClientCommon.getAnalyticsConnector>);
-      await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
-      expect(sessionReplay.getDeviceId()).toEqual(storedDeviceId);
-    });
     test('should return config device id if set', async () => {
       await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
       expect(sessionReplay.getDeviceId()).toEqual(mockOptions.deviceId);
+    });
+    test('should be consistent with session replay id', async () => {
+      await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
+      const deviceIdFromSRId = sessionReplay.identifiers?.sessionReplayId?.split('/')[0];
+      expect(sessionReplay.getDeviceId()).toEqual(deviceIdFromSRId);
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
The fix for bug: https://amplitude.atlassian.net/browse/AMP-104886

We used to get device ID from analyticsConnector which turned out can be changed in the middle of an ongoing replay capturing and broke it. This PR changed to read from the current session identifiers that are stored in the replay object.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
