### PR TITLE
chore: init unified sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+
+# local debug
+packages/unified-sdk/playground/html/amplitude-min.js

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -26,3 +26,4 @@ export const {
 export { runQueuedFunctions } from './utils/snippet-helper';
 export { Revenue, Identify } from '@amplitude/analytics-core';
 export * as Types from '@amplitude/analytics-types';
+export { AmplitudeBrowser } from './browser-client';

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -23,6 +23,7 @@ import {
   setTransport,
   setUserId,
   track,
+  AmplitudeBrowser,
 } from '../src/index';
 
 describe('index', () => {
@@ -51,5 +52,6 @@ describe('index', () => {
     expect(typeof setTransport).toBe('function');
     expect(typeof setUserId).toBe('function');
     expect(typeof track).toBe('function');
+    expect(typeof AmplitudeBrowser).toBe('function');
   });
 });

--- a/packages/unified-sdk/package.json
+++ b/packages/unified-sdk/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@amplitude/unified-sdk",
+  "version": "0.0.0",
+  "description": "Official Amplitude Unified SDK for Web",
+  "keywords": [
+    "amplitude",
+    "analytics",
+    "experiment",
+    "session replay"
+  ],
+  "author": "Amplitude Inc",
+  "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
+  "license": "MIT",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
+  },
+  "scripts": {
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm && ",
+    "bundle": "rollup --config rollup.config.js",
+    "build:es5": "tsc -p ./tsconfig.es5.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "clean": "rimraf node_modules lib coverage",
+    "fix": "yarn fix:eslint & yarn fix:prettier",
+    "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
+    "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
+    "lint": "yarn lint:eslint & yarn lint:prettier",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
+    "playground:html": "cp ./lib/scripts/amplitude-min.js playground/html/amplitude-min.js && http-server ./playground/html",
+    "playground:react-spa": "cp lib/scripts/amplitude-min.js playground/react-spa/public/amplitude.js && cd ./playground/react-spa && yarn install && yarn start",
+    "publish": "node ../../scripts/publish/upload-to-s3.js",
+    "test": "jest",
+    "typecheck": "tsc -p ./tsconfig.json",
+    "version": "yarn version-file && GENERATE_SNIPPET=true yarn build && cp lib/scripts/amplitude-min.js playground/html/amplitude.js && cp lib/scripts/amplitude-min.js playground/react-spa/public/amplitude.js",
+    "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
+  },
+  "bugs": {
+    "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
+  },
+  "dependencies": {
+    "@amplitude/analytics-browser": "^2.3.7",
+    "@amplitude/analytics-types": "^2.8.4",
+    "@amplitude/experiment-js-client": "^1.14.1",
+    "@amplitude/plugin-session-replay-browser": "^1.13.0",
+    "tslib": "^2.4.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^23.0.4",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^10.0.1",
+    "http-server": "^14.1.1",
+    "isomorphic-fetch": "^3.0.0",
+    "rollup": "^2.79.1",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "files": [
+    "lib"
+  ]
+}
+

--- a/packages/unified-sdk/package.json
+++ b/packages/unified-sdk/package.json
@@ -25,7 +25,7 @@
     "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
   },
   "scripts": {
-    "build": "yarn bundle && yarn build:es5 && yarn build:esm && ",
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
     "bundle": "rollup --config rollup.config.js",
     "build:es5": "tsc -p ./tsconfig.es5.json",
     "build:esm": "tsc -p ./tsconfig.esm.json",

--- a/packages/unified-sdk/package.json
+++ b/packages/unified-sdk/package.json
@@ -39,7 +39,6 @@
     "playground:html": "cp ./lib/scripts/amplitude-min.js playground/html/amplitude-min.js && http-server ./playground/html",
     "playground:react-spa": "cp lib/scripts/amplitude-min.js playground/react-spa/public/amplitude.js && cd ./playground/react-spa && yarn install && yarn start",
     "publish": "node ../../scripts/publish/upload-to-s3.js",
-    "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
     "version": "yarn version-file && GENERATE_SNIPPET=true yarn build && cp lib/scripts/amplitude-min.js playground/html/amplitude.js && cp lib/scripts/amplitude-min.js playground/react-spa/public/amplitude.js",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"

--- a/packages/unified-sdk/playground/html/README.md
+++ b/packages/unified-sdk/playground/html/README.md
@@ -5,4 +5,4 @@ This is a demo project for instrumenting events using local Amplitude Unified SD
 1. Run `yarn bundle` to generate the script at `lib/scripts/amplitude-min.js`.
 2. Update API key in `playground/index.html`.
 3. Run `yarn playground:html` to start the server. 
-4. Open [http://localhost:8080](http://localhost:8080) with your browser to see the result.
+4. Open [http://localhost:8080](http://localhost:8080) with your browser and open console to see the result.

--- a/packages/unified-sdk/playground/html/README.md
+++ b/packages/unified-sdk/playground/html/README.md
@@ -1,0 +1,8 @@
+This is a demo project for instrumenting events using local Amplitude Unified SDK in a basic HTML page.
+
+## Getting Started
+
+1. Run `yarn bundle` to generate the script at `lib/scripts/amplitude-min.js`.
+2. Update API key in `playground/index.html`.
+3. Run `yarn playground:html` to start the server. 
+4. Open [http://localhost:8080](http://localhost:8080) with your browser to see the result.

--- a/packages/unified-sdk/playground/html/index.html
+++ b/packages/unified-sdk/playground/html/index.html
@@ -6,12 +6,12 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Amplitude SDK Playground</title>
   </head>
-  <script src="./amplitude-min.umd.js"></script>
+  <script src="./amplitude-min.js"></script>
 	
   <script>
-    const client = new amplitude.AmplitudeUnified()
-    client.init(
+    amplitude.init(
             '5b9a9510e261f9ead90865bbc5a7ad1d',
+            undefined,
             {sampleRate: 1},
             {deploymentKey: '5b9a9510e261f9ead90865bbc5a7ad1d'}
     );

--- a/packages/unified-sdk/playground/html/index.html
+++ b/packages/unified-sdk/playground/html/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Amplitude SDK Playground</title>
+  </head>
+  <script src="./amplitude-min.umd.js"></script>
+	
+  <script>
+    const client = new amplitude.AmplitudeUnified()
+    client.init(
+            '5b9a9510e261f9ead90865bbc5a7ad1d',
+            {sampleRate: 1},
+            {deploymentKey: '5b9a9510e261f9ead90865bbc5a7ad1d'}
+    );
+  </script>
+  <body>
+    <h1>Amplitude SDK Playground</h1>
+    <p>This playground has Amplitude SDK script loaded, initialized, and available as <code>amplitude</code>.</p>
+    <ul>
+      <li>Check if you have a valid API KEY</li>
+      <li>Open Developer Tools</li>
+      <li>Go to Console tab</li>
+      <li>Play with the SDK</li>
+    </ul>
+  </body>
+</html>

--- a/packages/unified-sdk/playground/html/index.html
+++ b/packages/unified-sdk/playground/html/index.html
@@ -7,7 +7,6 @@
     <title>Amplitude SDK Playground</title>
   </head>
   <script src="./amplitude-min.js"></script>
-	
   <script>
     amplitude.init(
             '5b9a9510e261f9ead90865bbc5a7ad1d',
@@ -15,6 +14,15 @@
             {sampleRate: 1},
             {deploymentKey: '5b9a9510e261f9ead90865bbc5a7ad1d'}
     );
+
+    amplitude.track('unified sdk tracked').promise.then((result) => {
+      console.log(`amplitude.track('unified sdk tracked') result: ${JSON.stringify(result, null, 2)}`)
+    });
+
+    amplitude.experiment.fetch().then((client) => {
+      console.log('amplitude.experiment.fetch() result:', client);
+    })
+
   </script>
   <body>
     <h1>Amplitude SDK Playground</h1>

--- a/packages/unified-sdk/rollup.config.js
+++ b/packages/unified-sdk/rollup.config.js
@@ -1,0 +1,3 @@
+import { umd, iife } from '../../scripts/build/rollup.config';
+
+export default [umd, iife];

--- a/packages/unified-sdk/src/index.ts
+++ b/packages/unified-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export { AmplitudeUnified } from './unified-client';

--- a/packages/unified-sdk/src/index.ts
+++ b/packages/unified-sdk/src/index.ts
@@ -1,1 +1,2 @@
 export { AmplitudeUnified } from './unified-client';
+// TODO(xinyi): export destructed unified client. Refer to index.ts in analytics-browser

--- a/packages/unified-sdk/src/snippet-index.ts
+++ b/packages/unified-sdk/src/snippet-index.ts
@@ -1,5 +1,5 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { AmplitudeUnified } from './index';
+import { AmplitudeUnified } from './unified-client';
 
 // https://developer.mozilla.org/en-US/docs/Glossary/IIFE
 (function () {

--- a/packages/unified-sdk/src/snippet-index.ts
+++ b/packages/unified-sdk/src/snippet-index.ts
@@ -1,0 +1,16 @@
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { AmplitudeUnified } from './index';
+
+// https://developer.mozilla.org/en-US/docs/Glossary/IIFE
+(function () {
+  const GlobalScope = getGlobalScope();
+
+  if (!GlobalScope) {
+    console.error('[Amplitude] Error: GlobalScope is not defined');
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  GlobalScope.amplitude = new AmplitudeUnified();
+})();

--- a/packages/unified-sdk/src/unified-client.ts
+++ b/packages/unified-sdk/src/unified-client.ts
@@ -1,0 +1,49 @@
+import { AmplitudeReturn, BrowserOptions, BrowserClient } from '@amplitude/analytics-types';
+import { Client, Experiment, ExperimentConfig } from '@amplitude/experiment-js-client';
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
+import { returnWrapper } from '@amplitude/analytics-core';
+import { SessionReplayOptions } from '@amplitude/plugin-session-replay-browser/lib/scripts/typings/session-replay';
+
+import { createInstance } from '@amplitude/analytics-browser';
+
+interface UnifiedClient {
+  init(
+    apiKey: string,
+    options?: BrowserOptions,
+    srOptions?: SessionReplayOptions,
+    experimentOptions?: { deploymentKey?: string; experimentConfig?: ExperimentConfig },
+  ): AmplitudeReturn<void>;
+}
+
+export class AmplitudeUnified implements UnifiedClient {
+  // init() will always be called and the following will be initialized there
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  analytics: BrowserClient;
+  experiment?: Client;
+
+  init(
+    apiKey: string,
+    options?: BrowserOptions,
+    srOptions?: SessionReplayOptions,
+    experimentOptions?: { deploymentKey: string; experimentConfig?: ExperimentConfig },
+  ) {
+    // Initialize analytics SDK
+    this.analytics = createInstance();
+    this.analytics.init(apiKey, options);
+
+    // Install SR plugin
+    const srPlugin = sessionReplayPlugin(srOptions);
+    this.analytics.add(srPlugin);
+
+    // Initialize experiment SDK
+    if (experimentOptions) {
+      this.experiment = Experiment.initializeWithAmplitudeAnalytics(
+        experimentOptions.deploymentKey,
+        experimentOptions.experimentConfig,
+      );
+    }
+
+    return returnWrapper(Promise.resolve());
+  }
+}

--- a/packages/unified-sdk/src/unified-client.ts
+++ b/packages/unified-sdk/src/unified-client.ts
@@ -1,23 +1,16 @@
-import {
-  AmplitudeReturn,
-  BrowserOptions,
-  BrowserClient,
-  EventOptions,
-  Result,
-  BaseEvent,
-  TransportType,
-  BrowserConfig,
-  Plugin,
-  Identify,
-  Revenue,
-} from '@amplitude/analytics-types';
+import { AmplitudeReturn, BrowserOptions, BrowserClient } from '@amplitude/analytics-types';
 import { Client, Experiment, ExperimentConfig } from '@amplitude/experiment-js-client';
 import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 import { returnWrapper } from '@amplitude/analytics-core';
 import { SessionReplayOptions } from '@amplitude/plugin-session-replay-browser/lib/scripts/typings/session-replay';
-import { createInstance } from '@amplitude/analytics-browser';
+import { AmplitudeBrowser } from '@amplitude/analytics-browser';
 
-interface UnifiedClient extends Omit<BrowserClient, 'init'> {
+interface UnifiedClient extends BrowserClient {
+  // Keep existing ones from BrowserClient
+  // Those only initialize analytics client
+  init(apiKey: string, options?: BrowserOptions): AmplitudeReturn<void>;
+  init(apiKey: string, userId?: string, options?: BrowserOptions): AmplitudeReturn<void>;
+  // Initialize all blades all at once
   init(
     apiKey: string,
     options?: BrowserOptions,
@@ -26,29 +19,62 @@ interface UnifiedClient extends Omit<BrowserClient, 'init'> {
   ): AmplitudeReturn<void>;
 }
 
-export class AmplitudeUnified implements UnifiedClient {
-  analytics: BrowserClient;
-  experiment?: Client;
-
-  constructor() {
-    this.analytics = createInstance();
+// Helpers - type guards
+// TODO(xinyi): should move it to sr package
+function isSessionReplayOptions(obj: unknown): obj is SessionReplayOptions {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
   }
+
+  const o = obj as SessionReplayOptions;
+
+  return (
+    (o.sampleRate === undefined || typeof o.sampleRate === 'number') &&
+    (o.privacyConfig === undefined || typeof o.privacyConfig === 'object') &&
+    (o.debugMode === undefined || typeof o.debugMode === 'boolean') &&
+    (o.forceSessionTracking === undefined || typeof o.forceSessionTracking === 'boolean') &&
+    (o.configServerUrl === undefined || typeof o.configServerUrl === 'string') &&
+    (o.trackServerUrl === undefined || typeof o.trackServerUrl === 'string') &&
+    (o.shouldInlineStylesheet === undefined || typeof o.shouldInlineStylesheet === 'boolean') &&
+    (o.performanceConfig === undefined || typeof o.performanceConfig === 'object') &&
+    (o.storeType === undefined || typeof o.storeType === 'string') &&
+    (o.deviceId === undefined || typeof o.deviceId === 'string') &&
+    (o.customSessionId === undefined || typeof o.customSessionId === 'function') &&
+    (o.experimental === undefined ||
+      (typeof o.experimental === 'object' && typeof o.experimental.useWebWorker === 'boolean'))
+  );
+}
+
+export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient {
+  experiment?: Client;
 
   init(
     apiKey: string,
-    options?: BrowserOptions,
-    srOptions?: SessionReplayOptions,
+    userIdOrOptions?: string | BrowserOptions,
+    analyticsOrSrOptions?: BrowserOptions | SessionReplayOptions,
     experimentOptions?: { deploymentKey: string; experimentConfig?: ExperimentConfig },
   ) {
-    // Initialize analytics SDK
-    this.analytics.init(apiKey, options);
+    if (arguments.length <= 2) {
+      super.init(apiKey, userIdOrOptions);
+      return returnWrapper(Promise.resolve());
+    }
+
+    // eslint-disable-next-line prefer-rest-params
+    if (!isSessionReplayOptions(arguments[2])) {
+      super.init(apiKey, userIdOrOptions, analyticsOrSrOptions);
+      return returnWrapper(Promise.resolve());
+    }
+
+    super.init(apiKey, userIdOrOptions);
 
     // Install SR plugin
-    const srPlugin = sessionReplayPlugin(srOptions);
-    this.analytics.add(srPlugin);
+    // this.config.loggerProvider.debug(`Installing session reply plugin with config: ${JSON.stringify(analyticsOrSrOptions, null, 2)}`);
+    const srPlugin = sessionReplayPlugin(analyticsOrSrOptions);
+    this.add(srPlugin);
 
     // Initialize experiment SDK
     if (experimentOptions) {
+      // this.config.loggerProvider.debug(`Installing experiment SDK with config: ${JSON.stringify(experimentOptions, null, 2)}`);
       this.experiment = Experiment.initializeWithAmplitudeAnalytics(
         experimentOptions.deploymentKey,
         experimentOptions.experimentConfig,
@@ -56,98 +82,5 @@ export class AmplitudeUnified implements UnifiedClient {
     }
 
     return returnWrapper(Promise.resolve());
-  }
-
-  add(plugin: Plugin<BrowserClient, BrowserConfig>): AmplitudeReturn<void> {
-    return this.analytics.add(plugin);
-  }
-
-  extendSession(): void {
-    return this.analytics.extendSession();
-  }
-
-  flush(): AmplitudeReturn<void> {
-    return this.analytics.flush();
-  }
-
-  getDeviceId(): string | undefined {
-    return this.analytics.getDeviceId();
-  }
-
-  getSessionId(): number | undefined {
-    return this.analytics.getSessionId();
-  }
-
-  getUserId(): string | undefined {
-    return this.analytics.getUserId();
-  }
-
-  groupIdentify(
-    groupType: string,
-    groupName: string | string[],
-    identify: Identify,
-    eventOptions: EventOptions | undefined,
-  ): AmplitudeReturn<Result> {
-    return this.analytics.groupIdentify(groupType, groupName, identify, eventOptions);
-  }
-
-  identify(identify: Identify, eventOptions: EventOptions | undefined): AmplitudeReturn<Result> {
-    return this.analytics.identify(identify, eventOptions);
-  }
-
-  logEvent(
-    eventInput: BaseEvent | string,
-    eventProperties: Record<string, any> | undefined,
-    eventOptions: EventOptions | undefined,
-  ): AmplitudeReturn<Result> {
-    return this.analytics.logEvent(eventInput, eventProperties, eventOptions);
-  }
-
-  remove(pluginName: string): AmplitudeReturn<void> {
-    return this.analytics.remove(pluginName);
-  }
-
-  reset(): void {
-    return this.analytics.reset();
-  }
-
-  revenue(revenue: Revenue, eventOptions: EventOptions | undefined): AmplitudeReturn<Result> {
-    return this.analytics.revenue(revenue, eventOptions);
-  }
-
-  setDeviceId(deviceId: string): void {
-    return this.analytics.setDeviceId(deviceId);
-  }
-
-  setGroup(
-    groupType: string,
-    groupName: string | string[],
-    eventOptions: EventOptions | undefined,
-  ): AmplitudeReturn<Result> {
-    return this.analytics.setGroup(groupType, groupName, eventOptions);
-  }
-
-  setOptOut(optOut: boolean): void {
-    return this.analytics.setOptOut(optOut);
-  }
-
-  setSessionId(sessionId: number): void {
-    return this.analytics.setSessionId(sessionId);
-  }
-
-  setTransport(transport: TransportType): void {
-    return this.analytics.setTransport(transport);
-  }
-
-  setUserId(userId: string | undefined): void {
-    return this.analytics.setUserId(userId);
-  }
-
-  track(
-    eventInput: BaseEvent | string,
-    eventProperties: Record<string, any> | undefined,
-    eventOptions: EventOptions | undefined,
-  ): AmplitudeReturn<Result> {
-    return this.analytics.track(eventInput, eventProperties, eventOptions);
   }
 }

--- a/packages/unified-sdk/src/unified-client.ts
+++ b/packages/unified-sdk/src/unified-client.ts
@@ -1,12 +1,23 @@
-import { AmplitudeReturn, BrowserOptions, BrowserClient } from '@amplitude/analytics-types';
+import {
+  AmplitudeReturn,
+  BrowserOptions,
+  BrowserClient,
+  EventOptions,
+  Result,
+  BaseEvent,
+  TransportType,
+  BrowserConfig,
+  Plugin,
+  Identify,
+  Revenue,
+} from '@amplitude/analytics-types';
 import { Client, Experiment, ExperimentConfig } from '@amplitude/experiment-js-client';
 import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 import { returnWrapper } from '@amplitude/analytics-core';
 import { SessionReplayOptions } from '@amplitude/plugin-session-replay-browser/lib/scripts/typings/session-replay';
-
 import { createInstance } from '@amplitude/analytics-browser';
 
-interface UnifiedClient {
+interface UnifiedClient extends Omit<BrowserClient, 'init'> {
   init(
     apiKey: string,
     options?: BrowserOptions,
@@ -16,11 +27,12 @@ interface UnifiedClient {
 }
 
 export class AmplitudeUnified implements UnifiedClient {
-  // init() will always be called and the following will be initialized there
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   analytics: BrowserClient;
   experiment?: Client;
+
+  constructor() {
+    this.analytics = createInstance();
+  }
 
   init(
     apiKey: string,
@@ -29,7 +41,6 @@ export class AmplitudeUnified implements UnifiedClient {
     experimentOptions?: { deploymentKey: string; experimentConfig?: ExperimentConfig },
   ) {
     // Initialize analytics SDK
-    this.analytics = createInstance();
     this.analytics.init(apiKey, options);
 
     // Install SR plugin
@@ -45,5 +56,98 @@ export class AmplitudeUnified implements UnifiedClient {
     }
 
     return returnWrapper(Promise.resolve());
+  }
+
+  add(plugin: Plugin<BrowserClient, BrowserConfig>): AmplitudeReturn<void> {
+    return this.analytics.add(plugin);
+  }
+
+  extendSession(): void {
+    return this.analytics.extendSession();
+  }
+
+  flush(): AmplitudeReturn<void> {
+    return this.analytics.flush();
+  }
+
+  getDeviceId(): string | undefined {
+    return this.analytics.getDeviceId();
+  }
+
+  getSessionId(): number | undefined {
+    return this.analytics.getSessionId();
+  }
+
+  getUserId(): string | undefined {
+    return this.analytics.getUserId();
+  }
+
+  groupIdentify(
+    groupType: string,
+    groupName: string | string[],
+    identify: Identify,
+    eventOptions: EventOptions | undefined,
+  ): AmplitudeReturn<Result> {
+    return this.analytics.groupIdentify(groupType, groupName, identify, eventOptions);
+  }
+
+  identify(identify: Identify, eventOptions: EventOptions | undefined): AmplitudeReturn<Result> {
+    return this.analytics.identify(identify, eventOptions);
+  }
+
+  logEvent(
+    eventInput: BaseEvent | string,
+    eventProperties: Record<string, any> | undefined,
+    eventOptions: EventOptions | undefined,
+  ): AmplitudeReturn<Result> {
+    return this.analytics.logEvent(eventInput, eventProperties, eventOptions);
+  }
+
+  remove(pluginName: string): AmplitudeReturn<void> {
+    return this.analytics.remove(pluginName);
+  }
+
+  reset(): void {
+    return this.analytics.reset();
+  }
+
+  revenue(revenue: Revenue, eventOptions: EventOptions | undefined): AmplitudeReturn<Result> {
+    return this.analytics.revenue(revenue, eventOptions);
+  }
+
+  setDeviceId(deviceId: string): void {
+    return this.analytics.setDeviceId(deviceId);
+  }
+
+  setGroup(
+    groupType: string,
+    groupName: string | string[],
+    eventOptions: EventOptions | undefined,
+  ): AmplitudeReturn<Result> {
+    return this.analytics.setGroup(groupType, groupName, eventOptions);
+  }
+
+  setOptOut(optOut: boolean): void {
+    return this.analytics.setOptOut(optOut);
+  }
+
+  setSessionId(sessionId: number): void {
+    return this.analytics.setSessionId(sessionId);
+  }
+
+  setTransport(transport: TransportType): void {
+    return this.analytics.setTransport(transport);
+  }
+
+  setUserId(userId: string | undefined): void {
+    return this.analytics.setUserId(userId);
+  }
+
+  track(
+    eventInput: BaseEvent | string,
+    eventProperties: Record<string, any> | undefined,
+    eventOptions: EventOptions | undefined,
+  ): AmplitudeReturn<Result> {
+    return this.analytics.track(eventInput, eventProperties, eventOptions);
   }
 }

--- a/packages/unified-sdk/tsconfig.es5.json
+++ b/packages/unified-sdk/tsconfig.es5.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "lib/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/packages/unified-sdk/tsconfig.esm.json
+++ b/packages/unified-sdk/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "es6",
+    "noEmit": false,
+    "outDir": "lib/esm",
+    "rootDir": "./src"
+  }
+}

--- a/packages/unified-sdk/tsconfig.json
+++ b/packages/unified-sdk/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "noEmit": true,
+    "rootDir": ".",
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
   integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
 
+"@amplitude/analytics-connector@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.2.tgz#0c0da82fe4722061591c1c5b75d7f585b95cb292"
+  integrity sha512-9bk2IjyV3VgUdbI3ounKUuP+4u4ABftDWGdOKxshEQrHg6WhgC8V4hdhSHv9wOHebGTvZntRKM5LlSXUyDYBpw==
+  dependencies:
+    "@amplitude/experiment-core" "^0.10.1"
+
 "@amplitude/analytics-remote-config@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.0.tgz#e9835836ef40c6b2e72bc8c7a88803dda5559556"
@@ -17,6 +24,34 @@
     "@amplitude/analytics-types" ">=1 <3"
     tslib "^2.4.1"
 
+"@amplitude/analytics-remote-config@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.6.0.tgz#699b0d6038b33729e5e3432dea7233b3f0c61155"
+  integrity sha512-2VgRG2spUcpoU8IR+CSYJK8ugtYvPOM7EPl+nZ3amYngbF+/ASMx+kJUG+CzlWNz2CvRwP/6ipdhBGhd/p5htg==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-core" ">=1 <3"
+    "@amplitude/analytics-types" ">=1 <3"
+    tslib "^2.4.1"
+
+"@amplitude/experiment-core@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.10.1.tgz#85bb0bf55b419fe1b7bcee428182ed1eda010ff3"
+  integrity sha512-2h0vqOaHoACmNiliGT78hnu9K/tmb7pWU1xw1KitlTtxK6wQqsY/IZPLMwBMG5MLp/AOzNEA/uelODfhBC5+SQ==
+  dependencies:
+    js-base64 "^3.7.5"
+
+"@amplitude/experiment-js-client@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-js-client/-/experiment-js-client-1.14.1.tgz#c86a54d576aa419fcc174745d9395e797927431a"
+  integrity sha512-PUjCSWJXxu5bKXcNPEr+QMPOWy6h4nsc25AN59hiDhepGY5etPEoXMVIuCuynNvsPOgB/aE5F5eYiGv6yNTI+g==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.6.2"
+    "@amplitude/experiment-core" "^0.10.1"
+    "@amplitude/ua-parser-js" "^0.7.31"
+    base64-js "1.5.1"
+    unfetch "4.1.0"
+
 "@amplitude/plugin-autocapture-browser@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.2.tgz#9f983ebab82142311dfe35e77a54c539e8293279"
@@ -25,6 +60,82 @@
     "@amplitude/analytics-client-common" ">=1 <3"
     "@amplitude/analytics-types" ">=1 <3"
     rxjs "^7.8.1"
+    tslib "^2.4.1"
+
+"@amplitude/plugin-session-replay-browser@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-session-replay-browser/-/plugin-session-replay-browser-1.13.0.tgz#bcb96d2824adbeedf84086c9b6683b3e41f1b634"
+  integrity sha512-reBrbfkf6RXmNADSA/9jxEHfMXGgJxP/K84Cwu7NriQooUYJXUpTUYJF3WaVILBJ1vpqBMQsnKTLH1DZQ+r+ug==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-core" ">=1 <3"
+    "@amplitude/analytics-types" ">=1 <3"
+    "@amplitude/session-replay-browser" "^1.19.0"
+    idb-keyval "^6.2.1"
+    tslib "^2.4.1"
+
+"@amplitude/rrdom@^2.0.0-alpha.26":
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/rrdom/-/rrdom-2.0.0-alpha.26.tgz#4a1b6434371a90bf788b47256d35e18fad33bd18"
+  integrity sha512-pxuDZjc86cCrNwjQ+00TYNmVKZHm50wmcCd0u0bHgrasVuRSBWddB5Nt70TyvXC40oelAEDYyJWOoVWU+W+9gA==
+  dependencies:
+    "@amplitude/rrweb-snapshot" "^2.0.0-alpha.26"
+
+"@amplitude/rrweb-packer@2.0.0-alpha.26":
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/rrweb-packer/-/rrweb-packer-2.0.0-alpha.26.tgz#9d34ca929773943a33c342d77a03d0cab91816a3"
+  integrity sha512-uJM5/VFdjLUsKM++pAaXAAxpkBbh3r2Skxjx+3YS4OY49/kjA+KgzX1ottT8niOWQCxPngFgfOwle18z0QBXGA==
+  dependencies:
+    "@amplitude/rrweb-types" "^2.0.0-alpha.26"
+    fflate "^0.4.4"
+
+"@amplitude/rrweb-snapshot@2.0.0-alpha.26", "@amplitude/rrweb-snapshot@^2.0.0-alpha.26":
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.26.tgz#67c1e74e1dbb9a189823daa1b9b9fb8f225e661b"
+  integrity sha512-ZXAqF+fX/0ngyCS8/Iu83FeMMMXuw9FRKFFK6vTUjvXXvFnBx1WjQZLVNJbaZu3hZUN7sECATuOXQklccY/TJw==
+  dependencies:
+    postcss "^8.4.38"
+
+"@amplitude/rrweb-types@^2.0.0-alpha.26":
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/rrweb-types/-/rrweb-types-2.0.0-alpha.26.tgz#e5ff279b8f89e9ccb6cb6a3072906b639a39a48d"
+  integrity sha512-50SnMId2Xp3dGaVAEAQCwF3PkX0As8JSMpBoqrw+0bX8uubUySE4mR/tpv75wQ81JK49ruwrdMcmFWSWLfHA/w==
+  dependencies:
+    "@amplitude/rrweb-snapshot" "^2.0.0-alpha.26"
+
+"@amplitude/rrweb-utils@^2.0.0-alpha.26":
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/rrweb-utils/-/rrweb-utils-2.0.0-alpha.26.tgz#b03b1ecce9cf2a8d3b9608eab245d71919a53bce"
+  integrity sha512-8GHzpI3nqI6GKGGwrBj3TClWqQ4g9TwXlnPZthGbiUgJ1U3mgF06u4e4tsort958IujYZQf0hk6JdLwB9HgvCg==
+
+"@amplitude/rrweb@2.0.0-alpha.26":
+  version "2.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/rrweb/-/rrweb-2.0.0-alpha.26.tgz#0c386131d64f3bdf48a4e6f327e757644c565c20"
+  integrity sha512-VDJc81dNyzYSlC+afCG7kikT6OjiWjxo1o/75jNu67AAxOKRuQkddGn0jiwJDgwMYDmqw6jje0QNufbsTpci2g==
+  dependencies:
+    "@amplitude/rrdom" "^2.0.0-alpha.26"
+    "@amplitude/rrweb-snapshot" "^2.0.0-alpha.26"
+    "@amplitude/rrweb-types" "^2.0.0-alpha.26"
+    "@amplitude/rrweb-utils" "^2.0.0-alpha.26"
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    mitt "^3.0.0"
+
+"@amplitude/session-replay-browser@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/session-replay-browser/-/session-replay-browser-1.19.0.tgz#07b9891afa5dde796f5b0d4b4a099b6cc79b9045"
+  integrity sha512-6WADPKj14vpQP71FUnf6Jq6Mbr1De+/+hOLBu+gXxVXpXyhPvJYm2sd/bkDEutHNgGy9BheXPvrMMNVNFED1NQ==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-core" ">=1 <3"
+    "@amplitude/analytics-remote-config" "^0.6.0"
+    "@amplitude/analytics-types" ">=1 <3"
+    "@amplitude/rrweb" "2.0.0-alpha.26"
+    "@amplitude/rrweb-packer" "2.0.0-alpha.26"
+    "@amplitude/rrweb-snapshot" "2.0.0-alpha.26"
+    "@rollup/plugin-replace" "^6.0.1"
+    idb "^8.0.0"
     tslib "^2.4.1"
 
 "@amplitude/ua-parser-js@^0.7.31":
@@ -2587,6 +2698,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -3277,6 +3393,14 @@
     is-module "^1.0.0"
     resolve "^1.22.1"
 
+"@rollup/plugin-replace@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-6.0.2.tgz#2f565d312d681e4570ff376c55c5c08eb6f1908d"
+  integrity sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
+
 "@rollup/plugin-typescript@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-10.0.1.tgz#270b515b116ea28320e6bb62451c4767d49072d6"
@@ -3451,6 +3575,11 @@
   integrity sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/css-font-loading-module@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz#2f98ede46acc0975de85c0b7b0ebe06041d24601"
+  integrity sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==
 
 "@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.0"
@@ -3699,6 +3828,11 @@
   dependencies:
     "@typescript-eslint/types" "5.46.1"
     eslint-visitor-keys "^3.3.0"
+
+"@xstate/fsm@^1.4.0":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.5.tgz#f599e301997ad7e3c572a0b1ff0696898081bea5"
+  integrity sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -4694,7 +4828,12 @@ base64-arraybuffer-es6@^0.7.0:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz#dbe1e6c87b1bf1ca2875904461a7de40f21abc86"
   integrity sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==
 
-base64-js@^1.1.2, base64-js@^1.3.1:
+base64-arraybuffer@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
+base64-js@1.5.1, base64-js@^1.1.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -6244,6 +6383,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@^0.4.4:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
+
 figures@3.2.0, figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -6974,6 +7118,16 @@ iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+idb-keyval@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
+  integrity sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==
+
+idb@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.2.tgz#349af3974281879889e0572bbb231f978b9f3cf0"
+  integrity sha512-CX70rYhx7GDDQzwwQMDwF6kDRQi5vVs6khHUumDrMecBylKkwvZ8HWvKV08AGb7VbpoGCWUQ4aHzNDgoUiOIUg==
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -7971,6 +8125,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-base64@^3.7.5:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 js-sdsl@^4.1.4:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.2.0.tgz#278e98b7bea589b8baaf048c20aeb19eb7ad09d0"
@@ -8581,6 +8740,13 @@ magic-string@^0.26.4:
   dependencies:
     sourcemap-codec "^1.4.8"
 
+magic-string@^0.30.3:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+
 make-dir@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -9165,6 +9331,11 @@ minizlib@^2.1.1, minizlib@^2.1.2:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
+mitt@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -9225,6 +9396,11 @@ mute-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
+nanoid@^3.3.8:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -9940,6 +10116,11 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -10010,6 +10191,15 @@ postcss-selector-parser@^6.0.10:
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
+
+postcss@^8.4.38:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.1.tgz#e2272a1f8a807fafa413218245630b5db10a3214"
+  integrity sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==
+  dependencies:
+    nanoid "^3.3.8"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -11035,6 +11225,11 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -11757,6 +11952,11 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
+
+unfetch@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-123227](https://amplitude.atlassian.net/browse/AMP-123227)

Initialize analytics, experiment, and SR in one line of code. Example is at `/packages/unified-sdk/playground`
```
<script src="./amplitude-min.js"></script>
  <script>
    amplitude.init(
            '5b9a9510e261f9ead90865bbc5a7ad1d',
            undefined,
            {sampleRate: 1},
            {deploymentKey: '5b9a9510e261f9ead90865bbc5a7ad1d'}
    );


  </script>
```


This PR will be merged in v3.x and will not be published until beta. 

TODOs:
- API key will be cleaned before publish with the jira ticket https://amplitude.atlassian.net/browse/AMP-123458. Leave it here only for easy development and debugging
- Tests will also be added later at https://amplitude.atlassian.net/browse/AMP-123457
- Export `AmplitudeBrowser` from analytics-browser at https://amplitude.atlassian.net/browse/AMP-123503. Using `yarn link` to install local analytics-browser package currently


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-123227]: https://amplitude.atlassian.net/browse/AMP-123227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ