### PR TITLE
feat(session-replay-browser): support custom urls for remote config and track endpoints.

### DIFF
--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -4,6 +4,7 @@ import {
   CreateRemoteConfigFetch,
   RemoteConfigFetch as IRemoteConfigFetch,
   RemoteConfigAPIResponse,
+  RemoteConfigLocalConfig,
   RemoteConfigMetric,
 } from './types';
 
@@ -20,7 +21,7 @@ export const REMOTE_CONFIG_SERVER_URL_EU = 'https://sr-client-cfg.eu.amplitude.c
 export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   implements IRemoteConfigFetch<RemoteConfig>
 {
-  localConfig: Config;
+  localConfig: RemoteConfigLocalConfig;
   retryTimeout = 1000;
   attempts = 0;
   lastFetchedSessionId: number | string | undefined;
@@ -53,6 +54,10 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
   };
 
   getServerUrl() {
+    if (this.localConfig.configServerUrl) {
+      return this.localConfig.configServerUrl;
+    }
+
     if (this.localConfig.serverZone === ServerZone.STAGING) {
       return REMOTE_CONFIG_SERVER_URL_STAGING;
     }
@@ -156,7 +161,7 @@ export const createRemoteConfigFetch: CreateRemoteConfigFetch = async <
   localConfig,
   configKeys,
 }: {
-  localConfig: Config;
+  localConfig: RemoteConfigLocalConfig;
   configKeys: string[];
 }) => {
   return new RemoteConfigFetch<RemoteConfig>({ localConfig, configKeys });

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -6,6 +6,10 @@ export interface RemoteConfigAPIResponse<RemoteConfig extends { [key: string]: o
   };
 }
 
+export interface RemoteConfigLocalConfig extends Config {
+  configServerUrl?: string;
+}
+
 export interface BaseRemoteConfigFetch<T> {
   getRemoteConfig: <K extends keyof T>(
     configNamespace: string,

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -1,5 +1,5 @@
 import { Config } from '@amplitude/analytics-core';
-import { Config as IConfig, Logger, ServerZone } from '@amplitude/analytics-types';
+import { Logger, ServerZone } from '@amplitude/analytics-types';
 import {
   REMOTE_CONFIG_SERVER_URL,
   REMOTE_CONFIG_SERVER_URL_EU,
@@ -7,7 +7,7 @@ import {
   RemoteConfigFetch,
   createRemoteConfigFetch,
 } from '../src/remote-config';
-import { RemoteConfigAPIResponse, RemoteConfigIDBStore } from '../src/types';
+import { RemoteConfigAPIResponse, RemoteConfigIDBStore, RemoteConfigLocalConfig } from '../src/types';
 
 type MockedLogger = jest.Mocked<Logger>;
 
@@ -55,7 +55,7 @@ describe('RemoteConfigFetch', () => {
     warn: jest.fn(),
     debug: jest.fn(),
   };
-  let localConfig: IConfig;
+  let localConfig: RemoteConfigLocalConfig;
   let mockConfigStore: RemoteConfigIDBStore<{ [key: string]: object }>;
 
   let remoteConfigFetch: RemoteConfigFetch<typeof samplingConfig>;
@@ -452,11 +452,16 @@ describe('RemoteConfigFetch', () => {
       await initialize(config);
       expect(remoteConfigFetch.getServerUrl()).toEqual(REMOTE_CONFIG_SERVER_URL_EU);
     });
-
     test('should return staging server url if staging config set', async () => {
       const config = { ...localConfig, optOut: localConfig.optOut, serverZone: ServerZone.STAGING };
       await initialize(config);
       expect(remoteConfigFetch.getServerUrl()).toEqual(REMOTE_CONFIG_SERVER_URL_STAGING);
+    });
+    test('should allow custom server url', async () => {
+      const configServerUrl = 'http://localhost:3000';
+      const config = { ...localConfig, optOut: localConfig.optOut, serverZone: ServerZone.STAGING, configServerUrl };
+      await initialize(config);
+      expect(remoteConfigFetch.getServerUrl()).toEqual(configServerUrl);
     });
   });
 

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -45,6 +45,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
       }
 
       await sessionReplay.init(config.apiKey, {
+        ...this.options,
         instanceName: this.config.instanceName,
         deviceId: this.config.deviceId,
         optOut: this.config.optOut,
@@ -61,7 +62,6 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
           defaultMaskLevel: this.options.privacyConfig?.defaultMaskLevel,
         },
         debugMode: this.options.debugMode,
-        configEndpointUrl: this.options.configEndpointUrl,
         shouldInlineStylesheet: this.options.shouldInlineStylesheet,
         version: { type: 'plugin', version: VERSION },
         performanceConfig: this.options.performanceConfig,

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -45,7 +45,6 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
       }
 
       await sessionReplay.init(config.apiKey, {
-        ...this.options,
         instanceName: this.config.instanceName,
         deviceId: this.config.deviceId,
         optOut: this.config.optOut,
@@ -54,6 +53,8 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
         logLevel: this.config.logLevel,
         flushMaxRetries: this.config.flushMaxRetries,
         serverZone: this.config.serverZone,
+        configServerUrl: this.options.configServerUrl,
+        trackServerUrl: this.options.trackServerUrl,
         sampleRate: this.options.sampleRate,
         privacyConfig: {
           blockSelector: this.options.privacyConfig?.blockSelector,

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -23,7 +23,8 @@ export interface SessionReplayOptions {
   privacyConfig?: SessionReplayPrivacyConfig;
   debugMode?: boolean;
   forceSessionTracking?: boolean;
-  configEndpointUrl?: string;
+  configServerUrl?: string;
+  trackServerUrl?: string;
   shouldInlineStylesheet?: boolean;
   performanceConfig?: SessionReplayPerformanceConfig;
   storeType?: StoreType;

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -185,6 +185,44 @@ describe('SessionReplayPlugin', () => {
       });
     });
 
+    test('should call initalize on session replay sdk with custom server urls', async () => {
+      const configServerUrl = 'http://localhost:3000';
+      const trackServerUrl = 'http://localhost:3001';
+
+      const sessionReplay = new SessionReplayPlugin({
+        sampleRate: 0.4,
+        privacyConfig: {
+          blockSelector: ['#id'],
+        },
+        configServerUrl,
+        trackServerUrl,
+      });
+      await sessionReplay.setup(mockConfig);
+
+      expect(init).toHaveBeenCalledTimes(1);
+
+      expect(init.mock.calls[0][0]).toEqual(mockConfig.apiKey);
+      expect(init.mock.calls[0][1]).toEqual({
+        deviceId: mockConfig.deviceId,
+        flushMaxRetries: mockConfig.flushMaxRetries,
+        logLevel: mockConfig.logLevel,
+        loggerProvider: mockConfig.loggerProvider,
+        optOut: mockConfig.optOut,
+        sampleRate: 0.4,
+        serverZone: mockConfig.serverZone,
+        configServerUrl,
+        trackServerUrl,
+        sessionId: mockConfig.sessionId,
+        privacyConfig: {
+          blockSelector: ['#id'],
+        },
+        version: {
+          type: 'plugin',
+          version: VERSION,
+        },
+      });
+    });
+
     test('should fail gracefully', async () => {
       const sessionReplay = new SessionReplayPlugin();
       init.mockImplementation(() => {

--- a/packages/session-replay-browser/src/beacon-transport.ts
+++ b/packages/session-replay-browser/src/beacon-transport.ts
@@ -53,7 +53,7 @@ export class BeaconTransport<T> {
       return true;
     };
 
-    this.basePageUrl = getServerUrl(config.serverZone);
+    this.basePageUrl = getServerUrl(config.serverZone, config.trackServerUrl);
     this.apiKey = config.apiKey;
     this.context = context;
   }

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -24,7 +24,8 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   privacyConfig?: PrivacyConfig;
   interactionConfig?: InteractionConfig;
   debugMode?: boolean;
-  configEndpointUrl?: string;
+  configServerUrl?: string;
+  trackServerUrl?: string;
   shouldInlineStylesheet?: boolean;
   version?: SessionReplayVersion;
   storeType: StoreType;
@@ -45,7 +46,8 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     this.apiKey = apiKey;
     this.sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
     this.serverZone = options.serverZone || DEFAULT_SERVER_ZONE;
-    this.configEndpointUrl = options.configEndpointUrl;
+    this.configServerUrl = options.configServerUrl;
+    this.trackServerUrl = options.trackServerUrl;
     this.shouldInlineStylesheet = options.shouldInlineStylesheet;
     this.version = options.version;
     this.performanceConfig = options.performanceConfig;

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -47,7 +47,12 @@ export interface SessionReplayLocalConfig extends Config {
   sampleRate: number;
   privacyConfig?: PrivacyConfig;
   debugMode?: boolean;
-  configEndpointUrl?: string;
+  // This will control which endpoint is used for remote config.
+  // This will override server zone if specified.
+  configServerUrl?: string;
+  // This will control which endpoint is used for session replay track calls.
+  // This will override server zone if specified.
+  trackServerUrl?: string;
   shouldInlineStylesheet?: boolean;
   version?: SessionReplayVersion;
   performanceConfig?: SessionReplayPerformanceConfig;

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -28,7 +28,11 @@ export const createEventsManager = async <Type extends EventType>({
   payloadBatcher?: PayloadBatcher;
   storeType: StoreType;
 }): Promise<AmplitudeSessionReplayEventsManager<Type, string>> => {
-  const trackDestination = new SessionReplayTrackDestination({ loggerProvider: config.loggerProvider, payloadBatcher });
+  const trackDestination = new SessionReplayTrackDestination({
+    ...config,
+    loggerProvider: config.loggerProvider,
+    payloadBatcher,
+  });
 
   const getMemoryStore = (): EventsStore<number> => {
     return new InMemoryEventsStore({

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -128,7 +128,11 @@ export const generateSessionReplayId = (sessionId: string | number, deviceId: st
   return `${deviceId}/${sessionId}`;
 };
 
-export const getServerUrl = (serverZone?: keyof typeof ServerZone): string => {
+export const getServerUrl = (serverZone?: keyof typeof ServerZone, trackServerUrl?: string): string => {
+  if (trackServerUrl) {
+    return trackServerUrl;
+  }
+
   if (serverZone === ServerZone.STAGING) {
     return SESSION_REPLAY_STAGING_URL;
   }

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -218,6 +218,12 @@ describe('SessionReplayPlugin helpers', () => {
     test('should return eu server url if eu config set', async () => {
       expect(getServerUrl(ServerZone.EU)).toEqual(SESSION_REPLAY_EU_URL);
     });
+
+    test('should allow server url override', async () => {
+      const customUrl = 'http://localhost:3000';
+
+      expect(getServerUrl(ServerZone.EU, customUrl)).toEqual(customUrl);
+    });
   });
 
   describe('getStorageSize', () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This allows for custom urls for the remote config and track endpoints to help with testing against mocked or local versions of these services. There is an old config that was changed, but it seems like that was not used at all.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes, but the old config was not used.
