### PR TITLE
fix(session-replay-browser): prevent finder errors from affecting session replay

### DIFF
--- a/packages/session-replay-browser/src/hooks/click.ts
+++ b/packages/session-replay-browser/src/hooks/click.ts
@@ -4,6 +4,7 @@ import { SessionReplayEventsManager as AmplitudeSessionReplayEventsManager } fro
 import { PayloadBatcher } from 'src/track-destination';
 import { finder } from '../libs/finder';
 import { getGlobalScope } from '@amplitude/analytics-client-common';
+import type { Logger } from '@amplitude/analytics-types';
 
 // exported for testing
 export type ClickEvent = {
@@ -67,8 +68,8 @@ export const clickBatcher: PayloadBatcher = ({ version, events }) => {
   return { version, events: Object.values(reduced) };
 };
 
-export const clickHook: (options: Options) => mouseInteractionCallBack =
-  ({ eventsManager, sessionId, deviceIdFn }) =>
+export const clickHook: (logger: Logger, options: Options) => mouseInteractionCallBack =
+  (logger, { eventsManager, sessionId, deviceIdFn }) =>
   (e) => {
     if (e.type !== MouseInteractions.Click) {
       return;
@@ -93,7 +94,11 @@ export const clickHook: (options: Options) => mouseInteractionCallBack =
     const node = record.mirror.getNode(e.id);
     let selector;
     if (node) {
-      selector = finder(node as Element);
+      try {
+        selector = finder(node as Element);
+      } catch (err) {
+        logger.debug('error resolving selector from finder');
+      }
     }
 
     const { left: scrollX, top: scrollY } = utils.getWindowScroll(globalScope as unknown as Window);

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -327,7 +327,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       ? {
           mouseInteraction:
             this.eventsManager &&
-            clickHook({
+            clickHook(this.loggerProvider, {
               eventsManager: this.eventsManager,
               sessionId,
               deviceIdFn: this.getDeviceId.bind(this),

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -321,7 +321,20 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return;
     }
     this.stopRecordingEvents();
-    const { privacyConfig } = config;
+    const { privacyConfig, interactionConfig } = config;
+
+    const hooks = interactionConfig?.enabled
+      ? {
+          mouseInteraction:
+            this.eventsManager &&
+            clickHook({
+              eventsManager: this.eventsManager,
+              sessionId,
+              deviceIdFn: this.getDeviceId.bind(this),
+            }),
+          scroll: this.scrollHook,
+        }
+      : {};
 
     this.loggerProvider.log(`Session Replay capture beginning for ${sessionId}.`);
     this.recordCancelCallback = record({
@@ -339,16 +352,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         }
       },
       inlineStylesheet: config.shouldInlineStylesheet,
-      hooks: {
-        mouseInteraction:
-          this.eventsManager &&
-          clickHook({
-            eventsManager: this.eventsManager,
-            sessionId,
-            deviceIdFn: this.getDeviceId.bind(this),
-          }),
-        scroll: this.scrollHook,
-      },
+      hooks,
       maskAllInputs: true,
       maskTextClass: MASK_TEXT_CLASS,
       blockClass: BLOCK_CLASS,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Does not add click/scroll hooks if interaction config is not present. Also prevents finder errors from affecting session replay.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
