### PR TITLE
feat(plugin-session-replay-browser): support custom device id

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -42,7 +42,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
 
       await sessionReplay.init(config.apiKey, {
         instanceName: this.config.instanceName,
-        deviceId: this.config.deviceId,
+        deviceId: this.options.deviceId ?? this.config.deviceId,
         optOut: this.config.optOut,
         sessionId: this.options.customSessionId ? undefined : this.config.sessionId,
         loggerProvider: this.config.loggerProvider,

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -28,6 +28,7 @@ export interface SessionReplayOptions {
   shouldInlineStylesheet?: boolean;
   performanceConfig?: SessionReplayPerformanceConfig;
   storeType?: StoreType;
+  deviceId?: string;
   customSessionId?: (event: Event) => string | undefined;
   experimental?: {
     useWebWorker: boolean;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

In some cases, customers aren't able to get the right device id configured. This could be due to an issue with the browser SDK or multiple instances of the browser SDK with the plugin. In order to support issues where this is a problem, instead of requiring users to move to the standalone SDK we can allow them to override the device ID.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
