### PR TITLE
fix(plugin-autocapture-browser): import types from analytics-types

### DIFF
--- a/packages/plugin-autocapture-browser/package.json
+++ b/packages/plugin-autocapture-browser/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-client-common": ">=1 <3",
-    "@amplitude/analytics-types": ">=1 <3",
+    "@amplitude/analytics-types": "^2.8.2",
     "rxjs": "^7.8.1",
     "tslib": "^2.4.1"
   },

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -1,5 +1,15 @@
 /* eslint-disable no-restricted-globals */
-import { BrowserClient, BrowserConfig, EnrichmentPlugin, Logger } from '@amplitude/analytics-types';
+import {
+  BrowserClient,
+  BrowserConfig,
+  EnrichmentPlugin,
+  Logger,
+  ElementInteractionsOptions,
+  DEFAULT_CSS_SELECTOR_ALLOWLIST,
+  DEFAULT_DATA_ATTRIBUTE_PREFIX,
+  DEFAULT_ACTION_CLICK_ALLOWLIST,
+  ActionType,
+} from '@amplitude/analytics-types';
 import * as constants from './constants';
 import { fromEvent, map, Observable, Subscription } from 'rxjs';
 import {
@@ -11,8 +21,7 @@ import {
   createShouldTrackEvent,
   getClosestElement,
 } from './helpers';
-import { Messenger, WindowMessenger } from './libs/messenger';
-import { ActionType } from './typings/autocapture';
+import { WindowMessenger } from './libs/messenger';
 import { getHierarchy } from './hierarchy';
 import { trackClicks } from './autocapture/track-click';
 import { trackChange } from './autocapture/track-change';
@@ -52,77 +61,10 @@ interface NavigateEvent extends Event {
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 
-export const DEFAULT_CSS_SELECTOR_ALLOWLIST = [
-  'a',
-  'button',
-  'input',
-  'select',
-  'textarea',
-  'label',
-  'video',
-  'audio',
-  '[contenteditable="true" i]',
-  '[data-amp-default-track]',
-  '.amp-default-track',
-];
-export const DEFAULT_ACTION_CLICK_ALLOWLIST = ['div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
-export const DEFAULT_DATA_ATTRIBUTE_PREFIX = 'data-amp-track-';
-
-export interface AutocaptureOptions {
-  /**
-   * List of CSS selectors to allow auto tracking on.
-   * When provided, allow elements matching any selector to be tracked.
-   * Default is ['a', 'button', 'input', 'select', 'textarea', 'label', '[data-amp-default-track]', '.amp-default-track'].
-   */
-  cssSelectorAllowlist?: string[];
-
-  /**
-   * List of page URLs to allow auto tracking on.
-   * When provided, only allow tracking on these URLs.
-   * Both full URLs and regex are supported.
-   */
-  pageUrlAllowlist?: (string | RegExp)[];
-
-  /**
-   * Function to determine whether an event should be tracked.
-   * When provided, this function overwrites all other allowlists and configurations.
-   * If the function returns true, the event will be tracked.
-   * If the function returns false, the event will not be tracked.
-   * @param actionType - The type of action that triggered the event.
-   * @param element - The element that triggered the event.
-   */
-  shouldTrackEventResolver?: (actionType: ActionType, element: Element) => boolean;
-
-  /**
-   * Prefix for data attributes to allow auto collecting.
-   * Default is 'data-amp-track-'.
-   */
-  dataAttributePrefix?: string;
-
-  /**
-   * Options for integrating visual tagging selector.
-   */
-  visualTaggingOptions?: {
-    enabled?: boolean;
-    messenger?: Messenger;
-  };
-
-  /**
-   * Debounce time in milliseconds for tracking events.
-   * This is used to detect rage clicks.
-   */
-  debounceTime?: number;
-
-  /**
-   * CSS selector allowlist for tracking clicks that result in a DOM change/navigation on elements not already allowed by the cssSelectorAllowlist
-   */
-  actionClickAllowlist?: string[];
-}
-
 export type AutoCaptureOptionsWithDefaults = Required<
-  Pick<AutocaptureOptions, 'debounceTime' | 'cssSelectorAllowlist' | 'actionClickAllowlist'>
+  Pick<ElementInteractionsOptions, 'debounceTime' | 'cssSelectorAllowlist' | 'actionClickAllowlist'>
 > &
-  AutocaptureOptions;
+  ElementInteractionsOptions;
 
 export enum ObservablesEnum {
   ClickObservable = 'clickObservable',
@@ -164,7 +106,7 @@ export function isElementBasedEvent<T>(event: BaseTimestampedEvent<T>): event is
   return event.type === 'click' || event.type === 'change';
 }
 
-export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnrichmentPlugin => {
+export const autocapturePlugin = (options: ElementInteractionsOptions = {}): BrowserEnrichmentPlugin => {
   const {
     dataAttributePrefix = DEFAULT_DATA_ATTRIBUTE_PREFIX,
     visualTaggingOptions = {
@@ -292,13 +234,6 @@ export const autocapturePlugin = (options: AutocaptureOptions = {}): BrowserEnri
   };
 
   const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
-    if (!amplitude) {
-      /* istanbul ignore next */
-      config?.loggerProvider?.warn(
-        `${name} plugin requires a later version of @amplitude/analytics-browser. Events are not tracked.`,
-      );
-      return;
-    }
     logger = config.loggerProvider;
 
     /* istanbul ignore if */

--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -5,8 +5,7 @@ import {
   ObservablesEnum,
 } from 'src/autocapture-plugin';
 import { filter, map, merge, switchMap, take, timeout, EMPTY } from 'rxjs';
-import { ActionType } from 'src/typings/autocapture';
-import { BrowserClient } from '@amplitude/analytics-types';
+import { BrowserClient, ActionType } from '@amplitude/analytics-types';
 import { filterOutNonTrackableEvents, getClosestElement, shouldTrackEvent } from '../helpers';
 import { AMPLITUDE_ELEMENT_CLICKED_EVENT } from '../constants';
 

--- a/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-change.ts
@@ -1,7 +1,6 @@
 import { AllWindowObservables } from 'src/autocapture-plugin';
 import { filter } from 'rxjs';
-import { ActionType } from 'src/typings/autocapture';
-import { BrowserClient } from '@amplitude/analytics-types';
+import { BrowserClient, ActionType } from '@amplitude/analytics-types';
 import { filterOutNonTrackableEvents, shouldTrackEvent } from '../helpers';
 import { AMPLITUDE_ELEMENT_CHANGED_EVENT } from '../constants';
 

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-restricted-globals */
 import { finder } from './libs/finder';
 import * as constants from './constants';
-import { Logger } from '@amplitude/analytics-types';
-import { AutocaptureOptions, ElementBasedEvent, ElementBasedTimestampedEvent } from './autocapture-plugin';
-import { ActionType } from './typings/autocapture';
+import { Logger, ElementInteractionsOptions, ActionType } from '@amplitude/analytics-types';
+import { ElementBasedEvent, ElementBasedTimestampedEvent } from './autocapture-plugin';
 
 export type JSONValue = string | number | boolean | null | { [x: string]: JSONValue } | Array<JSONValue>;
 
@@ -12,7 +11,7 @@ const SENSITIVE_TAGS = ['input', 'select', 'textarea'];
 export type shouldTrackEvent = (actionType: ActionType, element: Element) => boolean;
 
 export const createShouldTrackEvent = (
-  autocaptureOptions: AutocaptureOptions,
+  autocaptureOptions: ElementInteractionsOptions,
   allowlist: string[], // this can be any type of css selector allow list
 ): shouldTrackEvent => {
   return (actionType: ActionType, element: Element) => {

--- a/packages/plugin-autocapture-browser/src/index.ts
+++ b/packages/plugin-autocapture-browser/src/index.ts
@@ -1,8 +1,2 @@
-export {
-  autocapturePlugin as plugin,
-  autocapturePlugin,
-  DEFAULT_CSS_SELECTOR_ALLOWLIST,
-  DEFAULT_DATA_ATTRIBUTE_PREFIX,
-  AutocaptureOptions,
-} from './autocapture-plugin';
-export { Messenger, Action, ActionData, Message, WindowMessenger } from './libs/messenger';
+export { autocapturePlugin as plugin, autocapturePlugin } from './autocapture-plugin';
+export { Action, ActionData, Message, WindowMessenger } from './libs/messenger';

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -6,13 +6,7 @@ import {
   AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
 } from '../constants';
 import { asyncLoadScript, generateUniqueId, getEventTagProps } from '../helpers';
-import { Logger } from '@amplitude/analytics-types';
-import { ActionType } from '../typings/autocapture';
-
-export interface Messenger {
-  logger?: Logger;
-  setup: () => void;
-}
+import { Logger, Messenger, ActionType } from '@amplitude/analytics-types';
 
 export type Action =
   | 'ping'

--- a/packages/plugin-autocapture-browser/src/typings/autocapture.ts
+++ b/packages/plugin-autocapture-browser/src/typings/autocapture.ts
@@ -1,5 +1,3 @@
-export type ActionType = 'click' | 'change';
-
 export type HierarchyNode = {
   tag: string;
   id?: string;

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -109,7 +109,7 @@ describe('action clicks:', () => {
     });
 
     test('should track button click even if there is no DOM change', async () => {
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger 2 click events on button
       const realButton = document.getElementById('real-button');
@@ -121,7 +121,7 @@ describe('action clicks:', () => {
     });
 
     test('should not track div click if it does not change the DOM or navigate', async () => {
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event on div which is acting as a button
       document.getElementById('no-action-div')?.dispatchEvent(new Event('click'));
@@ -131,7 +131,7 @@ describe('action clicks:', () => {
     });
 
     test('should track div click if it causes a DOM change', async () => {
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event on div which is acting as a button
       document.getElementById('addDivButton')?.dispatchEvent(new Event('click'));
@@ -190,7 +190,7 @@ describe('action clicks:', () => {
     });
 
     test('should not trigger duplicate events if the immediate click target is in the action click allowlist', async () => {
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event on span in a button
       document.getElementById('button-text')?.dispatchEvent(new Event('click', { bubbles: true }));
@@ -212,7 +212,7 @@ describe('action clicks:', () => {
     });
 
     test('should trigger action click on innermost element', async () => {
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event on span in a button
       document.getElementById('inner-div-button-text')?.dispatchEvent(new Event('click', { bubbles: true }));
@@ -236,7 +236,7 @@ describe('action clicks:', () => {
       test('should be able to track non-default tags by overwriting default actionClickAllowlist', async () => {
         // Use only div in allowlist
         plugin = autocapturePlugin({ actionClickAllowlist: ['h1'], debounceTime: TESTING_DEBOUNCE_TIME });
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click on card which should result in no event since div is not in the allowlist
         document.querySelector('.card')?.dispatchEvent(new Event('click'));
@@ -268,7 +268,7 @@ describe('action clicks:', () => {
     test('should not track when element type is hidden', async () => {
       // Use only div in allowlist
       plugin = autocapturePlugin({ actionClickAllowlist: ['input'], debounceTime: TESTING_DEBOUNCE_TIME });
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       const input = document.createElement('input');
       input.setAttribute('id', 'my-input-id');

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -72,25 +72,6 @@ describe('autoTrackingPlugin', () => {
       expect(loggerProvider.log).toHaveBeenNthCalledWith(1, `${plugin?.name as string} has been successfully added.`);
     });
 
-    test('should handle incompatible Amplitude SDK version', async () => {
-      const loggerProvider: Partial<Logger> = {
-        log: jest.fn(),
-        warn: jest.fn(),
-      };
-      const config: Partial<BrowserConfig> = {
-        defaultTracking: false,
-        loggerProvider: loggerProvider as Logger,
-      };
-      await plugin?.setup?.(config as BrowserConfig);
-      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
-      expect(loggerProvider.warn).toHaveBeenNthCalledWith(
-        1,
-        `${
-          plugin?.name as string
-        } plugin requires a later version of @amplitude/analytics-browser. Events are not tracked.`,
-      );
-    });
-
     test('should setup visual tagging selector', async () => {
       window.opener = true;
       const messengerMock = {
@@ -118,7 +99,7 @@ describe('autoTrackingPlugin', () => {
 
   describe('execute', () => {
     test('should return the same event type', async () => {
-      const event = await plugin?.execute({
+      const event = await plugin?.execute?.({
         event_type: 'custom_event',
       });
       expect(event).toEqual({
@@ -173,7 +154,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event
       document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
@@ -311,7 +292,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event
       const linkEl = document.getElementById('my-link-id') as HTMLAnchorElement;
@@ -380,7 +361,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click event
       const button = document.createElement('button');
@@ -452,7 +433,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       bodyParent?.appendChild(body);
       // fire the load event, so that the mutation observer can be mounted
@@ -525,7 +506,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click div which should not be tracked
       document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
@@ -557,7 +538,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click link
         document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
@@ -593,7 +574,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider as Logger,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click button
         document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
@@ -635,7 +616,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider as Logger,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click button
         document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
@@ -667,7 +648,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click link
       document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
@@ -717,7 +698,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click button2
       document.getElementById('my-button-id-2')?.dispatchEvent(new Event('click'));
@@ -752,7 +733,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click button
       document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
@@ -827,7 +808,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click button
       document.getElementById('my-button-id')?.dispatchEvent(new Event('click'));
@@ -847,7 +828,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click input
       document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
@@ -871,7 +852,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click input
       document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
@@ -897,7 +878,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider as Logger,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click input
       document.getElementById('my-input-id')?.dispatchEvent(new Event('click'));
@@ -922,7 +903,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider as Logger,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // trigger click input
       document.getElementById('my-div-id')?.dispatchEvent(new Event('click'));
@@ -942,7 +923,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider as Logger,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       const textNode = document.createTextNode('Some text node');
       document.body.appendChild(textNode);
@@ -988,7 +969,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click inner
         document.getElementById('inner')?.dispatchEvent(new Event('click', { bubbles: true }));
@@ -1046,7 +1027,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click inner
         document.getElementById('inner')?.dispatchEvent(new Event('click', { bubbles: true }));
@@ -1100,7 +1081,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click inner
         document.getElementById('inner')?.dispatchEvent(new Event('click', { bubbles: true }));
@@ -1155,7 +1136,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         // trigger click inner
         document.getElementById('inner')?.dispatchEvent(new Event('click', { bubbles: true }));
@@ -1206,7 +1187,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         const button = document.createElement('button');
         document.body.appendChild(button);
@@ -1227,7 +1208,7 @@ describe('autoTrackingPlugin', () => {
           defaultTracking: false,
           loggerProvider: loggerProvider,
         };
-        await plugin?.setup(config as BrowserConfig, instance);
+        await plugin?.setup?.(config as BrowserConfig, instance);
 
         const button = document.createElement('button');
         document.body.appendChild(button);

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -223,7 +223,7 @@ describe('autoTrackingPlugin', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       };
-      await plugin?.setup(config as BrowserConfig, instance);
+      await plugin?.setup?.(config as BrowserConfig, instance);
 
       // Create scenario where element properties are elements
       const formEl = document.createElement('form');

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,11 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.6.0.tgz#00d1957d3f5eecb85e00ef4a1b2f65c497967d46"
   integrity sha512-7MSENvLCTGjec7K45JT+RcOuoPTCvq1MMq/HRLiQK/BMR4taX7f/uXldEc8b//o+ZZP45IBqFroR7Bl8LwJQrQ==
 
+"@amplitude/analytics-types@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.8.2.tgz#aee2b0d42c962d8408056b45b957f18dbb2529ef"
+  integrity sha512-SWFXIMxhFm1/k3PUvxvYLY1iwzS28yd9A6pa5pEnrbaAZwM+E/24ucxs59VGp1N5qlIsvF0aVGSoKzN4ydh4eA==
+
 "@amplitude/experiment-core@0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.7.2.tgz#f94219d68d86322e8d580c8fbe0672dcd29f86bb"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request. 
--->

### Summary

<!-- What does the PR do? -->

- plugin-autocapture-browser imports types from analytics-types higher than 2.8.2
- Remove `${name} plugin requires a later version of @amplitude/analytics-browser. Events are not tracked.` warning because 
  - analytics-types v2.x always requires client in plugin.setup() https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/plugin.ts#L14
  - client is optional in analytics-types v1.x https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/analytics-types/src/plugin.ts#L15


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
