### PR TITLE
ci: update publish-v2 to use node node 18.17.x

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -34,7 +34,7 @@ jobs:
       RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
     strategy:
       matrix:
-        node-version: [18.15.x]
+        node-version: [18.17.x]
 
     steps:
       - name: Check out git repository


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

![image](https://github.com/user-attachments/assets/1e61b760-faab-4c1a-8a06-7c796df91ed1)


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
