### PR TITLE
fix(analytics-react-native): support RN 0.73

### DIFF
--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -40,7 +40,6 @@ android {
             }
         }
     }
-    }
 
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')

--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -19,6 +19,18 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    def agpMajorVersion = agpVersion.tokenize('.')[0].toInteger()
+    def agpMinorVersion = agpVersion.tokenize('.')[1].toInteger()
+
+    /**
+     * Namespace is required starting from AGP 8.x. AGP 7.x starts to support namespace.
+     * See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
+     */
+    if (agpMajorVersion >= 8 || (agpMajorVersion == 7 && agpMinorVersion >= 3)) {
+        namespace "com.amplitude.reactnative"
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {

--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.5.30"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -18,17 +18,28 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-android {
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-    def agpMajorVersion = agpVersion.tokenize('.')[0].toInteger()
-    def agpMinorVersion = agpVersion.tokenize('.')[1].toInteger()
+def isSupportNamespace() {
+    def apgParsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+    def agpMajorVersion = apgParsed[0].toInteger()
+    def agpMinorVersion = apgParsed[1].toInteger()
 
     /**
-     * Namespace is required starting from AGP 8.x. AGP 7.x starts to support namespace.
+     * Namespace is added in AGP 7.3 and is required starting from AGP 8.x.
      * See: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
      */
-    if (agpMajorVersion >= 8 || (agpMajorVersion == 7 && agpMinorVersion >= 3)) {
+    return (agpMajorVersion == 7 && agpMinorVersion >= 3) || agpMajorVersion >= 8
+}
+
+android {
+    if (isSupportNamespace()) {
         namespace "com.amplitude.reactnative"
+
+        sourceSets {
+            main {
+                manifest.srcFile "src/main/AndroidManifestNew.xml"
+            }
+        }
+    }
     }
 
     compileSdkVersion safeExtGet('compileSdkVersion', 29)

--- a/packages/analytics-react-native/android/src/main/AndroidManifestNew.xml
+++ b/packages/analytics-react-native/android/src/main/AndroidManifestNew.xml
@@ -1,0 +1,7 @@
+<!--
+  Remove namespace here as it's supported in build.gradle
+  from AGP 7.3 and is required starting from AGP 8.x.
+ -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+</manifest>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- To support RN 0.73, library authors have to bump to AGP 8.1.1 according to the [breaking changes list](https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#other-breaking-changes)
- AGP 8.0 requires namespace in module level gradle.build https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
- Replace JCenter with Maven Center by following https://developer.android.com/build/jcenter-migration

For RN >= 0.73
- Added new `AndroidManifestNew.xml without namespace`
- Added namespace in build.gradle


Fix
- https://github.com/amplitude/Amplitude-TypeScript/pull/616
- https://github.com/amplitude/Amplitude-TypeScript/pull/617
- https://github.com/amplitude/Amplitude-TypeScript/issues/665

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
