### PR TITLE
fix: disable network checker if navigator is unavailable

### DIFF
--- a/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
@@ -33,6 +33,14 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   };
 
   const setup = async (config: BrowserConfig, amplitude: BrowserClient) => {
+    if (typeof navigator === 'undefined') {
+      config.loggerProvider.debug(
+        'Network connectivity checker plugin is disabled because navigator is not available.',
+      );
+      config.offline = true;
+      return;
+    }
+
     config.offline = !navigator.onLine;
 
     addNetworkListener('online', () => {

--- a/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
@@ -37,7 +37,7 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       config.loggerProvider.debug(
         'Network connectivity checker plugin is disabled because navigator is not available.',
       );
-      config.offline = true;
+      config.offline = false;
       return;
     }
 

--- a/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
@@ -43,4 +43,17 @@ describe('networkConnectivityCheckerPlugin', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith('online', expect.any(Function));
     expect(removeEventListenerSpy).toHaveBeenCalledWith('offline', expect.any(Function));
   });
+
+  test('should do nothing when not on a browser', async () => {
+    const plugin = networkConnectivityCheckerPlugin();
+    // @ts-expect-error we are mocking a node.js environment
+    jest.spyOn(window, 'navigator', 'get').mockReturnValue(undefined);
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+    await plugin.setup?.(config, amplitude);
+
+    expect(config.offline).toEqual(true);
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+    addEventListenerSpy.mockRestore();
+  });
 });

--- a/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
@@ -52,7 +52,7 @@ describe('networkConnectivityCheckerPlugin', () => {
 
     await plugin.setup?.(config, amplitude);
 
-    expect(config.offline).toEqual(true);
+    expect(config.offline).toEqual(false);
     expect(addEventListenerSpy).not.toHaveBeenCalled();
     addEventListenerSpy.mockRestore();
   });


### PR DESCRIPTION
### Summary

Check if navigator is available before using it for network connectivity checks

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
