### PR TITLE
feat(session-replay-browser): WebWorker support for compression

### DIFF
--- a/packages/plugin-session-replay-browser/rollup.config.js
+++ b/packages/plugin-session-replay-browser/rollup.config.js
@@ -1,65 +1,14 @@
 import { iife, umd } from '../../scripts/build/rollup.config';
-
-import resolve from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
-import { terser } from 'rollup-plugin-terser';
-import typescript from '@rollup/plugin-typescript';
-import { rollup } from 'rollup';
-import path from 'node:path';
+import { webWorkerPlugins } from '../session-replay-browser/rollup.config';
 
 iife.input = umd.input;
 iife.output.name = 'sessionReplay';
 
-async function buildWebWorker() {
-  const bundle = await rollup({
-    input: path.join(__dirname, '../session-replay-browser/src/worker/compression.ts'),
-    plugins: [
-      resolve({
-        browser: true,
-      }),
-      typescript({
-        tsconfig: 'tsconfig.json',
-        // no need to output types
-        declaration: false,
-        declarationMap: false,
-      }),
-      terser(),
-    ],
-  });
-
-  const { output } = await bundle.generate({
-    format: 'iife',
-    name: 'WebWorker',
-    inlineDynamicImports: true,
-  });
-  const webWorkerCode = output[0].code;
-  console.log(webWorkerCode);
-
-  return webWorkerCode;
-}
-
 export default async () => {
-  const { iifeWorker, umdWorker } = await buildWebWorker();
+  const commonPlugins = await webWorkerPlugins();
 
-  iife.plugins = [
-    replace({
-      preventAssignment: true,
-      values: {
-        'replace.COMPRESSION_WEBWORKER_BODY': JSON.stringify(iifeWorker),
-      },
-    }),
-    ...iife.plugins,
-  ];
-
-  umd.plugins = [
-    replace({
-      preventAssignment: true,
-      values: {
-        'replace.COMPRESSION_WEBWORKER_BODY': JSON.stringify(umdWorker),
-      },
-    }),
-    ...umd.plugins,
-  ];
+  iife.plugins = [...commonPlugins, ...iife.plugins];
+  umd.plugins = [...commonPlugins, ...umd.plugins];
 
   return [iife, umd];
 };

--- a/packages/plugin-session-replay-browser/rollup.config.js
+++ b/packages/plugin-session-replay-browser/rollup.config.js
@@ -1,6 +1,65 @@
 import { iife, umd } from '../../scripts/build/rollup.config';
 
+import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
+import { terser } from 'rollup-plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import { rollup } from 'rollup';
+import path from 'node:path';
+
 iife.input = umd.input;
 iife.output.name = 'sessionReplay';
 
-export default [umd, iife];
+async function buildWebWorker() {
+  const bundle = await rollup({
+    input: path.join(__dirname, '../session-replay-browser/src/worker/compression.ts'),
+    plugins: [
+      resolve({
+        browser: true,
+      }),
+      typescript({
+        tsconfig: 'tsconfig.json',
+        // no need to output types
+        declaration: false,
+        declarationMap: false,
+      }),
+      terser(),
+    ],
+  });
+
+  const { output } = await bundle.generate({
+    format: 'iife',
+    name: 'WebWorker',
+    inlineDynamicImports: true,
+  });
+  const webWorkerCode = output[0].code;
+  console.log(webWorkerCode);
+
+  return webWorkerCode;
+}
+
+export default async () => {
+  const { iifeWorker, umdWorker } = await buildWebWorker();
+
+  iife.plugins = [
+    replace({
+      preventAssignment: true,
+      values: {
+        'replace.COMPRESSION_WEBWORKER_BODY': JSON.stringify(iifeWorker),
+      },
+    }),
+    ...iife.plugins,
+  ];
+
+  umd.plugins = [
+    replace({
+      preventAssignment: true,
+      values: {
+        'replace.COMPRESSION_WEBWORKER_BODY': JSON.stringify(umdWorker),
+      },
+    }),
+    ...umd.plugins,
+  ];
+
+  return [iife, umd];
+};

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -67,6 +67,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
         version: { type: 'plugin', version: VERSION },
         performanceConfig: this.options.performanceConfig,
         storeType: this.options.storeType,
+        experimental: this.options.experimental,
       }).promise;
     } catch (error) {
       config.loggerProvider.error(`Session Replay: Failed to initialize due to ${(error as Error).message}`);

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -29,4 +29,7 @@ export interface SessionReplayOptions {
   performanceConfig?: SessionReplayPerformanceConfig;
   storeType?: StoreType;
   customSessionId?: (event: Event) => string | undefined;
+  experimental?: {
+    useWebWorker: boolean;
+  };
 }

--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -61,8 +61,7 @@
     "rollup": "^2.79.1",
     "rollup-plugin-execute": "^1.1.1",
     "rollup-plugin-gzip": "^3.1.0",
-    "rollup-plugin-terser": "^7.0.2",
-    "serve": "^14.2.4"
+    "rollup-plugin-terser": "^7.0.2"
   },
   "files": [
     "lib"

--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -45,6 +45,7 @@
     "@amplitude/rrweb": "2.0.0-alpha.26",
     "@amplitude/rrweb-packer": "2.0.0-alpha.26",
     "@amplitude/rrweb-snapshot": "2.0.0-alpha.26",
+    "@rollup/plugin-replace": "^6.0.1",
     "idb": "^8.0.0",
     "tslib": "^2.4.1"
   },
@@ -60,7 +61,8 @@
     "rollup": "^2.79.1",
     "rollup-plugin-execute": "^1.1.1",
     "rollup-plugin-gzip": "^3.1.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "serve": "^14.2.4"
   },
   "files": [
     "lib"

--- a/packages/session-replay-browser/rollup.config.js
+++ b/packages/session-replay-browser/rollup.config.js
@@ -1,6 +1,83 @@
 import { iife, umd } from '../../scripts/build/rollup.config';
 
+import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
+import typescript from '@rollup/plugin-typescript';
+import { rollup } from 'rollup';
+
 iife.input = umd.input;
 iife.output.name = 'sessionReplay';
 
-export default [umd, iife];
+async function buildWebWorker() {
+  console.log('building wworker');
+  const bundle = await rollup({
+    input: 'src/worker/compression.ts',
+    plugins: [
+      resolve({
+        browser: true,
+      }),
+      typescript({
+        tsconfig: 'tsconfig.json',
+        // no need to output types
+        declaration: false,
+        declarationMap: false,
+      }),
+      // terser(),
+    ],
+  });
+
+  const { output } = await bundle.generate({
+    format: 'iife',
+    name: 'WebWorker',
+    inlineDynamicImports: true,
+  });
+  const webWorkerCodeIife = output[0].code;
+
+  const { output: outputUmd } = await bundle.generate({
+    format: 'iife',
+    name: 'WebWorker',
+    inlineDynamicImports: true,
+  });
+  const webWorkerCodeUmd = outputUmd[0].code;
+
+  console.log('webworker done!', output.length);
+
+  return { iifeWorker: webWorkerCodeIife, umdWorker: webWorkerCodeUmd };
+}
+
+// export default [umd];
+
+export default async () => {
+  const { iifeWorker, umdWorker } = await buildWebWorker();
+
+  const commonPlugins = [
+    replace({
+      preventAssignment: true,
+      values: {
+        'replace.WEBWORKER_BODY': JSON.stringify('hello, world'),
+      },
+    }),
+  ];
+
+  iife.plugins = [
+    replace({
+      preventAssignment: true,
+      values: {
+        'replace.WEBWORKER_BODY': JSON.stringify(iifeWorker),
+      },
+    }),
+    ...iife.plugins,
+  ];
+
+  umd.plugins = [
+    replace({
+      preventAssignment: true,
+      values: {
+        'replace.WEBWORKER_BODY': JSON.stringify(umdWorker),
+      },
+    }),
+    ...umd.plugins,
+  ];
+
+  return [iife, umd];
+};

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -30,6 +30,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   version?: SessionReplayVersion;
   storeType: StoreType;
   performanceConfig?: SessionReplayPerformanceConfig;
+  experimental?: { useWebWorker: boolean };
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -58,6 +59,9 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     }
     if (options.debugMode) {
       this.debugMode = options.debugMode;
+    }
+    if (options.experimental) {
+      this.experimental = options.experimental;
     }
   }
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -57,6 +57,10 @@ export interface SessionReplayLocalConfig extends Config {
   version?: SessionReplayVersion;
   performanceConfig?: SessionReplayPerformanceConfig;
   storeType: StoreType;
+
+  experimental?: {
+    useWebWorker: boolean;
+  };
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -38,7 +38,7 @@ export class EventCompressor {
     // This next line is going to be ridiculously hard to cover in unit tests, ignoring.
     /* istanbul ignore next */
     const workerScript = replace.COMPRESSION_WEBWORKER_BODY ?? workerScriptInternal;
-    if (globalScope && globalScope.Worker && workerScript) {
+    if (this.config.experimental?.useWebWorker && globalScope && globalScope.Worker && workerScript) {
       config.loggerProvider.log('[Experimental] Enabling web worker for compression');
 
       const worker = new Worker(URL.createObjectURL(new Blob([workerScript], { type: 'application/javascript' })));
@@ -121,11 +121,14 @@ export class EventCompressor {
   public addCompressedEvent = (event: eventWithTime, sessionId: string | number) => {
     if (this.worker) {
       // This indirectly compresses the event.
-      console.log('posted message', { event, sessionId });
       this.worker.postMessage({ event, sessionId });
     } else {
       const compressedEvent = this.compressEvent(event);
       this.addCompressedEventToManager(compressedEvent, sessionId);
     }
+  };
+
+  public terminate = () => {
+    this.worker?.terminate();
   };
 }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -138,6 +138,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     this.eventsManager = new MultiEventManager<'replay' | 'interaction', string>(...managers);
+    // To prevent too many threads.
+    if (this.eventCompressor) {
+      this.eventCompressor.terminate();
+    }
     this.eventCompressor = new EventCompressor(this.eventsManager, this.config, this.getDeviceId());
 
     this.loggerProvider.log('Installing @amplitude/session-replay-browser.');

--- a/packages/session-replay-browser/src/worker/compression.ts
+++ b/packages/session-replay-browser/src/worker/compression.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { pack } from '@amplitude/rrweb-packer';
+
+onmessage = (e) => {
+  const { event, sessionId } = e.data;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const compressedEvent = JSON.stringify(pack(event));
+
+  postMessage({ compressedEvent, sessionId });
+};
+
+// added for testing
+export const compressionOnMessage: (e: any) => void = onmessage

--- a/packages/session-replay-browser/src/worker/compression.ts
+++ b/packages/session-replay-browser/src/worker/compression.ts
@@ -12,4 +12,4 @@ onmessage = (e) => {
 };
 
 // added for testing
-export const compressionOnMessage: (e: any) => void = onmessage
+export const compressionOnMessage = onmessage;

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -43,6 +43,9 @@ describe('EventCompressor', () => {
       enabled: true,
       timeout: 2000,
     },
+    experimental: {
+      useWebWorker: true,
+    },
   });
 
   beforeEach(async () => {
@@ -166,6 +169,7 @@ describe('EventCompressor', () => {
     let postMessageMock = jest.fn();
     let onMessageMock = jest.fn();
     let onErrorMock = jest.fn();
+    let terminateMock = jest.fn();
     class MockWorker {
       postMessage = (e: any) => {
         postMessageMock = jest.fn(() => {
@@ -187,6 +191,10 @@ describe('EventCompressor', () => {
       onerror = (e: any) => {
         onErrorMock = jest.fn();
         onErrorMock(e);
+      };
+      terminate = () => {
+        terminateMock = jest.fn();
+        terminateMock();
       };
     }
 
@@ -214,5 +222,8 @@ describe('EventCompressor', () => {
 
     expect(postMessageMock).toHaveBeenCalledTimes(error ? 0 : 1);
     expect(onErrorMock).toHaveBeenCalledTimes(error ? 1 : 0);
+
+    eventCompressor.terminate();
+    expect(terminateMock).toHaveBeenCalled();
   });
 });

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-conditional-expect */
 import { Logger } from '@amplitude/analytics-types';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
 import { EventCompressor } from '../src/events/event-compressor';

--- a/packages/session-replay-browser/test/worker/compression.test.ts
+++ b/packages/session-replay-browser/test/worker/compression.test.ts
@@ -16,7 +16,8 @@ describe('compression', () => {
       },
     };
 
-    compressionOnMessage({
+    // hack to make typescript not complain
+    (compressionOnMessage as (_: unknown) => void)({
       data: {
         event: testEvent,
         sessionId: 1234,

--- a/packages/session-replay-browser/test/worker/compression.test.ts
+++ b/packages/session-replay-browser/test/worker/compression.test.ts
@@ -1,0 +1,31 @@
+import { eventWithTime } from '@amplitude/rrweb';
+import { compressionOnMessage } from '../../src/worker/compression';
+import { pack } from '@amplitude/rrweb-packer';
+
+describe('compression', () => {
+  test('should compress event', async () => {
+    global.postMessage = jest.fn();
+
+    const testEvent: eventWithTime = {
+      timestamp: 1,
+      type: 4,
+      data: {
+        height: 1,
+        width: 1,
+        href: 'http://localhost',
+      },
+    };
+
+    compressionOnMessage({
+      data: {
+        event: testEvent,
+        sessionId: 1234,
+      },
+    });
+
+    expect(global.postMessage).toHaveBeenCalledWith({
+      sessionId: 1234,
+      compressedEvent: JSON.stringify(pack(testEvent)),
+    });
+  });
+});


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds experimental support for WebWorkers to offload compression. This is an initial first pass to see performance with hopefully later iterations being more complex and offloading not only compression, but other things such as networking calls.

To enable add to your local config:

```javascript
{
  experimental: {
    useWebWorker: true
  }
}
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
