### PR TITLE
feat(analytics-core): remote config client

### DIFF
--- a/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
+++ b/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
@@ -1,4 +1,4 @@
-import { RemoteConfigStorage, RemoteConfigInfo, RemoteConfig } from './remote-config';
+import { RemoteConfigStorage, RemoteConfigInfo } from './remote-config';
 import { ILogger } from '../logger';
 
 export class RemoteConfigLocalstorage implements RemoteConfigStorage {
@@ -20,11 +20,11 @@ export class RemoteConfigLocalstorage implements RemoteConfigStorage {
       });
     } else {
       try {
-        const remoteConfig: RemoteConfig = JSON.parse(result) as RemoteConfig;
+        const remoteConfigInfo: RemoteConfigInfo = JSON.parse(result) as RemoteConfigInfo;
         this.logger.debug('Remote config localstorage get successfully.');
         return Promise.resolve({
-          remoteConfig: remoteConfig,
-          lastFetch: new Date(),
+          remoteConfig: remoteConfigInfo.remoteConfig,
+          lastFetch: new Date(remoteConfigInfo.lastFetch),
         });
       } catch (error) {
         this.logger.debug('Remote config localstorage failed to get: ', error);

--- a/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
+++ b/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
@@ -1,0 +1,42 @@
+import { RemoteConfigStorage, RemoteConfigInfo, RemoteConfig } from './remote-config';
+import { ILogger } from '../logger';
+
+export class RemoteConfigLocalstorage implements RemoteConfigStorage {
+  private readonly key: string;
+  private readonly logger: ILogger;
+
+  constructor(apiKey: string, logger: ILogger) {
+    this.key = `AMP_remote_config_${apiKey.substring(0, 10)}`;
+    this.logger = logger;
+  }
+
+  fetchConfig(): Promise<RemoteConfigInfo> {
+    const result = localStorage.getItem(this.key);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const remoteConfig: RemoteConfig | null = result ? (JSON.parse(result) as RemoteConfig) : null;
+      this.logger.debug('Remote config localstorage get successfully.');
+      return Promise.resolve({
+        remoteConfig: remoteConfig,
+        lastFetch: new Date(),
+      });
+    } catch (error) {
+      this.logger.debug('Remote config localstorage failed to get: ', error);
+      return Promise.resolve({
+        remoteConfig: null,
+        lastFetch: new Date(),
+      });
+    }
+  }
+
+  setConfig(config: RemoteConfigInfo): Promise<boolean> {
+    try {
+      localStorage.setItem(this.key, JSON.stringify(config));
+      this.logger.debug('Remote config localstorage set successfully.');
+      return Promise.resolve(true);
+    } catch (error) {
+      this.logger.debug('Remote config localstorage failed to set: ', error);
+    }
+    return Promise.resolve(false);
+  }
+}

--- a/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
+++ b/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
@@ -1,7 +1,7 @@
 import { RemoteConfigStorage, RemoteConfigInfo } from './remote-config';
 import { ILogger } from '../logger';
 
-export class RemoteConfigLocalstorage implements RemoteConfigStorage {
+export class RemoteConfigLocalStorage implements RemoteConfigStorage {
   private readonly key: string;
   private readonly logger: ILogger;
 
@@ -31,13 +31,13 @@ export class RemoteConfigLocalstorage implements RemoteConfigStorage {
 
     try {
       const remoteConfigInfo: RemoteConfigInfo = JSON.parse(result) as RemoteConfigInfo;
-      this.logger.debug('Remote config localstorage get successfully.');
+      this.logger.debug('Remote config localstorage parsed successfully.');
       return Promise.resolve({
         remoteConfig: remoteConfigInfo.remoteConfig,
         lastFetch: new Date(remoteConfigInfo.lastFetch),
       });
     } catch (error) {
-      this.logger.debug('Remote config localstorage failed to get: ', error);
+      this.logger.debug('Remote config localstorage failed to parse: ', error);
       localStorage.removeItem(this.key);
       return Promise.resolve(failedRemoteConfigInfo);
     }

--- a/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
+++ b/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
@@ -12,20 +12,27 @@ export class RemoteConfigLocalstorage implements RemoteConfigStorage {
 
   fetchConfig(): Promise<RemoteConfigInfo> {
     const result = localStorage.getItem(this.key);
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const remoteConfig: RemoteConfig | null = result ? (JSON.parse(result) as RemoteConfig) : null;
-      this.logger.debug('Remote config localstorage get successfully.');
-      return Promise.resolve({
-        remoteConfig: remoteConfig,
-        lastFetch: new Date(),
-      });
-    } catch (error) {
-      this.logger.debug('Remote config localstorage failed to get: ', error);
+    if (result === null) {
+      this.logger.debug('Remote config localstorage gets null because the key does not exist');
       return Promise.resolve({
         remoteConfig: null,
         lastFetch: new Date(),
       });
+    } else {
+      try {
+        const remoteConfig: RemoteConfig = JSON.parse(result) as RemoteConfig;
+        this.logger.debug('Remote config localstorage get successfully.');
+        return Promise.resolve({
+          remoteConfig: remoteConfig,
+          lastFetch: new Date(),
+        });
+      } catch (error) {
+        this.logger.debug('Remote config localstorage failed to get: ', error);
+        return Promise.resolve({
+          remoteConfig: null,
+          lastFetch: new Date(),
+        });
+      }
     }
   }
 

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -56,7 +56,6 @@ export interface RemoteConfigStorage {
 
   /**
    * Set remote config to storage asynchronously.
-   * @param config
    */
   setConfig(config: RemoteConfigInfo): Promise<boolean>;
 }
@@ -167,7 +166,6 @@ export class RemoteConfigClient implements IRemoteConfigClient {
    * Send remote first. If it's already complete, we can skip the cached response.
    * - if remote is fetched first, no cache fetch.
    * - if cache is fetched first, still fetching remote.
-   * @param callbackInfo
    */
   async subscribeAll(callbackInfo: CallbackInfo) {
     const remotePromise = this.fetch().then((result) => {
@@ -224,9 +222,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
 
   /**
    * Call the callback with filtered remote config based on key.
-   * @param callbackInfo
    * @param remoteConfigInfo - the whole remote config object without filtering by key.
-   * @param source
    */
   sendCallback(callbackInfo: CallbackInfo, remoteConfigInfo: RemoteConfigInfo, source: Source) {
     callbackInfo.lastCallback = new Date();
@@ -288,11 +284,18 @@ export class RemoteConfigClient implements IRemoteConfigClient {
       // wait for the specified interval before the next attempt
       // except after the last attempt.
       if (attempt < retries - 1) {
-        await new Promise((resolve) => setTimeout(resolve, interval));
+        await new Promise((resolve) => setTimeout(resolve, this.getJitterDelay(interval)));
       }
     }
 
     return failedRemoteConfigInfo;
+  }
+
+  /**
+   * Return jitter in the bound of [0,baseDelay) and then floor round.
+   */
+  getJitterDelay(baseDelay: number): number {
+    return Math.floor(Math.random() * baseDelay);
   }
 
   getUrlParams(): string {

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -1,6 +1,6 @@
 import { ServerZoneType } from '../types/server-zone';
 import { ILogger } from '../logger';
-import { RemoteConfigIdbStorage } from './remote-config-idb-storage';
+import { RemoteConfigLocalstorage } from './remote-config-localstorage';
 import { UUID } from '../utils/uuid';
 
 /**
@@ -32,7 +32,7 @@ const FETCHED_KEYS = [
   'sessionReplay.sr_targeting_config',
 ];
 
-interface RemoteConfig {
+export interface RemoteConfig {
   [key: string]: any;
 }
 
@@ -46,7 +46,6 @@ export interface RemoteConfigStorage {
   /**
    * Fetch remote config from storage asynchronously.
    */
-  //
   fetchConfig(): Promise<RemoteConfigInfo>;
   /**
    * Set remote config to storage asynchronously.
@@ -86,7 +85,7 @@ export class RemoteConfigClient {
     this.apiKey = apiKey;
     this.serverUrl = serverZone === 'US' ? US_SERVER_URL : EU_SERVER_URL;
     this.logger = logger;
-    this.storage = new RemoteConfigIdbStorage(apiKey);
+    this.storage = new RemoteConfigLocalstorage(apiKey, logger);
   }
 
   /**

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -1,6 +1,6 @@
 import { ServerZoneType } from '../types/server-zone';
 import { ILogger } from '../logger';
-import { RemoteConfigLocalstorage } from './remote-config-localstorage';
+import { RemoteConfigLocalStorage } from './remote-config-localstorage';
 import { UUID } from '../utils/uuid';
 
 /**
@@ -115,7 +115,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     this.apiKey = apiKey;
     this.serverUrl = serverZone === 'US' ? US_SERVER_URL : EU_SERVER_URL;
     this.logger = logger;
-    this.storage = new RemoteConfigLocalstorage(apiKey, logger);
+    this.storage = new RemoteConfigLocalStorage(apiKey, logger);
   }
 
   subscribe(key: string | undefined, deliveryMode: DeliveryMode, callback: RemoteConfigCallback): string {

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -1,0 +1,291 @@
+import { ServerZoneType } from '../types/server-zone';
+import { ILogger } from '../logger';
+import { RemoteConfigIdbStorage } from './remote-config-idb-storage';
+import { UUID } from '../utils/uuid';
+
+/**
+ * Modes for receiving remote config updates:
+ * - `'all'` – Receive all config updates as they occur.
+ * - `{ timeout: number }` – Wait for a remote response until the specified timeout (in milliseconds),
+ *   then return a cached copy if available.
+ */
+export type DeliveryMode = 'all' | { timeout: number };
+
+/**
+ * Sources of returned remote config:
+ * - `cache` - Fetched from local storage.
+ * - `remote` - Fetched from remote.
+ */
+export type Source = 'cache' | 'remote';
+
+const US_SERVER_URL = 'https://sr-client-cfg.amplitude.com/config';
+const EU_SERVER_URL = 'https://sr-client-cfg.eu.amplitude.com/config';
+const DEFAULT_MAX_RETRIES = 3;
+// TODO(xinyi)
+// const DEFAULT_MIN_TIME_BETWEEN_FETCHES = 5 * 60 * 1000; // 5 minutes
+const FETCHED_KEYS = [
+  'analyticsSDK.browserSDK',
+  'sessionReplay.sr_interaction_config',
+  'sessionReplay.sr_logging_config',
+  'sessionReplay.sr_privacy_config',
+  'sessionReplay.sr_sampling_config',
+  'sessionReplay.sr_targeting_config',
+];
+
+interface RemoteConfig {
+  [key: string]: any;
+}
+
+export interface RemoteConfigInfo {
+  remoteConfig: RemoteConfig | null;
+  // Timestamp of when the remote config was fetched.
+  lastFetch: Date;
+}
+
+export interface RemoteConfigStorage {
+  /**
+   * Fetch remote config from storage asynchronously.
+   */
+  //
+  fetchConfig(): Promise<RemoteConfigInfo>;
+  /**
+   * Set remote config to storage asynchronously.
+   * @param config
+   */
+  setConfig(config: RemoteConfigInfo): Promise<boolean>;
+}
+
+/**
+ * Information about each callback registered by `RemoteConfigClient.subscribe()`,
+ * managed internally by `RemoteConfigClient`.
+ */
+interface CallbackInfo {
+  id: string;
+  key?: string;
+  deliveryMode: DeliveryMode;
+  callback: RemoteConfigCallback;
+  lastCallback?: Date;
+}
+
+/**
+ * Callback used in `RemoteConfigClient.subscribe()`.
+ * This function is called when the remote config is fetched.
+ */
+type RemoteConfigCallback = (remoteConfig: RemoteConfig | null, source: Source, lastFetch: Date) => void;
+
+export class RemoteConfigClient {
+  private readonly apiKey: string;
+  private readonly serverUrl: string;
+  private readonly logger: ILogger;
+  private readonly storage: RemoteConfigStorage;
+
+  // Registered callbackInfos by subscribe().
+  private callbackInfos: CallbackInfo[] = [];
+
+  constructor(apiKey: string, logger: ILogger, serverZone: ServerZoneType = 'US') {
+    this.apiKey = apiKey;
+    this.serverUrl = serverZone === 'US' ? US_SERVER_URL : EU_SERVER_URL;
+    this.logger = logger;
+    this.storage = new RemoteConfigIdbStorage(apiKey);
+  }
+
+  /**
+   * Subscribe for updates to remote config.
+   * Callback is guaranteed to be called at least once,
+   * Whether we are able to fetch a config or not.
+   *
+   * @param key - a string containing a series of period delimited keys to filter the returned config.
+   * Ie, {a: {b: {c: ...}}} would return {b: {c: ...}} for "a" or {c: ...} for "a.b".
+   * Set to `undefined` to subscribe all keys.
+   * @param deliveryMode - how the initial callback is sent.
+   * @param callback - a block that will be called when remote config is fetched.
+   * @return id - identification of the subscribe and can be used to unsubscribe from updates.
+   */
+  subscribe(key: string | undefined, deliveryMode: DeliveryMode = 'all', callback: RemoteConfigCallback): string {
+    const id = UUID();
+    const callbackInfo = {
+      id: id,
+      key: key,
+      deliveryMode: deliveryMode,
+      callback: callback,
+    };
+    this.callbackInfos.push(callbackInfo);
+
+    if (deliveryMode === 'all') {
+      void this.subscribeAll(callbackInfo);
+    } else {
+      void this.subscribeWaitForRemote(callbackInfo, deliveryMode.timeout);
+    }
+
+    return id;
+  }
+
+  /**
+   * Unsubscribe a callback from receiving future updates.
+   *
+   * @param id - identification of the callback that you want to unsubscribe.
+   * It's the return value of subscribe().
+   */
+  unsubscribe(id: string) {
+    const index = this.callbackInfos.findIndex((callbackInfo) => callbackInfo.id === id);
+    if (index === -1) {
+      this.logger.debug(`Remote config client unsubscribe failed because callback with id ${id} doesn't exist.`);
+      return;
+    }
+
+    this.callbackInfos.splice(index, 1);
+    this.logger.debug(`Remote config client unsubscribe succeeded removing callback with id ${id}.`);
+  }
+
+  /**
+   * Request the remote config client to fetch from remote, update cache, and callback.
+   */
+  updateConfigs() {
+    void this.fetch().then((result) => {
+      void this.storage.setConfig(result);
+      this.callbackInfos.forEach((callbackInfo) => {
+        this.sendCallback(callbackInfo, result, 'remote');
+      });
+    });
+  }
+
+  /**
+   * Send remote first. If it's already complete, we can skip the cached response.
+   * - if remote is fetched first, no cache fetch.
+   * - if cache is fetched first, still fetching remote.
+   * @param callbackInfo
+   * @private
+   */
+  private async subscribeAll(callbackInfo: CallbackInfo) {
+    const remotePromise = this.fetch().then((result) => {
+      this.logger.debug('Remote config client subscription all mode fetched from remote.');
+      this.sendCallback(callbackInfo, result, 'remote');
+      void this.storage.setConfig(result);
+    });
+
+    const cachePromise = this.storage.fetchConfig().then((result) => {
+      return result;
+    });
+
+    // Wait for the first result to resolve
+    const result = await Promise.race([remotePromise, cachePromise]);
+
+    // If cache is fetched first, wait for remote.
+    if (result !== undefined) {
+      this.logger.debug('Remote config client subscription all mode fetched from cache.');
+      this.sendCallback(callbackInfo, result, 'cache');
+    }
+    await remotePromise;
+  }
+
+  /**
+   * Waits for a remote response until the given timeout, then return a cached copy, if available.
+   * @param callbackInfo
+   * @param timeout
+   * @private
+   */
+  private async subscribeWaitForRemote(callbackInfo: CallbackInfo, timeout: number) {
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => {
+        reject('Timeout exceeded');
+      }, timeout);
+    });
+
+    try {
+      const result: RemoteConfigInfo = (await Promise.race([this.fetch(), timeoutPromise])) as RemoteConfigInfo;
+
+      this.logger.debug('Remote config client subscription wait for remote mode returns from remote.');
+      this.sendCallback(callbackInfo, result, 'remote');
+      void this.storage.setConfig(result);
+    } catch (error) {
+      this.logger.debug(
+        'Remote config client subscription wait for remote mode exceeded timeout. Try to fetch from cache.',
+      );
+      const result = await this.storage.fetchConfig();
+      if (result.remoteConfig !== null) {
+        this.logger.debug('Remote config client subscription wait for remote mode returns a cached copy.');
+        this.sendCallback(callbackInfo, result, 'cache');
+      } else {
+        this.logger.debug('Remote config client subscription wait for remote mode failed to fetch cache.');
+        this.sendCallback(callbackInfo, { remoteConfig: null, lastFetch: new Date() }, 'remote');
+      }
+    }
+  }
+
+  /**
+   * Call the callback with filtered remote config based on key.
+   * @param callbackInfo
+   * @param remoteConfigInfo - the whole remote config object without filtering by key.
+   * @param source
+   * @private
+   */
+  private sendCallback(callbackInfo: CallbackInfo, remoteConfigInfo: RemoteConfigInfo, source: Source) {
+    callbackInfo.lastCallback = new Date();
+
+    let filteredConfig: RemoteConfig | null;
+    if (callbackInfo.key) {
+      // Filter remote config by key.
+      // For example, if remote config is {a: {b: {c: 1}}},
+      // if key = 'a', filter result is {b: {c: 1}};
+      // if key = 'a.b', filter result is {c: 1}
+      filteredConfig = callbackInfo.key.split('.').reduce((config, key) => {
+        return config ? config : ([key] as RemoteConfig);
+      }, remoteConfigInfo.remoteConfig);
+    } else {
+      filteredConfig = remoteConfigInfo.remoteConfig;
+    }
+
+    callbackInfo.callback(filteredConfig, source, remoteConfigInfo.lastFetch);
+  }
+
+  private async fetch(retries: number = DEFAULT_MAX_RETRIES): Promise<RemoteConfigInfo> {
+    const failedRemoteConfigInfo: RemoteConfigInfo = {
+      remoteConfig: null,
+      lastFetch: new Date(),
+    };
+
+    try {
+      const res = await fetch(this.getUrlParams(), {
+        method: 'GET',
+        headers: {
+          Accept: '*/*',
+        },
+      });
+
+      // Handle unsuccessful fetch
+      if (!res.ok) {
+        const body = await res.text();
+        this.logger.debug(`Remote config client fetch with retry time ${retries} failed with ${res.status}: ${body}`);
+        if (retries > 1) {
+          return this.fetch(retries--);
+        }
+        return failedRemoteConfigInfo;
+      }
+
+      // Handle successful fetch
+      const remoteConfig: RemoteConfig = (await res.json()) as RemoteConfig;
+      return {
+        remoteConfig: remoteConfig,
+        lastFetch: new Date(),
+      };
+    } catch (error) {
+      // Handle rejects when the request fails, for example, a network error
+      this.logger.debug(`Remote config client fetch with retry time ${retries} is rejected because: `, error);
+      if (retries > 1) {
+        return this.fetch(retries--);
+      }
+      return failedRemoteConfigInfo;
+    }
+  }
+
+  private getUrlParams(): string {
+    const urlParams = new URLSearchParams({
+      api_key: this.apiKey,
+    });
+    FETCHED_KEYS.forEach((key) => {
+      urlParams.append('config_keys', key);
+    });
+
+    return `${this.serverUrl}?${urlParams.toString()}`;
+  }
+}

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -187,8 +187,6 @@ export class RemoteConfigClient implements IRemoteConfigClient {
 
   /**
    * Waits for a remote response until the given timeout, then return a cached copy, if available.
-   * @param callbackInfo
-   * @param timeout
    */
   async subscribeWaitForRemote(callbackInfo: CallbackInfo, timeout: number) {
     const timeoutPromise = new Promise((_, reject) => {

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -118,7 +118,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     this.storage = new RemoteConfigLocalstorage(apiKey, logger);
   }
 
-  subscribe(key: string | undefined, deliveryMode: DeliveryMode = 'all', callback: RemoteConfigCallback): string {
+  subscribe(key: string | undefined, deliveryMode: DeliveryMode, callback: RemoteConfigCallback): string {
     const id = UUID();
     const callbackInfo = {
       id: id,
@@ -247,6 +247,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     callbackInfo.callback(filteredConfig, source, remoteConfigInfo.lastFetch);
   }
 
+  /* istanbul ignore next */
   async fetch(retries: number = DEFAULT_MAX_RETRIES): Promise<RemoteConfigInfo> {
     const failedRemoteConfigInfo: RemoteConfigInfo = {
       remoteConfig: null,

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -247,7 +247,6 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     callbackInfo.callback(filteredConfig, source, remoteConfigInfo.lastFetch);
   }
 
-  /* istanbul ignore next */
   async fetch(retries: number = DEFAULT_MAX_RETRIES): Promise<RemoteConfigInfo> {
     const failedRemoteConfigInfo: RemoteConfigInfo = {
       remoteConfig: null,
@@ -266,8 +265,9 @@ export class RemoteConfigClient implements IRemoteConfigClient {
       if (!res.ok) {
         const body = await res.text();
         this.logger.debug(`Remote config client fetch with retry time ${retries} failed with ${res.status}: ${body}`);
-        if (retries > 1) {
-          return this.fetch(retries--);
+        retries -= 1;
+        if (retries > 0) {
+          return this.fetch(retries);
         }
         return failedRemoteConfigInfo;
       }
@@ -281,8 +281,9 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     } catch (error) {
       // Handle rejects when the request fails, for example, a network error
       this.logger.debug(`Remote config client fetch with retry time ${retries} is rejected because: `, error);
-      if (retries > 1) {
-        return this.fetch(retries--);
+      retries -= 1;
+      if (retries > 0) {
+        return this.fetch(retries);
       }
       return failedRemoteConfigInfo;
     }

--- a/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
@@ -2,14 +2,14 @@
  * @jest-environment jsdom
  */
 
-import { RemoteConfigLocalstorage } from '../../src/remote-config/remote-config-localstorage';
+import { RemoteConfigLocalStorage } from '../../src/remote-config/remote-config-localstorage';
 import { RemoteConfig, RemoteConfigInfo } from '../../src/remote-config/remote-config';
 import { ILogger } from '../../src/logger';
 
-describe('RemoteConfigLocalstorage', () => {
+describe('RemoteConfigLocalStorage', () => {
   let logger: ILogger;
   let loggerDebug: jest.SpyInstance;
-  let storage: RemoteConfigLocalstorage;
+  let storage: RemoteConfigLocalStorage;
   const apiKey = '12345678901234567890';
   const storageKey = `AMP_remote_config_${apiKey.substring(0, 10)}`;
   const mockDate = new Date('2025-03-18T12:00:00Z');
@@ -25,7 +25,7 @@ describe('RemoteConfigLocalstorage', () => {
     };
     loggerDebug = jest.spyOn(logger, 'debug');
 
-    storage = new RemoteConfigLocalstorage(apiKey, logger);
+    storage = new RemoteConfigLocalStorage(apiKey, logger);
     localStorage.clear();
 
     jest.useFakeTimers().setSystemTime(mockDate);
@@ -49,7 +49,7 @@ describe('RemoteConfigLocalstorage', () => {
 
       expect(result.remoteConfig).toEqual(remoteConfig);
       expect(result.lastFetch).toEqual(lastFetch);
-      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage get successfully.');
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage parsed successfully.');
     });
 
     it('should return remote config info null and clear storage if JSON parsing fails', async () => {
@@ -59,7 +59,7 @@ describe('RemoteConfigLocalstorage', () => {
 
       expect(result.remoteConfig).toBeNull();
       expect(result.lastFetch).toEqual(mockDate);
-      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage failed to get: ', expect.any(Error));
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage failed to parse: ', expect.any(Error));
       expect(localStorage.getItem(storageKey)).toBeNull();
     });
 

--- a/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { RemoteConfigLocalstorage } from '../../src/remote-config/remote-config-localstorage';
-import { RemoteConfigInfo, RemoteConfig } from '../../src/remote-config/remote-config';
+import { RemoteConfig, RemoteConfigInfo } from '../../src/remote-config/remote-config';
 import { ILogger } from '../../src/logger';
 
 describe('RemoteConfigLocalstorage', () => {
@@ -37,13 +37,18 @@ describe('RemoteConfigLocalstorage', () => {
 
   describe('fetchConfig', () => {
     it('should return remote config info', async () => {
-      const mockConfig: RemoteConfig = { key1: 'value1' };
-      localStorage.setItem(storageKey, JSON.stringify(mockConfig));
+      const lastFetch = new Date('2025-03-20T12:00:00Z');
+      const remoteConfig: RemoteConfig = { key1: 'value1' };
+      const mockConfigInfo: RemoteConfigInfo = {
+        remoteConfig: remoteConfig,
+        lastFetch: lastFetch,
+      };
+      localStorage.setItem(storageKey, JSON.stringify(mockConfigInfo));
 
       const result = await storage.fetchConfig();
 
-      expect(result.remoteConfig).toEqual(mockConfig);
-      expect(result.lastFetch).toEqual(mockDate);
+      expect(result.remoteConfig).toEqual(remoteConfig);
+      expect(result.lastFetch).toEqual(lastFetch);
       expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage get successfully.');
     });
 

--- a/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { RemoteConfigLocalstorage } from '../../src/remote-config/remote-config-localstorage';
+import { RemoteConfigInfo, RemoteConfig } from '../../src/remote-config/remote-config';
+import { ILogger } from '../../src/logger';
+
+describe('RemoteConfigLocalstorage', () => {
+  let logger: ILogger;
+  let loggerDebug: jest.SpyInstance;
+  let storage: RemoteConfigLocalstorage;
+  const apiKey = '12345678901234567890';
+  const storageKey = `AMP_remote_config_${apiKey.substring(0, 10)}`;
+  const mockDate = new Date('2025-03-18T12:00:00Z');
+
+  beforeEach(() => {
+    logger = {
+      disable: jest.fn(),
+      enable: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    loggerDebug = jest.spyOn(logger, 'debug');
+
+    storage = new RemoteConfigLocalstorage(apiKey, logger);
+    localStorage.clear();
+
+    jest.useFakeTimers().setSystemTime(mockDate);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('fetchConfig', () => {
+    it('should return remote config info', async () => {
+      const mockConfig: RemoteConfig = { key1: 'value1' };
+      localStorage.setItem(storageKey, JSON.stringify(mockConfig));
+
+      const result = await storage.fetchConfig();
+
+      expect(result.remoteConfig).toEqual(mockConfig);
+      expect(result.lastFetch).toEqual(mockDate);
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage get successfully.');
+    });
+
+    it('should return remote config info null if JSON parsing fails', async () => {
+      localStorage.setItem(storageKey, '{ invalid json }');
+
+      const result = await storage.fetchConfig();
+
+      expect(result.remoteConfig).toBeNull();
+      expect(result.lastFetch).toEqual(mockDate);
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage failed to get: ', expect.any(Error));
+    });
+
+    it('should return remote config info null localStorage is empty', async () => {
+      const result = await storage.fetchConfig();
+
+      expect(result.remoteConfig).toBeNull();
+      expect(result.lastFetch).toBeInstanceOf(Date);
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage gets null because the key does not exist');
+    });
+  });
+
+  describe('setConfig', () => {
+    it('should store the config in localStorage and return true', async () => {
+      const info: RemoteConfigInfo = {
+        remoteConfig: { key1: 'value1' },
+        lastFetch: new Date(),
+      };
+
+      const result = await storage.setConfig(info);
+
+      expect(result).toBe(true);
+      expect(localStorage.getItem(storageKey)).toEqual(JSON.stringify(info));
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage set successfully.');
+    });
+
+    it('should return false and log an error if storing the config fails', async () => {
+      // Mock localStorage.setItem to throw an error
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('Storage quota exceeded');
+      });
+
+      const info: RemoteConfigInfo = {
+        remoteConfig: { key1: 'value1' },
+        lastFetch: new Date(),
+      };
+
+      const result = await storage.setConfig(info);
+
+      expect(result).toBe(false);
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config localstorage failed to set: ', expect.any(Error));
+
+      // Restore the mock
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -7,7 +7,7 @@ import {
   US_SERVER_URL,
 } from '../../src/remote-config/remote-config';
 import { ILogger } from '../../src/logger';
-import { RemoteConfigLocalstorage } from '../../src/remote-config/remote-config-localstorage';
+import { RemoteConfigLocalStorage } from '../../src/remote-config/remote-config-localstorage';
 
 jest.mock('../../src/remote-config/remote-config-localstorage');
 const mockUuid = 'uuid123456789';
@@ -49,7 +49,7 @@ describe('RemoteConfigClient', () => {
     loggerDebug = jest.spyOn(mockLogger, 'debug');
     storageFetchConfig = jest.spyOn(mockStorage, 'fetchConfig');
 
-    (RemoteConfigLocalstorage as jest.Mock).mockImplementation(() => mockStorage);
+    (RemoteConfigLocalStorage as jest.Mock).mockImplementation(() => mockStorage);
     client = new RemoteConfigClient(mockApiKey, mockLogger);
 
     // Clears only the call history but keeps the original mock implementation

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -1,0 +1,158 @@
+import { DeliveryMode, EU_SERVER_URL, RemoteConfigClient, US_SERVER_URL } from '../../src/remote-config/remote-config';
+import { ILogger } from '../../src/logger';
+import { RemoteConfigLocalstorage } from '../../src/remote-config/remote-config-localstorage';
+
+jest.mock('../../src/remote-config/remote-config-localstorage');
+const mockUuid = 'uuid123456789';
+jest.mock('../../src/utils/uuid', () => ({
+  __esModule: true, // This is important for ES modules
+  UUID: jest.fn(() => mockUuid),
+}));
+
+const mockLogger: ILogger = {
+  disable: jest.fn(),
+  enable: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+const mockStorage = {
+  fetchConfig: jest.fn(),
+  setConfig: jest.fn(),
+};
+const mockApiKey = 'test-api-key';
+const testKey = 'browser';
+
+describe('RemoteConfigClient', () => {
+  let client: RemoteConfigClient;
+  let loggerDebug: jest.SpyInstance;
+
+  beforeEach(() => {
+    loggerDebug = jest.spyOn(mockLogger, 'debug');
+
+    (RemoteConfigLocalstorage as jest.Mock).mockImplementation(() => mockStorage);
+    client = new RemoteConfigClient(mockApiKey, mockLogger);
+  });
+
+  describe('constructor', () => {
+    test('should initialize correctly', () => {
+      expect(client.serverUrl).toBe(US_SERVER_URL);
+      expect(client.apiKey).toBe(mockApiKey);
+      expect(client.logger).toBeDefined();
+      expect(client.storage).toBeDefined();
+
+      const usClient = new RemoteConfigClient(mockApiKey, mockLogger, 'US');
+      expect(usClient.serverUrl).toBe(US_SERVER_URL);
+
+      const euClient = new RemoteConfigClient(mockApiKey, mockLogger, 'EU');
+      expect(euClient.serverUrl).toBe(EU_SERVER_URL);
+    });
+  });
+
+  describe('subscribe', () => {
+    test('should set callback info and call subscribeAll', async () => {
+      const subscribeAll = jest.spyOn(client, 'subscribeAll');
+      subscribeAll.mockImplementation(jest.fn());
+      const callback = jest.fn();
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all',
+        callback: callback,
+      };
+
+      expect(client.callbackInfos.length).toBe(0);
+      client.subscribe(testKey, 'all', callback);
+      expect(client.callbackInfos.length).toBe(1);
+      expect(client.callbackInfos[0]).toEqual(callbackInfo);
+      expect(subscribeAll).toHaveBeenCalledTimes(1);
+      expect(subscribeAll).toHaveBeenCalledWith(callbackInfo);
+    });
+
+    test('should set callback info and call subscribeWaitForRemote', async () => {
+      const subscribeWaitForRemote = jest.spyOn(client, 'subscribeWaitForRemote');
+      subscribeWaitForRemote.mockImplementation(jest.fn());
+      const timeout = 5000;
+      const callback = jest.fn();
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: { timeout: timeout },
+        callback: callback,
+      };
+
+      expect(client.callbackInfos.length).toBe(0);
+      client.subscribe(testKey, { timeout: timeout }, callback);
+      expect(client.callbackInfos.length).toBe(1);
+      expect(client.callbackInfos[0]).toEqual(callbackInfo);
+      expect(subscribeWaitForRemote).toHaveBeenCalledTimes(1);
+      expect(subscribeWaitForRemote).toHaveBeenCalledWith(callbackInfo, timeout);
+    });
+  });
+
+  describe('unsubscribe', () => {
+    test('should remove callback', () => {
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      client.callbackInfos.push(callbackInfo);
+
+      expect(client.callbackInfos.length).toBe(1);
+      const result = client.unsubscribe(mockUuid);
+      expect(client.callbackInfos.length).toBe(0);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        `Remote config client unsubscribe succeeded removing callback with id ${mockUuid}.`,
+      );
+      expect(result).toBe(true);
+    });
+
+    test('should log when id does not exit', () => {
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      client.callbackInfos.push(callbackInfo);
+
+      expect(client.callbackInfos.length).toBe(1);
+      const testId = 'id-does-not-exist';
+      const result = client.unsubscribe(testId);
+      expect(client.callbackInfos.length).toBe(1);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        `Remote config client unsubscribe failed because callback with id ${testId} doesn't exist.`,
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateConfigs', () => {
+    test('should call fetch, storage set, and call callbacks', async () => {
+      const fetch = jest.spyOn(client, 'fetch');
+      const sendCallback = jest.spyOn(client, 'sendCallback');
+      const remoteConfigInfo = {
+        remoteConfig: null,
+        lastFetch: new Date(),
+      };
+      const fetchPromise = Promise.resolve(remoteConfigInfo);
+      fetch.mockReturnValueOnce(fetchPromise);
+
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      client.callbackInfos.push(callbackInfo);
+
+      await client.updateConfigs();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.setConfig).toHaveBeenCalledWith(remoteConfigInfo);
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
+    });
+  });
+});

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -1,4 +1,11 @@
-import { DeliveryMode, EU_SERVER_URL, RemoteConfigClient, US_SERVER_URL } from '../../src/remote-config/remote-config';
+import {
+  CallbackInfo,
+  DeliveryMode,
+  EU_SERVER_URL,
+  RemoteConfigClient,
+  RemoteConfigInfo,
+  US_SERVER_URL,
+} from '../../src/remote-config/remote-config';
 import { ILogger } from '../../src/logger';
 import { RemoteConfigLocalstorage } from '../../src/remote-config/remote-config-localstorage';
 
@@ -8,6 +15,15 @@ jest.mock('../../src/utils/uuid', () => ({
   __esModule: true, // This is important for ES modules
   UUID: jest.fn(() => mockUuid),
 }));
+jest.mock('../../src/remote-config/remote-config', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const actual = jest.requireActual('../../src/remote-config/remote-config');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return {
+    ...actual,
+    FETCHED_KEYS: ['test_key_1', 'test_key_2'],
+  };
+});
 
 const mockLogger: ILogger = {
   disable: jest.fn(),
@@ -27,12 +43,17 @@ const testKey = 'browser';
 describe('RemoteConfigClient', () => {
   let client: RemoteConfigClient;
   let loggerDebug: jest.SpyInstance;
+  let storageFetchConfig: jest.SpyInstance;
 
   beforeEach(() => {
     loggerDebug = jest.spyOn(mockLogger, 'debug');
+    storageFetchConfig = jest.spyOn(mockStorage, 'fetchConfig');
 
     (RemoteConfigLocalstorage as jest.Mock).mockImplementation(() => mockStorage);
     client = new RemoteConfigClient(mockApiKey, mockLogger);
+
+    // Clears only the call history but keeps the original mock implementation
+    jest.clearAllMocks();
   });
 
   describe('constructor', () => {
@@ -153,6 +174,299 @@ describe('RemoteConfigClient', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(mockStorage.setConfig).toHaveBeenCalledWith(remoteConfigInfo);
       expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
+    });
+  });
+
+  describe('subscribeAll', () => {
+    test('should return remote only if remote returns first', async () => {
+      // fetch() returns immediately
+      const fetch = jest.spyOn(client, 'fetch');
+      const sendCallback = jest.spyOn(client, 'sendCallback');
+      const remoteConfigInfo = {
+        remoteConfig: null,
+        lastFetch: new Date(),
+      };
+      const fetchPromise = Promise.resolve(remoteConfigInfo);
+      fetch.mockReturnValueOnce(fetchPromise);
+
+      // storage.fetchConfig() returns after 1s
+      storageFetchConfig.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(remoteConfigInfo);
+            }, 1000);
+          }),
+      );
+
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      await client.subscribeAll(callbackInfo);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.fetchConfig).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config client subscription all mode fetched from remote.');
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
+      expect(mockStorage.setConfig).toHaveBeenCalledWith(remoteConfigInfo);
+    });
+
+    test('should return cache and then remote if cache returns first', async () => {
+      // fetch() returns after 1s
+      const fetch = jest.spyOn(client, 'fetch');
+      const sendCallback = jest.spyOn(client, 'sendCallback');
+      const remoteConfigInfo = {
+        remoteConfig: null,
+        lastFetch: new Date(),
+      };
+      fetch.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(remoteConfigInfo);
+            }, 1000);
+          }),
+      );
+
+      // storage.fetchConfig() returns immediately
+      storageFetchConfig.mockReturnValueOnce(Promise.resolve(remoteConfigInfo));
+
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      await client.subscribeAll(callbackInfo);
+      // Wait 1s for fetch() returns
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.fetchConfig).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config client subscription all mode fetched from cache.');
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config client subscription all mode fetched from remote.');
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'cache');
+      expect(mockStorage.setConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('subscribeWaitForRemote', () => {
+    test('should return remote', async () => {
+      // fetch() returns immediately
+      const fetch = jest.spyOn(client, 'fetch');
+      const sendCallback = jest.spyOn(client, 'sendCallback');
+      const remoteConfigInfo = {
+        remoteConfig: null,
+        lastFetch: new Date(),
+      };
+      fetch.mockReturnValueOnce(Promise.resolve(remoteConfigInfo));
+
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      await client.subscribeWaitForRemote(callbackInfo, 1000);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        'Remote config client subscription wait for remote mode returns from remote.',
+      );
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
+    });
+
+    test('should return cache if remote fetch exceed timeout', async () => {
+      // fetch() returns in 1.5s
+      const fetch = jest.spyOn(client, 'fetch');
+      const sendCallback = jest.spyOn(client, 'sendCallback');
+      const remoteConfigInfo = {
+        remoteConfig: { a: { b: 1 } },
+        lastFetch: new Date(),
+      };
+      fetch.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(remoteConfigInfo);
+            }, 1500);
+          }),
+      );
+
+      // storage.fetchConfig() returns immediately
+      storageFetchConfig.mockReturnValueOnce(Promise.resolve(remoteConfigInfo));
+
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      await client.subscribeWaitForRemote(callbackInfo, 1000);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        'Remote config client subscription wait for remote mode exceeded timeout. Try to fetch from cache.',
+      );
+      expect(storageFetchConfig).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        'Remote config client subscription wait for remote mode returns a cached copy.',
+      );
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'cache');
+    });
+
+    test('should return nil if remote fetch exceed timeout and cache is empty', async () => {
+      // fetch() returns in 1.5s
+      const fetch = jest.spyOn(client, 'fetch');
+      const sendCallback = jest.spyOn(client, 'sendCallback');
+      const remoteConfigInfo = {
+        remoteConfig: null, // cache is empty
+        lastFetch: new Date(),
+      };
+      fetch.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(remoteConfigInfo);
+            }, 1500);
+          }),
+      );
+
+      // storage.fetchConfig() returns immediately
+      storageFetchConfig.mockReturnValueOnce(Promise.resolve(remoteConfigInfo));
+
+      const callbackInfo = {
+        id: mockUuid,
+        key: testKey,
+        deliveryMode: 'all' as DeliveryMode,
+        callback: jest.fn(),
+      };
+      await client.subscribeWaitForRemote(callbackInfo, 1000);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        'Remote config client subscription wait for remote mode exceeded timeout. Try to fetch from cache.',
+      );
+      expect(storageFetchConfig).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith(
+        'Remote config client subscription wait for remote mode failed to fetch cache.',
+      );
+      expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
+    });
+  });
+
+  describe('sendCallback', () => {
+    let callback: jest.Mock;
+    let remoteConfigInfo: RemoteConfigInfo;
+
+    beforeEach(() => {
+      callback = jest.fn();
+      remoteConfigInfo = {
+        remoteConfig: {
+          a: {
+            b: {
+              c: 1,
+            },
+            d: 2,
+          },
+        },
+        lastFetch: new Date(),
+      };
+    });
+
+    test('should call callback with filtered config if key exists', () => {
+      const callbackInfo: CallbackInfo = {
+        id: mockUuid,
+        key: 'a.b',
+        deliveryMode: 'all' as DeliveryMode,
+        callback,
+      };
+
+      client.sendCallback(callbackInfo, remoteConfigInfo, 'remote');
+
+      expect(callback).toHaveBeenCalledWith(
+        { c: 1 }, // Expected filtered config
+        'remote',
+        remoteConfigInfo.lastFetch,
+      );
+      expect(callbackInfo.lastCallback).toBeDefined();
+    });
+
+    test('should call callback with null if key is not found', () => {
+      const callbackInfo: CallbackInfo = {
+        id: mockUuid,
+        key: 'x.y', // Non-existent key
+        deliveryMode: 'all' as DeliveryMode,
+        callback,
+      };
+
+      client.sendCallback(callbackInfo, remoteConfigInfo, 'remote');
+
+      expect(callback).toHaveBeenCalledWith(null, 'remote', remoteConfigInfo.lastFetch);
+      expect(callbackInfo.lastCallback).toBeDefined();
+    });
+
+    test('should call callback with full config if key is empty', () => {
+      const callbackInfo: CallbackInfo = {
+        id: mockUuid,
+        key: '',
+        deliveryMode: 'all' as DeliveryMode,
+        callback,
+      };
+
+      client.sendCallback(callbackInfo, remoteConfigInfo, 'remote');
+
+      expect(callback).toHaveBeenCalledWith(remoteConfigInfo.remoteConfig, 'remote', remoteConfigInfo.lastFetch);
+      expect(callbackInfo.lastCallback).toBeDefined();
+    });
+
+    test('should call callback with full config if key is undefined', () => {
+      const callbackInfo: CallbackInfo = {
+        id: mockUuid,
+        key: undefined,
+        deliveryMode: 'all' as DeliveryMode,
+        callback,
+      };
+
+      client.sendCallback(callbackInfo, remoteConfigInfo, 'remote');
+
+      expect(callback).toHaveBeenCalledWith(remoteConfigInfo.remoteConfig, 'remote', remoteConfigInfo.lastFetch);
+      expect(callbackInfo.lastCallback).toBeDefined();
+    });
+  });
+
+  describe('getUrlParams', () => {
+    test('should generate correct US URL', () => {
+      const expectedUrl =
+        `https://sr-client-cfg.amplitude.com/config?` +
+        `api_key=test-api-key&` +
+        `config_keys=analyticsSDK.browserSDK&` +
+        `config_keys=sessionReplay.sr_interaction_config&` +
+        `config_keys=sessionReplay.sr_logging_config&` +
+        `config_keys=sessionReplay.sr_privacy_config&` +
+        `config_keys=sessionReplay.sr_sampling_config&` +
+        `config_keys=sessionReplay.sr_targeting_config`;
+      const url = client.getUrlParams();
+      expect(url).toBe(expectedUrl);
+    });
+
+    test('should generate correct EU URL', () => {
+      client = new RemoteConfigClient(mockApiKey, mockLogger, 'EU');
+      const expectedUrl =
+        `https://sr-client-cfg.eu.amplitude.com/config?` +
+        `api_key=test-api-key&` +
+        `config_keys=analyticsSDK.browserSDK&` +
+        `config_keys=sessionReplay.sr_interaction_config&` +
+        `config_keys=sessionReplay.sr_logging_config&` +
+        `config_keys=sessionReplay.sr_privacy_config&` +
+        `config_keys=sessionReplay.sr_sampling_config&` +
+        `config_keys=sessionReplay.sr_targeting_config`;
+      const url = client.getUrlParams();
+      expect(url).toBe(expectedUrl);
     });
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-124564]

Remote config client
- Have the same design and APIs as the iOS one https://github.com/amplitude/AmplitudeCore-Swift/pull/2
- A remote config client based on request-on-demand and subscription + callback modes. 
- The remote config client has 3 public APIs. See code comment for more details. 
- `subscribe()` is very similar to `addEventListener()`. Callback is called when the remote config fetched. 
- Analytics SDK will initialize a remote config client and plugins can use it for request remote config on their needs.
```
export interface IRemoteConfigClient {
  subscribe(key: string | undefined, deliveryMode: DeliveryMode, callback: RemoteConfigCallback): string;

  unsubscribe(id: string): boolean;

  updateConfigs(): void;
}
```

Remote config storage

- Default to local storage. Ideally we can take advantages of browser storage instead of using local storage, but it requires extra response headers ([AMP-126646]) and work. 



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-124564]: https://amplitude.atlassian.net/browse/AMP-124564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AMP-126646]: https://amplitude.atlassian.net/browse/AMP-126646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ