### PR TITLE
fix(autocapture): remove time assignment for element interactions tracking

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-action-click.ts
@@ -75,9 +75,6 @@ export function trackActionClick({
     amplitude?.track(
       AMPLITUDE_ELEMENT_CLICKED_EVENT,
       getEventProperties('click', (actionClick as ElementBasedTimestampedEvent<MouseEvent>).closestTrackedAncestor),
-      {
-        time: actionClick.timestamp,
-      },
     );
   });
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-click.ts
@@ -60,9 +60,7 @@ export function trackClicks({
 
     for (const click of clicks) {
       /* istanbul ignore next */
-      amplitude?.track(clickType, click.targetElementProperties, {
-        time: click.timestamp,
-      });
+      amplitude?.track(clickType, click.targetElementProperties);
     }
   });
 }

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -140,53 +140,48 @@ describe('action clicks:', () => {
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 503));
 
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(
-        1,
-        '[Amplitude] Element Clicked',
-        {
-          '[Amplitude] Element Hierarchy': [
-            {
-              id: 'addDivButton',
-              index: 0,
-              indexOfType: 0,
-              tag: 'div',
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Hierarchy': [
+          {
+            id: 'addDivButton',
+            index: 0,
+            indexOfType: 0,
+            tag: 'div',
+          },
+          {
+            id: 'inner-left',
+            classes: ['column'],
+            index: 0,
+            indexOfType: 0,
+            tag: 'div',
+          },
+          {
+            attrs: {
+              'data-test-attr': 'test-attr',
             },
-            {
-              id: 'inner-left',
-              classes: ['column'],
-              index: 0,
-              indexOfType: 0,
-              tag: 'div',
-            },
-            {
-              attrs: {
-                'data-test-attr': 'test-attr',
-              },
-              id: 'main',
-              classes: ['class1', 'class2'],
-              index: 0,
-              indexOfType: 0,
-              tag: 'div',
-            },
-            {
-              index: 1,
-              indexOfType: 0,
-              prevSib: 'head',
-              tag: 'body',
-            },
-          ],
-          '[Amplitude] Element ID': 'addDivButton',
-          '[Amplitude] Element Parent Label': 'Card Title',
-          '[Amplitude] Element Position Left': 0,
-          '[Amplitude] Element Position Top': 0,
-          '[Amplitude] Element Selector': '#addDivButton',
-          '[Amplitude] Element Tag': 'div',
-          '[Amplitude] Element Text': 'Add div',
-          '[Amplitude] Viewport Height': 768,
-          '[Amplitude] Viewport Width': 1024,
-        },
-        { time: expect.any(Number) as number },
-      );
+            id: 'main',
+            classes: ['class1', 'class2'],
+            index: 0,
+            indexOfType: 0,
+            tag: 'div',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+        ],
+        '[Amplitude] Element ID': 'addDivButton',
+        '[Amplitude] Element Parent Label': 'Card Title',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Selector': '#addDivButton',
+        '[Amplitude] Element Tag': 'div',
+        '[Amplitude] Element Text': 'Add div',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
     });
 
     test('should not trigger duplicate events if the immediate click target is in the action click allowlist', async () => {
@@ -207,7 +202,6 @@ describe('action clicks:', () => {
           '[Amplitude] Element Tag': 'button',
           '[Amplitude] Element Text': 'Click me',
         }),
-        { time: expect.any(Number) as number },
       );
     });
 
@@ -228,7 +222,6 @@ describe('action clicks:', () => {
           '[Amplitude] Element Parent Label': 'Add div',
           '[Amplitude] Element Tag': 'span',
         }),
-        { time: expect.any(Number) as number },
       );
     });
 
@@ -259,7 +252,6 @@ describe('action clicks:', () => {
             '[Amplitude] Element Parent Label': 'Card Title',
             '[Amplitude] Element Tag': 'h1',
           }),
-          { time: expect.any(Number) as number },
         );
         expect(document.querySelectorAll('.new-div').length).toBe(2);
       });

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -162,45 +162,40 @@ describe('autoTrackingPlugin', () => {
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(
-        1,
-        '[Amplitude] Element Clicked',
-        {
-          '[Amplitude] Element Class': 'my-link-class',
-          '[Amplitude] Element Hierarchy': [
-            {
-              attrs: {
-                'aria-label': 'my-link',
-                href: 'https://www.amplitude.com/click-link',
-              },
-              classes: ['my-link-class'],
-              id: 'my-link-id',
-              index: 0,
-              indexOfType: 0,
-              tag: 'a',
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-link-class',
+        '[Amplitude] Element Hierarchy': [
+          {
+            attrs: {
+              'aria-label': 'my-link',
+              href: 'https://www.amplitude.com/click-link',
             },
-            {
-              index: 1,
-              indexOfType: 0,
-              prevSib: 'head',
-              tag: 'body',
-            },
-          ],
-          '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
-          '[Amplitude] Element ID': 'my-link-id',
-          '[Amplitude] Element Position Left': 0,
-          '[Amplitude] Element Position Top': 0,
-          '[Amplitude] Element Tag': 'a',
-          '[Amplitude] Element Text': 'my-link-text',
-          '[Amplitude] Element Aria Label': 'my-link',
-          '[Amplitude] Element Selector': '#my-link-id',
-          '[Amplitude] Element Parent Label': 'my-h2-text',
-          '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-          '[Amplitude] Viewport Height': 768,
-          '[Amplitude] Viewport Width': 1024,
-        },
-        { time: expect.any(Number) as number },
-      );
+            classes: ['my-link-class'],
+            id: 'my-link-id',
+            index: 0,
+            indexOfType: 0,
+            tag: 'a',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+        ],
+        '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
+        '[Amplitude] Element ID': 'my-link-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'a',
+        '[Amplitude] Element Text': 'my-link-text',
+        '[Amplitude] Element Aria Label': 'my-link',
+        '[Amplitude] Element Selector': '#my-link-id',
+        '[Amplitude] Element Parent Label': 'my-h2-text',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
 
       // stop observer and listeners
       await plugin?.teardown?.();
@@ -272,7 +267,6 @@ describe('autoTrackingPlugin', () => {
             { index: 1, indexOfType: 0, prevSib: 'head', tag: 'body' },
           ],
         }),
-        { time: expect.any(Number) as number },
       );
 
       // stop observer and listeners
@@ -304,45 +298,40 @@ describe('autoTrackingPlugin', () => {
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(
-        1,
-        '[Amplitude] Element Clicked',
-        {
-          '[Amplitude] Element Class': 'my-link-class',
-          '[Amplitude] Element Hierarchy': [
-            {
-              attrs: {
-                'aria-label': 'my-link',
-                href: 'https://www.amplitude.com/click-link',
-              },
-              classes: ['my-link-class'],
-              id: 'my-link-id',
-              index: 0,
-              indexOfType: 0,
-              tag: 'a',
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-link-class',
+        '[Amplitude] Element Hierarchy': [
+          {
+            attrs: {
+              'aria-label': 'my-link',
+              href: 'https://www.amplitude.com/click-link',
             },
-            {
-              index: 1,
-              indexOfType: 0,
-              prevSib: 'head',
-              tag: 'body',
-            },
-          ],
-          '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
-          '[Amplitude] Element ID': 'my-link-id',
-          '[Amplitude] Element Position Left': 0,
-          '[Amplitude] Element Position Top': 0,
-          '[Amplitude] Element Tag': 'a',
-          '[Amplitude] Element Text': 'my-link-text',
-          '[Amplitude] Element Aria Label': 'my-link',
-          '[Amplitude] Element Selector': '#my-link-id',
-          '[Amplitude] Element Parent Label': 'my-h2-text',
-          '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-          '[Amplitude] Viewport Height': 768,
-          '[Amplitude] Viewport Width': 1024,
-        },
-        { time: expect.any(Number) as number },
-      );
+            classes: ['my-link-class'],
+            id: 'my-link-id',
+            index: 0,
+            indexOfType: 0,
+            tag: 'a',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+        ],
+        '[Amplitude] Element Href': 'https://www.amplitude.com/click-link',
+        '[Amplitude] Element ID': 'my-link-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'a',
+        '[Amplitude] Element Text': 'my-link-text',
+        '[Amplitude] Element Aria Label': 'my-link',
+        '[Amplitude] Element Selector': '#my-link-id',
+        '[Amplitude] Element Parent Label': 'my-h2-text',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
 
       // stop observer and listeners
       await plugin?.teardown?.();
@@ -376,44 +365,39 @@ describe('autoTrackingPlugin', () => {
 
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(
-        1,
-        '[Amplitude] Element Clicked',
-        {
-          '[Amplitude] Element Class': 'my-button-class',
-          '[Amplitude] Element Hierarchy': [
-            {
-              attrs: {
-                'aria-label': 'my-button',
-              },
-              classes: ['my-button-class'],
-              id: 'my-button-id',
-              index: 2,
-              indexOfType: 0,
-              prevSib: 'h2',
-              tag: 'button',
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-button-class',
+        '[Amplitude] Element Hierarchy': [
+          {
+            attrs: {
+              'aria-label': 'my-button',
             },
-            {
-              index: 1,
-              indexOfType: 0,
-              prevSib: 'head',
-              tag: 'body',
-            },
-          ],
-          '[Amplitude] Element ID': 'my-button-id',
-          '[Amplitude] Element Position Left': 0,
-          '[Amplitude] Element Position Top': 0,
-          '[Amplitude] Element Tag': 'button',
-          '[Amplitude] Element Text': 'submit',
-          '[Amplitude] Element Aria Label': 'my-button',
-          '[Amplitude] Element Selector': '#my-button-id',
-          '[Amplitude] Element Parent Label': 'my-h2-text',
-          '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-          '[Amplitude] Viewport Height': 768,
-          '[Amplitude] Viewport Width': 1024,
-        },
-        { time: expect.any(Number) as number },
-      );
+            classes: ['my-button-class'],
+            id: 'my-button-id',
+            index: 2,
+            indexOfType: 0,
+            prevSib: 'h2',
+            tag: 'button',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+        ],
+        '[Amplitude] Element ID': 'my-button-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'button',
+        '[Amplitude] Element Text': 'submit',
+        '[Amplitude] Element Aria Label': 'my-button',
+        '[Amplitude] Element Selector': '#my-button-id',
+        '[Amplitude] Element Parent Label': 'my-h2-text',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
 
       // stop observer and listeners
       await plugin?.teardown?.();
@@ -453,44 +437,39 @@ describe('autoTrackingPlugin', () => {
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(
-        1,
-        '[Amplitude] Element Clicked',
-        {
-          '[Amplitude] Element Class': 'my-button-class',
-          '[Amplitude] Element Hierarchy': [
-            {
-              attrs: {
-                'aria-label': 'my-button',
-              },
-              classes: ['my-button-class'],
-              id: 'my-button-id',
-              index: 2,
-              indexOfType: 0,
-              prevSib: 'h2',
-              tag: 'button',
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-button-class',
+        '[Amplitude] Element Hierarchy': [
+          {
+            attrs: {
+              'aria-label': 'my-button',
             },
-            {
-              index: 1,
-              indexOfType: 0,
-              prevSib: 'head',
-              tag: 'body',
-            },
-          ],
-          '[Amplitude] Element ID': 'my-button-id',
-          '[Amplitude] Element Position Left': 0,
-          '[Amplitude] Element Position Top': 0,
-          '[Amplitude] Element Tag': 'button',
-          '[Amplitude] Element Text': 'submit',
-          '[Amplitude] Element Aria Label': 'my-button',
-          '[Amplitude] Element Selector': '#my-button-id',
-          '[Amplitude] Element Parent Label': 'my-h2-text',
-          '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-          '[Amplitude] Viewport Height': 768,
-          '[Amplitude] Viewport Width': 1024,
-        },
-        { time: expect.any(Number) as number },
-      );
+            classes: ['my-button-class'],
+            id: 'my-button-id',
+            index: 2,
+            indexOfType: 0,
+            prevSib: 'h2',
+            tag: 'button',
+          },
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+        ],
+        '[Amplitude] Element ID': 'my-button-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'button',
+        '[Amplitude] Element Text': 'submit',
+        '[Amplitude] Element Aria Label': 'my-button',
+        '[Amplitude] Element Selector': '#my-button-id',
+        '[Amplitude] Element Parent Label': 'my-h2-text',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+      });
 
       // stop observer and listeners
       await plugin?.teardown?.();
@@ -740,51 +719,46 @@ describe('autoTrackingPlugin', () => {
       await new Promise((r) => setTimeout(r, TESTING_DEBOUNCE_TIME + 3));
 
       expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenNthCalledWith(
-        1,
-        '[Amplitude] Element Clicked',
-        {
-          '[Amplitude] Element Class': 'my-button-class',
-          '[Amplitude] Element Hierarchy': [
-            {
-              attrs: {
-                'data-amp-test-hello': 'world',
-                'data-amp-test-test': '',
-                'data-amp-test-time': 'machine',
-              },
-              classes: ['my-button-class'],
-              id: 'my-button-id',
-              index: 2,
-              indexOfType: 0,
-              prevSib: 'h2',
-              tag: 'button',
+      expect(track).toHaveBeenNthCalledWith(1, '[Amplitude] Element Clicked', {
+        '[Amplitude] Element Class': 'my-button-class',
+        '[Amplitude] Element Hierarchy': [
+          {
+            attrs: {
+              'data-amp-test-hello': 'world',
+              'data-amp-test-test': '',
+              'data-amp-test-time': 'machine',
             },
-
-            {
-              index: 1,
-              indexOfType: 0,
-              prevSib: 'head',
-              tag: 'body',
-            },
-          ],
-          '[Amplitude] Element ID': 'my-button-id',
-          '[Amplitude] Element Position Left': 0,
-          '[Amplitude] Element Position Top': 0,
-          '[Amplitude] Element Tag': 'button',
-          '[Amplitude] Element Text': 'submit',
-          '[Amplitude] Element Selector': '#my-button-id',
-          '[Amplitude] Element Parent Label': 'my-h2-text',
-          '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-          '[Amplitude] Viewport Height': 768,
-          '[Amplitude] Viewport Width': 1024,
-          '[Amplitude] Element Attributes': {
-            hello: 'world',
-            time: 'machine',
-            test: '',
+            classes: ['my-button-class'],
+            id: 'my-button-id',
+            index: 2,
+            indexOfType: 0,
+            prevSib: 'h2',
+            tag: 'button',
           },
+
+          {
+            index: 1,
+            indexOfType: 0,
+            prevSib: 'head',
+            tag: 'body',
+          },
+        ],
+        '[Amplitude] Element ID': 'my-button-id',
+        '[Amplitude] Element Position Left': 0,
+        '[Amplitude] Element Position Top': 0,
+        '[Amplitude] Element Tag': 'button',
+        '[Amplitude] Element Text': 'submit',
+        '[Amplitude] Element Selector': '#my-button-id',
+        '[Amplitude] Element Parent Label': 'my-h2-text',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+        '[Amplitude] Viewport Height': 768,
+        '[Amplitude] Viewport Width': 1024,
+        '[Amplitude] Element Attributes': {
+          hello: 'world',
+          time: 'machine',
+          test: '',
         },
-        { time: expect.any(Number) as number },
-      );
+      });
     });
     test('should follow default debounceTime configuration', async () => {
       const oldFetch = global.fetch;
@@ -982,7 +956,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'inner',
           }),
-          { time: expect.any(Number) as number },
         );
 
         // trigger click container
@@ -996,7 +969,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'container1',
           }),
-          { time: expect.any(Number) as number },
         );
       });
 
@@ -1040,7 +1012,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'container1',
           }),
-          { time: expect.any(Number) as number },
         );
 
         // trigger click container
@@ -1054,7 +1025,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'container1',
           }),
-          { time: expect.any(Number) as number },
         );
       });
 
@@ -1094,7 +1064,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'container',
           }),
-          { time: expect.any(Number) as number },
         );
 
         // trigger click container
@@ -1108,7 +1077,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'container',
           }),
-          { time: expect.any(Number) as number },
         );
       });
 
@@ -1149,7 +1117,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'inner',
           }),
-          { time: expect.any(Number) as number },
         );
 
         // trigger click container
@@ -1163,7 +1130,6 @@ describe('autoTrackingPlugin', () => {
           expect.objectContaining({
             '[Amplitude] Element ID': 'container',
           }),
-          { time: expect.any(Number) as number },
         );
       });
     });


### PR DESCRIPTION
### Summary
[AMP-122086](https://amplitude.atlassian.net/browse/AMP-122086)

Previously time was assigned to the event based on the exact timestamp of the event when it was fired. This was meant to ensure that any delay in calling track() would not impact the ordering of events.
However it seems like this potentially has the opposite effect where it causes these events to appear in the wrong order in the user timeline

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-122086]: https://amplitude.atlassian.net/browse/AMP-122086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ