### PR TITLE
feat(analytics-core): add support for revenue receipt and receipt sig

### DIFF
--- a/packages/analytics-browser-test/test/index.test.ts
+++ b/packages/analytics-browser-test/test/index.test.ts
@@ -784,6 +784,8 @@ describe('integration', () => {
       rev.setRevenueType('t');
       rev.setCurrency('USD');
       rev.setRevenue(200);
+      rev.setReceipt('receipt');
+      rev.setReceiptSig('receipt sig');
       const response = await client.revenue(rev).promise;
       expect(response.event).toEqual({
         device_id: uuid,
@@ -795,6 +797,8 @@ describe('integration', () => {
           $revenue: 200,
           $revenueType: 't',
           $currency: 'USD',
+          $receipt: 'receipt',
+          $receiptSig: 'receipt sig',
         },
         event_type: 'revenue_amount',
         insert_id: uuid,

--- a/packages/analytics-core/src/revenue.ts
+++ b/packages/analytics-core/src/revenue.ts
@@ -9,6 +9,8 @@ export interface IRevenue {
   setCurrency(currency: string): IRevenue;
   setEventProperties(properties: { [key: string]: any }): IRevenue;
   setRevenue(revenue: number): IRevenue;
+  setReceipt(receipt: string): IRevenue;
+  setReceiptSig(receiptSig: string): IRevenue;
 }
 
 export class Revenue implements IRevenue {
@@ -19,6 +21,8 @@ export class Revenue implements IRevenue {
   private currency?: string;
   private properties?: { [key: string]: any };
   private revenue?: number;
+  private receipt?: string;
+  private receiptSig?: string;
 
   constructor() {
     this.productId = '';
@@ -58,6 +62,16 @@ export class Revenue implements IRevenue {
     return this;
   }
 
+  setReceipt(receipt: string) {
+    this.receipt = receipt;
+    return this;
+  }
+
+  setReceiptSig(receiptSig: string) {
+    this.receiptSig = receiptSig;
+    return this;
+  }
+
   setEventProperties(properties: { [key: string]: ValidPropertyType }) {
     if (isValidObject(properties)) {
       this.properties = properties;
@@ -73,6 +87,8 @@ export class Revenue implements IRevenue {
     eventProperties[RevenueProperty.REVENUE_TYPE] = this.revenueType;
     eventProperties[RevenueProperty.REVENUE_CURRENCY] = this.currency;
     eventProperties[RevenueProperty.REVENUE] = this.revenue;
+    eventProperties[RevenueProperty.RECEIPT] = this.receipt;
+    eventProperties[RevenueProperty.RECEIPT_SIG] = this.receiptSig;
     return eventProperties;
   }
 }
@@ -84,6 +100,8 @@ export interface RevenueEventProperties {
   [RevenueProperty.REVENUE_TYPE]?: string;
   [RevenueProperty.REVENUE_CURRENCY]?: string;
   [RevenueProperty.REVENUE]?: number;
+  [RevenueProperty.RECEIPT]?: string;
+  [RevenueProperty.RECEIPT_SIG]?: string;
 }
 
 export enum RevenueProperty {
@@ -93,6 +111,8 @@ export enum RevenueProperty {
   REVENUE_TYPE = '$revenueType',
   REVENUE_CURRENCY = '$currency',
   REVENUE = '$revenue',
+  RECEIPT = '$receipt',
+  RECEIPT_SIG = '$receiptSig',
 }
 
 export type ValidPropertyType =

--- a/packages/analytics-core/src/types/event/base-event.ts
+++ b/packages/analytics-core/src/types/event/base-event.ts
@@ -37,6 +37,8 @@ export interface EventOptions {
   price?: number;
   quantity?: number;
   revenue?: number;
+  receipt?: string;
+  receiptSig?: string;
   productId?: string;
   revenueType?: string;
   currency?: string;

--- a/packages/analytics-core/test/revenue.test.ts
+++ b/packages/analytics-core/test/revenue.test.ts
@@ -1,6 +1,5 @@
 import { createRevenueEvent } from '../src/utils/event-builder';
-import { Revenue } from '../src/index';
-import { RevenueProperty } from '@amplitude/analytics-types';
+import { Revenue, RevenueProperty } from '../src/revenue';
 
 const defaultRevenueProperty = {
   [RevenueProperty.REVENUE_PRODUCT_ID]: '',
@@ -78,6 +77,28 @@ describe('Revenue class', () => {
     const event = createRevenueEvent(revenue);
 
     const expectedProperties = { ...defaultRevenueProperty, [RevenueProperty.REVENUE]: revenueAmount };
+
+    expect(event.event_properties).toEqual(expectedProperties);
+  });
+
+  test('setReceipt', () => {
+    const receipt = 'test receipt';
+    const revenue = new Revenue();
+    revenue.setReceipt(receipt);
+    const event = createRevenueEvent(revenue);
+
+    const expectedProperties = { ...defaultRevenueProperty, [RevenueProperty.RECEIPT]: receipt };
+
+    expect(event.event_properties).toEqual(expectedProperties);
+  });
+
+  test('setReceiptSig', () => {
+    const receitSig = 'test receiptSig';
+    const revenue = new Revenue();
+    revenue.setReceiptSig(receitSig);
+    const event = createRevenueEvent(revenue);
+
+    const expectedProperties = { ...defaultRevenueProperty, [RevenueProperty.RECEIPT_SIG]: receitSig };
 
     expect(event.event_properties).toEqual(expectedProperties);
   });

--- a/packages/analytics-core/test/revenue.test.ts
+++ b/packages/analytics-core/test/revenue.test.ts
@@ -93,13 +93,12 @@ describe('Revenue class', () => {
   });
 
   test('setReceiptSig', () => {
-    const receitSig = 'test receiptSig';
+    const receiptSig = 'test receiptSig';
     const revenue = new Revenue();
-    revenue.setReceiptSig(receitSig);
+    revenue.setReceiptSig(receiptSig);
     const event = createRevenueEvent(revenue);
 
-    const expectedProperties = { ...defaultRevenueProperty, [RevenueProperty.RECEIPT_SIG]: receitSig };
-
+    const expectedProperties = { ...defaultRevenueProperty, [RevenueProperty.RECEIPT_SIG]: receiptSig };
     expect(event.event_properties).toEqual(expectedProperties);
   });
 

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -86,6 +86,8 @@ const snippet = (
       'setPrice',
       'setRevenue',
       'setRevenueType',
+      'setReceipt',
+      'setReceiptSig',
       'setEventProperties',
     ];
     for (var j = 0; j < revenueFuncs.length; j++) {

--- a/scripts/templates/browser-bookmarklet.template.js
+++ b/scripts/templates/browser-bookmarklet.template.js
@@ -88,6 +88,7 @@ const snippet = (
       'setRevenueType',
       'setReceipt',
       'setReceiptSig',
+      'setCurrency',
       'setEventProperties',
     ];
     for (var j = 0; j < revenueFuncs.length; j++) {

--- a/scripts/templates/browser-snippet.template.js
+++ b/scripts/templates/browser-snippet.template.js
@@ -60,6 +60,7 @@ const snippet = (name, integrity, version, globalVar) => `
       'setRevenueType',
       'setReceipt',
       'setReceiptSig',
+      'setCurrency',
       'setEventProperties',
     ];
     for (var j = 0; j < revenueFuncs.length; j++) {

--- a/scripts/templates/browser-snippet.template.js
+++ b/scripts/templates/browser-snippet.template.js
@@ -58,6 +58,8 @@ const snippet = (name, integrity, version, globalVar) => `
       'setPrice',
       'setRevenue',
       'setRevenueType',
+      'setReceipt',
+      'setReceiptSig',
       'setEventProperties',
     ];
     for (var j = 0; j < revenueFuncs.length; j++) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
https://amplitude.atlassian.net/browse/AMP-126168

Add missing revenue properties: revenue and revenue sig. 
https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2#revenue-interface
<img width="715" alt="image" src="https://github.com/user-attachments/assets/b7da507f-c3de-4199-839f-54c7ec1f5d7e" />

```
const event = new amplitude.Revenue()
  .setProductId('com.company.productId')
  .setPrice(3.99)
  .setQuantity(3);
  .setReceipt('receipt');
  .setReceiptSig('receipt signature');
 
amplitude.revenue(event);
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
