### PR TITLE
fix: plugin remove should only remove plugin if it exists

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -92,7 +92,7 @@ export class AmplitudeCore implements CoreClient {
       this.q.push(this.remove.bind(this, pluginName));
       return returnWrapper();
     }
-    return returnWrapper(this.timeline.deregister(pluginName));
+    return returnWrapper(this.timeline.deregister(pluginName, this.config));
   }
 
   dispatchWithCallback(event: Event, callback: (result: Result) => void): void {

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -27,8 +27,12 @@ export class Timeline {
     this.plugins.push(plugin);
   }
 
-  async deregister(pluginName: string) {
+  async deregister(pluginName: string, config: Config) {
     const index = this.plugins.findIndex((plugin) => plugin.name === pluginName);
+    if (index === -1) {
+      config.loggerProvider.warn(`Plugin with name ${pluginName} does not exist, skipping deregistration`);
+      return;
+    }
     const plugin = this.plugins[index];
     this.plugins.splice(index, 1);
     await plugin.teardown?.();

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -12,6 +12,37 @@ describe('timeline', () => {
     timeline = new Timeline(new AmplitudeCore());
   });
 
+  describe('deregister', () => {
+    const config = useDefaultConfig();
+    const enrichmentSetup = jest.fn().mockReturnValue(Promise.resolve());
+    const enrichmentExecute = jest.fn().mockImplementation((event: Event) =>
+      Promise.resolve({
+        ...event,
+        user_id: '2',
+      }),
+    );
+    const enrichment: Plugin = {
+      name: 'plugin:enrichment',
+      type: PluginType.ENRICHMENT,
+      setup: enrichmentSetup,
+      execute: enrichmentExecute,
+    };
+
+    test('should remove plugin correctly', async () => {
+      await timeline.register(enrichment, config);
+      expect(timeline.plugins.length).toBe(1);
+      await timeline.deregister('plugin:enrichment', config);
+      expect(timeline.plugins.length).toBe(0);
+    });
+
+    test('should only remove plugin that was already registered', async () => {
+      await timeline.register(enrichment, config);
+      expect(timeline.plugins.length).toBe(1);
+      await timeline.deregister('bad-test-plugin', config);
+      expect(timeline.plugins.length).toBe(1);
+    });
+  });
+
   describe('reset', () => {
     test('should reset timeline', () => {
       const timeline = new Timeline(new AmplitudeCore());
@@ -138,9 +169,9 @@ describe('timeline', () => {
     expect(destinationExecute).toHaveBeenCalledTimes(10);
 
     // deregister
-    await timeline.deregister(before.name);
-    await timeline.deregister(enrichment.name);
-    await timeline.deregister(destination.name);
+    await timeline.deregister(before.name, config);
+    await timeline.deregister(enrichment.name, config);
+    await timeline.deregister(destination.name, config);
     expect(timeline.plugins.length).toBe(0);
   });
 
@@ -173,7 +204,7 @@ describe('timeline', () => {
       const config = useDefaultConfig();
       await timeline.register(before, config);
       await timeline.apply(undefined);
-      await timeline.deregister(before.name);
+      await timeline.deregister(before.name, config);
       expect(beforeExecute).toHaveBeenCalledTimes(0);
     });
 
@@ -223,9 +254,9 @@ describe('timeline', () => {
       const callback = jest.fn();
       await timeline.apply([event, callback]);
 
-      await timeline.deregister(before.name);
-      await timeline.deregister(enrichment.name);
-      await timeline.deregister(destination.name);
+      await timeline.deregister(before.name, config);
+      await timeline.deregister(enrichment.name, config);
+      await timeline.deregister(destination.name, config);
 
       expect(beforeExecute).toHaveBeenCalledTimes(1);
       expect(enrichmentExecute).toHaveBeenCalledTimes(1);
@@ -295,11 +326,11 @@ describe('timeline', () => {
       const callback = jest.fn();
       await timeline.apply([event, callback]);
 
-      await timeline.deregister(before1.name);
-      await timeline.deregister(before2.name);
-      await timeline.deregister(before3.name);
-      await timeline.deregister(enrichment.name);
-      await timeline.deregister(destination.name);
+      await timeline.deregister(before1.name, config);
+      await timeline.deregister(before2.name, config);
+      await timeline.deregister(before3.name, config);
+      await timeline.deregister(enrichment.name, config);
+      await timeline.deregister(destination.name, config);
 
       expect(beforeExecute1).toHaveBeenCalledTimes(1);
       expect(beforeExecute2).toHaveBeenCalledTimes(1);
@@ -371,11 +402,11 @@ describe('timeline', () => {
       const callback = jest.fn();
       await timeline.apply([event, callback]);
 
-      await timeline.deregister(before.name);
-      await timeline.deregister(enrichment1.name);
-      await timeline.deregister(enrichment2.name);
-      await timeline.deregister(enrichment3.name);
-      await timeline.deregister(destination.name);
+      await timeline.deregister(before.name, config);
+      await timeline.deregister(enrichment1.name, config);
+      await timeline.deregister(enrichment2.name, config);
+      await timeline.deregister(enrichment3.name, config);
+      await timeline.deregister(destination.name, config);
 
       expect(beforeExecute).toHaveBeenCalledTimes(1);
       expect(enrichmentExecute1).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Summary

Replicating the fix that we did on the main branch for v1.x as well

https://github.com/amplitude/Amplitude-TypeScript/pull/936/files

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
