### PR TITLE
feat: moves groups to eventoptions type

### DIFF
--- a/packages/analytics-types/src/base-event.ts
+++ b/packages/analytics-types/src/base-event.ts
@@ -6,7 +6,6 @@ export interface BaseEvent extends EventOptions {
   event_properties?: { [key: string]: any } | undefined;
   user_properties?: { [key: string]: any } | undefined;
   group_properties?: { [key: string]: any } | undefined;
-  groups?: { [key: string]: any } | undefined;
 }
 
 export interface EventOptions {
@@ -50,4 +49,5 @@ export interface EventOptions {
   user_agent?: string;
   android_app_set_id?: string;
   extra?: { [key: string]: any };
+  groups?: { [key: string]: any } | undefined;
 }


### PR DESCRIPTION
### Summary

* Moves groups to EventOptions from BaseEvent
* Should not be a breaking change because BaseEvent still has groups

> w/o it, i can't instrument group level events using ampli cause eventoptions don't have the groups key and baseevent isn't part of the params 😬 so for example

```
ampli.pageViewed(
  { path: 'home' },
  { groups: { 'org id': 'orgId' }}
)
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
