### PR TITLE
build(analytics-react-native): bump async storage to v2

### DIFF
--- a/examples/react-native/app/package-lock.json
+++ b/examples/react-native/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@amplitude/analytics-react-native": "^1.4.8",
-        "@react-native-async-storage/async-storage": "^1.23.1",
+        "@react-native-async-storage/async-storage": "^2.0.0",
         "react": "18.2.0",
         "react-native": "0.74.1",
         "react-native-toast-message": "^2.2.0"
@@ -75,6 +75,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@amplitude/analytics-react-native/node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@amplitude/analytics-types": {
@@ -3095,14 +3107,15 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
-      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.0.0.tgz",
+      "integrity": "sha512-af6H9JjfL6G/PktBfUivvexoiFKQTJGQCtSWxMdivLzNIY94mu9DdiY0JqCSg/LyPCLGKhHPUlRQhNvpu3/KVA==",
+      "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {

--- a/examples/react-native/app/package.json
+++ b/examples/react-native/app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-react-native": "^1.4.8",
-    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-native-async-storage/async-storage": "^2.0.0",
     "react": "18.2.0",
     "react-native": "0.74.1",
     "react-native-toast-message": "^2.2.0"

--- a/examples/react-native/expo-app/package.json
+++ b/examples/react-native/expo-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-react-native": "0.7.0",
-    "@react-native-async-storage/async-storage": "~1.17.11",
+    "@react-native-async-storage/async-storage": "~2.0.0",
     "expo": "~47.0.8",
     "expo-splash-screen": "~0.17.5",
     "expo-status-bar": "~1.4.2",

--- a/examples/react-native/expo-app/yarn.lock
+++ b/examples/react-native/expo-app/yarn.lock
@@ -1545,10 +1545,17 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@react-native-async-storage/async-storage@^1.17.7", "@react-native-async-storage/async-storage@~1.17.11":
+"@react-native-async-storage/async-storage@^1.17.7":
   version "1.17.11"
   resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
   integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+  dependencies:
+    merge-options "^3.0.4"
+
+"@react-native-async-storage/async-storage@~2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-2.0.0.tgz#22373f7f83132547701637fc574ddb83b83b384e"
+  integrity sha512-af6H9JjfL6G/PktBfUivvexoiFKQTJGQCtSWxMdivLzNIY94mu9DdiY0JqCSg/LyPCLGKhHPUlRQhNvpu3/KVA==
   dependencies:
     merge-options "^3.0.4"
 

--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -62,7 +62,7 @@
     "@amplitude/analytics-core": "^2.0.0",
     "@amplitude/analytics-types": "^2.0.0",
     "@amplitude/ua-parser-js": "^0.7.31",
-    "@react-native-async-storage/async-storage": "^1.17.11",
+    "@react-native-async-storage/async-storage": "^2.0.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,10 +3070,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@react-native-async-storage/async-storage@^1.17.11":
-  version "1.17.11"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
-  integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+"@react-native-async-storage/async-storage@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-2.0.0.tgz#22373f7f83132547701637fc574ddb83b83b384e"
+  integrity sha512-af6H9JjfL6G/PktBfUivvexoiFKQTJGQCtSWxMdivLzNIY94mu9DdiY0JqCSg/LyPCLGKhHPUlRQhNvpu3/KVA==
   dependencies:
     merge-options "^3.0.4"
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

Bump `@react-native-async-storage/async-storage` to v2 on `analytics-react-native` package.

Examples must be updated after the new version

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
