### PR TITLE
chore: update script library

### DIFF
--- a/packages/analytics-browser/src/lib-prefix.ts
+++ b/packages/analytics-browser/src/lib-prefix.ts
@@ -1,0 +1,1 @@
+export const LIBPREFIX = 'amplitude-ts';

--- a/packages/analytics-browser/src/plugins/context.ts
+++ b/packages/analytics-browser/src/plugins/context.ts
@@ -2,6 +2,7 @@ import { BeforePlugin, BrowserConfig, Event } from '@amplitude/analytics-types';
 import { UUID } from '@amplitude/analytics-core';
 import { getLanguage } from '@amplitude/analytics-client-common';
 import { VERSION } from '../version';
+import { LIBPREFIX } from '../lib-prefix';
 
 const BROWSER_PLATFORM = 'Web';
 const IP_ADDRESS = '$remote';
@@ -14,7 +15,7 @@ export class Context implements BeforePlugin {
   // @ts-ignore
   config: BrowserConfig;
   userAgent: string | undefined;
-  library = `amplitude-ts/${VERSION}`;
+  library = `${LIBPREFIX}/${VERSION}`;
 
   constructor() {
     /* istanbul ignore else */

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -72,11 +72,12 @@ const updateLibPrefix = (isUndo) => {
   }
 
   fs.writeFileSync(path, updatedContent, 'utf-8');
+  // Supported in rollup 4, we're currently rollup 2
   // this.info(`File updated: ${path}`);
 }
 
 
-const updateLibPrefixPlugin = (isUndo) => {
+const updateLibPrefixPlugin = () => {
   return {
     name: 'update-lib-prefix',
     buildStart() {

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -55,43 +55,36 @@ export const umd = {
   ],
 };
 
+const updateLibPrefix = (isUndo) => {
+  const path = 'src/lib-prefix.ts'
+  if (!fs.existsSync(path)) {
+    // Supported in rollup 4, we're currently rollup 2
+    // this.error(`File not found: ${path}`);
+    return;
+  }
+
+  let content = fs.readFileSync(path, 'utf-8');
+  let updatedContent;
+  if (isUndo) {
+    updatedContent = content.replace(/amplitude-ts-sdk-script/g, 'amplitude-ts');
+  } else {
+    updatedContent = content.replace(/amplitude-ts/g, 'amplitude-ts-sdk-script');
+  }
+
+  fs.writeFileSync(path, updatedContent, 'utf-8');
+  // this.info(`File updated: ${path}`);
+}
 
 
-const updateLibPrefix = () => {
+const updateLibPrefixPlugin = (isUndo) => {
   return {
     name: 'update-lib-prefix',
     buildStart() {
-      const path = 'src/lib-prefix.ts'
-      if (!fs.existsSync(path)) {
-        // Supported in rollup 4, we're currently rollup 2
-        // this.error(`File not found: ${path}`);
-        return;
-      }
-
-      let content = fs.readFileSync(path, 'utf-8');
-      const updatedContent = content.replace(/amplitude-ts/g, 'amplitude-ts-sdk-script');
-      fs.writeFileSync(path, updatedContent, 'utf-8');
-      // this.info(`File updated: ${path}`);
+      updateLibPrefix(false);
     },
-  };
-}
-
-const undoLibPrefix = () => {
-  return {
-    name: 'undo-lib-prefix',
     buildEnd() {
-      const path = 'src/lib-prefix.ts'
-      if (!fs.existsSync(path)) {
-        // Supported in rollup 4, we're currently rollup 2
-        // this.error(`File not found: ${path}`);
-        return;
-      }
-
-      let content = fs.readFileSync(path, 'utf-8');
-      const updatedContent = content.replace(/amplitude-ts-sdk-script/g, 'amplitude-ts');
-      fs.writeFileSync(path, updatedContent, 'utf-8');
-      // this.info(`File updated: ${path}`);
-    },
+      updateLibPrefix(true);
+    }
   };
 }
 
@@ -104,7 +97,7 @@ export const iife = {
     sourcemap: true,
   },
   plugins: [
-    updateLibPrefix(),
+    updateLibPrefixPlugin(),
     typescript({
       module: 'es6',
       noEmit: false,
@@ -121,7 +114,6 @@ export const iife = {
       },
     }),
     gzip(),
-    undoLibPrefix(),
   ],
 };
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Change library to `amplitude-ts-sdk-script` in amplitude-min.js which is renamed as `analytics-browser-x.x.x-min.js.gz`and uploaded to s3 at https://github.com/amplitude/Amplitude-TypeScript/blob/cbb0afa63034959559216d4ea5217b50ce6f4cf1/scripts/publish/upload-to-s3.js#L9
- The main goal is to be able to distinguish installation methods: script vs npm/yarn which remains to be `amplitude-ts`
```
// install by script example
<script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.10-min.js.gz"></script>
```
- Keep this as part of rollup instead of updating amplitude-min.js to avoid amplitude-min.js is used before library updated
- library in lib/esm and lib/cjs remains `amplitude-ts`
<img width="1597" alt="image" src="https://github.com/user-attachments/assets/7d120828-59b6-447a-a9ba-397594827bef" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
