### PR TITLE
fix(plugin-form-interaction-tracking-browser): Access element attributes through getAttribute

### DIFF
--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -56,9 +56,9 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       addEventListener(form, 'change', () => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
-            [FORM_ID]: form.id,
-            [FORM_NAME]: form.name,
-            [FORM_DESTINATION]: form.action,
+            [FORM_ID]: form.getAttribute('id'),
+            [FORM_NAME]: form.getAttribute('name'),
+            [FORM_DESTINATION]: form.getAttribute('action'),
           });
         }
         hasFormChanged = true;
@@ -67,16 +67,16 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       addEventListener(form, 'submit', () => {
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
-            [FORM_ID]: form.id,
-            [FORM_NAME]: form.name,
-            [FORM_DESTINATION]: form.action,
+            [FORM_ID]: form.getAttribute('id'),
+            [FORM_NAME]: form.getAttribute('name'),
+            [FORM_DESTINATION]: form.getAttribute('action'),
           });
         }
 
         amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
-          [FORM_ID]: form.id,
-          [FORM_NAME]: form.name,
-          [FORM_DESTINATION]: form.action,
+          [FORM_ID]: form.getAttribute('id'),
+          [FORM_NAME]: form.getAttribute('name'),
+          [FORM_DESTINATION]: form.getAttribute('action'),
         });
         hasFormChanged = false;
       });

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -33,6 +33,18 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     eventListeners = [];
   };
 
+  // Extracts the form action attribute, and normalizes it to a valid URL to preserve the previous behavior of accessing the action property directly.
+  const extractFormAction = (form: HTMLFormElement): string | null => {
+    let formDestination = form.getAttribute('action');
+    try {
+      // eslint-disable-next-line no-restricted-globals
+      formDestination = new URL(encodeURI(formDestination ?? ''), window.location.href).href;
+    } catch {
+      //
+    }
+    return formDestination;
+  };
+
   const name = '@amplitude/plugin-form-interaction-tracking-browser';
   const type = PluginType.ENRICHMENT;
   const setup = async (config: BrowserConfig, amplitude?: BrowserClient) => {
@@ -55,28 +67,30 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
 
       addEventListener(form, 'change', () => {
         if (!hasFormChanged) {
+          const formDestination = extractFormAction(form);
           amplitude.track(DEFAULT_FORM_START_EVENT, {
             [FORM_ID]: form.getAttribute('id'),
             [FORM_NAME]: form.getAttribute('name'),
-            [FORM_DESTINATION]: form.getAttribute('action'),
+            [FORM_DESTINATION]: formDestination,
           });
         }
         hasFormChanged = true;
       });
 
       addEventListener(form, 'submit', () => {
+        const formDestination = extractFormAction(form);
         if (!hasFormChanged) {
           amplitude.track(DEFAULT_FORM_START_EVENT, {
             [FORM_ID]: form.getAttribute('id'),
             [FORM_NAME]: form.getAttribute('name'),
-            [FORM_DESTINATION]: form.getAttribute('action'),
+            [FORM_DESTINATION]: formDestination,
           });
         }
 
         amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
           [FORM_ID]: form.getAttribute('id'),
           [FORM_NAME]: form.getAttribute('name'),
-          [FORM_DESTINATION]: form.getAttribute('action'),
+          [FORM_DESTINATION]: formDestination,
         });
         hasFormChanged = false;
       });

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -56,6 +56,33 @@ describe('formInteractionTracking', () => {
     expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
+  test('should return current location if form action attribute is missing', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = formInteractionTracking();
+    await plugin.setup(config, amplitude);
+
+    // Remove form action
+    document.getElementById('my-form-id')?.removeAttribute('action');
+
+    // trigger change event
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
+
+    // assert first event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/',
+    });
+
+    // trigger change event again
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
+
+    // assert second event was not tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+  });
+
   test('should track form_start event for a dynamically added form tag', async () => {
     // setup
     const config = createConfigurationMock();


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Instead of accessing an element's attributes through it's object property, access it using `getAttribute()`
This is especially important in form elements where property values can be overridden by it's children inputs with that have an attribute `name` or `id` where the value matches property name.

Ex:
```html
<form action="/form_submit.php">
  <input name="action" />
</form>
```
```js
// console.log(form.action)
// <input name="action" />
```
### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
