### PR TITLE
feat(session-replay-browser): in memory events storage

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -64,6 +64,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
       shouldInlineStylesheet: this.options.shouldInlineStylesheet,
       version: { type: 'plugin', version: VERSION },
       performanceConfig: this.options.performanceConfig,
+      storeType: this.options.storeType,
     }).promise;
   }
 

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,3 +1,5 @@
+import { StoreType } from '@amplitude/session-replay-browser';
+
 export type MaskLevel =
   | 'light' // only mask a subset of inputs that’s deemed sensitive - password, credit card, telephone #, email. These are information we never want to capture.
   | 'medium' // mask all inputs
@@ -23,4 +25,5 @@ export interface SessionReplayOptions {
   configEndpointUrl?: string;
   shouldInlineStylesheet?: boolean;
   performanceConfig?: SessionReplayPerformanceConfig;
+  storeType?: StoreType;
 }

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -2,7 +2,7 @@ import { FetchTransport } from '@amplitude/analytics-client-common';
 import { Config, Logger } from '@amplitude/analytics-core';
 import { LogLevel } from '@amplitude/analytics-types';
 import { DEFAULT_SAMPLE_RATE, DEFAULT_SERVER_ZONE } from '../constants';
-import { SessionReplayOptions } from '../typings/session-replay';
+import { SessionReplayOptions, StoreType } from '../typings/session-replay';
 import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
   InteractionConfig,
@@ -27,6 +27,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   configEndpointUrl?: string;
   shouldInlineStylesheet?: boolean;
   version?: SessionReplayVersion;
+  storeType: StoreType;
   performanceConfig?: SessionReplayPerformanceConfig;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
@@ -48,6 +49,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     this.shouldInlineStylesheet = options.shouldInlineStylesheet;
     this.version = options.version;
     this.performanceConfig = options.performanceConfig;
+    this.storeType = options.storeType ?? 'idb';
 
     if (options.privacyConfig) {
       this.privacyConfig = options.privacyConfig;

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -51,7 +51,7 @@ export interface SessionReplayLocalConfig extends Config {
   shouldInlineStylesheet?: boolean;
   version?: SessionReplayVersion;
   performanceConfig?: SessionReplayPerformanceConfig;
-  storeType?: StoreType;
+  storeType: StoreType;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -1,4 +1,5 @@
 import { Config, LogLevel, Logger } from '@amplitude/analytics-types';
+import { StoreType } from '../typings/session-replay';
 
 export interface SamplingConfig {
   sample_rate: number;
@@ -50,6 +51,7 @@ export interface SessionReplayLocalConfig extends Config {
   shouldInlineStylesheet?: boolean;
   version?: SessionReplayVersion;
   performanceConfig?: SessionReplayPerformanceConfig;
+  storeType?: StoreType;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/events/base-events-store.ts
+++ b/packages/session-replay-browser/src/events/base-events-store.ts
@@ -1,0 +1,55 @@
+import { MAX_EVENT_LIST_SIZE_IN_BYTES, MAX_INTERVAL, MIN_INTERVAL } from '../constants';
+import { Events, EventsStore, SendingSequencesReturn } from '../typings/session-replay';
+import { Logger } from '@amplitude/analytics-types';
+
+export type InstanceArgs = {
+  loggerProvider: Logger;
+  minInterval?: number;
+  maxInterval?: number;
+  maxPersistedEventsSize?: number;
+};
+
+export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
+  protected readonly loggerProvider: Logger;
+  private minInterval = MIN_INTERVAL;
+  private maxInterval = MAX_INTERVAL;
+  private maxPersistedEventsSize = MAX_EVENT_LIST_SIZE_IN_BYTES;
+  private interval = this.minInterval;
+  private timeAtLastSplit = Date.now(); // Initialize this so we have a point of comparison when events are recorded
+
+  constructor(args: InstanceArgs) {
+    this.loggerProvider = args.loggerProvider;
+    this.minInterval = args.minInterval ?? this.minInterval;
+    this.maxInterval = args.maxInterval ?? this.maxInterval;
+    this.maxPersistedEventsSize = args.maxPersistedEventsSize ?? this.maxPersistedEventsSize;
+  }
+
+  abstract addEventToCurrentSequence(
+    sessionId: number,
+    event: string,
+  ): Promise<SendingSequencesReturn<KeyType> | undefined>;
+  abstract getSequencesToSend(): Promise<SendingSequencesReturn<KeyType>[] | undefined>;
+  abstract storeCurrentSequence(sessionId: number): Promise<SendingSequencesReturn<KeyType> | undefined>;
+  abstract storeSendingEvents(sessionId: number, events: Events): Promise<KeyType | undefined>;
+  abstract cleanUpSessionEventsStore(sessionId: number, sequenceId: KeyType): Promise<void>;
+
+  /**
+   * Determines whether to send the events list to the backend and start a new
+   * empty events list, based on the size of the list as well as the last time sent
+   * @param nextEventString
+   * @returns boolean
+   */
+  shouldSplitEventsList = (events: Events, nextEventString: string): boolean => {
+    const sizeOfNextEvent = new Blob([nextEventString]).size;
+    const sizeOfEventsList = new Blob(events).size;
+    if (sizeOfEventsList + sizeOfNextEvent >= this.maxPersistedEventsSize) {
+      return true;
+    }
+    if (Date.now() - this.timeAtLastSplit > this.interval && events.length) {
+      this.interval = Math.min(this.maxInterval, this.interval + this.minInterval);
+      this.timeAtLastSplit = Date.now();
+      return true;
+    }
+    return false;
+  };
+}

--- a/packages/session-replay-browser/src/events/base-events-store.ts
+++ b/packages/session-replay-browser/src/events/base-events-store.ts
@@ -15,7 +15,11 @@ export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
   private maxInterval = MAX_INTERVAL;
   private maxPersistedEventsSize = MAX_EVENT_LIST_SIZE_IN_BYTES;
   private interval = this.minInterval;
-  private timeAtLastSplit = Date.now(); // Initialize this so we have a point of comparison when events are recorded
+  private _timeAtLastSplit = Date.now(); // Initialize this so we have a point of comparison when events are recorded
+
+  public get timeAtLastSplit() {
+    return this._timeAtLastSplit;
+  }
 
   constructor(args: InstanceArgs) {
     this.loggerProvider = args.loggerProvider;
@@ -47,7 +51,7 @@ export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
     }
     if (Date.now() - this.timeAtLastSplit > this.interval && events.length) {
       this.interval = Math.min(this.maxInterval, this.interval + this.minInterval);
-      this.timeAtLastSplit = Date.now();
+      this._timeAtLastSplit = Date.now();
       return true;
     }
     return false;

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -281,7 +281,7 @@ export class SessionReplayEventsIDBStore implements EventsStore<number> {
     return undefined;
   };
 
-  cleanUpSessionEventsStore = async (sequenceId: number) => {
+  cleanUpSessionEventsStore = async (_sessionId: number, sequenceId: number) => {
     try {
       await this.db.delete<'sequencesToSend'>(sequencesToSendKey, sequenceId);
     } catch (e) {

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -1,6 +1,7 @@
 import {
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
   EventType,
+  StoreType,
 } from '../typings/session-replay';
 
 import { SessionReplayJoinedConfig } from '../config/types';
@@ -8,8 +9,6 @@ import { getStorageSize } from '../helpers';
 import { PayloadBatcher, SessionReplayTrackDestination } from '../track-destination';
 import { SessionReplayEventsIDBStore } from './events-idb-store';
 import { InMemoryEventsStore } from './in-memory-events-store';
-
-type StoreType = 'memory' | 'idb';
 
 export const createEventsManager = async <Type extends EventType>({
   config,

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -8,7 +8,7 @@ import { SessionReplayJoinedConfig } from '../config/types';
 import { getStorageSize } from '../helpers';
 import { PayloadBatcher, SessionReplayTrackDestination } from '../track-destination';
 import { SessionReplayEventsIDBStore } from './events-idb-store';
-import { InMemoryEventsStore } from './in-memory-events-store';
+import { InMemoryEventsStore } from './events-memory-store';
 
 export const createEventsManager = async <Type extends EventType>({
   config,
@@ -31,15 +31,21 @@ export const createEventsManager = async <Type extends EventType>({
 
   const store =
     storeType === 'idb'
-      ? await SessionReplayEventsIDBStore.new({
-          loggerProvider: config.loggerProvider,
-          apiKey: config.apiKey,
-          sessionId,
-          minInterval,
-          maxInterval,
+      ? await SessionReplayEventsIDBStore.new(
           type,
-        })
-      : new InMemoryEventsStore();
+          {
+            loggerProvider: config.loggerProvider,
+            minInterval,
+            maxInterval,
+            apiKey: config.apiKey,
+          },
+          sessionId,
+        )
+      : new InMemoryEventsStore({
+          loggerProvider: config.loggerProvider,
+          maxInterval,
+          minInterval,
+        });
 
   /**
    * Immediately sends events to the track destination.

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -4,9 +4,9 @@ import {
 } from '../typings/session-replay';
 
 import { SessionReplayJoinedConfig } from '../config/types';
-import { createEventsIDBStore } from './events-idb-store';
-import { PayloadBatcher, SessionReplayTrackDestination } from '../track-destination';
 import { getStorageSize } from '../helpers';
+import { PayloadBatcher, SessionReplayTrackDestination } from '../track-destination';
+import { SessionReplayEventsIDBStore } from './events-idb-store';
 
 export const createEventsManager = async <Type extends EventType>({
   config,
@@ -25,7 +25,7 @@ export const createEventsManager = async <Type extends EventType>({
 }): Promise<AmplitudeSessionReplayEventsManager<Type, string>> => {
   const trackDestination = new SessionReplayTrackDestination({ loggerProvider: config.loggerProvider, payloadBatcher });
 
-  const eventsIDBStore = await createEventsIDBStore({
+  const eventsIDBStore = await SessionReplayEventsIDBStore.new({
     loggerProvider: config.loggerProvider,
     apiKey: config.apiKey,
     sessionId,
@@ -41,12 +41,11 @@ export const createEventsManager = async <Type extends EventType>({
     events,
     sessionId,
     deviceId,
-    sequenceId,
   }: {
     events: string[];
     sessionId: number;
     deviceId: string;
-    sequenceId: number;
+    sequenceId?: number;
   }) => {
     if (config.debugMode) {
       getStorageSize()
@@ -62,7 +61,6 @@ export const createEventsManager = async <Type extends EventType>({
 
     trackDestination.sendEventsList({
       events: events,
-      sequenceId: sequenceId,
       sessionId: sessionId,
       flushMaxRetries: config.flushMaxRetries,
       apiKey: config.apiKey,
@@ -71,7 +69,13 @@ export const createEventsManager = async <Type extends EventType>({
       serverZone: config.serverZone,
       version: config.version,
       type,
-      onComplete: eventsIDBStore.cleanUpSessionEventsStore.bind(eventsIDBStore),
+      onComplete: async () => {
+        // if (!sequenceId) {
+        //   return;
+        // }
+        // await eventsIDBStore.cleanUpSessionEventsStore(sequenceId);
+        // return;
+      },
     });
   };
 

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -50,7 +50,7 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     let sequenceReturn: SendingSequencesReturn<number> | undefined;
     if (this.shouldSplitEventsList(this.sequences[sessionId], event)) {
       const sequenceId = await this.storeSendingEvents(sessionId, this.sequences[sessionId]);
-      if (sequenceId) {
+      if (sequenceId !== undefined) {
         sequenceReturn = {
           sequenceId,
           events: [...this.sequences[sessionId]],

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -4,39 +4,33 @@ import { BaseEventsStore } from './base-events-store';
 export class InMemoryEventsStore extends BaseEventsStore<number> {
   private finalizedSequences: Record<number, { sessionId: number; events: string[] }> = {};
   private sequences: Record<number, string[]> = {};
-  private sequenceLengths: Record<number, number> = {};
   private sequenceId = 0;
 
   private resetCurrentSequence(sessionId: number) {
     this.sequences[sessionId] = [];
-    this.sequenceLengths[sessionId] = 0;
+  }
+
+  private addSequence(sessionId: number): SendingSequencesReturn<number> {
+    const sequenceId = this.sequenceId++;
+    const events = [...this.sequences[sessionId]];
+    this.finalizedSequences[sequenceId] = { sessionId, events };
+    this.resetCurrentSequence(sessionId);
+    return { sequenceId, events, sessionId };
   }
 
   async getSequencesToSend(): Promise<SendingSequencesReturn<number>[] | undefined> {
-    const sequenceNumbers: SendingSequencesReturn<number>[] = [];
-    for (const [sequenceId, { sessionId, events }] of Object.entries(this.finalizedSequences)) {
-      sequenceNumbers.push({
-        events,
-        sequenceId: Number(sequenceId),
-        sessionId,
-      });
-    }
-
-    return sequenceNumbers;
+    return Object.entries(this.finalizedSequences).map(([sequenceId, { sessionId, events }]) => ({
+      sequenceId: Number(sequenceId),
+      sessionId,
+      events,
+    }));
   }
 
   async storeCurrentSequence(sessionId: number): Promise<SendingSequencesReturn<number> | undefined> {
     if (!this.sequences[sessionId]) {
       return undefined;
     }
-
-    this.finalizedSequences[this.sequenceId] = { sessionId, events: this.sequences[sessionId] };
-    this.resetCurrentSequence(sessionId);
-    return {
-      events: [...this.finalizedSequences[this.sequenceId].events],
-      sequenceId: this.sequenceId++,
-      sessionId,
-    };
+    return this.addSequence(sessionId);
   }
 
   async addEventToCurrentSequence(
@@ -49,31 +43,23 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
 
     let sequenceReturn: SendingSequencesReturn<number> | undefined;
     if (this.shouldSplitEventsList(this.sequences[sessionId], event)) {
-      const sequenceId = await this.storeSendingEvents(sessionId, this.sequences[sessionId]);
-      if (sequenceId !== undefined) {
-        sequenceReturn = {
-          sequenceId,
-          events: [...this.sequences[sessionId]],
-          sessionId,
-        };
-      }
-      this.resetCurrentSequence(sessionId);
+      sequenceReturn = this.addSequence(sessionId);
     }
 
     this.sequences[sessionId].push(event);
-    this.sequenceLengths[sessionId] += event.length;
+
     return sequenceReturn;
   }
 
   async storeSendingEvents(sessionId: number, events: Events): Promise<number | undefined> {
     this.finalizedSequences[this.sequenceId] = { sessionId, events };
+
     return this.sequenceId++;
   }
 
-  async cleanUpSessionEventsStore(sessionId: number, sequenceId?: number): Promise<void> {
+  async cleanUpSessionEventsStore(_sessionId: number, sequenceId?: number): Promise<void> {
     if (sequenceId !== undefined) {
       delete this.finalizedSequences[sequenceId];
     }
-    this.resetCurrentSequence(sessionId);
   }
 }

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -70,8 +70,10 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     return this.sequenceId++;
   }
 
-  async cleanUpSessionEventsStore(sessionId: number, sequenceId: number): Promise<void> {
-    delete this.finalizedSequences[sequenceId];
+  async cleanUpSessionEventsStore(sessionId: number, sequenceId?: number): Promise<void> {
+    if (sequenceId !== undefined) {
+      delete this.finalizedSequences[sequenceId];
+    }
     this.resetCurrentSequence(sessionId);
   }
 }

--- a/packages/session-replay-browser/src/events/in-memory-events-store.ts
+++ b/packages/session-replay-browser/src/events/in-memory-events-store.ts
@@ -1,0 +1,68 @@
+import { MAX_EVENT_LIST_SIZE_IN_BYTES } from '../constants';
+import { Events, EventsStore, SendingSequencesReturn } from '../typings/session-replay';
+
+export class InMemoryEventsStore implements EventsStore<number> {
+  private finalizedSequences: Record<number, { sessionId: number; events: string[] }> = {};
+  private sequences: Record<number, string[]> = {};
+  private sequenceLengths: Record<number, number> = {};
+  private sequenceId = 0;
+
+  private resetCurrentSequence(sessionId: number) {
+    this.sequences[sessionId] = [];
+    this.sequenceLengths[sessionId] = 0;
+  }
+
+  async getSequencesToSend(): Promise<SendingSequencesReturn<number>[] | undefined> {
+    const sequenceNumbers: SendingSequencesReturn<number>[] = [];
+    for (const [sequenceId, { sessionId, events }] of Object.entries(this.finalizedSequences)) {
+      sequenceNumbers.push({
+        events,
+        sequenceId: Number(sequenceId),
+        sessionId,
+      });
+    }
+
+    return sequenceNumbers;
+  }
+
+  async storeCurrentSequence(sessionId: number): Promise<SendingSequencesReturn<number> | undefined> {
+    if (!this.sequences[sessionId]) {
+      return undefined;
+    }
+
+    this.finalizedSequences[this.sequenceId] = { sessionId, events: this.sequences[sessionId] };
+    this.resetCurrentSequence(sessionId);
+    return {
+      events: this.finalizedSequences[this.sequenceId].events,
+      sequenceId: this.sequenceId++,
+      sessionId,
+    };
+  }
+
+  async addEventToCurrentSequence(
+    sessionId: number,
+    event: string,
+  ): Promise<SendingSequencesReturn<number> | undefined> {
+    if (!this.sequences[sessionId]) {
+      this.resetCurrentSequence(sessionId);
+    }
+
+    if (this.sequenceLengths[sessionId] + event.length > MAX_EVENT_LIST_SIZE_IN_BYTES) {
+      await this.storeCurrentSequence(sessionId);
+    }
+
+    this.sequences[sessionId].push(event);
+    this.sequenceLengths[sessionId] += event.length;
+    return undefined;
+  }
+
+  async storeSendingEvents(sessionId: number, events: Events): Promise<number | undefined> {
+    this.finalizedSequences[this.sequenceId++] = { sessionId, events };
+    return undefined;
+  }
+
+  async cleanUpSessionEventsStore(sessionId: number, sequenceId: number): Promise<void> {
+    delete this.finalizedSequences[sequenceId];
+    this.resetCurrentSequence(sessionId);
+  }
+}

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,3 +1,3 @@
 import sessionReplay from './session-replay-factory';
 export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
-export { SessionReplayOptions } from './typings/session-replay';
+export { SessionReplayOptions, StoreType } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -99,13 +99,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     const managers: EventsManagerWithType<EventType, string>[] = [];
-
+    const storeType = this.config.storeType ?? 'idb';
     try {
       const rrwebEventManager = await createEventsManager<'replay'>({
         config: this.config,
         sessionId: this.identifiers.sessionId,
         type: 'replay',
-        storeType: 'memory',
+        storeType,
       });
       managers.push({ name: 'replay', manager: rrwebEventManager });
     } catch (error) {
@@ -123,7 +123,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
           minInterval: this.config.interactionConfig.trackEveryNms ?? INTERACTION_MIN_INTERVAL,
           maxInterval: INTERACTION_MAX_INTERVAL,
           payloadBatcher,
-          storeType: 'memory',
+          storeType,
         });
         managers.push({ name: 'interaction', manager: interactionEventManager });
       } catch (error) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -99,7 +99,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     const managers: EventsManagerWithType<EventType, string>[] = [];
-    const storeType = this.config.storeType ?? 'idb';
+    let storeType = this.config.storeType ?? 'idb';
+    if (storeType === 'idb' && !getGlobalScope()?.indexedDB) {
+      storeType = 'memory';
+      this.loggerProvider.warn('Could not use preferred indexedDB storage, reverting to in memory option.');
+    }
+    this.loggerProvider.log(`Using ${storeType} for event storage.`);
     try {
       const rrwebEventManager = await createEventsManager<'replay'>({
         config: this.config,

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -105,6 +105,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         config: this.config,
         sessionId: this.identifiers.sessionId,
         type: 'replay',
+        storeType: 'memory',
       });
       managers.push({ name: 'replay', manager: rrwebEventManager });
     } catch (error) {
@@ -122,6 +123,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
           minInterval: this.config.interactionConfig.trackEveryNms ?? INTERACTION_MIN_INTERVAL,
           maxInterval: INTERACTION_MAX_INTERVAL,
           payloadBatcher,
+          storeType: 'memory',
         });
         managers.push({ name: 'interaction', manager: interactionEventManager });
       } catch (error) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -99,7 +99,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     const managers: EventsManagerWithType<EventType, string>[] = [];
-    let storeType = this.config.storeType ?? 'idb';
+    let { storeType } = this.config;
     if (storeType === 'idb' && !getGlobalScope()?.indexedDB) {
       storeType = 'memory';
       this.loggerProvider.warn('Could not use preferred indexedDB storage, reverting to in memory option.');

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -50,7 +50,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       }
       this.completeRequest({
         context,
-        err: `${MAX_RETRIES_EXCEEDED_MESSAGE}, batch sequence id, ${context.sequenceId}`,
+        err: MAX_RETRIES_EXCEEDED_MESSAGE,
       });
       return false;
     });
@@ -108,7 +108,6 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     const urlParams = new URLSearchParams({
       device_id: deviceId,
       session_id: `${context.sessionId}`,
-      seq_number: `${context.sequenceId}`,
       type: `${context.type}`,
     });
     const sessionReplayLibrary = `${context.version?.type || 'standalone'}/${context.version?.version || version}`;
@@ -176,7 +175,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     const sizeOfEventsList = Math.round(new Blob(context.events).size / KB_SIZE);
     this.completeRequest({
       context,
-      success: `Session replay event batch with seq id ${context.sequenceId} tracked successfully for session id ${context.sessionId}, size of events: ${sizeOfEventsList} KB`,
+      success: `Session replay event batch tracked successfully for session id ${context.sessionId}, size of events: ${sizeOfEventsList} KB`,
     });
   }
 
@@ -196,7 +195,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     err?: string;
     success?: string;
   }) {
-    void context.onComplete(context.sequenceId);
+    void context.onComplete();
     if (err) {
       this.loggerProvider.warn(err);
     } else if (success) {

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -39,7 +39,6 @@ export interface SessionReplayDestinationContext extends SessionReplayDestinatio
 
 export interface SendingSequencesReturn<KeyType> {
   sequenceId: KeyType;
-  deviceId?: string;
   sessionId: number;
   events: Events;
 }

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -67,7 +67,7 @@ export interface EventsStore<KeyType> {
   /**
    * Permanently removes the events batch for the session/sequence pair.
    */
-  cleanUpSessionEventsStore(sessionId: number, sequenceId: KeyType): Promise<void>;
+  cleanUpSessionEventsStore(sessionId: number, sequenceId?: KeyType): Promise<void>;
 }
 export interface SessionIdentifiers {
   deviceId?: string;

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -14,6 +14,8 @@ export interface DebugInfo extends Partial<StorageData> {
 
 export type Events = string[];
 
+export type StoreType = 'memory' | 'idb';
+
 export type EventType = 'replay' | 'interaction';
 
 export interface SessionReplayDestinationSessionMetadata {

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -25,12 +25,11 @@ export interface SessionReplayDestinationSessionMetadata {
 
 export type SessionReplayDestination = {
   events: Events;
-  sequenceId: number;
   flushMaxRetries?: number;
   apiKey?: string;
   sampleRate: number;
   serverZone?: keyof typeof ServerZone;
-  onComplete: (sequenceId: number) => Promise<void>;
+  onComplete: () => Promise<void>;
 } & SessionReplayDestinationSessionMetadata;
 
 export interface SessionReplayDestinationContext extends SessionReplayDestination {
@@ -38,28 +37,36 @@ export interface SessionReplayDestinationContext extends SessionReplayDestinatio
   timeout: number;
 }
 
-export interface SendingSequencesIDBInput {
-  sequenceId?: number;
+export interface SendingSequencesReturn<KeyType> {
+  sequenceId: KeyType;
+  deviceId?: string;
   sessionId: number;
   events: Events;
 }
 
-export type SendingSequencesIDBReturn = Required<SendingSequencesIDBInput>;
-
-export interface SessionReplayEventsIDBStore {
-  initialize(type: EventType): Promise<void>;
-  getSequencesToSend(): Promise<SendingSequencesIDBReturn[] | undefined>;
+/**
+ * This interface is not guaranteed to be stable, yet.
+ */
+export interface EventsStore<KeyType> {
+  getSequencesToSend(): Promise<SendingSequencesReturn<KeyType>[] | undefined>;
   /**
    * Moves current sequence of events to long term storage and resets short term storage.
    */
-  storeCurrentSequence(sessionId: number): Promise<SendingSequencesIDBInput | undefined>;
+  storeCurrentSequence(sessionId: number): Promise<SendingSequencesReturn<KeyType> | undefined>;
   /**
    * Adds events to the current IDB sequence. Returns events that should be
    * sent to the track destination right away if should split events is true.
    */
-  addEventToCurrentSequence(sessionId: number, event: string): Promise<SendingSequencesIDBReturn | undefined>;
-  storeSendingEvents(sessionId: number, events: Events): Promise<number | undefined>;
-  cleanUpSessionEventsStore(sessionId: number, sequenceId: number): Promise<void>;
+  addEventToCurrentSequence(sessionId: number, event: string): Promise<SendingSequencesReturn<KeyType> | undefined>;
+  /**
+   * Returns the sequence id associated with the events batch.
+   * @returns the new sequence id or undefined if it cannot be determined or on any error.
+   */
+  storeSendingEvents(sessionId: number, events: Events): Promise<KeyType | undefined>;
+  /**
+   * Permanently removes the events batch for the session/sequence pair.
+   */
+  cleanUpSessionEventsStore(sessionId: number, sequenceId: KeyType): Promise<void>;
 }
 export interface SessionIdentifiers {
   deviceId?: string;

--- a/packages/session-replay-browser/test/base-events-store.test.ts
+++ b/packages/session-replay-browser/test/base-events-store.test.ts
@@ -1,0 +1,29 @@
+import { Logger } from '@amplitude/analytics-types';
+import { InMemoryEventsStore } from '../src/events/events-memory-store';
+
+describe('BaseEventsStore', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const mockLoggerProvider: Logger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+
+  test('should split based on time', async () => {
+    jest.useFakeTimers().setSystemTime(Date.now());
+    const store = new InMemoryEventsStore({
+      loggerProvider: mockLoggerProvider,
+    });
+    await store.addEventToCurrentSequence(1234, 'test');
+    jest.advanceTimersByTime(36_000_000);
+
+    expect(store.shouldSplitEventsList(['test'], 'test')).toBe(true);
+    return;
+  });
+});

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -47,6 +47,7 @@ describe('EventCompressor', () => {
     eventsManager = await createEventsManager<'replay'>({
       config,
       type: 'replay',
+      storeType: 'memory',
     });
     eventCompressor = new EventCompressor(eventsManager, config, deviceId);
     deferEvents = global.requestIdleCallback;

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -31,14 +31,13 @@ describe('InMemoryEventsStore', () => {
     test('returns sequence id on split', async () => {
       await store.addEventToCurrentSequence(sessionId, 'test');
       store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
-      await store.addEventToCurrentSequence(sessionId, 'test');
 
       const {
         sequenceId,
         events,
         sessionId: sequenceSessionId,
       } = (await store.addEventToCurrentSequence(sessionId, 'test'))!;
-      expect(sequenceId).toBeGreaterThanOrEqual(0);
+      expect(sequenceId).toBe(0);
       expect(events).toStrictEqual(['test']);
       expect(sequenceSessionId).toStrictEqual(sessionId);
     });
@@ -52,7 +51,7 @@ describe('InMemoryEventsStore', () => {
     test('sequence id produced', async () => {
       await store.addEventToCurrentSequence(sessionId, 'test');
       const { sequenceId, events, sessionId: sequenceSessionId } = (await store.storeCurrentSequence(sessionId))!;
-      expect(sequenceId).toBeGreaterThanOrEqual(0);
+      expect(sequenceId).toBe(0);
       expect(events).toStrictEqual(['test']);
       expect(sequenceSessionId).toStrictEqual(sessionId);
     });
@@ -70,7 +69,7 @@ describe('InMemoryEventsStore', () => {
       expect(sequences).toHaveLength(1);
 
       const { sequenceId, events, sessionId: sequenceSessionId } = sequences[0];
-      expect(sequenceId).toBeGreaterThanOrEqual(0);
+      expect(sequenceId).toBe(0);
       expect(events).toStrictEqual(['test']);
       expect(sequenceSessionId).toStrictEqual(sessionId);
     });
@@ -78,7 +77,7 @@ describe('InMemoryEventsStore', () => {
 
   describe('storeSendingEvents', () => {
     test('stores events', async () => {
-      expect(await store.storeSendingEvents(sessionId, ['test'])).toBeGreaterThanOrEqual(0);
+      expect(await store.storeSendingEvents(sessionId, ['test'])).toBe(0);
     });
   });
 

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -1,0 +1,102 @@
+// We don't want to call expects in conditions and typescript doesn't take these checks into account.
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Logger } from '@amplitude/analytics-types';
+import { InMemoryEventsStore } from '../src/events/events-memory-store';
+
+const mockLoggerProvider: Logger = {
+  error: jest.fn(),
+  log: jest.fn(),
+  disable: jest.fn(),
+  enable: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('InMemoryEventsStore', () => {
+  let store: InMemoryEventsStore;
+  let sessionId: number;
+
+  beforeEach(() => {
+    sessionId = Math.floor(Math.random() * 10000);
+    store = new InMemoryEventsStore({
+      loggerProvider: mockLoggerProvider,
+    });
+  });
+
+  describe('addEventToCurrentSequence', () => {
+    test('store does not produce sequence id after one event', async () => {
+      expect(await store.addEventToCurrentSequence(sessionId, 'test')).toBeUndefined();
+    });
+
+    test('returns sequence id on split', async () => {
+      await store.addEventToCurrentSequence(sessionId, 'test');
+      store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
+      await store.addEventToCurrentSequence(sessionId, 'test');
+
+      const {
+        sequenceId,
+        events,
+        sessionId: sequenceSessionId,
+      } = (await store.addEventToCurrentSequence(sessionId, 'test'))!;
+      expect(sequenceId).toBeGreaterThanOrEqual(0);
+      expect(events).toStrictEqual(['test']);
+      expect(sequenceSessionId).toStrictEqual(sessionId);
+    });
+  });
+
+  describe('storeCurrentSequence', () => {
+    test('no sequence id produced', async () => {
+      expect(await store.storeCurrentSequence(sessionId)).toBeUndefined();
+    });
+
+    test('sequence id produced', async () => {
+      await store.addEventToCurrentSequence(sessionId, 'test');
+      const { sequenceId, events, sessionId: sequenceSessionId } = (await store.storeCurrentSequence(sessionId))!;
+      expect(sequenceId).toBeGreaterThanOrEqual(0);
+      expect(events).toStrictEqual(['test']);
+      expect(sequenceSessionId).toStrictEqual(sessionId);
+    });
+  });
+
+  describe('getSequencesToSend', () => {
+    test('get sequences', async () => {
+      expect(await store.getSequencesToSend()).toStrictEqual([]);
+    });
+
+    test('get stored sequences', async () => {
+      await store.addEventToCurrentSequence(sessionId, 'test');
+      await store.storeCurrentSequence(sessionId);
+      const sequences = (await store.getSequencesToSend())!;
+      expect(sequences).toHaveLength(1);
+
+      const { sequenceId, events, sessionId: sequenceSessionId } = sequences[0];
+      expect(sequenceId).toBeGreaterThanOrEqual(0);
+      expect(events).toStrictEqual(['test']);
+      expect(sequenceSessionId).toStrictEqual(sessionId);
+    });
+  });
+
+  describe('storeSendingEvents', () => {
+    test('stores events', async () => {
+      expect(await store.storeSendingEvents(sessionId, ['test'])).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('cleanUpSessionEventsStore', () => {
+    test('deletes sequence', async () => {
+      // first build a new sequence
+      const sequenceId = (await store.storeSendingEvents(sessionId, ['test']))!;
+      const sequences = (await store.getSequencesToSend())!;
+      expect(sequences).toHaveLength(1);
+
+      const sequence = sequences[0];
+      expect(sequence.sequenceId).toBe(sequenceId);
+
+      // then delete it
+      await store.cleanUpSessionEventsStore(sessionId, sequenceId);
+
+      // then confirm it's deleted
+      expect(await store.getSequencesToSend()).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -73,7 +73,7 @@ describe('module level integration', () => {
       getRemoteConfig: getRemoteConfigMock,
       metrics: {},
     });
-    jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
+    jest.spyOn(SessionReplayIDB.SessionReplayEventsIDBStore, 'new');
     jest.useFakeTimers();
     originalFetch = global.fetch;
     global.fetch = jest.fn(() =>
@@ -112,8 +112,8 @@ describe('module level integration', () => {
     test('should handle unknown event type', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
       if (!sessionReplay.eventsManager) {
@@ -132,8 +132,8 @@ describe('module level integration', () => {
     test('should handle unexpected error', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock).mockImplementationOnce(() => Promise.reject('API Failure'));
       if (!sessionReplay.eventsManager) {
@@ -148,7 +148,7 @@ describe('module level integration', () => {
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
-        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=1&type=replay`,
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&type=replay`,
         expect.anything(),
       );
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith('API Failure');
@@ -156,8 +156,8 @@ describe('module level integration', () => {
     test('should not retry for 400 error', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock)
         .mockImplementationOnce(() => {
@@ -184,7 +184,7 @@ describe('module level integration', () => {
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
-        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=1&type=replay`,
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&type=replay`,
         expect.anything(),
       );
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -193,8 +193,8 @@ describe('module level integration', () => {
     test('should not retry for 413 error', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock)
         .mockImplementationOnce(() => {
@@ -220,7 +220,7 @@ describe('module level integration', () => {
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
-        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=1&type=replay`,
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&type=replay`,
         expect.anything(),
       );
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -229,8 +229,8 @@ describe('module level integration', () => {
     test('should handle retry for 500 error', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock).mockReset();
       (fetch as jest.Mock)
@@ -262,8 +262,8 @@ describe('module level integration', () => {
     test('should only retry once for 500 error, even if config set to higher than one retry', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 10 }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock).mockReset();
       (fetch as jest.Mock)
@@ -294,8 +294,8 @@ describe('module level integration', () => {
     test('should handle retry for 503 error', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock).mockReset();
       (fetch as jest.Mock)
@@ -326,8 +326,8 @@ describe('module level integration', () => {
     test('should handle unexpected error where fetch response is null', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
-      const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-        .value;
+      const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        .results[0].value;
       jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
       (fetch as jest.Mock).mockImplementationOnce(() => {
         return Promise.resolve(null);
@@ -345,7 +345,7 @@ describe('module level integration', () => {
       await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
       await runScheduleTimers();
       expect(fetch).toHaveBeenLastCalledWith(
-        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&seq_number=1&type=replay`,
+        `${SESSION_REPLAY_EU_SERVER_URL}?device_id=1a2b3c&session_id=123&type=replay`,
         expect.anything(),
       );
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -84,7 +84,7 @@ describe('module level integration', () => {
       getRemoteConfig: getRemoteConfigMock,
       metrics: {},
     });
-    jest.spyOn(SessionReplayIDB, 'createEventsIDBStore');
+    jest.spyOn(SessionReplayIDB.SessionReplayEventsIDBStore, 'new');
     jest.useFakeTimers({ doNotFake: ['nextTick'] });
     originalFetch = global.fetch;
     global.fetch = jest.fn(() =>
@@ -128,8 +128,8 @@ describe('module level integration', () => {
       test('should capture', async () => {
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions }).promise;
-        const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-          .value;
+        const createEventsIDBStoreInstance = await(SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+          .results[0].value;
 
         jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
@@ -144,11 +144,11 @@ describe('module level integration', () => {
 
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(
-          `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&seq_number=1&type=replay`,
+          `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&type=replay`,
           expect.anything(),
         );
         expect(mockLoggerProvider.log).toHaveBeenLastCalledWith(
-          'Session replay event batch with seq id 1 tracked successfully for session id 1719847315000, size of events: 0 KB',
+          'Session replay event batch tracked successfully for session id 1719847315000, size of events: 0 KB',
         );
       });
 
@@ -167,8 +167,8 @@ describe('module level integration', () => {
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions }).promise;
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
-        const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-          .value;
+        const createEventsIDBStoreInstance = await(SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+          .results[0].value;
 
         jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
         expect(sessionRecordingProperties).toMatchObject({
@@ -181,12 +181,12 @@ describe('module level integration', () => {
         await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(
-          `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&seq_number=1&type=replay`,
+          `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&type=replay`,
           expect.anything(),
         );
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockLoggerProvider.log).toHaveBeenLastCalledWith(
-          'Session replay event batch with seq id 1 tracked successfully for session id 1719847315000, size of events: 0 KB',
+          'Session replay event batch tracked successfully for session id 1719847315000, size of events: 0 KB',
         );
       });
 
@@ -218,8 +218,8 @@ describe('module level integration', () => {
       test('should record session if included due to sampling', async () => {
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.8 }).promise;
-        const createEventsIDBStoreInstance = await (SessionReplayIDB.createEventsIDBStore as jest.Mock).mock.results[0]
-          .value;
+        const createEventsIDBStoreInstance = await(SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+          .results[0].value;
         jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
         expect(sessionRecordingProperties).toMatchObject({
@@ -234,12 +234,12 @@ describe('module level integration', () => {
         await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(
-          `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&seq_number=1&type=replay`,
+          `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&type=replay`,
           expect.anything(),
         );
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockLoggerProvider.log).toHaveBeenLastCalledWith(
-          'Session replay event batch with seq id 1 tracked successfully for session id 1719847315000, size of events: 0 KB',
+          'Session replay event batch tracked successfully for session id 1719847315000, size of events: 0 KB',
         );
       });
     });

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -128,7 +128,7 @@ describe('module level integration', () => {
       test('should capture', async () => {
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions }).promise;
-        const createEventsIDBStoreInstance = await(SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
           .results[0].value;
 
         jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
@@ -167,7 +167,7 @@ describe('module level integration', () => {
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions }).promise;
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
-        const createEventsIDBStoreInstance = await(SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
           .results[0].value;
 
         jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
@@ -218,7 +218,7 @@ describe('module level integration', () => {
       test('should record session if included due to sampling', async () => {
         const sessionReplay = new SessionReplay();
         await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.8 }).promise;
-        const createEventsIDBStoreInstance = await(SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
+        const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
           .results[0].value;
         jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -56,7 +56,7 @@ describe('SessionReplayTrackDestination', () => {
       const schedule = jest.spyOn(trackDestination, 'schedule').mockReturnValueOnce(undefined);
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -79,7 +79,7 @@ describe('SessionReplayTrackDestination', () => {
       const completeRequest = jest.spyOn(trackDestination, 'completeRequest').mockReturnValueOnce(undefined);
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 1,
@@ -94,7 +94,7 @@ describe('SessionReplayTrackDestination', () => {
       expect(completeRequest).toHaveBeenCalledTimes(1);
       expect(completeRequest).toHaveBeenCalledWith({
         context: context,
-        err: 'Session replay event batch rejected due to exceeded retry count, batch sequence id, 1',
+        err: 'Session replay event batch rejected due to exceeded retry count',
       });
     });
 
@@ -103,7 +103,7 @@ describe('SessionReplayTrackDestination', () => {
       const schedule = jest.spyOn(trackDestination, 'schedule').mockReturnValueOnce(undefined);
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -131,7 +131,7 @@ describe('SessionReplayTrackDestination', () => {
       trackDestination.queue = [
         {
           events: [mockEventString],
-          sequenceId: 1,
+
           sessionId: 123,
           apiKey,
           attempts: 0,
@@ -173,7 +173,7 @@ describe('SessionReplayTrackDestination', () => {
       trackDestination.queue = [
         {
           events: [mockEventString],
-          sequenceId: 1,
+
           sessionId: 123,
           apiKey,
           attempts: 0,
@@ -197,7 +197,7 @@ describe('SessionReplayTrackDestination', () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -224,7 +224,7 @@ describe('SessionReplayTrackDestination', () => {
       trackDestination.loggerProvider = mockLoggerProvider;
       const context: SessionReplayDestinationContext = {
         events: [],
-        sequenceId: 1,
+
         sessionId: 123,
         attempts: 0,
         timeout: 0,
@@ -244,7 +244,7 @@ describe('SessionReplayTrackDestination', () => {
       trackDestination.loggerProvider = mockLoggerProvider;
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         attempts: 0,
         timeout: 0,
@@ -264,7 +264,7 @@ describe('SessionReplayTrackDestination', () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -285,7 +285,7 @@ describe('SessionReplayTrackDestination', () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -305,7 +305,7 @@ describe('SessionReplayTrackDestination', () => {
       await trackDestination.send(context);
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith(
-        'https://api-sr.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&seq_number=1&type=replay',
+        'https://api-sr.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&type=replay',
         {
           body: JSON.stringify({ version: 1, events: [mockEventString] }),
           headers: {
@@ -326,7 +326,7 @@ describe('SessionReplayTrackDestination', () => {
 
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -342,7 +342,7 @@ describe('SessionReplayTrackDestination', () => {
       await trackDestination.send(context);
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith(
-        'https://api-sr.eu.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&seq_number=1&type=replay',
+        'https://api-sr.eu.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&type=replay',
         {
           body: JSON.stringify({ version: 1, events: [mockEventString] }),
           headers: {
@@ -363,7 +363,7 @@ describe('SessionReplayTrackDestination', () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,
@@ -401,7 +401,7 @@ describe('SessionReplayTrackDestination', () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const context: SessionReplayDestinationContext = {
         events: [mockEventString],
-        sequenceId: 1,
+
         sessionId: 123,
         apiKey,
         attempts: 0,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

~~**Do not merge, still testing with the tasks app**~~

Currently, we store events using indexedDB (IDB). However, it's not possible in all cases where we want to capture replays that IDB is present. This PR adds an in-memory version of the event store that can either be the default store or will be the fallback if IDB is not present. The storage API is not quite stable yet and the implementation to make both stores unified needs a bit of work. This is small holdover to help in certain situations and to prevent a very large initial PR.

_Sorry for the long PR! This was an attempt at the minimal amount of changes with a few quality of life things thrown in._

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
