### PR TITLE
chore(plugin-autocapture-browser): remove analytics-client-common

### DIFF
--- a/packages/plugin-autocapture-browser/package.json
+++ b/packages/plugin-autocapture-browser/package.json
@@ -39,7 +39,6 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": ">=1 <3",
     "@amplitude/analytics-types": "^2.9.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.4.1"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

A follow-up PR of https://github.com/amplitude/Amplitude-TypeScript/pull/977. 
analytics-client-common is not used in the autocapture plugin. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
