### PR TITLE
fix(autocapture): use getAttribute to more safely access attributes

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -243,8 +243,8 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
     const selector = getSelector(element, logger);
     /* istanbul ignore next */
     const properties: Record<string, any> = {
-      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ID]: element.id,
-      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_CLASS]: element.className,
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ID]: element.getAttribute('id') || '',
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_CLASS]: element.getAttribute('class'),
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_HIERARCHY]: getHierarchy(element),
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: getText(element),

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -34,7 +34,7 @@ export const createShouldTrackEvent = (
     }
 
     /* istanbul ignore next */
-    const elementType = (element as HTMLInputElement)?.type || '';
+    const elementType = String(element?.getAttribute('type')) || '';
     if (typeof elementType === 'string') {
       switch (elementType.toLowerCase()) {
         case 'hidden':
@@ -146,10 +146,12 @@ export const getSelector = (element: Element, logger?: Logger): string => {
   if (tag) {
     selector = tag;
   }
-  if (element.id) {
-    selector = `#${element.id}`;
-  } else if (element.className) {
-    const classes = element.className
+  const id = element.getAttribute('id');
+  const className = element.getAttribute('class');
+  if (id) {
+    selector = `#${id}`;
+  } else if (className) {
+    const classes = className
       .split(' ')
       .filter((name) => name !== constants.AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS)
       .join('.');
@@ -209,7 +211,12 @@ export const getNearestLabel = (element: Element): string => {
   if (!parent) {
     return '';
   }
-  const labelElement = parent.querySelector(':scope>span,h1,h2,h3,h4,h5,h6');
+  let labelElement;
+  try {
+    labelElement = parent.querySelector(':scope>span,h1,h2,h3,h4,h5,h6');
+  } catch (error) {
+    labelElement = null;
+  }
   if (labelElement) {
     /* istanbul ignore next */
     const labelText = labelElement.textContent || '';

--- a/packages/plugin-autocapture-browser/src/hierarchy.ts
+++ b/packages/plugin-autocapture-browser/src/hierarchy.ts
@@ -40,7 +40,7 @@ export function getElementProperties(element: Element | null): HierarchyNode | n
     return null;
   }
 
-  const tagName = element.tagName.toLowerCase();
+  const tagName = String(element.tagName).toLowerCase();
   const properties: HierarchyNode = {
     tag: tagName,
   };
@@ -53,12 +53,12 @@ export function getElementProperties(element: Element | null): HierarchyNode | n
 
   const prevSiblingTag = element.previousElementSibling?.tagName?.toLowerCase();
   if (prevSiblingTag) {
-    properties.prevSib = prevSiblingTag;
+    properties.prevSib = String(prevSiblingTag);
   }
 
-  const id = element.id;
+  const id = element.getAttribute('id');
   if (id) {
-    properties.id = id;
+    properties.id = String(id);
   }
 
   const classes = Array.from(element.classList);
@@ -72,14 +72,14 @@ export function getElementProperties(element: Element | null): HierarchyNode | n
   const isSensitiveElement = !isNonSensitiveElement(element);
 
   // if input is hidden or password or for SVGs, skip attribute collection entirely
-  if (!HIGHLY_SENSITIVE_INPUT_TYPES.includes((element as HTMLInputElement).type) && !SVG_TAGS.includes(tagName)) {
+  if (!HIGHLY_SENSITIVE_INPUT_TYPES.includes(String(element.getAttribute('type'))) && !SVG_TAGS.includes(tagName)) {
     for (const attr of filteredAttributes) {
       // If sensitive element, only allow certain attributes
       if (isSensitiveElement && !SENSITIVE_ELEMENT_ATTRIBUTE_ALLOWLIST.includes(attr.name)) {
         continue;
       }
 
-      // Finally limit attribute value length and save it
+      // Finally cast attribute value to string and limit attribute value length
       attributes[attr.name] = String(attr.value).substring(0, MAX_ATTRIBUTE_LENGTH);
     }
   }

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -455,7 +455,7 @@ describe('autocapture-plugin helpers', () => {
       `;
 
       const inner = document.getElementById('inner');
-      expect(getClosestElement(inner, ['span', 'div'])?.id).toEqual('inner');
+      expect(getClosestElement(inner, ['span', 'div'])?.getAttribute('id')).toEqual('inner');
     });
 
     test('should return closest element if it matches any selectors', () => {
@@ -472,7 +472,7 @@ describe('autocapture-plugin helpers', () => {
       `;
 
       const inner = document.getElementById('inner');
-      expect(getClosestElement(inner, ['span', '[data-target]'])?.id).toEqual('parent2');
+      expect(getClosestElement(inner, ['span', '[data-target]'])?.getAttribute('id')).toEqual('parent2');
     });
 
     test('should return null when no element matches', () => {


### PR DESCRIPTION
### Summary

This fixes scenarios where the `id` property inside the hierarchy was returning `{}` instead of a string.

The approach here is to use `getAttribute` for attributes and to cast these to a string to handle edge cases where another element can be returned in any property on the target element.

This happens because the `id` property of form elements (and some other specific elements) can sometimes return an element reference instead of a string as a special case. This behavior is part of an old DOM feature called "named property access" or "named access on the window object".

This would happen for form elements which have children inputs where the `name` or `id` attribute on those inputs overrides the property accessor with the same `name` or `id` value on the ancestor form element.

Example:
```html
<form id="myForm">
  <input id="id" name="id" />
</form>

<script>
  const form = document.getElementById('myForm');
  console.log(form.id); // Returns the input element (<input id="id" name="id" />) instead of the string "myForm"
</script>
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
