### PR TITLE
fix(analytics-types): allow an array of objects as identity value type

### DIFF
--- a/packages/analytics-core/test/identify.test.ts
+++ b/packages/analytics-core/test/identify.test.ts
@@ -186,4 +186,26 @@ describe('Identify class', () => {
 
     expect(identify.getUserProperties()).toStrictEqual(expectedProperties);
   });
+
+  test('should allow to set an array of objects', () => {
+    const identify = new Identify();
+    const propertyValue = [
+      {
+        key1: 'value1',
+        key2: 'value2',
+      },
+      {
+        key1: 'value3',
+        key2: 'value4',
+      },
+    ];
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore bypassing ts rules to test unexpected input
+    identify.set('PROPERTY_NAME', propertyValue);
+    const expectedProperties = {
+      [IdentifyOperation.SET]: { PROPERTY_NAME: propertyValue },
+    };
+
+    expect(identify.getUserProperties()).toStrictEqual(expectedProperties);
+  });
 });

--- a/packages/analytics-types/src/event.ts
+++ b/packages/analytics-types/src/event.ts
@@ -39,7 +39,8 @@ export type ValidPropertyType =
   | string
   | boolean
   | Array<string | number>
-  | { [key: string]: ValidPropertyType };
+  | { [key: string]: ValidPropertyType }
+  | Array<{ [key: string]: ValidPropertyType }>;
 
 interface BaseOperationConfig {
   [key: string]: ValidPropertyType;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Jira: [AMP-114927]

Allow an array of objects as identify value type
```
    const identify = new Identify();
    const propertyValue = [
      {
        key1: 'value1',
        key2: 'value2',
      },
      {
        key1: 'value3',
        key2: 'value4',
      },
    ];
    identify.set('PROPERTY_NAME', propertyValue);
```
![image](https://github.com/user-attachments/assets/50c435fc-2b84-4eb3-8cd2-417af6e900b8)


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-114927]: https://amplitude.atlassian.net/browse/AMP-114927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ