### PR TITLE
fix(analytics-core): should not flush until previous request resolves

### DIFF
--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@amplitude/analytics-client-common';
 import { WebAttribution } from '@amplitude/analytics-client-common/src';
 import * as core from '@amplitude/analytics-core';
-import { AutocaptureOptions, LogLevel, OfflineDisabled, UserSession } from '@amplitude/analytics-types';
+import { AutocaptureOptions, LogLevel, OfflineDisabled, Status, UserSession } from '@amplitude/analytics-types';
 import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
 import * as autocapture from '@amplitude/plugin-autocapture-browser';
 import { AmplitudeBrowser } from '../src/browser-client';
@@ -817,6 +817,20 @@ describe('browser-client', () => {
       // assert sessionId is set
       expect(client.config.sessionId).toBe(firstSessionId);
       expect(client.config.lastEventTime).toBeUndefined();
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      jest.spyOn(client.config.transportProvider, 'send').mockReturnValue(
+        Promise.resolve({
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        }),
+      );
 
       // send an event
       await client.track('test 1').promise;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -122,6 +122,10 @@ export class Destination implements DestinationPlugin {
     }
 
     if (this.scheduleId === null || (this.scheduleId && timeout > this.scheduledTimeout)) {
+      if (this.scheduleId) {
+        clearTimeout(this.scheduleId);
+      }
+      this.scheduledTimeout = timeout;
       this.scheduleId = setTimeout(() => {
         this.queue = this.queue.map((context) => {
           context.timeout = 0;

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -146,14 +146,14 @@ export class Destination implements DestinationPlugin {
 
     const batches = chunk(list, this.config.flushQueueSize);
 
+    this.scheduleTryable(later);
+
     // Promise.all() doesn't guarantee resolve order.
     // Sequentially resolve to make sure backend receives events in order
     await batches.reduce(async (promise, batch) => {
       await promise;
       return await this.send(batch, useRetry);
     }, Promise.resolve());
-
-    this.scheduleTryable(later);
 
     if (this.scheduled) {
       clearTimeout(this.scheduled);

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -52,7 +52,16 @@ export class Destination implements DestinationPlugin {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   config: Config;
-  private scheduled: ReturnType<typeof setTimeout> | null = null;
+  // Indicator of whether events that are scheduled (but not flushed yet).
+  // When flush:
+  //   1. assign `scheduleId` to `flushId`
+  //   2. set `scheduleId` to null
+  scheduleId: ReturnType<typeof setTimeout> | null = null;
+  // Timeout in milliseconds of current schedule
+  scheduledTimeout = 0;
+  // Indicator of whether current flush resolves.
+  // When flush resolves, set `flushId` to null
+  flushId: ReturnType<typeof setTimeout> | null = null;
   queue: Context[] = [];
 
   async setup(config: Config): Promise<undefined> {
@@ -80,14 +89,16 @@ export class Destination implements DestinationPlugin {
         callback: (result: Result) => resolve(result),
         timeout: 0,
       };
-      void this.addToQueue(context);
+      this.queue.push(context);
+      this.schedule(this.config.flushIntervalMillis);
+      this.saveEvents();
     });
   }
 
-  getTryableList(list: Context[]) {
+  removeEventsExceedFlushMaxRetries(list: Context[]) {
     return list.filter((context) => {
+      context.attempts += 1;
       if (context.attempts < this.config.flushMaxRetries) {
-        context.attempts += 1;
         return true;
       }
       void this.fulfillRequest([context], 500, MAX_RETRIES_EXCEEDED_MESSAGE);
@@ -95,58 +106,62 @@ export class Destination implements DestinationPlugin {
     });
   }
 
-  scheduleTryable(list: Context[], shouldAddToQueue = false) {
+  scheduleEvents(list: Context[]) {
     list.forEach((context) => {
-      // Only need to concat the queue for the first time
-      if (shouldAddToQueue) {
-        this.queue = this.queue.concat(context);
-      }
-      if (context.timeout === 0) {
-        this.schedule(this.config.flushIntervalMillis);
-        return;
-      }
-
-      setTimeout(() => {
-        context.timeout = 0;
-        this.schedule(0);
-      }, context.timeout);
+      this.schedule(context.timeout === 0 ? this.config.flushIntervalMillis : context.timeout);
     });
   }
 
-  addToQueue(...list: Context[]) {
-    const tryable = this.getTryableList(list);
-    this.scheduleTryable(tryable, true);
-    this.saveEvents();
-  }
-
+  // Schedule a flush in timeout when
+  // 1. No schedule
+  // 2. Timeout greater than existing timeout.
+  // This makes sure that when throttled, no flush when throttle timeout expires.
   schedule(timeout: number) {
-    if (this.scheduled || this.config.offline) {
+    if (this.config.offline) {
       return;
     }
 
-    this.scheduled = setTimeout(() => {
-      void this.flush(true).then(() => {
-        if (this.queue.length > 0) {
-          this.schedule(timeout);
-        }
-      });
-    }, timeout);
+    if (this.scheduleId === null || (this.scheduleId && timeout > this.scheduledTimeout)) {
+      this.scheduleId = setTimeout(() => {
+        this.queue = this.queue.map((context) => {
+          context.timeout = 0;
+          return context;
+        });
+        void this.flush(true);
+      }, timeout);
+      return;
+    }
   }
 
+  // Mark current schedule is flushed.
+  resetSchedule() {
+    this.scheduleId = null;
+    this.scheduledTimeout = 0;
+  }
+
+  // Flush all events regardless of their timeout
   async flush(useRetry = false) {
     // Skip flush if offline
     if (this.config.offline) {
+      this.resetSchedule();
       this.config.loggerProvider.debug('Skipping flush while offline.');
       return;
     }
+
+    if (this.flushId) {
+      this.resetSchedule();
+      this.config.loggerProvider.debug('Skipping flush because previous flush has not resolved.');
+      return;
+    }
+
+    this.flushId = this.scheduleId;
+    this.resetSchedule();
 
     const list: Context[] = [];
     const later: Context[] = [];
     this.queue.forEach((context) => (context.timeout === 0 ? list.push(context) : later.push(context)));
 
     const batches = chunk(list, this.config.flushQueueSize);
-
-    this.scheduleTryable(later);
 
     // Promise.all() doesn't guarantee resolve order.
     // Sequentially resolve to make sure backend receives events in order
@@ -155,10 +170,10 @@ export class Destination implements DestinationPlugin {
       return await this.send(batch, useRetry);
     }, Promise.resolve());
 
-    if (this.scheduled) {
-      clearTimeout(this.scheduled);
-      this.scheduled = null;
-    }
+    // Mark current flush is done
+    this.flushId = null;
+
+    this.scheduleEvents(this.queue);
   }
 
   async send(list: Context[], useRetry = true) {
@@ -264,8 +279,8 @@ export class Destination implements DestinationPlugin {
       this.config.loggerProvider.warn(getResponseBodyString(res));
     }
 
-    const tryable = this.getTryableList(retry);
-    this.scheduleTryable(tryable);
+    const tryable = this.removeEventsExceedFlushMaxRetries(retry);
+    this.scheduleEvents(tryable);
   }
 
   handlePayloadTooLargeResponse(res: PayloadTooLargeResponse, list: Context[]) {
@@ -279,8 +294,8 @@ export class Destination implements DestinationPlugin {
 
     this.config.flushQueueSize /= 2;
 
-    const tryable = this.getTryableList(list);
-    this.scheduleTryable(tryable);
+    const tryable = this.removeEventsExceedFlushMaxRetries(list);
+    this.scheduleEvents(tryable);
   }
 
   handleRateLimitResponse(res: RateLimitResponse, list: Context[]) {
@@ -310,8 +325,8 @@ export class Destination implements DestinationPlugin {
       this.config.loggerProvider.warn(getResponseBodyString(res));
     }
 
-    const tryable = this.getTryableList(retry);
-    this.scheduleTryable(tryable);
+    const tryable = this.removeEventsExceedFlushMaxRetries(retry);
+    this.scheduleEvents(tryable);
   }
 
   handleOtherResponse(list: Context[]) {
@@ -320,8 +335,8 @@ export class Destination implements DestinationPlugin {
       return context;
     });
 
-    const tryable = this.getTryableList(later);
-    this.scheduleTryable(tryable);
+    const tryable = this.removeEventsExceedFlushMaxRetries(later);
+    this.scheduleEvents(tryable);
   }
 
   fulfillRequest(list: Context[], code: number, message: string) {

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -144,11 +144,6 @@ export class Destination implements DestinationPlugin {
     const later: Context[] = [];
     this.queue.forEach((context) => (context.timeout === 0 ? list.push(context) : later.push(context)));
 
-    if (this.scheduled) {
-      clearTimeout(this.scheduled);
-      this.scheduled = null;
-    }
-
     const batches = chunk(list, this.config.flushQueueSize);
 
     // Promise.all() doesn't guarantee resolve order.
@@ -159,6 +154,11 @@ export class Destination implements DestinationPlugin {
     }, Promise.resolve());
 
     this.scheduleTryable(later);
+
+    if (this.scheduled) {
+      clearTimeout(this.scheduled);
+      this.scheduled = null;
+    }
   }
 
   async send(list: Context[], useRetry = true) {

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -861,7 +861,7 @@ describe('destination', () => {
       });
       void destination.execute({ event_type: 'event_type_1' });
 
-      await wait(2500);
+      await wait(2500 + 100);
 
       expect(request1Payload.events.length).toBe(1);
       expect(request1Payload.events[0].event_type).toBe('event_type_1');

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -759,8 +759,8 @@ describe('destination', () => {
     //  0       -> event_type_1
     //  1000    -> flush() because of flush interval -> request1
     //  1050    -> event_type_2
-    //  2000    -> no flush() because request1 hasn't fulfilled
-    //  2100    -> request1 fulfilled
+    //  2000    -> no flush() because request1 hasn't resolved
+    //  2100    -> request1 resolved
     //  3000    -> flush() with only event2
     test('should schedule another flush after the previous resolves', async () => {
       const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -811,29 +811,6 @@ describe('destination', () => {
       expect(transportProvider.send).toHaveBeenCalledTimes(2);
     });
 
-    test('should handle unexpected error', async () => {
-      class Http {
-        send = jest.fn().mockImplementationOnce(() => {
-          return Promise.resolve(null);
-        });
-      }
-      const transportProvider = new Http();
-      const destination = new Destination();
-      const config = {
-        ...useDefaultConfig(),
-        flushQueueSize: 2,
-        flushIntervalMillis: 500,
-        transportProvider,
-      };
-      await destination.setup(config);
-      const result = await destination.execute({
-        event_type: 'event_type',
-      });
-      expect(result.code).toBe(0);
-      expect(result.message).toBe(UNEXPECTED_ERROR_MESSAGE);
-      expect(transportProvider.send).toHaveBeenCalledTimes(1);
-    });
-
     // timeline:
     //  0       -> setup with event2 with timeout 1200
     //             event1 tracked
@@ -894,6 +871,29 @@ describe('destination', () => {
       expect(request2Payload.events.length).toBe(1);
       expect(request2Payload.events[0].event_type).toBe('event_type_2');
       expect(transportProvider.send).toHaveBeenCalledTimes(2);
+    });
+
+    test('should handle unexpected error', async () => {
+      class Http {
+        send = jest.fn().mockImplementationOnce(() => {
+          return Promise.resolve(null);
+        });
+      }
+      const transportProvider = new Http();
+      const destination = new Destination();
+      const config = {
+        ...useDefaultConfig(),
+        flushQueueSize: 2,
+        flushIntervalMillis: 500,
+        transportProvider,
+      };
+      await destination.setup(config);
+      const result = await destination.execute({
+        event_type: 'event_type',
+      });
+      expect(result.code).toBe(0);
+      expect(result.message).toBe(UNEXPECTED_ERROR_MESSAGE);
+      expect(transportProvider.send).toHaveBeenCalledTimes(1);
     });
 
     test('should not retry with invalid api key', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

##  Fix: should not flush until previous request resolves
This PR fixes https://github.com/amplitude/Amplitude-TypeScript/issues/963

When network is bad, for example, 3G, a network request takes time greater than flush interval to resolve, the SDK shouldn't keep sending events before the previous request.

Current behavior:
0       -> event1, schedule(1000)
1000    -> flush(event1)
1050    -> event2, schedule
**2000    -> flush(event1 + event2)**
2100    -> request1 resolve


Expected behavior:
0       -> event1, schedule(1000)
1000    -> flush(event1)
1050    -> event2, schedule(1000)
2050 (1050 + 1000)   -> no flush(event2) because request1 has not resolved
2200(1000 + 1200)    -> request1 resolved, schedule(1000)
3200    -> flush(event2)


## Refactor destination 

![image](https://github.com/user-attachments/assets/9f31a857-2163-46d5-8195-a00f034584ce)


- Introduce 2 schedule indicators in blue
  - scheduleTimeout: the timeout of the current schedule. If there is a schedule with flush interval (by default 1s), but the SDK gets a rate limit, then the SDK should not flush the current schedule, but instead should respect the throttled timeout (30). 
  - scheduleId: whether there is a flush scheduled.
  - They are reset in flush() to indicate that the schedule job is done
- Introduce 1 flush indicator in pink
  - flushId: whether there is a flush in progress
  - reset when it's finished
- Now Every function has a clear functionality. Detangle the mess of timers. 


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
