### PR TITLE
fix(analytics-react-native): should export extendSession in client

### DIFF
--- a/packages/analytics-react-native/src/index.ts
+++ b/packages/analytics-react-native/src/index.ts
@@ -20,6 +20,7 @@ export const {
   setSessionId,
   setUserId,
   track,
+  extendSession,
 } = client;
 export { Revenue, Identify } from '@amplitude/analytics-core';
 // Hack - react-native apps have trouble with:

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -34,7 +34,7 @@ import { isNative } from './utils/platform';
 const START_SESSION_EVENT = 'session_start';
 const END_SESSION_EVENT = 'session_end';
 
-export class AmplitudeReactNative extends AmplitudeCore {
+export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeClient {
   appState: AppStateStatus = 'background';
   private appStateChangeHandler: NativeEventSubscription | undefined;
   explicitSessionId: number | undefined;

--- a/packages/plugin-autocapture-browser/package.json
+++ b/packages/plugin-autocapture-browser/package.json
@@ -32,7 +32,7 @@
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn version-file && yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\"",
+    "version": "yarn version-file && yarn add @amplitude/analytics-client-common@\">=1 <3\"",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-client-common": ">=1 <3",
-    "@amplitude/analytics-types": ">=1 <3",
+    "@amplitude/analytics-types": "^2.8.2",
     "rxjs": "^7.8.1",
     "tslib": "^2.4.1"
   },


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

[AMP-104265]

Should export `extendSession` in `client` to fix the error `Property extendSession is missing in type
typeof import("/Users/xinyi.ye/Documents/GitHub/ampli-examples/react-native/typescript/v2/AmpliApp/node_modules/@amplitude/analytics-react-native/lib/typescript/index")
but required in type ReactNativeClient`. 

Example:
```
amplitude.init('API_KEY');
await ampli.load({client: {instance: amplitude}}).promise;
```
---

This PR also updates `package.json` in `plugin-autocapture-browser` to use the correct type set in https://github.com/amplitude/Amplitude-TypeScript/commit/9d00976708f749dfbf4ad2e4627bd3981fd8fa2a

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-104265]: https://amplitude.atlassian.net/browse/AMP-104265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ