### PR TITLE
fix: make table non nullable

### DIFF
--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/LegacyDatabaseStorage.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/LegacyDatabaseStorage.kt
@@ -55,7 +55,7 @@ class LegacyDatabaseStorage(context: Context, databaseName: String) : SQLiteOpen
 
     private fun queryDb(
         db: SQLiteDatabase,
-        table: String?,
+        table: String,
         columns: Array<String?>?,
         selection: String?,
         selectionArgs: Array<String?>?,


### PR DESCRIPTION
### Summary

Android SDK version 35 makes the table property non nullable in sqlite. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
