### PR TITLE
chore(analytics-remote-config): update package.json

### DIFF
--- a/packages/analytics-remote-config/package.json
+++ b/packages/analytics-remote-config/package.json
@@ -31,15 +31,13 @@
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\" @amplitude/analytics-core@\">=1 <3\"",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": ">=1 <3",
-    "@amplitude/analytics-core": ">=1 <3",
+    "@amplitude/analytics-core": ">=1 <2",
     "@amplitude/analytics-types": ">=1 <2",
     "tslib": "^2.4.1"
   },


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Delete `version` command as it shouldn't reinstall dependencies. And that's why publish-v2 fails
```
src/config/joined-config.ts:198:5 - error TS2322: Type 'SessionReplayLocalConfig' is not assignable to type 'Config'.
  Types of property 'serverZone' are incompatible.
    Type '"US" | "EU" | "STAGING" | undefined' is not assignable to type 'ServerZoneType | undefined'.
      Type '"STAGING"' is not assignable to type 'ServerZoneType | undefined'.
198     localConfig,
        ~~~~~~~~~~~
  ../analytics-remote-config/lib/esm/types.d.ts:32:5
    32     localConfig: Config;
           ~~~~~~~~~~~
    The expected type comes from property 'localConfig' which is declared here on type '{ localConfig: Config; configKeys: string[]; }'
```
- Delete analytics-client-common as it's not used

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
