### PR TITLE
feat(session replay): initial network observers

### DIFF
--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -17,7 +17,7 @@ export interface LoggingConfig {
     enabled: boolean;
     levels: ConsoleLogLevel[];
   };
-  network: {
+  network?: {
     enabled: boolean;
   };
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -17,6 +17,9 @@ export interface LoggingConfig {
     enabled: boolean;
     levels: ConsoleLogLevel[];
   };
+  network: {
+    enabled: boolean;
+  };
 }
 
 export type SessionReplayRemoteConfig = {

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -30,4 +30,5 @@ export const MAX_URL_LENGTH = 1000;
 export enum CustomRRwebEvent {
   GET_SR_PROPS = 'get-sr-props',
   DEBUG_INFO = 'debug-info',
+  FETCH_REQUEST = 'fetch-request',
 }

--- a/packages/session-replay-browser/src/observers.ts
+++ b/packages/session-replay-browser/src/observers.ts
@@ -32,6 +32,10 @@ export class NetworkObservers {
     this.eventCallback = undefined;
   }
 
+  protected notifyEvent(event: NetworkRequestEvent) {
+    this.eventCallback?.(event);
+  }
+
   private observeFetch() {
     const globalScope = getGlobalScope();
     if (!globalScope) return;
@@ -63,7 +67,7 @@ export class NetworkObservers {
         });
         requestEvent.responseHeaders = headers;
 
-        this.eventCallback?.(requestEvent);
+        this.notifyEvent(requestEvent);
         return response;
       } catch (error) {
         const endTime = Date.now();
@@ -76,7 +80,7 @@ export class NetworkObservers {
           message: typedError.message || 'An unknown error occurred',
         };
 
-        this.eventCallback?.(requestEvent);
+        this.notifyEvent(requestEvent);
         throw error;
       }
     };

--- a/packages/session-replay-browser/src/observers.ts
+++ b/packages/session-replay-browser/src/observers.ts
@@ -1,0 +1,83 @@
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+// import type { Logger } from '@amplitude/analytics-types';
+
+export interface NetworkRequestEvent {
+  timestamp: number;
+  type: 'fetch';
+  method: string;
+  url: string;
+  status?: number;
+  duration?: number;
+  requestHeaders?: Record<string, string>;
+  responseHeaders?: Record<string, string>;
+}
+
+export type NetworkEventCallback = (event: NetworkRequestEvent) => void;
+
+export class NetworkObservers {
+  private fetchObserver: (() => void) | null = null;
+  //   private loggerProvider: Logger;
+  private eventCallback?: NetworkEventCallback;
+
+  //   constructor(loggerProvider: Logger) {
+  constructor() {
+    // this.loggerProvider = loggerProvider;
+  }
+
+  start(eventCallback: NetworkEventCallback) {
+    this.eventCallback = eventCallback;
+    this.observeFetch();
+  }
+
+  stop() {
+    this.fetchObserver?.();
+    this.fetchObserver = null;
+    this.eventCallback = undefined;
+  }
+
+  private observeFetch() {
+    const globalScope = getGlobalScope();
+    if (!globalScope) return;
+
+    const originalFetch = globalScope.fetch;
+    if (!originalFetch) return;
+
+    globalScope.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const startTime = Date.now();
+      const requestEvent: NetworkRequestEvent = {
+        timestamp: startTime,
+        type: 'fetch',
+        method: init?.method || 'GET',
+        url: input.toString(),
+        requestHeaders: init?.headers as Record<string, string>,
+      };
+
+      try {
+        const response = await originalFetch(input, init);
+        const endTime = Date.now();
+
+        requestEvent.status = response.status;
+        requestEvent.duration = endTime - startTime;
+
+        // Convert Headers
+        const headers: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+          headers[key] = value;
+        });
+        requestEvent.responseHeaders = headers;
+
+        this.eventCallback?.(requestEvent);
+        return response;
+      } catch (error) {
+        const endTime = Date.now();
+        requestEvent.duration = endTime - startTime;
+        this.eventCallback?.(requestEvent);
+        throw error;
+      }
+    };
+
+    this.fetchObserver = () => {
+      globalScope.fetch = originalFetch;
+    };
+  }
+}

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -148,6 +148,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
     this.eventCompressor = new EventCompressor(this.eventsManager, this.config, this.getDeviceId());
 
+    // Initialize network observers if logging is enabled
+    if (this.config?.loggingConfig?.network?.enabled) {
+      this.networkObservers = new NetworkObservers();
+    }
+
     this.loggerProvider.log('Installing @amplitude/session-replay-browser.');
 
     this.teardownEventListeners(false);
@@ -354,10 +359,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
       void this.addCustomRRWebEvent(CustomRRwebEvent.FETCH_REQUEST, event);
     });
     const { privacyConfig, interactionConfig, loggingConfig } = config;
-
-    if (loggingConfig?.network?.enabled) {
-      this.networkObservers = new NetworkObservers();
-    }
 
     const hooks = interactionConfig?.enabled
       ? {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -149,7 +149,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.eventCompressor = new EventCompressor(this.eventsManager, this.config, this.getDeviceId());
 
     // Initialize network observers if logging is enabled
-    if (this.config?.loggingConfig?.network?.enabled) {
+    if (this.config.loggingConfig?.network?.enabled) {
       this.networkObservers = new NetworkObservers();
     }
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -33,6 +33,7 @@ import { VERSION } from './version';
 import { EventCompressor } from './events/event-compressor';
 import { getRecordConsolePlugin } from '@amplitude/rrweb-plugin-console-record';
 import { SafeLoggerProvider } from './logger';
+import { NetworkObservers, NetworkRequestEvent } from './observers';
 
 type PageLeaveFn = (e: PageTransitionEvent | Event) => void;
 
@@ -50,6 +51,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   // Visible for testing
   pageLeaveFns: PageLeaveFn[] = [];
   private scrollHook?: scrollCallback;
+  private networkObservers?: NetworkObservers;
 
   constructor() {
     this.loggerProvider = new SafeLoggerProvider(new Logger());
@@ -87,6 +89,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     this.config = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
+    // this.networkObservers = new NetworkObservers(this.loggerProvider);
+    this.networkObservers = new NetworkObservers();
 
     if (options.sessionId && this.config.interactionConfig?.enabled) {
       const scrollWatcher = ScrollWatcher.default(
@@ -348,6 +352,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return;
     }
     this.stopRecordingEvents();
+    this.networkObservers?.start((event: NetworkRequestEvent) => {
+      void this.addCustomRRWebEvent(CustomRRwebEvent.FETCH_REQUEST, event);
+    });
     const { privacyConfig, interactionConfig, loggingConfig } = config;
 
     const hooks = interactionConfig?.enabled
@@ -438,6 +445,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       }
       // Check first to ensure we are recording
       if (this.recordCancelCallback) {
+        this.loggerProvider.debug('Adding custom replay capture event:', JSON.stringify(eventData));
         record.addCustomEvent(eventName, {
           ...eventData,
           ...debugInfo,
@@ -457,6 +465,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.loggerProvider.log('Session Replay capture stopping.');
       this.recordCancelCallback && this.recordCancelCallback();
       this.recordCancelCallback = null;
+      this.networkObservers?.stop();
     } catch (error) {
       const typedError = error as Error;
       this.loggerProvider.warn(`Error occurred while stopping replay capture: ${typedError.toString()}`);

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -353,6 +353,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
     this.stopRecordingEvents();
     this.networkObservers?.start((event: NetworkRequestEvent) => {
+      console.log('event in observer', event);
       void this.addCustomRRWebEvent(CustomRRwebEvent.FETCH_REQUEST, event);
     });
     const { privacyConfig, interactionConfig, loggingConfig } = config;

--- a/packages/session-replay-browser/test/observers.test.ts
+++ b/packages/session-replay-browser/test/observers.test.ts
@@ -1,0 +1,213 @@
+import { NetworkObservers, NetworkRequestEvent } from '../src/observers';
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+
+type PartialGlobal = Pick<typeof globalThis, 'fetch'>;
+
+// Test subclass to access protected methods
+class TestNetworkObservers extends NetworkObservers {
+  public testNotifyEvent(event: NetworkRequestEvent) {
+    this.notifyEvent(event);
+  }
+}
+
+describe('NetworkObservers', () => {
+  let networkObservers: TestNetworkObservers;
+  let mockFetch: jest.Mock;
+  let events: NetworkRequestEvent[] = [];
+  let globalScope: PartialGlobal;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    events = [];
+    mockFetch = jest.fn();
+    globalScope = { fetch: mockFetch };
+
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+
+    networkObservers = new TestNetworkObservers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const callback = (event: NetworkRequestEvent) => {
+    events.push(event);
+  };
+
+  describe('successful requests', () => {
+    it('should track successful fetch requests with headers', async () => {
+      // Create a simple mock response
+      const mockResponse = {
+        status: 200,
+        headers: {
+          forEach: (callback: (value: string, key: string) => void) => {
+            callback('application/json', 'content-type');
+            callback('test-server', 'server');
+          },
+        },
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      networkObservers.start(callback);
+
+      const requestHeaders = {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token123',
+      };
+
+      await globalScope.fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: requestHeaders,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'fetch',
+        method: 'POST',
+        url: 'https://api.example.com/data',
+        status: 200,
+        requestHeaders,
+        responseHeaders: {
+          'content-type': 'application/json',
+          server: 'test-server',
+        },
+      });
+      expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should track successful fetch requests without headers', async () => {
+      const mockResponse = {
+        status: 200,
+        headers: {
+          forEach: jest.fn(), // Mock function that does nothing
+        },
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      networkObservers.start(callback);
+
+      await globalScope.fetch('https://api.example.com/data');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'fetch',
+        method: 'GET',
+        url: 'https://api.example.com/data',
+        status: 200,
+        requestHeaders: undefined,
+        responseHeaders: {},
+      });
+      expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('failed requests', () => {
+    it('should track network errors', async () => {
+      const networkError = new TypeError('Failed to fetch');
+      mockFetch.mockRejectedValue(networkError);
+
+      networkObservers.start(callback);
+
+      await expect(globalScope.fetch('https://api.example.com/data')).rejects.toThrow('Failed to fetch');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'fetch',
+        method: 'GET',
+        url: 'https://api.example.com/data',
+        error: {
+          name: 'TypeError',
+          message: 'Failed to fetch',
+        },
+      });
+      expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle non-Error throws', async () => {
+      mockFetch.mockRejectedValue('string error');
+
+      networkObservers.start(callback);
+
+      await expect(globalScope.fetch('https://api.example.com/data')).rejects.toBe('string error');
+
+      expect(events).toHaveLength(1);
+      expect(events[0].error).toEqual({
+        name: 'UnknownError',
+        message: 'An unknown error occurred',
+      });
+    });
+  });
+
+  describe('observer lifecycle', () => {
+    it('should stop tracking when stopped', async () => {
+      networkObservers.start(callback);
+      networkObservers.stop();
+
+      expect(globalScope.fetch).toBe(mockFetch);
+
+      await mockFetch('https://api.example.com/data');
+      expect(events).toHaveLength(0);
+    });
+
+    it('should handle missing global scope', () => {
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+
+      networkObservers.start(callback);
+
+      expect(() => networkObservers.stop()).not.toThrow();
+    });
+
+    it('should handle missing fetch', () => {
+      const scopeWithoutFetch = {} as typeof globalThis;
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(scopeWithoutFetch);
+
+      networkObservers.start(callback);
+
+      expect(() => networkObservers.stop()).not.toThrow();
+    });
+
+    it('should call eventCallback with request event data', async () => {
+      const mockCallback = jest.fn();
+      const mockResponse = {
+        status: 200,
+        headers: {
+          forEach: (callback: (value: string, key: string) => void) => {
+            callback('application/json', 'content-type');
+          },
+        },
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      networkObservers.start(mockCallback);
+
+      await globalScope.fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle notifyEvent with optional chaining', async () => {
+      const mockEvent = {
+        timestamp: Date.now(),
+        type: 'fetch' as const,
+        method: 'GET',
+        url: 'https://api.example.com/data',
+      };
+
+      // Test with callback
+      const mockCallback = jest.fn();
+      networkObservers.start(mockCallback);
+      networkObservers.testNotifyEvent(mockEvent);
+      expect(mockCallback).toHaveBeenCalledWith(mockEvent);
+
+      // Test without callback
+      networkObservers.stop();
+      networkObservers.testNotifyEvent(mockEvent);
+      expect(mockCallback).toHaveBeenCalledTimes(1); // Still only called once
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -13005,16 +13005,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13046,7 +13037,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13066,13 +13057,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -13952,7 +13936,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13965,15 +13949,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Summary

New network observer for observing fetch requests. This is currently set up to watch ALL requests and enabled through remote config. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
