### PR TITLE
fix(analytics-types): build in next.js

### DIFF
--- a/examples/browser/next-app/.eslintrc.json
+++ b/examples/browser/next-app/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  }
 }

--- a/examples/browser/next-app/pages/index.tsx
+++ b/examples/browser/next-app/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import Image from 'next/image'
 import styles from '../styles/Home.module.css'
 import { identify, setGroup, groupIdentify, track, Identify } from '@amplitude/analytics-browser'
 

--- a/packages/analytics-types/src/element-interactions.ts
+++ b/packages/analytics-types/src/element-interactions.ts
@@ -94,7 +94,8 @@ export interface Messenger {
 // DomElement is [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) if the dom library is included in tsconfig.json
 // and never if it is not included
 // eslint-disable-next-line no-restricted-globals
-type DomElement = typeof globalThis extends { Element: abstract new (...args: any) => any }
-  ? // eslint-disable-next-line no-restricted-globals
-    InstanceType<typeof globalThis['Element']>
+type DomElement = typeof globalThis extends {
+  Element: new (...args: any) => infer T;
+}
+  ? T
   : never;

--- a/packages/analytics-types/src/element-interactions.ts
+++ b/packages/analytics-types/src/element-interactions.ts
@@ -94,6 +94,7 @@ export interface Messenger {
 // DomElement is [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) if the dom library is included in tsconfig.json
 // and never if it is not included
 // eslint-disable-next-line no-restricted-globals
-type DomElement = typeof globalThis extends { Element: infer T extends abstract new (...args: any) => any }
-  ? InstanceType<T>
+type DomElement = typeof globalThis extends { Element: abstract new (...args: any) => any }
+  ? // eslint-disable-next-line no-restricted-globals
+    InstanceType<typeof globalThis['Element']>
   : never;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Jira: [AMP-110387]

Fix https://github.com/amplitude/Amplitude-TypeScript/issues/883 by referring `globalThis['Element']` instead of using `infer T` to avoid build error in next.js. The root cause is that the syntax `infer T extends` is introduced in 4.8 https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#improved-inference-for-infer-types-in-template-string-types.

Test with examples/browser/next-app with typescript 4.6.3

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-110387]: https://amplitude.atlassian.net/browse/AMP-110387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ