### PR TITLE
fix(autocapture): prevent potential memory exhaustion when generating combinations

### DIFF
--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -131,6 +131,7 @@ export const getSelector = (element: Element, logger?: Logger): string => {
   try {
     selector = finder(element, {
       className: (name: string) => name !== constants.AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
+      maxNumberOfTries: 1000,
     });
     return selector;
   } catch (error) {

--- a/packages/plugin-autocapture-browser/src/libs/finder.ts
+++ b/packages/plugin-autocapture-browser/src/libs/finder.ts
@@ -272,7 +272,7 @@ function notEmpty<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
 }
 
-export function* combinations(stack: Knot[][], path: Knot[] = []): Generator<Knot[]> {
+function* combinations(stack: Knot[][], path: Knot[] = []): Generator<Knot[]> {
   if (stack.length > 0) {
     for (const node of stack[0]) {
       yield* combinations(stack.slice(1, stack.length), path.concat(node));

--- a/packages/plugin-autocapture-browser/src/libs/finder.ts
+++ b/packages/plugin-autocapture-browser/src/libs/finder.ts
@@ -132,10 +132,13 @@ function bottomUpSearch(
 }
 
 function findUniquePath(stack: Knot[][], fallback?: () => Path | null): Path | null {
-  const paths = sort(combinations(stack));
-  if (paths.length > config.threshold) {
+  // Check first the total number of combinations first since generating the combinations can cause memory exhaustion
+  const numCombinations = stack.reduce((acc, i) => acc * i.length, 1);
+  if (numCombinations > config.threshold) {
     return fallback ? fallback() : null;
   }
+
+  const paths = sort(combinations(stack));
   for (const candidate of paths) {
     if (unique(candidate)) {
       return candidate;
@@ -269,7 +272,7 @@ function notEmpty<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
 }
 
-function* combinations(stack: Knot[][], path: Knot[] = []): Generator<Knot[]> {
+export function* combinations(stack: Knot[][], path: Knot[] = []): Generator<Knot[]> {
   if (stack.length > 0) {
     for (const node of stack[0]) {
       yield* combinations(stack.slice(1, stack.length), path.concat(node));


### PR DESCRIPTION
### Summary

This change mirrors this PR in the upstream library: https://github.com/antonmedv/finder/pull/84
This prevents a scenario where a very large number of combinations are generated and causes memory exhaustion.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
