### PR TITLE
feat(analytics-core): merge analytics-client-common 

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -45,7 +45,6 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^2.3.8",
     "@amplitude/analytics-core": "^2.5.6",
     "@amplitude/analytics-remote-config": "^0.4.0",
     "@amplitude/analytics-types": "^2.9.0",

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -1,22 +1,27 @@
-import { AmplitudeCore, Destination, Identify, returnWrapper, Revenue, UUID } from '@amplitude/analytics-core';
 import {
+  AmplitudeCore,
+  Destination,
+  Identify,
+  returnWrapper,
+  Revenue,
+  UUID,
   getAnalyticsConnector,
+  setConnectorDeviceId,
+  setConnectorUserId,
   getAttributionTrackingConfig,
   getPageViewTrackingConfig,
   getElementInteractionsConfig,
-  IdentityEventSender,
   isAttributionTrackingEnabled,
   isSessionTrackingEnabled,
   isFileDownloadTrackingEnabled,
   isFormInteractionTrackingEnabled,
   isElementInteractionsEnabled,
-  setConnectorDeviceId,
-  setConnectorUserId,
-  isNewSession,
   isPageViewTrackingEnabled,
+  isNewSession,
+  IdentityEventSender,
   WebAttribution,
   getQueryParams,
-} from '@amplitude/analytics-client-common';
+} from '@amplitude/analytics-core';
 import {
   BrowserClient,
   BrowserConfig,

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -16,8 +16,16 @@ import {
   OfflineDisabled,
   AutocaptureOptions,
 } from '@amplitude/analytics-types';
-import { Config, Logger, MemoryStorage, UUID } from '@amplitude/analytics-core';
-import { CookieStorage, getCookieName, FetchTransport, getQueryParams } from '@amplitude/analytics-client-common';
+import {
+  Config,
+  Logger,
+  MemoryStorage,
+  UUID,
+  CookieStorage,
+  getCookieName,
+  FetchTransport,
+  getQueryParams,
+} from '@amplitude/analytics-core';
 
 import { LocalStorage } from './storage/local-storage';
 import { SessionStorage } from './storage/session-storage';

--- a/packages/analytics-browser/src/cookie-migration/index.ts
+++ b/packages/analytics-browser/src/cookie-migration/index.ts
@@ -1,5 +1,5 @@
 import { Storage, UserSession } from '@amplitude/analytics-types';
-import { getOldCookieName } from '@amplitude/analytics-client-common';
+import { getOldCookieName } from '@amplitude/analytics-core';
 
 export const parseLegacyCookies = async (
   apiKey: string,

--- a/packages/analytics-browser/src/gtm-snippet-index.ts
+++ b/packages/analytics-browser/src/gtm-snippet-index.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import * as amplitudeGTM from './index';
 import { createInstance } from './browser-client-factory';
 import { runQueuedFunctions } from './utils/snippet-helper';

--- a/packages/analytics-browser/src/plugins/context.ts
+++ b/packages/analytics-browser/src/plugins/context.ts
@@ -1,6 +1,5 @@
 import { BeforePlugin, BrowserConfig, Event } from '@amplitude/analytics-types';
-import { UUID } from '@amplitude/analytics-core';
-import { getLanguage } from '@amplitude/analytics-client-common';
+import { UUID, getLanguage } from '@amplitude/analytics-core';
 import { VERSION } from '../version';
 import { LIBPREFIX } from '../lib-prefix';
 

--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -1,7 +1,7 @@
 import { BrowserClient, Event, EnrichmentPlugin } from '@amplitude/analytics-types';
 import { DEFAULT_FILE_DOWNLOAD_EVENT, FILE_EXTENSION, FILE_NAME, LINK_ID, LINK_TEXT, LINK_URL } from '../constants';
 import { BrowserConfig } from '../config';
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 
 interface EventListener {
   element: Element;

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -7,7 +7,7 @@ import {
   FORM_DESTINATION,
 } from '../constants';
 import { BrowserConfig } from '../config';
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 
 interface EventListener {
   element: Element;

--- a/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import { BeforePlugin, BrowserClient } from '@amplitude/analytics-types';
 import { BrowserConfig } from 'src/config';
 

--- a/packages/analytics-browser/src/session.ts
+++ b/packages/analytics-browser/src/session.ts
@@ -1,0 +1,6 @@
+export const isNewSession = (sessionTimeout: number, lastEventTime: number = Date.now()): boolean => {
+  const currentTime = Date.now();
+  const timeSinceLastEvent = currentTime - lastEventTime;
+
+  return timeSinceLastEvent > sessionTimeout;
+};

--- a/packages/analytics-browser/src/session.ts
+++ b/packages/analytics-browser/src/session.ts
@@ -1,6 +1,0 @@
-export const isNewSession = (sessionTimeout: number, lastEventTime: number = Date.now()): boolean => {
-  const currentTime = Date.now();
-  const timeSinceLastEvent = currentTime - lastEventTime;
-
-  return timeSinceLastEvent > sessionTimeout;
-};

--- a/packages/analytics-browser/src/snippet-index.ts
+++ b/packages/analytics-browser/src/snippet-index.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import * as amplitude from './index';
 import { createInstance } from './browser-client-factory';
 import { runQueuedFunctions } from './utils/snippet-helper';

--- a/packages/analytics-browser/src/storage/local-storage.ts
+++ b/packages/analytics-browser/src/storage/local-storage.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import { BrowserStorage } from './browser-storage';
 import { Logger } from '@amplitude/analytics-types';
 

--- a/packages/analytics-browser/src/storage/session-storage.ts
+++ b/packages/analytics-browser/src/storage/session-storage.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import { BrowserStorage } from './browser-storage';
 
 export class SessionStorage<T> extends BrowserStorage<T> {

--- a/packages/analytics-browser/src/transports/send-beacon.ts
+++ b/packages/analytics-browser/src/transports/send-beacon.ts
@@ -1,5 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { BaseTransport } from '@amplitude/analytics-core';
+import { BaseTransport, getGlobalScope } from '@amplitude/analytics-core';
 import { Payload, Response, Transport } from '@amplitude/analytics-types';
 
 export class SendBeaconTransport extends BaseTransport implements Transport {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1,11 +1,10 @@
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 import {
   CookieStorage,
   FetchTransport,
   getAnalyticsConnector,
   getCookieName,
-} from '@amplitude/analytics-client-common';
-import { WebAttribution } from '@amplitude/analytics-client-common/src';
+  WebAttribution,
+} from '@amplitude/analytics-core';
 import * as core from '@amplitude/analytics-core';
 import { AutocaptureOptions, LogLevel, OfflineDisabled, Status, UserSession } from '@amplitude/analytics-types';
 import * as pageViewTracking from '@amplitude/plugin-page-view-tracking-browser';
@@ -406,7 +405,7 @@ describe('browser-client', () => {
     });
 
     test('should not support offline mode if global scope returns undefined', async () => {
-      const getGlobalScopeMock = jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValueOnce(undefined);
+      const getGlobalScopeMock = jest.spyOn(core, 'getGlobalScope').mockReturnValueOnce(undefined);
       const addEventListenerMock = jest.spyOn(window, 'addEventListener');
 
       await client.init(apiKey, {
@@ -1169,7 +1168,7 @@ describe('browser-client', () => {
 
       client.webAttribution = new WebAttribution({}, { ...client.config, lastEventTime: undefined });
       client.webAttribution.shouldTrackNewCampaign = true;
-      jest.spyOn(AnalyticsClientCommon, 'isNewSession').mockReturnValueOnce(false);
+      jest.spyOn(core, 'isNewSession').mockReturnValueOnce(false);
       await client.process({
         event_type: 'event',
       });

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -3,15 +3,14 @@ import * as LocalStorageModule from '../src/storage/local-storage';
 import * as SessionStorageModule from '../src/storage/session-storage';
 import * as core from '@amplitude/analytics-core';
 import { LogLevel, Storage, UserSession } from '@amplitude/analytics-types';
-import * as BrowserUtils from '@amplitude/analytics-client-common';
-import { getCookieName, FetchTransport } from '@amplitude/analytics-client-common';
+import * as BrowserUtils from '@amplitude/analytics-core';
 import { XHRTransport } from '../src/transports/xhr';
 import { createTransport } from '../src/config';
 import { SendBeaconTransport } from '../src/transports/send-beacon';
 import { uuidPattern } from './helpers/constants';
 import { DEFAULT_IDENTITY_STORAGE, DEFAULT_SERVER_ZONE } from '../src/constants';
 import { AmplitudeBrowser } from '../src/browser-client';
-import { MemoryStorage } from '@amplitude/analytics-core';
+import { MemoryStorage, getCookieName, FetchTransport } from '@amplitude/analytics-core';
 
 describe('config', () => {
   const someUUID: string = expect.stringMatching(uuidPattern) as string;

--- a/packages/analytics-browser/test/cookie-migration/index.test.ts
+++ b/packages/analytics-browser/test/cookie-migration/index.test.ts
@@ -1,8 +1,7 @@
-import { CookieStorage, getOldCookieName } from '@amplitude/analytics-client-common';
 import { Storage, UserSession } from '@amplitude/analytics-types';
 import { decode, parseLegacyCookies, parseTime } from '../../src/cookie-migration';
 import * as LocalStorageModule from '../../src/storage/local-storage';
-import { MemoryStorage } from '@amplitude/analytics-core';
+import { MemoryStorage, CookieStorage, getOldCookieName } from '@amplitude/analytics-core';
 
 describe('cookie-migration', () => {
   const API_KEY = 'asdfasdf';

--- a/packages/analytics-browser/test/storage/browser-storage.test.ts
+++ b/packages/analytics-browser/test/storage/browser-storage.test.ts
@@ -1,6 +1,6 @@
 import { BrowserStorage } from '../../src/storage/browser-storage';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import { getGlobalScope } from '@amplitude/analytics-core';
 
 describe('browser-storage', () => {
   describe('isEnabled', () => {
@@ -58,7 +58,7 @@ describe('browser-storage', () => {
 
     test('should handle when GlobalScope is not defined', async () => {
       const sessionStorage = new BrowserStorage<number[]>(undefined);
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
       await sessionStorage.set('1', [1]);
       expect(await sessionStorage.get('1')).toEqual(undefined);
       await sessionStorage.remove('1');
@@ -79,7 +79,7 @@ describe('browser-storage', () => {
 
     test('should handle when GlobalScope is not defined', async () => {
       const sessionStorage = new BrowserStorage<number[]>(undefined);
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
       await sessionStorage.set('1', [1]);
       expect(await sessionStorage.get('1')).toEqual(undefined);
       await sessionStorage.reset();

--- a/packages/analytics-browser/test/storage/local-storage.test.ts
+++ b/packages/analytics-browser/test/storage/local-storage.test.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@amplitude/analytics-core';
 import { LocalStorage } from '../../src/storage/local-storage';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 
 describe('local-storage', () => {
   test('should return true if storage is available', async () => {
@@ -9,7 +9,7 @@ describe('local-storage', () => {
   });
 
   test('should return false if storage is unavailable', async () => {
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
     const localStorage = new LocalStorage();
     expect(await localStorage.isEnabled()).toBe(false);
   });

--- a/packages/analytics-browser/test/storage/session-storage.test.ts
+++ b/packages/analytics-browser/test/storage/session-storage.test.ts
@@ -1,5 +1,5 @@
 import { SessionStorage } from '../../src/storage/session-storage';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 
 describe('session-storage', () => {
   test('should return true if storage is available', async () => {
@@ -8,7 +8,7 @@ describe('session-storage', () => {
   });
 
   test('should return false if storage is unavailable', async () => {
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
     const sessionStorage = new SessionStorage();
     expect(await sessionStorage.isEnabled()).toBe(false);
   });

--- a/packages/analytics-browser/test/transport/send-beacon.test.ts
+++ b/packages/analytics-browser/test/transport/send-beacon.test.ts
@@ -1,6 +1,6 @@
 import { SendBeaconTransport } from '../../src/transports/send-beacon';
 import { Status } from '@amplitude/analytics-types';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 
 describe('beacon', () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -66,7 +66,7 @@ describe('beacon', () => {
     });
 
     test('should handle GlobalScope is not defined', async () => {
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValueOnce(undefined);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValueOnce(undefined);
       const transport = new SendBeaconTransport();
       const url = 'http://localhost:3000';
       const payload = {

--- a/packages/analytics-core/jest.config.js
+++ b/packages/analytics-core/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   setupFiles: ['./test/setup.js'],
   rootDir: '.',
   testEnvironment: 'node',
+  coveragePathIgnorePatterns: ['global-scope.ts'],
 };

--- a/packages/analytics-core/src/analytics-connector.ts
+++ b/packages/analytics-core/src/analytics-connector.ts
@@ -1,0 +1,15 @@
+import { AnalyticsConnector } from '@amplitude/analytics-connector';
+
+export const getAnalyticsConnector = (instanceName = '$default_instance'): AnalyticsConnector => {
+  return AnalyticsConnector.getInstance(instanceName);
+};
+
+export const setConnectorUserId = (userId: string | undefined, instanceName?: string): void => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  getAnalyticsConnector(instanceName).identityStore.editIdentity().setUserId(userId).commit();
+};
+
+export const setConnectorDeviceId = (deviceId: string, instanceName?: string): void => {
+  getAnalyticsConnector(instanceName).identityStore.editIdentity().setDeviceId(deviceId).commit();
+};

--- a/packages/analytics-core/src/attribution/campaign-parser.ts
+++ b/packages/analytics-core/src/attribution/campaign-parser.ts
@@ -1,0 +1,90 @@
+import { getQueryParams } from '../query-params';
+import {
+  UTM_CAMPAIGN,
+  UTM_CONTENT,
+  UTM_MEDIUM,
+  UTM_SOURCE,
+  UTM_TERM,
+  GCLID,
+  FBCLID,
+  BASE_CAMPAIGN,
+  DCLID,
+  MSCLKID,
+  RDT_CID,
+  TWCLID,
+  TTCLID,
+  KO_CLICK_ID,
+  LI_FAT_ID,
+  GBRAID,
+  WBRAID,
+  UTM_ID,
+} from './constants';
+import {
+  Campaign,
+  CampaignParser as ICampaignParser,
+  ClickIdParameters,
+  ReferrerParameters,
+  UTMParameters,
+} from '@amplitude/analytics-types';
+
+export class CampaignParser implements ICampaignParser {
+  async parse(): Promise<Campaign> {
+    return {
+      ...BASE_CAMPAIGN,
+      ...this.getUtmParam(),
+      ...this.getReferrer(),
+      ...this.getClickIds(),
+    } as Campaign;
+  }
+
+  getUtmParam(): UTMParameters {
+    const params = getQueryParams();
+
+    const utmCampaign = params[UTM_CAMPAIGN];
+    const utmContent = params[UTM_CONTENT];
+    const utmId = params[UTM_ID];
+    const utmMedium = params[UTM_MEDIUM];
+    const utmSource = params[UTM_SOURCE];
+    const utmTerm = params[UTM_TERM];
+
+    return {
+      utm_campaign: utmCampaign,
+      utm_content: utmContent,
+      utm_id: utmId,
+      utm_medium: utmMedium,
+      utm_source: utmSource,
+      utm_term: utmTerm,
+    };
+  }
+
+  getReferrer(): ReferrerParameters {
+    const data: ReferrerParameters = {
+      referrer: undefined,
+      referring_domain: undefined,
+    };
+    try {
+      data.referrer = document.referrer || undefined;
+      data.referring_domain = data.referrer?.split('/')[2] ?? undefined;
+    } catch {
+      // nothing to track
+    }
+    return data;
+  }
+
+  getClickIds(): ClickIdParameters {
+    const params = getQueryParams();
+    return {
+      [DCLID]: params[DCLID],
+      [FBCLID]: params[FBCLID],
+      [GBRAID]: params[GBRAID],
+      [GCLID]: params[GCLID],
+      [KO_CLICK_ID]: params[KO_CLICK_ID],
+      [LI_FAT_ID]: params[LI_FAT_ID],
+      [MSCLKID]: params[MSCLKID],
+      [RDT_CID]: params[RDT_CID],
+      [TTCLID]: params[TTCLID],
+      [TWCLID]: params[TWCLID],
+      [WBRAID]: params[WBRAID],
+    };
+  }
+}

--- a/packages/analytics-core/src/attribution/constants.ts
+++ b/packages/analytics-core/src/attribution/constants.ts
@@ -1,0 +1,46 @@
+import { Campaign } from '@amplitude/analytics-types';
+
+export const UTM_CAMPAIGN = 'utm_campaign';
+export const UTM_CONTENT = 'utm_content';
+export const UTM_ID = 'utm_id';
+export const UTM_MEDIUM = 'utm_medium';
+export const UTM_SOURCE = 'utm_source';
+export const UTM_TERM = 'utm_term';
+
+export const DCLID = 'dclid';
+export const FBCLID = 'fbclid';
+export const GBRAID = 'gbraid';
+export const GCLID = 'gclid';
+export const KO_CLICK_ID = 'ko_click_id';
+export const LI_FAT_ID = 'li_fat_id';
+export const MSCLKID = 'msclkid';
+export const RDT_CID = 'rtd_cid';
+export const TTCLID = 'ttclid';
+export const TWCLID = 'twclid';
+export const WBRAID = 'wbraid';
+
+export const EMPTY_VALUE = 'EMPTY';
+
+export const BASE_CAMPAIGN: Campaign = {
+  utm_campaign: undefined,
+  utm_content: undefined,
+  utm_id: undefined,
+  utm_medium: undefined,
+  utm_source: undefined,
+  utm_term: undefined,
+  referrer: undefined,
+  referring_domain: undefined,
+  dclid: undefined,
+  gbraid: undefined,
+  gclid: undefined,
+  fbclid: undefined,
+  ko_click_id: undefined,
+  li_fat_id: undefined,
+  msclkid: undefined,
+  rtd_cid: undefined,
+  ttclid: undefined,
+  twclid: undefined,
+  wbraid: undefined,
+};
+
+export const MKTG = 'MKTG';

--- a/packages/analytics-core/src/attribution/helpers.ts
+++ b/packages/analytics-core/src/attribution/helpers.ts
@@ -1,0 +1,97 @@
+import { createIdentifyEvent } from '../utils/event-builder';
+import { Identify } from '../identify';
+import { Campaign, Logger } from '@amplitude/analytics-types';
+import { BASE_CAMPAIGN } from './constants';
+
+export interface Options {
+  excludeReferrers?: (string | RegExp)[];
+  initialEmptyValue?: string;
+  resetSessionOnNewCampaign?: boolean;
+}
+
+const domainWithoutSubdomain = (domain: string) => {
+  const parts = domain.split('.');
+
+  if (parts.length <= 2) {
+    return domain;
+  }
+
+  return parts.slice(parts.length - 2, parts.length).join('.');
+};
+
+//Direct traffic mean no external referral, no UTMs, no click-ids, and no other customer identified marketing campaign url params.
+const isDirectTraffic = (current: Campaign) => {
+  return Object.values(current).every((value) => !value);
+};
+
+export const isNewCampaign = (
+  current: Campaign,
+  previous: Campaign | undefined,
+  options: Options,
+  logger: Logger,
+  isNewSession = true,
+) => {
+  const { referrer, referring_domain, ...currentCampaign } = current;
+  const { referrer: _previous_referrer, referring_domain: prevReferringDomain, ...previousCampaign } = previous || {};
+
+  if (isExcludedReferrer(options.excludeReferrers, current.referring_domain)) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    logger.debug(`This is not a new campaign because ${current.referring_domain} is in the exclude referrer list.`);
+    return false;
+  }
+
+  //In the same session, direct traffic should not override or unset any persisting query params
+  if (!isNewSession && isDirectTraffic(current) && previous) {
+    logger.debug('This is not a new campaign because this is a direct traffic in the same session.');
+    return false;
+  }
+
+  const hasNewCampaign = JSON.stringify(currentCampaign) !== JSON.stringify(previousCampaign);
+  const hasNewDomain =
+    domainWithoutSubdomain(referring_domain || '') !== domainWithoutSubdomain(prevReferringDomain || '');
+
+  const result = !previous || hasNewCampaign || hasNewDomain;
+
+  if (!result) {
+    logger.debug("This is not a new campaign because it's the same as the previous one.");
+  } else {
+    logger.debug(`This is a new campaign. An $identify event will be sent.`);
+  }
+
+  return result;
+};
+
+export const isExcludedReferrer = (excludeReferrers: (string | RegExp)[] = [], referringDomain = '') => {
+  return excludeReferrers.some((value) =>
+    value instanceof RegExp ? value.test(referringDomain) : value === referringDomain,
+  );
+};
+
+export const createCampaignEvent = (campaign: Campaign, options: Options) => {
+  const campaignParameters: Campaign = {
+    // This object definition allows undefined keys to be iterated on
+    // in .reduce() to build indentify object
+    ...BASE_CAMPAIGN,
+    ...campaign,
+  };
+  const identifyEvent = Object.entries(campaignParameters).reduce((identify, [key, value]) => {
+    identify.setOnce(`initial_${key}`, value ?? options.initialEmptyValue ?? 'EMPTY');
+    if (value) {
+      return identify.set(key, value);
+    }
+    return identify.unset(key);
+  }, new Identify());
+
+  return createIdentifyEvent(identifyEvent);
+};
+
+export const getDefaultExcludedReferrers = (cookieDomain: string | undefined) => {
+  let domain = cookieDomain;
+  if (domain) {
+    if (domain.startsWith('.')) {
+      domain = domain.substring(1);
+    }
+    return [new RegExp(`${domain.replace('.', '\\.')}$`)];
+  }
+  return [];
+};

--- a/packages/analytics-core/src/attribution/web-attribution.ts
+++ b/packages/analytics-core/src/attribution/web-attribution.ts
@@ -1,0 +1,68 @@
+import { BrowserConfig, Logger } from '@amplitude/analytics-types';
+import { Campaign, Storage } from '@amplitude/analytics-types';
+import { Options, getDefaultExcludedReferrers, createCampaignEvent, isNewCampaign } from './helpers';
+import { getStorageKey } from '../storage/helpers';
+import { CampaignParser } from './campaign-parser';
+import { BASE_CAMPAIGN } from './constants';
+import { isNewSession } from '../session';
+
+export class WebAttribution {
+  options: Options;
+  storage: Storage<Campaign>;
+  storageKey: string;
+  previousCampaign?: Campaign;
+  currentCampaign: Campaign;
+  shouldTrackNewCampaign = false;
+  sessionTimeout: number;
+  lastEventTime?: number;
+  logger: Logger;
+
+  constructor(options: Options, config: BrowserConfig) {
+    this.options = {
+      initialEmptyValue: 'EMPTY',
+      resetSessionOnNewCampaign: false,
+      excludeReferrers: getDefaultExcludedReferrers(config.cookieOptions?.domain),
+      ...options,
+    };
+    this.storage = config.cookieStorage as unknown as Storage<Campaign>;
+    this.storageKey = getStorageKey(config.apiKey, 'MKTG');
+    this.currentCampaign = BASE_CAMPAIGN;
+    this.sessionTimeout = config.sessionTimeout;
+    this.lastEventTime = config.lastEventTime;
+    this.logger = config.loggerProvider;
+    config.loggerProvider.log('Installing web attribution tracking.');
+  }
+
+  async init() {
+    [this.currentCampaign, this.previousCampaign] = await this.fetchCampaign();
+    const isEventInNewSession = !this.lastEventTime ? true : isNewSession(this.sessionTimeout, this.lastEventTime);
+
+    if (isNewCampaign(this.currentCampaign, this.previousCampaign, this.options, this.logger, isEventInNewSession)) {
+      this.shouldTrackNewCampaign = true;
+      await this.storage.set(this.storageKey, this.currentCampaign);
+    }
+  }
+
+  async fetchCampaign() {
+    return await Promise.all([new CampaignParser().parse(), this.storage.get(this.storageKey)]);
+  }
+
+  /**
+   * This can be called when enable web attribution and either
+   * 1. set a new session
+   * 2. has new campaign and enable resetSessionOnNewCampaign
+   */
+  generateCampaignEvent(event_id?: number) {
+    // Mark this campaign has been tracked
+    this.shouldTrackNewCampaign = false;
+    const campaignEvent = createCampaignEvent(this.currentCampaign, this.options);
+    if (event_id) {
+      campaignEvent.event_id = event_id;
+    }
+    return campaignEvent;
+  }
+
+  shouldSetSessionIdOnNewCampaign() {
+    return this.shouldTrackNewCampaign && !!this.options.resetSessionOnNewCampaign;
+  }
+}

--- a/packages/analytics-core/src/cookie-name.ts
+++ b/packages/analytics-core/src/cookie-name.ts
@@ -1,0 +1,9 @@
+import { AMPLITUDE_PREFIX } from './constants';
+
+export const getCookieName = (apiKey: string, postKey = '', limit = 10) => {
+  return [AMPLITUDE_PREFIX, postKey, apiKey.substring(0, limit)].filter(Boolean).join('_');
+};
+
+export const getOldCookieName = (apiKey: string) => {
+  return `${AMPLITUDE_PREFIX.toLowerCase()}_${apiKey.substring(0, 6)}`;
+};

--- a/packages/analytics-core/src/default-tracking.ts
+++ b/packages/analytics-core/src/default-tracking.ts
@@ -1,0 +1,128 @@
+import {
+  AttributionOptions,
+  AutocaptureOptions,
+  BrowserOptions,
+  PageTrackingHistoryChanges,
+  PageTrackingOptions,
+  PageTrackingTrackOn,
+  ElementInteractionsOptions,
+} from '@amplitude/analytics-types';
+
+/**
+ * Returns false if autocapture === false or if autocapture[event],
+ * otherwise returns true
+ */
+const isTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined, event: keyof AutocaptureOptions) => {
+  if (typeof autocapture === 'boolean') {
+    return autocapture;
+  }
+
+  if (autocapture?.[event] === false) {
+    return false;
+  }
+
+  return true;
+};
+
+export const isAttributionTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
+  isTrackingEnabled(autocapture, 'attribution');
+
+export const isFileDownloadTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
+  isTrackingEnabled(autocapture, 'fileDownloads');
+
+export const isFormInteractionTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
+  isTrackingEnabled(autocapture, 'formInteractions');
+
+export const isPageViewTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
+  isTrackingEnabled(autocapture, 'pageViews');
+
+export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
+  isTrackingEnabled(autocapture, 'sessions');
+
+/**
+ * Returns true if
+ * 1. autocapture === true
+ * 2. if autocapture.elementInteractions === true
+ * 3. if autocapture.elementInteractions === object
+ * otherwise returns false
+ */
+export const isElementInteractionsEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
+  if (typeof autocapture === 'boolean') {
+    return autocapture;
+  }
+
+  if (
+    typeof autocapture === 'object' &&
+    (autocapture.elementInteractions === true || typeof autocapture.elementInteractions === 'object')
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export const getElementInteractionsConfig = (config: BrowserOptions): ElementInteractionsOptions | undefined => {
+  if (
+    isElementInteractionsEnabled(config.autocapture) &&
+    typeof config.autocapture === 'object' &&
+    typeof config.autocapture.elementInteractions === 'object'
+  ) {
+    return config.autocapture.elementInteractions;
+  }
+  return undefined;
+};
+
+export const getPageViewTrackingConfig = (config: BrowserOptions): PageTrackingOptions => {
+  let trackOn: PageTrackingTrackOn | undefined = () => false;
+  let trackHistoryChanges: PageTrackingHistoryChanges | undefined = undefined;
+  let eventType: string | undefined;
+  const pageCounter = config.pageCounter;
+
+  const isDefaultPageViewTrackingEnabled = isPageViewTrackingEnabled(config.defaultTracking);
+  if (isDefaultPageViewTrackingEnabled) {
+    trackOn = undefined;
+    eventType = undefined;
+
+    if (
+      config.defaultTracking &&
+      typeof config.defaultTracking === 'object' &&
+      config.defaultTracking.pageViews &&
+      typeof config.defaultTracking.pageViews === 'object'
+    ) {
+      if ('trackOn' in config.defaultTracking.pageViews) {
+        trackOn = config.defaultTracking.pageViews.trackOn;
+      }
+
+      if ('trackHistoryChanges' in config.defaultTracking.pageViews) {
+        trackHistoryChanges = config.defaultTracking.pageViews.trackHistoryChanges;
+      }
+
+      if ('eventType' in config.defaultTracking.pageViews && config.defaultTracking.pageViews.eventType) {
+        eventType = config.defaultTracking.pageViews.eventType;
+      }
+    }
+  }
+
+  return {
+    trackOn,
+    trackHistoryChanges,
+    eventType,
+    pageCounter,
+  };
+};
+
+export const getAttributionTrackingConfig = (config: BrowserOptions): AttributionOptions => {
+  if (
+    isAttributionTrackingEnabled(config.defaultTracking) &&
+    config.defaultTracking &&
+    typeof config.defaultTracking === 'object' &&
+    config.defaultTracking.attribution &&
+    typeof config.defaultTracking.attribution === 'object'
+  ) {
+    return {
+      ...config.defaultTracking.attribution,
+    };
+  }
+
+  return {};
+};

--- a/packages/analytics-core/src/global-scope.ts
+++ b/packages/analytics-core/src/global-scope.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-restricted-globals */
+/* Only file allowed to access to globalThis, window, self */
+
+export const getGlobalScope = (): typeof globalThis | undefined => {
+  // This should only be used for integrations with Amplitude that are not running in a browser environment
+  //   We need to specify the name of the global variable as a string to prevent it from being minified
+  const ampIntegrationContextName = 'ampIntegrationContext' as keyof typeof globalThis;
+  if (typeof globalThis !== 'undefined' && typeof globalThis[ampIntegrationContextName] !== 'undefined') {
+    return globalThis[ampIntegrationContextName] as typeof globalThis;
+  }
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  return undefined;
+};

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -13,6 +13,26 @@ export { BaseTransport } from './transports/base';
 export { createIdentifyEvent } from './utils/event-builder';
 
 export { getGlobalScope } from './global-scope';
+export { getAnalyticsConnector, setConnectorDeviceId, setConnectorUserId } from './analytics-connector';
+export {
+  getPageViewTrackingConfig,
+  getAttributionTrackingConfig,
+  getElementInteractionsConfig,
+  isAttributionTrackingEnabled,
+  isFileDownloadTrackingEnabled,
+  isFormInteractionTrackingEnabled,
+  isPageViewTrackingEnabled,
+  isSessionTrackingEnabled,
+  isElementInteractionsEnabled,
+} from './default-tracking';
+export { isNewSession } from './session';
+export { IdentityEventSender } from './plugins/identity';
+export { WebAttribution } from './attribution/web-attribution';
+export { getQueryParams } from './query-params';
+export { CookieStorage } from './storage/cookie';
+export { getCookieName, getOldCookieName } from './cookie-name';
+export { FetchTransport } from './transports/fetch';
+export { getLanguage } from './language';
 
 // The following APIs are available in browser environment only.
 

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -33,7 +33,3 @@ export { CookieStorage } from './storage/cookie';
 export { getCookieName, getOldCookieName } from './cookie-name';
 export { FetchTransport } from './transports/fetch';
 export { getLanguage } from './language';
-
-// The following APIs are available in browser environment only.
-
-// The following APIs are available in node environment only.

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -11,3 +11,9 @@ export { UUID } from './utils/uuid';
 export { MemoryStorage } from './storage/memory';
 export { BaseTransport } from './transports/base';
 export { createIdentifyEvent } from './utils/event-builder';
+
+export { getGlobalScope } from './global-scope';
+
+// The following APIs are available in browser environment only.
+
+// The following APIs are available in node environment only.

--- a/packages/analytics-core/src/language.ts
+++ b/packages/analytics-core/src/language.ts
@@ -1,0 +1,7 @@
+export const getLanguage = (): string => {
+  if (typeof navigator === 'undefined') return '';
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const userLanguage = (navigator as any).userLanguage as string | undefined;
+
+  return navigator.languages?.[0] ?? navigator.language ?? userLanguage ?? '';
+};

--- a/packages/analytics-core/src/plugins/identity.ts
+++ b/packages/analytics-core/src/plugins/identity.ts
@@ -1,0 +1,23 @@
+import { BeforePlugin, Config, Event } from '@amplitude/analytics-types';
+import { getAnalyticsConnector } from '../analytics-connector';
+
+export class IdentityEventSender implements BeforePlugin {
+  name = 'identity';
+  type = 'before' as const;
+
+  identityStore = getAnalyticsConnector().identityStore;
+
+  async execute(context: Event): Promise<Event> {
+    const userProperties = context.user_properties as Record<string, any>;
+    if (userProperties) {
+      this.identityStore.editIdentity().updateUserProperties(userProperties).commit();
+    }
+    return context;
+  }
+
+  async setup(config: Config) {
+    if (config.instanceName) {
+      this.identityStore = getAnalyticsConnector(config.instanceName).identityStore;
+    }
+  }
+}

--- a/packages/analytics-core/src/query-params.ts
+++ b/packages/analytics-core/src/query-params.ts
@@ -1,0 +1,29 @@
+import { getGlobalScope } from './global-scope';
+
+export const getQueryParams = (): Record<string, string | undefined> => {
+  const globalScope = getGlobalScope();
+  /* istanbul ignore if */
+  if (!globalScope?.location?.search) {
+    return {};
+  }
+  const pairs = globalScope.location.search.substring(1).split('&').filter(Boolean);
+  const params = pairs.reduce<Record<string, string | undefined>>((acc, curr) => {
+    const query = curr.split('=', 2);
+    const key = tryDecodeURIComponent(query[0]);
+    const value = tryDecodeURIComponent(query[1]);
+    if (!value) {
+      return acc;
+    }
+    acc[key] = value;
+    return acc;
+  }, {});
+  return params;
+};
+
+export const tryDecodeURIComponent = (value = '') => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return '';
+  }
+};

--- a/packages/analytics-core/src/session.ts
+++ b/packages/analytics-core/src/session.ts
@@ -1,0 +1,6 @@
+export const isNewSession = (sessionTimeout: number, lastEventTime: number = Date.now()): boolean => {
+  const currentTime = Date.now();
+  const timeSinceLastEvent = currentTime - lastEventTime;
+
+  return timeSinceLastEvent > sessionTimeout;
+};

--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -1,0 +1,121 @@
+import { Storage, CookieStorageOptions } from '@amplitude/analytics-types';
+import { getGlobalScope } from '../global-scope';
+
+export class CookieStorage<T> implements Storage<T> {
+  options: CookieStorageOptions;
+  private static testValue: undefined | string;
+
+  constructor(options?: CookieStorageOptions) {
+    this.options = { ...options };
+  }
+
+  async isEnabled(): Promise<boolean> {
+    /* istanbul ignore if */
+    if (!getGlobalScope()) {
+      return false;
+    }
+
+    CookieStorage.testValue = String(Date.now());
+    const testStrorage = new CookieStorage<string>(this.options);
+    const testKey = 'AMP_TEST';
+    try {
+      await testStrorage.set(testKey, CookieStorage.testValue);
+      const value = await testStrorage.get(testKey);
+      return value === CookieStorage.testValue;
+    } catch {
+      /* istanbul ignore next */
+      return false;
+    } finally {
+      await testStrorage.remove(testKey);
+    }
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    const value = await this.getRaw(key);
+    if (!value) {
+      return undefined;
+    }
+    try {
+      const decodedValue = decodeCookiesAsDefault(value) ?? decodeCookiesWithDoubleUrlEncoding(value);
+      if (decodedValue === undefined) {
+        console.error(`Amplitude Logger [Error]: Failed to decode cookie value for key: ${key}, value: ${value}`);
+        return undefined;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return JSON.parse(decodedValue);
+    } catch {
+      console.error(`Amplitude Logger [Error]: Failed to parse cookie value for key: ${key}, value: ${value}`);
+      return undefined;
+    }
+  }
+
+  async getRaw(key: string): Promise<string | undefined> {
+    const globalScope = getGlobalScope();
+    const cookie = globalScope?.document?.cookie.split('; ') ?? [];
+    const match = cookie.find((c) => c.indexOf(key + '=') === 0);
+    if (!match) {
+      return undefined;
+    }
+    return match.substring(key.length + 1);
+  }
+
+  async set(key: string, value: T | null): Promise<void> {
+    try {
+      const expirationDays = this.options.expirationDays ?? 0;
+      const expires = value !== null ? expirationDays : -1;
+      let expireDate: Date | undefined = undefined;
+      if (expires) {
+        const date = new Date();
+        date.setTime(date.getTime() + expires * 24 * 60 * 60 * 1000);
+        expireDate = date;
+      }
+      let str = `${key}=${btoa(encodeURIComponent(JSON.stringify(value)))}`;
+      if (expireDate) {
+        str += `; expires=${expireDate.toUTCString()}`;
+      }
+      str += '; path=/';
+      if (this.options.domain) {
+        str += `; domain=${this.options.domain}`;
+      }
+      if (this.options.secure) {
+        str += '; Secure';
+      }
+      if (this.options.sameSite) {
+        str += `; SameSite=${this.options.sameSite}`;
+      }
+      const globalScope = getGlobalScope();
+      if (globalScope) {
+        globalScope.document.cookie = str;
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`Amplitude Logger [Error]: Failed to set cookie for key: ${key}. Error: ${errorMessage}`);
+    }
+  }
+
+  async remove(key: string): Promise<void> {
+    await this.set(key, null);
+  }
+
+  async reset(): Promise<void> {
+    return;
+  }
+}
+
+const decodeCookiesAsDefault = (value: string): string | undefined => {
+  try {
+    return decodeURIComponent(atob(value));
+  } catch {
+    return undefined;
+  }
+};
+
+const decodeCookiesWithDoubleUrlEncoding = (value: string): string | undefined => {
+  // Modern Ruby (v7+) automatically encodes cookies with URL encoding by
+  // https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html
+  try {
+    return decodeURIComponent(atob(decodeURIComponent(value)));
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/analytics-core/src/storage/helpers.ts
+++ b/packages/analytics-core/src/storage/helpers.ts
@@ -1,0 +1,5 @@
+import { AMPLITUDE_PREFIX } from '../constants';
+
+export const getStorageKey = (apiKey: string, postKey = '', limit = 10) => {
+  return [AMPLITUDE_PREFIX, postKey, apiKey.substring(0, limit)].filter(Boolean).join('_');
+};

--- a/packages/analytics-core/src/transports/fetch.ts
+++ b/packages/analytics-core/src/transports/fetch.ts
@@ -1,0 +1,27 @@
+import { BaseTransport } from './base';
+import { Payload, Response, Transport } from '@amplitude/analytics-types';
+
+export class FetchTransport extends BaseTransport implements Transport {
+  async send(serverUrl: string, payload: Payload): Promise<Response | null> {
+    /* istanbul ignore if */
+    if (typeof fetch === 'undefined') {
+      throw new Error('FetchTransport is not supported');
+    }
+    const options: RequestInit = {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      body: JSON.stringify(payload),
+      method: 'POST',
+    };
+    const response = await fetch(serverUrl, options);
+    const responseText = await response.text();
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      return this.buildResponse(JSON.parse(responseText));
+    } catch {
+      return this.buildResponse({ code: response.status });
+    }
+  }
+}

--- a/packages/analytics-core/test/analytics-connector.test.ts
+++ b/packages/analytics-core/test/analytics-connector.test.ts
@@ -1,0 +1,73 @@
+import { AnalyticsConnector } from '@amplitude/analytics-connector';
+import { getAnalyticsConnector, setConnectorDeviceId, setConnectorUserId } from '../src/analytics-connector';
+
+describe('analytics-connector', () => {
+  describe('getAnalyticsConnector', () => {
+    test('should return connector instance', () => {
+      const instance = new AnalyticsConnector();
+      const getInstance = jest.spyOn(AnalyticsConnector, 'getInstance').mockReturnValueOnce(instance);
+      expect(getAnalyticsConnector()).toBe(instance);
+      expect(getInstance).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setConnectorUserId', () => {
+    test('should return connector instance', () => {
+      const commit = jest.fn();
+      const identityEditor = {
+        setUserId: function () {
+          return this;
+        },
+        setDeviceId: function () {
+          return this;
+        },
+        setUserProperties: function () {
+          return this;
+        },
+        updateUserProperties: function () {
+          return this;
+        },
+        setOptOut: function () {
+          return this;
+        },
+        commit,
+      };
+      const instance = new AnalyticsConnector();
+      jest.spyOn(instance.identityStore, 'editIdentity').mockReturnValueOnce(identityEditor);
+      const getInstance = jest.spyOn(AnalyticsConnector, 'getInstance').mockReturnValueOnce(instance);
+      expect(setConnectorUserId('123')).toBe(undefined);
+      expect(getInstance).toHaveBeenCalledTimes(1);
+      expect(commit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setConnectorDeviceId', () => {
+    test('should return connector instance', () => {
+      const commit = jest.fn();
+      const identityEditor = {
+        setUserId: function () {
+          return this;
+        },
+        setDeviceId: function () {
+          return this;
+        },
+        setUserProperties: function () {
+          return this;
+        },
+        updateUserProperties: function () {
+          return this;
+        },
+        setOptOut: function () {
+          return this;
+        },
+        commit,
+      };
+      const instance = new AnalyticsConnector();
+      jest.spyOn(instance.identityStore, 'editIdentity').mockReturnValueOnce(identityEditor);
+      const getInstance = jest.spyOn(AnalyticsConnector, 'getInstance').mockReturnValueOnce(instance);
+      expect(setConnectorDeviceId('123')).toBe(undefined);
+      expect(getInstance).toHaveBeenCalledTimes(1);
+      expect(commit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/analytics-core/test/attribution/campaign-parser.test.ts
+++ b/packages/analytics-core/test/attribution/campaign-parser.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { BASE_CAMPAIGN } from '../../src/attribution/constants';
 import { CampaignParser } from '../../src/attribution/campaign-parser';
 import * as queryParams from '../../src/query-params';

--- a/packages/analytics-core/test/attribution/campaign-parser.test.ts
+++ b/packages/analytics-core/test/attribution/campaign-parser.test.ts
@@ -1,0 +1,112 @@
+import { BASE_CAMPAIGN } from '../../src/attribution/constants';
+import { CampaignParser } from '../../src/attribution/campaign-parser';
+import * as queryParams from '../../src/query-params';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: '',
+      href: '',
+      pathname: '',
+      search: '',
+    },
+    writable: true,
+  });
+  Object.defineProperty(document, 'referrer', {
+    value: '',
+    writable: true,
+  });
+});
+
+describe('campaign-parser', () => {
+  describe('parse', () => {
+    test('should return parameters', async () => {
+      const parser = new CampaignParser();
+      const referringDomain = 'https://google.com';
+      const search = '?utm_campaign=utm_campaign&gclid=123';
+      (document.referrer as any) = referringDomain;
+      window.location.search = search;
+
+      const campaign = await parser.parse();
+      expect(campaign).toEqual({
+        ...BASE_CAMPAIGN,
+        utm_campaign: 'utm_campaign',
+        referrer: 'https://google.com',
+        referring_domain: 'google.com',
+        gclid: '123',
+      });
+    });
+  });
+
+  describe('getUtmParam', () => {
+    test('should return utm param from query params', async () => {
+      const parser = new CampaignParser();
+      const getQueryParams = jest.spyOn(queryParams, 'getQueryParams');
+      window.location.search =
+        '?utm_source=utm_source&utm_medium=utm_medium&utm_campaign=utm_campaign&utm_term=utm_term&utm_content=utm_content';
+      const utmParam = parser.getUtmParam();
+      expect(utmParam).toEqual({
+        utm_source: 'utm_source',
+        utm_medium: 'utm_medium',
+        utm_campaign: 'utm_campaign',
+        utm_term: 'utm_term',
+        utm_content: 'utm_content',
+      });
+      expect(getQueryParams).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getReferrer', () => {
+    afterEach(() => {
+      Object.defineProperty(document, 'referrer', {
+        value: '',
+        writable: true,
+      });
+    });
+
+    test('should return referrer info', () => {
+      Object.defineProperty(document, 'referrer', {
+        value: 'https://amplitude.com',
+        writable: true,
+      });
+      const parser = new CampaignParser();
+      const referrer = parser.getReferrer();
+      expect(referrer).toEqual({
+        referrer: 'https://amplitude.com',
+        referring_domain: 'amplitude.com',
+      });
+    });
+
+    test('should return not referrer info', () => {
+      Object.defineProperty(document, 'referrer', {
+        value: undefined,
+        writable: true,
+      });
+      const parser = new CampaignParser();
+      const referrer = parser.getReferrer();
+      expect(referrer).toEqual({});
+    });
+  });
+
+  describe('getGclid', () => {
+    test('should return gclid data', () => {
+      const parser = new CampaignParser();
+      jest.spyOn(queryParams, 'getQueryParams').mockReturnValueOnce({
+        gclid: 'hello google',
+        fbclid: 'hello fb',
+      });
+      const data = parser.getClickIds();
+      expect(data).toEqual({
+        gclid: 'hello google',
+        fbclid: 'hello fb',
+      });
+    });
+
+    test('should return empty data', () => {
+      const parser = new CampaignParser();
+      jest.spyOn(queryParams, 'getQueryParams').mockReturnValueOnce({});
+      const data = parser.getClickIds();
+      expect(data).toEqual({});
+    });
+  });
+});

--- a/packages/analytics-core/test/attribution/helpers.test.ts
+++ b/packages/analytics-core/test/attribution/helpers.test.ts
@@ -1,0 +1,328 @@
+import { BASE_CAMPAIGN } from '../../src/attribution/constants';
+import {
+  isNewCampaign,
+  createCampaignEvent,
+  getDefaultExcludedReferrers,
+  isExcludedReferrer,
+} from '../../src/attribution/helpers';
+
+import { getStorageKey } from '../../src/storage/helpers';
+
+const loggerProvider = {
+  log: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  enable: jest.fn(),
+  disable: jest.fn(),
+};
+
+describe('getStorageKey', () => {
+  test('should return storage key without explicit suffix and limit', () => {
+    expect(getStorageKey('API_KEY')).toBe('AMP_API_KEY');
+  });
+
+  test('should return storage key', () => {
+    expect(getStorageKey('API_KEY', 'MKTG', 3)).toBe('AMP_MKTG_API');
+  });
+});
+
+describe('isNewCampaign', () => {
+  test('should return true for new campaign', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_campaign: 'utm_campaign',
+    };
+    expect(isNewCampaign(currentCampaign, previousCampaign, {}, loggerProvider)).toBe(true);
+  });
+
+  test('should return true for new referrer', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_campaign: 'utm_campaign',
+      referring_domain: 'a.b.c.d',
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_campaign: 'utm_campaign',
+      referring_domain: 'b.c.d.e',
+    };
+    expect(isNewCampaign(currentCampaign, previousCampaign, {}, loggerProvider)).toBe(true);
+  });
+
+  test('should return false for string excluded referrer', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      referring_domain: 'amplitude.com',
+    };
+    expect(
+      isNewCampaign(
+        currentCampaign,
+        previousCampaign,
+        {
+          excludeReferrers: ['amplitude.com'],
+        },
+        loggerProvider,
+      ),
+    ).toBe(false);
+  });
+
+  test('should return false for regexp excluded referrer', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      referring_domain: 'amplitude.com',
+    };
+    expect(
+      isNewCampaign(
+        currentCampaign,
+        previousCampaign,
+        {
+          excludeReferrers: getDefaultExcludedReferrers('.amplitude.com'),
+        },
+        loggerProvider,
+      ),
+    ).toBe(false);
+  });
+
+  test('should return false for cross subdomain regexp excluded referrer', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      referring_domain: 'analytics.amplitude.com',
+    };
+    expect(
+      isNewCampaign(
+        currentCampaign,
+        previousCampaign,
+        {
+          excludeReferrers: getDefaultExcludedReferrers('.amplitude.com'),
+        },
+        loggerProvider,
+      ),
+    ).toBe(false);
+  });
+
+  test('should return true for undefined previous campaign', () => {
+    const previousCampaign = undefined;
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+    };
+    expect(
+      isNewCampaign(
+        currentCampaign,
+        previousCampaign,
+        {
+          excludeReferrers: ['a'],
+        },
+        loggerProvider,
+      ),
+    ).toBe(true);
+  });
+
+  test('should return false for undefined previous campaign and excluded referrer', () => {
+    const previousCampaign = undefined;
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      referring_domain: 'a',
+    };
+    expect(
+      isNewCampaign(
+        currentCampaign,
+        previousCampaign,
+        {
+          excludeReferrers: ['a'],
+        },
+        loggerProvider,
+      ),
+    ).toBe(false);
+  });
+
+  test('should return false for no extra referrer with direct traffic in the same session', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_campaign: 'utm_campaign',
+      referring_domain: 'a.b.c.d',
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+    };
+
+    expect(isNewCampaign(currentCampaign, previousCampaign, {}, loggerProvider, false)).toBe(false);
+  });
+
+  test('should return true for no referrer with any new campaign in the same session', () => {
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_campaign: 'utm_campaign',
+      referring_domain: 'a.b.c.d',
+    };
+    const currentCampaign = {
+      ...BASE_CAMPAIGN,
+      utm_source: 'utm_source',
+    };
+
+    expect(isNewCampaign(currentCampaign, previousCampaign, {}, loggerProvider, false)).toBe(true);
+  });
+});
+
+describe('isExcludedReferrer', () => {
+  test('should return true with string excluded referrer', () => {
+    expect(isExcludedReferrer(['data.amplitude.com'], 'data.amplitude.com')).toEqual(true);
+  });
+
+  test('should return true with regexp excluded referrer', () => {
+    expect(isExcludedReferrer(getDefaultExcludedReferrers('.amplitude.com'), 'data.amplitude.com')).toEqual(true);
+  });
+});
+
+describe('createCampaignEvent', () => {
+  test('should return event', () => {
+    const campaignEvent = createCampaignEvent(
+      {
+        ...BASE_CAMPAIGN,
+        utm_campaign: 'utm_campaign',
+      },
+      {},
+    );
+    expect(campaignEvent).toEqual({
+      event_type: '$identify',
+      user_id: undefined,
+      user_properties: {
+        $set: {
+          utm_campaign: 'utm_campaign',
+        },
+        $setOnce: {
+          initial_dclid: 'EMPTY',
+          initial_fbclid: 'EMPTY',
+          initial_gbraid: 'EMPTY',
+          initial_gclid: 'EMPTY',
+          initial_ko_click_id: 'EMPTY',
+          initial_li_fat_id: 'EMPTY',
+          initial_msclkid: 'EMPTY',
+          initial_wbraid: 'EMPTY',
+          initial_referrer: 'EMPTY',
+          initial_referring_domain: 'EMPTY',
+          initial_rtd_cid: 'EMPTY',
+          initial_ttclid: 'EMPTY',
+          initial_twclid: 'EMPTY',
+          initial_utm_campaign: 'utm_campaign',
+          initial_utm_content: 'EMPTY',
+          initial_utm_id: 'EMPTY',
+          initial_utm_medium: 'EMPTY',
+          initial_utm_source: 'EMPTY',
+          initial_utm_term: 'EMPTY',
+        },
+        $unset: {
+          dclid: '-',
+          fbclid: '-',
+          gbraid: '-',
+          gclid: '-',
+          ko_click_id: '-',
+          li_fat_id: '-',
+          msclkid: '-',
+          wbraid: '-',
+          referrer: '-',
+          referring_domain: '-',
+          rtd_cid: '-',
+          ttclid: '-',
+          twclid: '-',
+          utm_content: '-',
+          utm_id: '-',
+          utm_medium: '-',
+          utm_source: '-',
+          utm_term: '-',
+        },
+      },
+    });
+  });
+
+  test('should return event with custom empty value', () => {
+    const campaignEvent = createCampaignEvent(
+      {
+        ...BASE_CAMPAIGN,
+        utm_campaign: 'utm_campaign',
+      },
+      {
+        initialEmptyValue: '(none)',
+      },
+    );
+    expect(campaignEvent).toEqual({
+      event_type: '$identify',
+      user_id: undefined,
+      user_properties: {
+        $set: {
+          utm_campaign: 'utm_campaign',
+        },
+        $setOnce: {
+          initial_dclid: '(none)',
+          initial_fbclid: '(none)',
+          initial_gbraid: '(none)',
+          initial_gclid: '(none)',
+          initial_ko_click_id: '(none)',
+          initial_li_fat_id: '(none)',
+          initial_msclkid: '(none)',
+          initial_wbraid: '(none)',
+          initial_referrer: '(none)',
+          initial_referring_domain: '(none)',
+          initial_rtd_cid: '(none)',
+          initial_ttclid: '(none)',
+          initial_twclid: '(none)',
+          initial_utm_campaign: 'utm_campaign',
+          initial_utm_content: '(none)',
+          initial_utm_id: '(none)',
+          initial_utm_medium: '(none)',
+          initial_utm_source: '(none)',
+          initial_utm_term: '(none)',
+        },
+        $unset: {
+          dclid: '-',
+          fbclid: '-',
+          gbraid: '-',
+          gclid: '-',
+          ko_click_id: '-',
+          li_fat_id: '-',
+          msclkid: '-',
+          wbraid: '-',
+          referrer: '-',
+          referring_domain: '-',
+          rtd_cid: '-',
+          ttclid: '-',
+          twclid: '-',
+          utm_content: '-',
+          utm_id: '-',
+          utm_medium: '-',
+          utm_source: '-',
+          utm_term: '-',
+        },
+      },
+    });
+  });
+});
+
+describe('getDefaultExcludedReferrers', () => {
+  test('should return empty array', () => {
+    const excludedReferrers = getDefaultExcludedReferrers(undefined);
+    expect(excludedReferrers).toEqual([]);
+  });
+
+  test('should return array with regex 1', () => {
+    const excludedReferrers = getDefaultExcludedReferrers('amplitude.com');
+    expect(excludedReferrers).toEqual([new RegExp('amplitude\\.com$')]);
+  });
+
+  test('should return array with regex 2', () => {
+    const excludedReferrers = getDefaultExcludedReferrers('.amplitude.com');
+    expect(excludedReferrers).toEqual([new RegExp('amplitude\\.com$')]);
+  });
+});

--- a/packages/analytics-core/test/attribution/web-attribution.test.ts
+++ b/packages/analytics-core/test/attribution/web-attribution.test.ts
@@ -1,0 +1,145 @@
+import { Logger, UUID } from '@amplitude/analytics-core';
+import { AttributionOptions, BrowserConfig, LogLevel } from '@amplitude/analytics-types';
+import { BASE_CAMPAIGN } from '../../src/attribution/constants';
+import { CampaignParser } from '../../src/attribution/campaign-parser';
+import { WebAttribution } from '../../src/attribution/web-attribution';
+import { FetchTransport } from '../../src/transports/fetch';
+import { CookieStorage } from '../../src/storage/cookie';
+
+describe('shouldTrackNewCampaign', () => {
+  const mockConfig: BrowserConfig = {
+    apiKey: UUID(),
+    flushIntervalMillis: 0,
+    flushMaxRetries: 0,
+    flushQueueSize: 0,
+    logLevel: LogLevel.None,
+    loggerProvider: new Logger(),
+    offline: false,
+    optOut: false,
+    serverUrl: undefined,
+    transportProvider: new FetchTransport(),
+    useBatch: false,
+    cookieOptions: {
+      domain: '.amplitude.com',
+      expiration: 365,
+      sameSite: 'Lax',
+      secure: false,
+      upgrade: true,
+    },
+    cookieStorage: new CookieStorage(),
+    sessionTimeout: 30 * 60 * 1000,
+    trackingOptions: {
+      ipAddress: true,
+      language: true,
+      platform: true,
+    },
+  };
+  const option: AttributionOptions = {};
+
+  test('should track campaign with new campaign', async () => {
+    const overrideMockConfig = {
+      ...mockConfig,
+      cookieOptions: undefined,
+    };
+    const webAttribution = new WebAttribution(option, overrideMockConfig);
+
+    jest.spyOn(CampaignParser.prototype, 'parse').mockResolvedValueOnce({
+      ...BASE_CAMPAIGN,
+      utm_source: 'amp-test',
+    });
+    jest.spyOn(webAttribution.storage, 'get').mockResolvedValueOnce({
+      ...BASE_CAMPAIGN,
+    });
+
+    await webAttribution.init();
+    expect(webAttribution.shouldTrackNewCampaign).toBe(true);
+  });
+
+  test('should not track campaign without new campaign', async () => {
+    const overrideMockConfig = {
+      ...mockConfig,
+      cookieOptions: undefined,
+    };
+    const emptyCampaign = { ...BASE_CAMPAIGN };
+    const webAttribution = new WebAttribution(option, overrideMockConfig);
+
+    jest.spyOn(CampaignParser.prototype, 'parse').mockResolvedValue(emptyCampaign);
+    jest.spyOn(webAttribution.storage, 'get').mockResolvedValue(emptyCampaign);
+
+    await webAttribution.init();
+    expect(webAttribution.shouldTrackNewCampaign).toBe(false);
+  });
+
+  test('should generate campaign event with given eventId', async () => {
+    const webAttribution = new WebAttribution(option, mockConfig);
+    const event_id = 1;
+    const campaignEvent = webAttribution.generateCampaignEvent(event_id);
+    expect(campaignEvent.event_id).toBe(event_id);
+  });
+
+  test('should set session id on a new Campaign', async () => {
+    const option = {
+      resetSessionOnNewCampaign: true,
+    };
+    const webAttribution = new WebAttribution(option, mockConfig);
+    await webAttribution.init();
+
+    expect(webAttribution.shouldSetSessionIdOnNewCampaign()).toBe(true);
+  });
+
+  test('should not set session id on a new Campaign', async () => {
+    const option = {
+      resetSessionOnNewCampaign: true,
+    };
+    const webAttribution = new WebAttribution(option, mockConfig);
+    await webAttribution.init();
+
+    webAttribution.generateCampaignEvent();
+    expect(webAttribution.shouldSetSessionIdOnNewCampaign()).toBe(false);
+  });
+
+  test('should ignore the campaign for direct traffic in session', async () => {
+    const lastEventTime = Date.now();
+
+    const overrideMockConfig = {
+      ...mockConfig,
+      // In session event
+      lastEventTime,
+    };
+    const webAttribution = new WebAttribution({}, overrideMockConfig);
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+      referrer: 'https://www.google.com',
+      referring_domain: 'www.google.com',
+    };
+
+    jest.spyOn(CampaignParser.prototype, 'parse').mockResolvedValue(BASE_CAMPAIGN); // Direct Traffic
+    jest.spyOn(webAttribution.storage, 'get').mockResolvedValue(previousCampaign);
+
+    await webAttribution.init();
+    expect(webAttribution.shouldTrackNewCampaign).toBe(false);
+  });
+
+  test('should not ignore the campaign for direct traffic in new session', async () => {
+    const lastEventTime = Date.now() - 2 * 30 * 60 * 1000;
+
+    const overrideMockConfig = {
+      ...mockConfig,
+      // Out of session event
+      lastEventTime,
+    };
+
+    const webAttribution = new WebAttribution({}, overrideMockConfig);
+    const previousCampaign = {
+      ...BASE_CAMPAIGN,
+      referrer: 'https://www.google.com',
+      referring_domain: 'www.google.com',
+    };
+
+    jest.spyOn(CampaignParser.prototype, 'parse').mockResolvedValue(BASE_CAMPAIGN); // Direct Traffic
+    jest.spyOn(webAttribution.storage, 'get').mockResolvedValue(previousCampaign);
+
+    await webAttribution.init();
+    expect(webAttribution.shouldTrackNewCampaign).toBe(true);
+  });
+});

--- a/packages/analytics-core/test/cookie-name.test.ts
+++ b/packages/analytics-core/test/cookie-name.test.ts
@@ -1,0 +1,24 @@
+import { getCookieName, getOldCookieName } from '../src/cookie-name';
+
+describe('cookie-name', () => {
+  const API_KEY = 'apiKey';
+  describe('getCookieName', () => {
+    test('should return cookie name', () => {
+      expect(getCookieName(API_KEY)).toBe('AMP_apiKey');
+    });
+
+    test('should handle apiKey is empty string', () => {
+      expect(getCookieName('')).toBe('AMP');
+    });
+  });
+
+  describe('getOldCookieName', () => {
+    test('should return cookie name', () => {
+      expect(getOldCookieName(API_KEY)).toBe('amp_apiKey');
+    });
+
+    test('should handle apiKey is empty string', () => {
+      expect(getOldCookieName('')).toBe('amp_');
+    });
+  });
+});

--- a/packages/analytics-core/test/default-tracking.test.ts
+++ b/packages/analytics-core/test/default-tracking.test.ts
@@ -1,0 +1,336 @@
+import {
+  getAttributionTrackingConfig,
+  getPageViewTrackingConfig,
+  getElementInteractionsConfig,
+  isAttributionTrackingEnabled,
+  isFileDownloadTrackingEnabled,
+  isFormInteractionTrackingEnabled,
+  isPageViewTrackingEnabled,
+  isSessionTrackingEnabled,
+  isElementInteractionsEnabled,
+} from '../src/default-tracking';
+
+describe('isFileDownloadTrackingEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isFileDownloadTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isFileDownloadTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isFileDownloadTrackingEnabled(false)).toBe(false);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isFileDownloadTrackingEnabled({
+        fileDownloads: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false with object parameter', () => {
+    expect(
+      isFileDownloadTrackingEnabled({
+        fileDownloads: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isFormInteractionTrackingEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isFormInteractionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isFormInteractionTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isFormInteractionTrackingEnabled(false)).toBe(false);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isFormInteractionTrackingEnabled({
+        formInteractions: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false with object parameter', () => {
+    expect(
+      isFormInteractionTrackingEnabled({
+        formInteractions: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isPageViewTrackingEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isPageViewTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isPageViewTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return true with false parameter', () => {
+    expect(isPageViewTrackingEnabled(false)).toBe(false);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isPageViewTrackingEnabled({
+        pageViews: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false with object parameter', () => {
+    expect(
+      isPageViewTrackingEnabled({
+        pageViews: false,
+      }),
+    ).toBe(false);
+  });
+
+  test('should return true with nested object parameter', () => {
+    expect(
+      isPageViewTrackingEnabled({
+        pageViews: {},
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('isSessionTrackingEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isSessionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isSessionTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isSessionTrackingEnabled(false)).toBe(false);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isSessionTrackingEnabled({
+        sessions: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false with object parameter', () => {
+    expect(
+      isSessionTrackingEnabled({
+        sessions: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isAttributionTrackingEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isAttributionTrackingEnabled(true)).toBe(true);
+  });
+
+  test('should return true with undefined parameter', () => {
+    expect(isAttributionTrackingEnabled(undefined)).toBe(true);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isAttributionTrackingEnabled(false)).toBe(false);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isAttributionTrackingEnabled({
+        attribution: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false with object parameter', () => {
+    expect(
+      isAttributionTrackingEnabled({
+        attribution: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isElementInteractionsEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isElementInteractionsEnabled(true)).toBe(true);
+  });
+
+  test('should return false with undefined parameter', () => {
+    expect(isElementInteractionsEnabled(undefined)).toBe(false);
+  });
+
+  test('should return false with false parameter', () => {
+    expect(isElementInteractionsEnabled(false)).toBe(false);
+  });
+
+  test('should return true with object parameter', () => {
+    expect(
+      isElementInteractionsEnabled({
+        elementInteractions: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false with object parameter', () => {
+    expect(
+      isElementInteractionsEnabled({
+        elementInteractions: false,
+      }),
+    ).toBe(false);
+  });
+
+  test('should return false with object parameter undefined', () => {
+    expect(
+      isElementInteractionsEnabled({
+        elementInteractions: undefined,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('getPageViewTrackingConfig', () => {
+  test('should return undefined trackOn config', () => {
+    const config = getPageViewTrackingConfig({
+      defaultTracking: {
+        pageViews: true,
+      },
+    });
+
+    expect(config.trackOn).toBe(undefined);
+  });
+
+  test('should return trackOn config returning false', () => {
+    const config = getPageViewTrackingConfig({
+      defaultTracking: {
+        pageViews: false,
+      },
+    });
+
+    expect(typeof config.trackOn).toBe('function');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore asserts that track on is a function that returns a boolean
+    expect(config.trackOn()).toBe(false);
+  });
+
+  test('should return advanced options', () => {
+    const config = getPageViewTrackingConfig({
+      defaultTracking: {
+        pageViews: {
+          trackOn: 'attribution',
+          trackHistoryChanges: 'all',
+          eventType: 'Page View',
+        },
+      },
+    });
+
+    expect(typeof config.trackOn).toBe('string');
+    expect(config.trackOn).toBe('attribution');
+    expect(config.trackHistoryChanges).toBe('all');
+    expect(config.eventType).toBe('Page View');
+  });
+});
+
+describe('getAttributionTrackingConfig', () => {
+  test('should return disabled config', () => {
+    const config = getAttributionTrackingConfig({
+      defaultTracking: {
+        attribution: false,
+      },
+    });
+    expect(config).toEqual({
+      excludeReferrers: undefined,
+      initialEmptyValue: undefined,
+      resetSessionOnNewCampaign: undefined,
+    });
+  });
+
+  test('should return default config', () => {
+    const config = getAttributionTrackingConfig({
+      defaultTracking: {
+        attribution: {},
+      },
+    });
+    expect(config).toEqual({
+      excludeReferrers: undefined,
+      initialEmptyValue: undefined,
+      resetSessionOnNewCampaign: undefined,
+    });
+  });
+
+  test('should return custom config', () => {
+    const config = getAttributionTrackingConfig({
+      defaultTracking: {
+        attribution: {
+          excludeReferrers: [],
+          initialEmptyValue: 'EMPTY',
+          resetSessionOnNewCampaign: true,
+        },
+      },
+    });
+    expect(config).toEqual({
+      excludeReferrers: [],
+      initialEmptyValue: 'EMPTY',
+      resetSessionOnNewCampaign: true,
+    });
+  });
+});
+
+describe('getElementInteractionsConfig', () => {
+  test('should return an empty object when autocapture is true', () => {
+    const config = getElementInteractionsConfig({
+      autocapture: true,
+    });
+
+    expect(config).toBeUndefined();
+  });
+
+  test('should return an empty object when userInteraction is true', () => {
+    const config = getElementInteractionsConfig({
+      autocapture: {
+        elementInteractions: true,
+      },
+    });
+
+    expect(config).toBeUndefined();
+  });
+
+  test('should return advanced options', () => {
+    const testCssSelectorAllowlist = ['button'];
+    const testPageUrlAllowlist = ['example.com'];
+    const mockedShouldTrackEventResolver = jest.fn(() => true);
+    const testDataAttributePrefix = 'data-amp-track';
+    const config = getElementInteractionsConfig({
+      autocapture: {
+        elementInteractions: {
+          cssSelectorAllowlist: testCssSelectorAllowlist,
+          pageUrlAllowlist: testPageUrlAllowlist,
+          shouldTrackEventResolver: mockedShouldTrackEventResolver,
+          dataAttributePrefix: testDataAttributePrefix,
+        },
+      },
+    });
+
+    expect(config?.cssSelectorAllowlist).toBe(testCssSelectorAllowlist);
+    expect(config?.pageUrlAllowlist).toBe(testPageUrlAllowlist);
+    expect(config?.shouldTrackEventResolver).toBe(mockedShouldTrackEventResolver);
+    expect(config?.dataAttributePrefix).toBe(testDataAttributePrefix);
+  });
+});

--- a/packages/analytics-core/test/global-scope.test.ts
+++ b/packages/analytics-core/test/global-scope.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { getGlobalScope } from '../src/global-scope';
 

--- a/packages/analytics-core/test/global-scope.test.ts
+++ b/packages/analytics-core/test/global-scope.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { getGlobalScope } from '../src/global-scope';
+
+describe('getGlobalScope', () => {
+  let originalGlobalThis: any;
+
+  beforeEach(() => {
+    originalGlobalThis = globalThis;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    globalThis = originalGlobalThis;
+    delete (globalThis as any).ampIntegrationContext;
+  });
+
+  test('returns ampIntegrationContext if it exists', () => {
+    (globalThis as any).ampIntegrationContext = { someKey: 'someValue' };
+    expect(getGlobalScope()).toBe((globalThis as any).ampIntegrationContext);
+  });
+
+  test('returns globalThis if ampIntegrationContext does not exist', () => {
+    const scope = getGlobalScope();
+    // Need to use Object.is because expect(scope).toBe(globalThis) will throw an error
+    expect(Object.is(scope, globalThis)).toBeTruthy();
+  });
+
+  test('should return window if globalThis is undefined and window is defined', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    globalThis = undefined;
+
+    const scope = getGlobalScope();
+
+    // Note: We NEED to reassign globalThis to its original state because the jest expect function requires it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    globalThis = originalGlobalThis;
+    // Need to use Object.is because expect(scope).toBe(globalThis) will throw an error
+    expect(Object.is(scope, window)).toBeTruthy();
+  });
+});

--- a/packages/analytics-core/test/index.test.ts
+++ b/packages/analytics-core/test/index.test.ts
@@ -15,6 +15,28 @@ import {
   MemoryStorage,
   createIdentifyEvent,
   RequestMetadata,
+  getGlobalScope,
+  getAnalyticsConnector,
+  setConnectorDeviceId,
+  setConnectorUserId,
+  getPageViewTrackingConfig,
+  getAttributionTrackingConfig,
+  getElementInteractionsConfig,
+  isAttributionTrackingEnabled,
+  isFileDownloadTrackingEnabled,
+  isFormInteractionTrackingEnabled,
+  isPageViewTrackingEnabled,
+  isSessionTrackingEnabled,
+  isElementInteractionsEnabled,
+  isNewSession,
+  getQueryParams,
+  getCookieName,
+  getOldCookieName,
+  getLanguage,
+  IdentityEventSender,
+  WebAttribution,
+  CookieStorage,
+  FetchTransport,
 } from '../src/index';
 
 describe('index', () => {
@@ -44,5 +66,31 @@ describe('index', () => {
     expect(typeof createIdentifyEvent).toBe('function');
     expect(AMPLITUDE_PREFIX).toBe('AMP');
     expect(STORAGE_PREFIX).toBe('AMP_unsent');
+    expect(typeof getGlobalScope).toBe('function');
+    expect(typeof getAnalyticsConnector).toBe('function');
+    expect(typeof setConnectorDeviceId).toBe('function');
+    expect(typeof setConnectorUserId).toBe('function');
+    expect(typeof getPageViewTrackingConfig).toBe('function');
+    expect(typeof getAttributionTrackingConfig).toBe('function');
+    expect(typeof getElementInteractionsConfig).toBe('function');
+    expect(typeof isAttributionTrackingEnabled).toBe('function');
+    expect(typeof isFileDownloadTrackingEnabled).toBe('function');
+    expect(typeof isFormInteractionTrackingEnabled).toBe('function');
+    expect(typeof isPageViewTrackingEnabled).toBe('function');
+    expect(typeof isSessionTrackingEnabled).toBe('function');
+    expect(typeof isElementInteractionsEnabled).toBe('function');
+    expect(typeof isNewSession).toBe('function');
+    expect(typeof getQueryParams).toBe('function');
+    expect(typeof getCookieName).toBe('function');
+    expect(typeof getOldCookieName).toBe('function');
+    expect(typeof getLanguage).toBe('function');
+    expect(typeof getPageViewTrackingConfig).toBe('function');
+    expect(typeof IdentityEventSender).toBe('function');
+    expect(() => new IdentityEventSender()).not.toThrow();
+    expect(typeof WebAttribution).toBe('function');
+    expect(typeof CookieStorage).toBe('function');
+    expect(() => new CookieStorage()).not.toThrow();
+    expect(typeof FetchTransport).toBe('function');
+    expect(() => new FetchTransport()).not.toThrow();
   });
 });

--- a/packages/analytics-core/test/language.test.ts
+++ b/packages/analytics-core/test/language.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getLanguage } from '../src/language';
+interface Navigator {
+  language: string | undefined;
+  languages: string[] | undefined;
+  userLanguage: string | undefined;
+}
+
+describe('language', () => {
+  // Simulates other browser version
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const nav: Navigator = navigator;
+
+  beforeAll(() => {
+    Object.defineProperty(nav, 'userLanguage', {
+      get: () => '',
+      configurable: true,
+      enumerable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (nav.userLanguage) {
+      delete nav.userLanguage;
+    }
+  });
+
+  test('should return a language', () => {
+    enableNavigatorLanguageProperties(['languages', 'language', 'userLanguage']);
+    expect(getLanguage()).not.toBeNull();
+  });
+
+  test('should prioritize the first language of navigator.languages', () => {
+    enableNavigatorLanguageProperties(['languages', 'language', 'userLanguage']);
+    expect(getLanguage()).toBe('some-locale');
+  });
+
+  test('should secondly use the language of navigator.language', () => {
+    enableNavigatorLanguageProperties(['language', 'userLanguage']);
+    expect(getLanguage()).toBe('some-second-locale');
+  });
+
+  test('should thirdly use the language of navigator.userLanguage', () => {
+    enableNavigatorLanguageProperties(['userLanguage']);
+    expect(getLanguage()).toBe('some-third-locale');
+  });
+
+  test('should return empty string if navigator language is not set', () => {
+    enableNavigatorLanguageProperties([]);
+    expect(getLanguage()).toBe('');
+  });
+
+  test('should return empty string if navigator is not set', () => {
+    jest.spyOn(window as any, 'navigator', 'get').mockReturnValue(undefined);
+    expect(getLanguage()).toBe('');
+  });
+
+  function enableNavigatorLanguageProperties(properties: Array<'languages' | 'language' | 'userLanguage'>) {
+    jest
+      .spyOn(nav, 'languages', 'get')
+      .mockReturnValue(properties.includes('languages') ? ['some-locale', 'some-other-locale'] : undefined);
+    jest
+      .spyOn(nav, 'language', 'get')
+      .mockReturnValue(properties.includes('language') ? 'some-second-locale' : undefined);
+    jest
+      .spyOn(nav, 'userLanguage', 'get')
+      .mockReturnValue(properties.includes('userLanguage') ? 'some-third-locale' : undefined);
+  }
+});

--- a/packages/analytics-core/test/plugins/identity.test.ts
+++ b/packages/analytics-core/test/plugins/identity.test.ts
@@ -1,0 +1,56 @@
+import { IdentityEventSender } from '../../src/plugins/identity';
+import { Config } from '@amplitude/analytics-types';
+import { getAnalyticsConnector } from '../../src/analytics-connector';
+
+describe('identity', () => {
+  describe('execute', () => {
+    beforeEach(() => {
+      getAnalyticsConnector().identityStore.setIdentity({ userProperties: {} });
+    });
+
+    test('should set identity in analytics connector on identify with default instance', async () => {
+      const plugin = new IdentityEventSender();
+      await plugin.setup({} as Config);
+      const event = {
+        event_type: '$identify',
+        user_properties: {
+          $set: { k: 'v' },
+        },
+      };
+      const result = await plugin.execute(event);
+      const identity = getAnalyticsConnector().identityStore.getIdentity();
+      expect(result).toEqual(event);
+      expect(identity.userProperties).toEqual({ k: 'v' });
+    });
+
+    test('should set identity in analytics connector on identify with instance name', async () => {
+      const plugin = new IdentityEventSender();
+      await plugin.setup({
+        instanceName: 'env',
+      } as Config);
+      const event = {
+        event_type: '$identify',
+        user_properties: {
+          $set: { k: 'v' },
+        },
+      };
+      const result = await plugin.execute(event);
+      const identity = getAnalyticsConnector('env').identityStore.getIdentity();
+      expect(result).toEqual(event);
+      expect(identity.userProperties).toEqual({ k: 'v' });
+    });
+
+    test('should do nothing on track event', async () => {
+      const plugin = new IdentityEventSender();
+      await plugin.setup({} as Config);
+      const event = {
+        event_type: 'test_track',
+      };
+      const result = await plugin.execute(event);
+      expect(result).toEqual(event);
+      const emptyIdentity = { userProperties: {} };
+      const identity = getAnalyticsConnector().identityStore.getIdentity();
+      expect(identity).toEqual(emptyIdentity);
+    });
+  });
+});

--- a/packages/analytics-core/test/query-params.test.ts
+++ b/packages/analytics-core/test/query-params.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getQueryParams } from '../src/query-params';
+import * as GlobalScopeModule from '../src/global-scope';
+
+describe('query-params', () => {
+  describe('getQueryParams', () => {
+    beforeAll(() => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '',
+          writable: true,
+        },
+      });
+    });
+
+    afterAll(() => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '',
+          writable: false,
+        },
+      });
+    });
+
+    test('should parse query params', () => {
+      window.location.search = '?a=1&b=2%20test&&c%24=hello&d';
+      const params = getQueryParams();
+      expect(params).toEqual({
+        a: '1',
+        b: '2 test',
+        c$: 'hello',
+      });
+    });
+
+    test('should parse malformed uri', () => {
+      window.location.search = '?fb=X+%EF%BF%BD%93+C';
+      const params = getQueryParams();
+      expect(params).toEqual({});
+    });
+
+    test('should handle undefined global scope', () => {
+      jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValueOnce(undefined);
+      const params = getQueryParams();
+      expect(params).toEqual({});
+    });
+  });
+});

--- a/packages/analytics-core/test/session.test.ts
+++ b/packages/analytics-core/test/session.test.ts
@@ -1,0 +1,25 @@
+import { isNewSession } from '../src/session';
+
+describe('session', () => {
+  const sessionTimeout: number = 30 * 60 * 1000;
+
+  test('should be in a same session for undefined lastEventTime', () => {
+    const isEventInNewSession = isNewSession(sessionTimeout, undefined);
+
+    expect(isEventInNewSession).toBe(false);
+  });
+
+  test('should be a new session', () => {
+    const lastEventTime = Date.now() - sessionTimeout * 2;
+    const isEventInNewSession = isNewSession(sessionTimeout, lastEventTime);
+
+    expect(isEventInNewSession).toBe(true);
+  });
+
+  test('should be in a same session', () => {
+    const lastEventTime = Date.now();
+    const isEventInNewSession = isNewSession(sessionTimeout, lastEventTime);
+
+    expect(isEventInNewSession).toBe(false);
+  });
+});

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { CookieStorage } from '../../src/storage/cookie';
 import * as GlobalScopeModule from '../../src/global-scope';
 

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -1,0 +1,142 @@
+import { CookieStorage } from '../../src/storage/cookie';
+import * as GlobalScopeModule from '../../src/global-scope';
+
+describe('cookies', () => {
+  describe('isEnabled', () => {
+    test('should return true', async () => {
+      const cookies = new CookieStorage();
+      expect(await cookies.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    test('should return undefined for no cookie value', async () => {
+      const cookies = new CookieStorage();
+      expect(await cookies.get('hello')).toBe(undefined);
+    });
+
+    test('should return non-encoded value', async () => {
+      const cookies = new CookieStorage();
+      document.cookie = 'hello=world';
+      expect(await cookies.get('hello')).toBe(undefined);
+      await cookies.remove('world');
+    });
+
+    test('should handle double url encoded value for Ruby Rails', async () => {
+      const cookies = new CookieStorage();
+      const value = { a: 1 };
+      const cookieValue = encodeURIComponent(btoa(encodeURIComponent(JSON.stringify(value))));
+      document.cookie = `hello=${cookieValue}`;
+      expect(await cookies.get('hello')).toEqual(value);
+      await cookies.remove('world');
+    });
+
+    test('should return cookie object value', async () => {
+      const cookies = new CookieStorage<Record<string, number>>();
+      await cookies.set('hello', { a: 1 });
+      expect(await cookies.get('hello')).toEqual({ a: 1 });
+      await cookies.remove('hello');
+    });
+
+    test('should catch non-json format value', async () => {
+      const cookies = new CookieStorage();
+      const value = '{"a":1';
+      const encodedValue = btoa(encodeURIComponent(value));
+      document.cookie = `hello=${encodedValue}`;
+      expect(await cookies.get('hello')).toBe(undefined);
+    });
+
+    test('should return cookie array value', async () => {
+      const cookies = new CookieStorage<number[]>();
+      await cookies.set('hello', [1]);
+      expect(await cookies.get('hello')).toEqual([1]);
+      await cookies.remove('hello');
+    });
+
+    test('should return undefined when global scope is not defined', async () => {
+      const cookies = new CookieStorage<number[]>();
+      await cookies.set('hello', [1]);
+      jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValueOnce(undefined);
+      expect(await cookies.get('hello')).toEqual(undefined);
+      await cookies.remove('hello');
+    });
+
+    test('should return undefined when global scope is defined but document is not', async () => {
+      const cookies = new CookieStorage<number[]>();
+      await cookies.set('hello', [1]);
+      jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValueOnce({} as typeof globalThis);
+      expect(await cookies.get('hello')).toEqual(undefined);
+      await cookies.remove('hello');
+    });
+  });
+
+  describe('set', () => {
+    test('should set cookie value', async () => {
+      const cookies = new CookieStorage();
+      await cookies.set('hello', 'world');
+      expect(await cookies.get('hello')).toBe('world');
+      await cookies.remove('hello');
+    });
+
+    test('should set cookie value with options', async () => {
+      const cookies = new CookieStorage({
+        expirationDays: 365,
+        domain: '',
+        secure: false,
+        sameSite: 'Lax',
+      });
+      await cookies.set('hello', 'world');
+      expect(await cookies.get('hello')).toBe('world');
+      await cookies.remove('hello');
+    });
+
+    test('should set restricted cookie value with options', async () => {
+      const cookies = new CookieStorage({
+        expirationDays: 365,
+        domain: '.amplitude.com',
+        secure: true,
+        sameSite: 'Lax',
+      });
+      await cookies.set('hello', 'world');
+      expect(await cookies.get('hello')).toBe(undefined);
+      await cookies.remove('hello');
+    });
+
+    test.each([new Error('Simulated error'), 'Simulated error'])(
+      'logs an error message when setting a cookie fails',
+      async (error) => {
+        console.error = jest.fn();
+        jest.spyOn(global, 'btoa').mockImplementation(() => {
+          throw error;
+        });
+
+        const cookies = new CookieStorage();
+        await cookies.set('hello', 'world');
+
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Amplitude Logger [Error]: Failed to set cookie for key: hello. Error: Simulated error`,
+          ),
+        );
+
+        jest.restoreAllMocks();
+      },
+    );
+  });
+
+  describe('remove', () => {
+    test('should call set', async () => {
+      const cookies = new CookieStorage();
+      const set = jest.spyOn(cookies, 'set');
+      await cookies.remove('key');
+      expect(set).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reset', () => {
+    test('should return undefined', async () => {
+      const cookies = new CookieStorage();
+      expect(await cookies.reset()).toBe(undefined);
+    });
+  });
+});

--- a/packages/analytics-core/test/transports/fetch.test.ts
+++ b/packages/analytics-core/test/transports/fetch.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { FetchTransport } from '../../src/transports/fetch';
+import { Status } from '@amplitude/analytics-types';
+import 'isomorphic-fetch';
+
+describe('fetch', () => {
+  describe('send', () => {
+    test.each([
+      ['{}'], // ideally response body should be json format to an application/json request
+      [''], // test the edge case where response body is non-json format
+      ['<'],
+    ])('should resolve with response', async (body) => {
+      const transport = new FetchTransport();
+      const url = 'http://localhost:3000';
+      const payload = {
+        api_key: '',
+        events: [],
+      };
+      const result = {
+        statusCode: 200,
+        status: Status.Success as const,
+        body: {
+          eventsIngested: 0,
+          payloadSizeBytes: 0,
+          serverUploadTime: 0,
+        },
+      };
+      jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response(body)));
+      jest.spyOn(transport, 'buildResponse').mockReturnValueOnce(result);
+      const response = await transport.send(url, payload);
+      expect(response).toEqual(result);
+    });
+  });
+});


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-125322](https://amplitude.atlassian.net/browse/AMP-125322)

- Merge analytics-client-common into analytics-core
- Remove analytics-client-common dependency in analytics-browser
- analytics-client-common is still used in analytics-react-native, SR SDK (@lewgordon-amplitude ) and autocapture (@Dogfalo). Will remove them in separate PRs.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-125322]: https://amplitude.atlassian.net/browse/AMP-125322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ