### PR TITLE
chore(plugin-autocapture-browser): remove analytics-client-common

### DIFF
--- a/packages/plugin-autocapture-browser/package.json
+++ b/packages/plugin-autocapture-browser/package.json
@@ -32,14 +32,13 @@
     "publish": "node ../../scripts/publish/upload-to-s3.js",
     "test": "jest",
     "typecheck": "tsc -p ./tsconfig.json",
-    "version": "yarn version-file && yarn add @amplitude/analytics-client-common@\">=1 <3\" && yarn build",
+    "version": "yarn version-file && yarn build",
     "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
   },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": ">=1 <3",
     "@amplitude/analytics-core": "^2.6.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.4.1"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

A follow up PR of https://github.com/amplitude/Amplitude-TypeScript/pull/988/files. 
analytics-client-common is not used in the autocapture plugin. Also remove `yarn add` command when `yarn version` to avoid reinstall the package when publishing. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
