### PR TITLE
fix(analytics-browser): form tracking accesses element attributes thr…

### DIFF
--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -62,29 +62,31 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
         let hasFormChanged = false;
 
         addEventListener(form, 'change', () => {
+          const formDestination = extractFormAction(form);
           if (!hasFormChanged) {
             amplitude.track(DEFAULT_FORM_START_EVENT, {
               [FORM_ID]: stringOrUndefined(form.id),
               [FORM_NAME]: stringOrUndefined(form.name),
-              [FORM_DESTINATION]: form.action,
+              [FORM_DESTINATION]: formDestination,
             });
           }
           hasFormChanged = true;
         });
 
         addEventListener(form, 'submit', () => {
+          const formDestination = extractFormAction(form);
           if (!hasFormChanged) {
             amplitude.track(DEFAULT_FORM_START_EVENT, {
               [FORM_ID]: stringOrUndefined(form.id),
               [FORM_NAME]: stringOrUndefined(form.name),
-              [FORM_DESTINATION]: form.action,
+              [FORM_DESTINATION]: formDestination,
             });
           }
 
           amplitude.track(DEFAULT_FORM_SUBMIT_EVENT, {
             [FORM_ID]: stringOrUndefined(form.id),
             [FORM_NAME]: stringOrUndefined(form.name),
-            [FORM_DESTINATION]: form.action,
+            [FORM_DESTINATION]: formDestination,
           });
           hasFormChanged = false;
         });
@@ -142,4 +144,16 @@ export const stringOrUndefined = <T>(name: T): T extends string ? string : undef
   }
 
   return name as T extends string ? string : undefined;
+};
+
+// Extracts the form action attribute, and normalizes it to a valid URL to preserve the previous behavior of accessing the action property directly.
+export const extractFormAction = (form: HTMLFormElement): string | null => {
+  let formDestination = form.getAttribute('action');
+  try {
+    // eslint-disable-next-line no-restricted-globals
+    formDestination = new URL(encodeURI(formDestination ?? ''), window.location.href).href;
+  } catch {
+    //
+  }
+  return formDestination;
 };

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -70,6 +70,30 @@ describe('formInteractionTracking', () => {
     expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
+  test('should return current location if form action attribute is missing', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = formInteractionTracking();
+    await plugin.setup?.(config, amplitude);
+    window.dispatchEvent(new Event('load'));
+
+    // Remove form action
+    document.getElementById('my-form-id')?.removeAttribute('action');
+    // trigger change event
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
+    // assert first event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+    expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
+      [FORM_ID]: 'my-form-id',
+      [FORM_NAME]: 'my-form-name',
+      [FORM_DESTINATION]: 'http://localhost/',
+    });
+    // trigger change event again
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
+    // assert second event was not tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+  });
+
   test('should track form_start event for a dynamically added form tag', async () => {
     // setup
     const config = createConfigurationMock();


### PR DESCRIPTION
…ough getAttribute

Related to fix on v1.x : #958

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Instead of accessing an element's attributes through it's object property, access it using `getAttribute()`
This is especially important in form elements where property values can be overridden by it's children inputs with that have an attribute `name` or `id` where the value matches property name.

Since the attribute returns the relative path instead of the fullly resolved URL, additional logic was added to retain the initial behavior.

Ex:
```html
<form action="/form_submit.php">
  <input name="action" />
</form>
```
```js
// console.log(form.action)
// <input name="action" />
```
### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No