### PR TITLE
fix: should default to empty string when document.title is not string

### DIFF
--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -34,6 +34,25 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
     return decodedLocationStr;
   };
 
+  /* istanbul ignore next */
+  const getDocumentTitle = () => {
+    if (typeof document === 'undefined') {
+      localConfig?.loggerProvider.warn('document is undefined. Default [Amplitude] Page Title to an empty string');
+      return '';
+    }
+
+    const title = document.title;
+    if (typeof title !== 'string') {
+      localConfig?.loggerProvider.warn(
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `document.title is not a string. Default [Amplitude] Page Title to an empty string. document.title: ${title}`,
+      );
+      return '';
+    }
+
+    return title;
+  };
+
   const createPageViewEvent = async (): Promise<Event> => {
     /* istanbul ignore next */
     const locationHREF = getDecodeURI((typeof location !== 'undefined' && location.href) || '');
@@ -46,7 +65,7 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
         '[Amplitude] Page Location': locationHREF,
         '[Amplitude] Page Path':
           /* istanbul ignore next */ (typeof location !== 'undefined' && getDecodeURI(location.pathname)) || '',
-        '[Amplitude] Page Title': /* istanbul ignore next */ (typeof document !== 'undefined' && document.title) || '',
+        '[Amplitude] Page Title': getDocumentTitle(),
         '[Amplitude] Page URL': locationHREF.split('?')[0],
       },
     };


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-120703](https://amplitude.atlassian.net/browse/AMP-120703)


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-120703]: https://amplitude.atlassian.net/browse/AMP-120703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ