### PR TITLE
build: add node 22.x to build env matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.15.x, 20.x]
+        node-version: [18.15.x, 20.x, 22.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
### Summary

Adds Node 22.x to build env matrix

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
