### PR TITLE
feat: adds support to \n separated request body for ga forwarding

### DIFF
--- a/packages/plugin-ga-events-forwarder-browser/test/constants.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/constants.ts
@@ -7,7 +7,7 @@ export const MOCK_REGIONAL_URL: string = (() => {
   return regionalUrl.toString();
 })();
 
-export const MOCK_GA_EVENT = {
+export const MOCK_GA_EVENT: Record<string, string | number> = {
   v: '2',
   tid: 'G-DELYSDZ9Q3',
   gtm: '45je3890',


### PR DESCRIPTION
### Summary

When this feature was originally built, GA sent bulk events in a single request using the request payload. The request payload is a list of valid query parameter formatted string separated by the `\\r\\` character. A customer reported that their GA-forwarded events are not being formatted correctly. After some investigating, we are seeing the list of valid query parameter formatted stings are separated by `\n` character. The changes here include adding support to `\n` separated strings and ignoring events that are formatted outside the supported formats.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
