### PR TITLE
fix(analytics-browser): should track file download when with url params

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -78,7 +78,7 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
       };
 
       const ext =
-        /\.(pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma)$/;
+        /\.(pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma)(\?.+)?$/;
 
       // Adds listener to existing anchor tags
       const links = Array.from(document.getElementsByTagName('a'));

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -36,9 +36,12 @@ describe('fileDownloadTracking', () => {
     expect(amplitude.track).toHaveBeenCalledTimes(0);
   });
 
-  test('should track file_download event', async () => {
+  test.each([
+    'https://analytics.amplitude.com/files/my-file.pdf',
+    'https://analytics.amplitude.com/files/my-file.pdf?foo=bar',
+  ])('should track file_download event', async (value) => {
     // setup
-    document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');
+    document.getElementById('my-link-id')?.setAttribute('href', value);
     const config = createConfigurationMock();
     const plugin = fileDownloadTracking();
     await plugin.setup?.(config, amplitude);
@@ -54,7 +57,7 @@ describe('fileDownloadTracking', () => {
       [FILE_NAME]: '/files/my-file.pdf',
       [LINK_ID]: 'my-link-id',
       [LINK_TEXT]: 'my-link-text',
-      [LINK_URL]: 'https://analytics.amplitude.com/files/my-file.pdf',
+      [LINK_URL]: value,
     });
 
     // stop observer and listeners


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Jira: [AMP-111576]

File download should also track when url contains url parameters. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-111576]: https://amplitude.atlassian.net/browse/AMP-111576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ