### PR TITLE
fix(autocapture): removed deprecated Element Selector event property …

### DIFF
--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -13,8 +13,6 @@ export const AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_LEFT = '[Amplitude] Element P
 export const AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_TOP = '[Amplitude] Element Position Top';
 export const AMPLITUDE_EVENT_PROP_ELEMENT_ARIA_LABEL = '[Amplitude] Element Aria Label';
 export const AMPLITUDE_EVENT_PROP_ELEMENT_ATTRIBUTES = '[Amplitude] Element Attributes';
-// Deprecated in favor of AMPLITUDE_EVENT_PROP_ELEMENT_HIERARCHY. Keeping for backwards compatibility.
-export const AMPLITUDE_EVENT_PROP_ELEMENT_SELECTOR = '[Amplitude] Element Selector';
 
 export const AMPLITUDE_EVENT_PROP_ELEMENT_PARENT_LABEL = '[Amplitude] Element Parent Label';
 export const AMPLITUDE_EVENT_PROP_PAGE_URL = '[Amplitude] Page URL';

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-globals */
-import { finder } from './libs/finder';
 import * as constants from './constants';
-import { ILogger, ElementInteractionsOptions, ActionType } from '@amplitude/analytics-core';
+import { ElementInteractionsOptions, ActionType } from '@amplitude/analytics-core';
 import { ElementBasedEvent, ElementBasedTimestampedEvent } from './autocapture-plugin';
 
 export type JSONValue = string | number | boolean | null | { [x: string]: JSONValue } | Array<JSONValue>;
@@ -125,42 +124,6 @@ export const getText = (element: Element): string => {
   return text;
 };
 
-export const getSelector = (element: Element, logger?: ILogger): string => {
-  let selector = '';
-  try {
-    selector = finder(element, {
-      className: (name: string) => name !== constants.AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
-      maxNumberOfTries: 1000,
-    });
-    return selector;
-  } catch (error) {
-    if (logger) {
-      const typedError = error as Error;
-      logger.warn(`Failed to get selector with finder, use fallback strategy instead: ${typedError.toString()}`);
-    }
-  }
-  // Fall back to use tag, id, and class name, if finder fails.
-  /* istanbul ignore next */
-  const tag = element?.tagName?.toLowerCase?.();
-  if (tag) {
-    selector = tag;
-  }
-  const id = element.getAttribute('id');
-  const className = element.getAttribute('class');
-  if (id) {
-    selector = `#${id}`;
-  } else if (className) {
-    const classes = className
-      .split(' ')
-      .filter((name) => name !== constants.AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS)
-      .join('.');
-    if (classes) {
-      selector = `${selector}.${classes}`;
-    }
-  }
-  return selector;
-};
-
 export const isPageUrlAllowed = (url: string, pageUrlAllowlist: (string | RegExp)[] | undefined) => {
   if (!pageUrlAllowlist || !pageUrlAllowlist.length) {
     return true;
@@ -254,18 +217,16 @@ export const getClosestElement = (element: Element | null, selectors: string[]):
 };
 
 // Returns the element properties for the given element in Visual Labeling.
-export const getEventTagProps = (element: Element, logger?: ILogger) => {
+export const getEventTagProps = (element: Element) => {
   if (!element) {
     return {};
   }
   /* istanbul ignore next */
   const tag = element?.tagName?.toLowerCase?.();
-  const selector = getSelector(element, logger);
 
   const properties: Record<string, JSONValue> = {
     [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
     [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: getText(element),
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_SELECTOR]: selector,
     [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: window.location.href.split('?')[0],
   };
   return removeEmptyProperties(properties);

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -27,7 +27,6 @@ interface ElementSelectedData {
   '[Amplitude] Element Hierarchy'?: string;
   '[Amplitude] Element Tag'?: string;
   '[Amplitude] Element Text'?: string;
-  '[Amplitude] Element Selector'?: string;
   '[Amplitude] Page URL'?: string;
   elementScreenshot?: Blob;
 }

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -176,7 +176,6 @@ describe('action clicks:', () => {
         '[Amplitude] Element Parent Label': 'Card Title',
         '[Amplitude] Element Position Left': 0,
         '[Amplitude] Element Position Top': 0,
-        '[Amplitude] Element Selector': '#addDivButton',
         '[Amplitude] Element Tag': 'div',
         '[Amplitude] Element Text': 'Add div',
         '[Amplitude] Viewport Height': 768,
@@ -198,7 +197,6 @@ describe('action clicks:', () => {
         '[Amplitude] Element Clicked',
         expect.objectContaining({
           '[Amplitude] Element ID': 'real-button',
-          '[Amplitude] Element Selector': '#real-button',
           '[Amplitude] Element Tag': 'button',
           '[Amplitude] Element Text': 'Click me',
         }),

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -3,7 +3,6 @@ import {
   isTextNode,
   isNonSensitiveElement,
   getText,
-  getSelector,
   isPageUrlAllowed,
   getAttributesWithPrefix,
   isEmpty,
@@ -17,7 +16,6 @@ import {
   createShouldTrackEvent,
 } from '../src/helpers';
 import { mockWindowLocationFromURL } from './utils';
-import { ILogger } from '@amplitude/analytics-core';
 
 describe('autocapture-plugin helpers', () => {
   afterEach(() => {
@@ -200,76 +198,6 @@ describe('autocapture-plugin helpers', () => {
     test('should return true when url is matching an item in the allow list with regex wildcard', () => {
       const result = isPageUrlAllowed(url, [new RegExp('http.?://amplitude.*'), new RegExp('http.?://test.*')]);
       expect(result).toEqual(true);
-    });
-  });
-
-  describe('getSelector', () => {
-    test('should return the selector with finder', () => {
-      document.getElementsByTagName('body')[0].innerHTML = `
-        <div id="container">
-        </div>
-      `;
-      const inner = document.createElement('div');
-      const container = document.getElementById('container');
-      container?.appendChild(inner);
-      expect(getSelector(inner)).toEqual('#container > div');
-    });
-
-    test('should use fallback logic with element id to get selector when finder has error', () => {
-      const loggerProvider: Partial<ILogger> = {
-        log: jest.fn(),
-        warn: jest.fn(),
-      };
-      const container = document.createElement('container');
-      container.innerHTML = `<div id="inner"></div>`;
-      const inner = container.querySelector('#inner');
-
-      // This is a floating element, so finder will throw error as it cannot find it in the document tree.
-      // This case might happen as some of the element might be removed from the DOM tree before the selector is retrieved.
-      const result = getSelector(inner as HTMLElement, loggerProvider as ILogger);
-      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
-      expect(loggerProvider.warn).toHaveBeenCalledWith(
-        `Failed to get selector with finder, use fallback strategy instead: Error: Can't select any node with this selector: #inner`,
-      );
-      expect(result).toEqual('#inner');
-    });
-
-    test('should use fallback logic with class to get selector when finder has error', () => {
-      const loggerProvider: Partial<ILogger> = {
-        log: jest.fn(),
-        warn: jest.fn(),
-      };
-      const container = document.createElement('container');
-      container.innerHTML = `<div class="inner"></div>`;
-      const inner = container.querySelector('.inner');
-
-      // This is a floating element, so finder will throw error as it cannot find it in the document tree.
-      // This case might happen as some of the element might be removed from the DOM tree before the selector is retrieved.
-      const result = getSelector(inner as HTMLElement, loggerProvider as ILogger);
-      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
-      expect(loggerProvider.warn).toHaveBeenCalledWith(
-        `Failed to get selector with finder, use fallback strategy instead: Error: Can't select any node with this selector: .inner`,
-      );
-      expect(result).toEqual('div.inner');
-    });
-
-    test('should use fallback logic with tag to get selector when finder has error', () => {
-      const loggerProvider: Partial<ILogger> = {
-        log: jest.fn(),
-        warn: jest.fn(),
-      };
-      const container = document.createElement('container');
-      container.innerHTML = `<div class="amp-visual-tagging-selector-highlight"></div>`;
-      const inner = container.querySelector('.amp-visual-tagging-selector-highlight');
-
-      // This is a floating element, so finder will throw error as it cannot find it in the document tree.
-      // This case might happen as some of the element might be removed from the DOM tree before the selector is retrieved.
-      const result = getSelector(inner as HTMLElement, loggerProvider as ILogger);
-      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
-      expect(loggerProvider.warn).toHaveBeenCalledWith(
-        `Failed to get selector with finder, use fallback strategy instead: Error: Can't select any node with this selector: div`,
-      );
-      expect(result).toEqual('div');
     });
   });
 
@@ -519,7 +447,6 @@ describe('autocapture-plugin helpers', () => {
 
       const inner = document.getElementById('inner');
       expect(getEventTagProps(inner as HTMLElement)).toEqual({
-        '[Amplitude] Element Selector': '#inner',
         '[Amplitude] Element Tag': 'div',
         '[Amplitude] Element Text': ' xxx ',
         '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
@@ -541,7 +468,6 @@ describe('autocapture-plugin helpers', () => {
 
       const inner = document.getElementsByClassName('amp-visual-tagging-selector-highlight')[0];
       expect(getEventTagProps(inner as HTMLElement)).toEqual({
-        '[Amplitude] Element Selector': '#container > div',
         '[Amplitude] Element Tag': 'div',
         '[Amplitude] Element Text': ' xxx ',
         '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',


### PR DESCRIPTION
…and improved click performance

### Summary
https://amplitude.atlassian.net/browse/AMP-126627

- Removed the deprecated `[Amplitude] Element Selector` property. This was problematic because finding a unique CSS selector for an element on the page is a expensive calculation.
- Improved performance on click tracking. This was mostly a bug in the previous version where the observable didn't multicast itself using share, so duplicate work was being done to grab proprties about the event.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
