### PR TITLE
chore(analytics browser): version to the config object

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -33,9 +33,11 @@ import { SendBeaconTransport } from './transports/send-beacon';
 import { parseLegacyCookies } from './cookie-migration';
 import { DEFAULT_IDENTITY_STORAGE, DEFAULT_SERVER_ZONE } from './constants';
 import { AmplitudeBrowser } from './browser-client';
+import { VERSION } from './version';
 
 // Exported for testing purposes only. Do not expose to public interface.
 export class BrowserConfig extends Config implements IBrowserConfig {
+  public readonly version = VERSION;
   protected _cookieStorage: Storage<UserSession>;
   protected _deviceId?: string;
   protected _lastEventId?: number;

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -11,6 +11,7 @@ import { uuidPattern } from './helpers/constants';
 import { DEFAULT_IDENTITY_STORAGE, DEFAULT_SERVER_ZONE } from '../src/constants';
 import { AmplitudeBrowser } from '../src/browser-client';
 import { MemoryStorage, getCookieName, FetchTransport } from '@amplitude/analytics-core';
+import { VERSION } from '../src/version';
 
 describe('config', () => {
   const someUUID: string = expect.stringMatching(uuidPattern) as string;
@@ -75,6 +76,7 @@ describe('config', () => {
         transportProvider: new FetchTransport(),
         useBatch: false,
         fetchRemoteConfig: false,
+        version: VERSION,
       });
     });
 
@@ -132,6 +134,7 @@ describe('config', () => {
         transportProvider: new FetchTransport(),
         useBatch: false,
         fetchRemoteConfig: false,
+        version: VERSION,
       });
       expect(getTopLevelDomain).toHaveBeenCalledTimes(1);
     });
@@ -233,6 +236,7 @@ describe('config', () => {
         transportProvider: new FetchTransport(),
         useBatch: false,
         fetchRemoteConfig: false,
+        version: VERSION,
       });
     });
 

--- a/packages/analytics-core/src/types/browser-config.ts
+++ b/packages/analytics-core/src/types/browser-config.ts
@@ -87,6 +87,7 @@ interface InternalBrowserConfig {
   lastEventTime?: number;
   lastEventId?: number;
   transportProvider: Transport;
+  version?: string;
 }
 
 /**


### PR DESCRIPTION
### Summary

Adding the version to BrowserConfig class. This one is slightly different from v1.x, since the code is different for `useBrowserConfig`.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
