### PR TITLE
ci: remove noImplicitUseStrict as it's deprecated in ts 5.5

### DIFF
--- a/packages/analytics-react-native/tsconfig.json
+++ b/packages/analytics-react-native/tsconfig.json
@@ -12,7 +12,6 @@
     "lib": ["esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
-    "noImplicitUseStrict": false,
     "noStrictGenericChecks": false,
     "skipLibCheck": true,
     "target": "es6"

--- a/packages/plugin-session-replay-react-native/tsconfig.json
+++ b/packages/plugin-session-replay-react-native/tsconfig.json
@@ -12,7 +12,6 @@
     "lib": ["esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
-    "noImplicitUseStrict": false,
     "noStrictGenericChecks": false,
     "skipLibCheck": true,
     "target": "es6"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitUseStrict": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

```
$ tsc -p ./tsconfig.es5.json
tsconfig.es5.json:4:3 - error TS5101: Option 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
```

According to https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#deprecations-and-default-changes, `noImplicitUseStrict` is deprecated in ts 5.0 and removed in ts 5.5. This setting no longer has any effect, meaning 
 it's now `"noImplicitUseStrict": false` and not configurable, and ts will always insert "user strict" at the top of modules ( all modules will be treated as strict mode js).

The root yarn.lock uses typescript 5.5.2 https://github.com/amplitude/Amplitude-TypeScript/blob/a9463e89a750d11163ecfd120e34e7498422bbfc/yarn.lock#L13551-L13554


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
