### PR TITLE
fix: missing body for fetch intercepts in ga events forwarder

### DIFF
--- a/packages/plugin-autocapture-browser/package.json
+++ b/packages/plugin-autocapture-browser/package.json
@@ -32,7 +32,7 @@
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn version-file && yarn add @amplitude/analytics-client-common@\">=1 <3\"",
+    "version": "yarn version-file && yarn add @amplitude/analytics-client-common@\">=1 <3\" && yarn build",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {

--- a/packages/plugin-ga-events-forwarder-browser/package.json
+++ b/packages/plugin-ga-events-forwarder-browser/package.json
@@ -32,7 +32,7 @@
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn version-file && yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\"",
+    "version": "yarn version-file && yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\" && yarn build",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {

--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -102,7 +102,7 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
     return intercept(requestUrl, data);
   };
 
-  const interceptFetch: FetchInterceptor = (resource, _options) => {
+  const interceptFetch: FetchInterceptor = (resource, options) => {
     let requestUrl: string | URL = '';
 
     // Fetch accepts strings, objects with stringifiers, or request objects
@@ -120,7 +120,7 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
       logger?.error(e);
     }
 
-    intercept(requestUrl, null);
+    intercept(requestUrl, options?.body);
   };
 
   /**


### PR DESCRIPTION
### Summary

* Fixes missing request body in intercept function call for fetch interception
* Fixes outdated version in builds

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
