### PR TITLE
fix(analytics-types): update Element in element interactions

### DIFF
--- a/packages/analytics-types/src/element-interactions.ts
+++ b/packages/analytics-types/src/element-interactions.ts
@@ -58,7 +58,7 @@ export interface ElementInteractionsOptions {
    * @param actionType - The type of action that triggered the event.
    * @param element - The [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) that triggered the event.
    */
-  shouldTrackEventResolver?: (actionType: ActionType, element: Element) => boolean;
+  shouldTrackEventResolver?: (actionType: ActionType, element: DomElement) => boolean;
 
   /**
    * Prefix for data attributes to allow auto collecting.
@@ -91,9 +91,9 @@ export interface Messenger {
   setup: () => void;
 }
 
-// The [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) type is used when the dom library is included in tsconfig.json
-// This interface is for packages without the dom library, for example, analytics-node
-interface Element {
-  id: string;
-  className: string;
-}
+// DomElement is [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) if the dom library is included in tsconfig.json
+// and never if it is not included
+// eslint-disable-next-line no-restricted-globals
+type DomElement = typeof globalThis extends { Element: infer T extends abstract new (...args: any) => any }
+  ? InstanceType<T>
+  : never;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

This PR fixes the issue in https://github.com/amplitude/Amplitude-TypeScript/pull/780 that `Element` type is resolved to the custom defined type because typescript looks up local scope first before global scope. 

Create a custom type `DomElement` if `Element` is available (`dom` library is added) otherwise set to `never`.
- `analytics-browser`, `plugin-autocapture-browser` will use `Element`
- `analytics-node` doesn't have access to `Element` and will use `never` instead


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
