### PR TITLE
feat(session replay): add rrweb log key to prevent infinite depth error

### DIFF
--- a/packages/analytics-core/src/logger.ts
+++ b/packages/analytics-core/src/logger.ts
@@ -5,8 +5,15 @@ const PREFIX = 'Amplitude Logger ';
 export class Logger implements ILogger {
   logLevel: LogLevel;
 
+  private readonly defaultLog: typeof console.log;
+  private readonly defaultWarn: typeof console.warn;
+  private readonly defaultError: typeof console.error;
+
   constructor() {
     this.logLevel = LogLevel.None;
+    this.defaultLog = Logger.getDefaultConsoleMethod(console.log);
+    this.defaultWarn = Logger.getDefaultConsoleMethod(console.warn);
+    this.defaultError = Logger.getDefaultConsoleMethod(console.error);
   }
 
   disable(): void {
@@ -21,21 +28,22 @@ export class Logger implements ILogger {
     if (this.logLevel < LogLevel.Verbose) {
       return;
     }
-    console.log(`${PREFIX}[Log]: ${args.join(' ')}`);
+
+    this.defaultLog(`${PREFIX}[Log]: ${args.join(' ')}`);
   }
 
   warn(...args: any[]): void {
     if (this.logLevel < LogLevel.Warn) {
       return;
     }
-    console.warn(`${PREFIX}[Warn]: ${args.join(' ')}`);
+    this.defaultWarn(`${PREFIX}[Warn]: ${args.join(' ')}`);
   }
 
   error(...args: any[]): void {
     if (this.logLevel < LogLevel.Error) {
       return;
     }
-    console.error(`${PREFIX}[Error]: ${args.join(' ')}`);
+    this.defaultError(`${PREFIX}[Error]: ${args.join(' ')}`);
   }
 
   debug(...args: any[]): void {
@@ -43,6 +51,10 @@ export class Logger implements ILogger {
       return;
     }
     // console.debug output is hidden by default in chrome
-    console.log(`${PREFIX}[Debug]: ${args.join(' ')}`);
+    this.defaultLog(`${PREFIX}[Debug]: ${args.join(' ')}`);
+  }
+
+  private static getDefaultConsoleMethod<T extends (...args: any[]) => void>(method: T): T {
+    return (method as { __rrweb_original__?: T })['__rrweb_original__'] || method;
   }
 }


### PR DESCRIPTION
### Summary

Need to add an additional key to prevent errors related to console tracking. Ref: [comments](https://github.com/amplitude/Amplitude-TypeScript/pull/961/commits/0de8d6f60c4726f8dc6bb4ee09a644887035f554#r1960748716)

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
