### PR TITLE
fix(analytics-browser): should track file download and form interaction when plugins are installed after page loads

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -29,12 +29,9 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
 
   const name = '@amplitude/plugin-file-download-tracking-browser';
   const type = 'enrichment';
+
   const setup = async (config: BrowserConfig, amplitude: BrowserClient) => {
-    // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
-    // after the body is built. When Amplitud gets initialized in a script tag, the body tag is still unavailable. So register this
-    // only after the window is loaded
-    /* istanbul ignore next */
-    getGlobalScope()?.addEventListener('load', function () {
+    const initializeFileDownloadTracking = () => {
       /* istanbul ignore if */
       if (!amplitude) {
         // TODO: Add required minimum version of @amplitude/analytics-browser
@@ -104,8 +101,24 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
           childList: true,
         });
       }
-    });
+    };
+
+    // If the document is already loaded, initialize immediately.
+    /* istanbul ignore else*/
+    if (document.readyState === 'complete') {
+      initializeFileDownloadTracking();
+    } else {
+      // Otherwise, wait for the load event.
+      const window = getGlobalScope();
+      /* istanbul ignore else*/
+      if (window) {
+        window.addEventListener('load', initializeFileDownloadTracking);
+      } else {
+        config.loggerProvider.debug('File download tracking is not installed because global is undefined.');
+      }
+    }
   };
+
   const execute = async (event: Event) => event;
   const teardown = async () => {
     observer?.disconnect();

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -38,11 +38,7 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
   const name = '@amplitude/plugin-form-interaction-tracking-browser';
   const type = 'enrichment';
   const setup = async (config: BrowserConfig, amplitude: BrowserClient) => {
-    // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
-    // after the body is built. When Amplitud gets initialized in a script tag, the body tag is still unavailable. So register this
-    // only after the window is loaded
-    /* istanbul ignore next */
-    getGlobalScope()?.addEventListener('load', function () {
+    const initializeFormTracking = () => {
       /* istanbul ignore if */
       if (!amplitude) {
         // TODO: Add required minimum version of @amplitude/analytics-browser
@@ -116,7 +112,19 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
           childList: true,
         });
       }
-    });
+    };
+
+    // If the document is already loaded, initialize immediately.
+    /* istanbul ignore else*/
+    if (document.readyState === 'complete') {
+      initializeFormTracking();
+    } else {
+      // Otherwise, wait for the load event.
+      // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
+      // after the body is built. When Amplitude gets initialized in a script tag, the body tag is still unavailable. So register this
+      // only after the window is loaded
+      getGlobalScope()?.addEventListener('load', initializeFormTracking);
+    }
   };
   const execute = async (event: Event) => event;
   const teardown = async () => {

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -115,7 +115,6 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
     };
 
     // If the document is already loaded, initialize immediately.
-    /* istanbul ignore else*/
     if (document.readyState === 'complete') {
       initializeFormTracking();
     } else {
@@ -123,7 +122,13 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       // The form interaction plugin observes changes in the dom. For this to work correctly, the observer can only be setup
       // after the body is built. When Amplitude gets initialized in a script tag, the body tag is still unavailable. So register this
       // only after the window is loaded
-      getGlobalScope()?.addEventListener('load', initializeFormTracking);
+      const window = getGlobalScope();
+      /* istanbul ignore else*/
+      if (window) {
+        window.addEventListener('load', initializeFormTracking);
+      } else {
+        config.loggerProvider.debug('Form interaction tracking is not installed because global is undefined.');
+      }
     }
   };
   const execute = async (event: Event) => event;

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -22,20 +22,6 @@ describe('fileDownloadTracking', () => {
     document.querySelector('a#my-link-id')?.remove();
   });
 
-  test('should not track file_download event if window load event was not triggered', async () => {
-    // setup
-    document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');
-    const config = createConfigurationMock();
-    const plugin = fileDownloadTracking();
-    await plugin.setup?.(config, amplitude);
-
-    // trigger click event
-    document.getElementById('my-link-id')?.dispatchEvent(new Event('click'));
-
-    // assert file download event was tracked
-    expect(amplitude.track).toHaveBeenCalledTimes(0);
-  });
-
   test.each([
     'https://analytics.amplitude.com/files/my-file.pdf',
     'https://analytics.amplitude.com/files/my-file.pdf?foo=bar',

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -32,17 +32,54 @@ describe('formInteractionTracking', () => {
     document.querySelector('form#my-form-id')?.remove();
   });
 
-  test('should not track form_start event when window load event was not triggered', async () => {
+  test('should track form_start event when the plugin is added after window load', async () => {
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
 
+    const originalReadyState = document.readyState;
+    Object.defineProperty(document, 'readyState', {
+      value: 'complete',
+      writable: true,
+    });
+
     // trigger change event
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
 
     // assert first event was tracked
-    expect(amplitude.track).toHaveBeenCalledTimes(0);
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+
+    // Restore the original value after each test
+    Object.defineProperty(document, 'readyState', {
+      value: originalReadyState,
+      writable: true,
+    });
+  });
+
+  test('should track form_start event when the plugin is added before window load', async () => {
+    // setup
+    const config = createConfigurationMock();
+    const plugin = formInteractionTracking();
+    await plugin.setup?.(config, amplitude);
+
+    const originalReadyState = document.readyState;
+    Object.defineProperty(document, 'readyState', {
+      value: 'loading',
+      writable: true,
+    });
+
+    // trigger change event
+    document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
+
+    // assert first event was tracked
+    expect(amplitude.track).toHaveBeenCalledTimes(1);
+
+    // Restore the original value after each test
+    Object.defineProperty(document, 'readyState', {
+      value: originalReadyState,
+      writable: true,
+    });
   });
 
   test('should track form_start event', async () => {

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -38,38 +38,28 @@ describe('formInteractionTracking', () => {
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
 
-    const originalReadyState = document.readyState;
-    Object.defineProperty(document, 'readyState', {
-      value: 'complete',
-      writable: true,
-    });
-
     // trigger change event
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
 
     // assert first event was tracked
     expect(amplitude.track).toHaveBeenCalledTimes(1);
-
-    // Restore the original value after each test
-    Object.defineProperty(document, 'readyState', {
-      value: originalReadyState,
-      writable: true,
-    });
   });
 
   test('should track form_start event when the plugin is added before window load', async () => {
+    const originalReadyState = document.readyState;
+    Object.defineProperty(document, 'readyState', {
+      value: 'loading',
+      writable: true,
+      configurable: true,
+    });
+
     // setup
     const config = createConfigurationMock();
     const plugin = formInteractionTracking();
     await plugin.setup?.(config, amplitude);
 
-    const originalReadyState = document.readyState;
-    Object.defineProperty(document, 'readyState', {
-      value: 'loading',
-      writable: true,
-    });
-
     // trigger change event
+    window.dispatchEvent(new Event('load'));
     document.getElementById('my-form-id')?.dispatchEvent(new Event('change'));
 
     // assert first event was tracked


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-126154]
Previously, we only add file download form interaction listeners when `load` event is dispatched. This works for scenarios when plugins are installed before page loads, for example, script tag in header. Events are not tracked when plugins are installed after page loads where no load event is dispatched. This PR fixes it. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-126154]: https://amplitude.atlassian.net/browse/AMP-126154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ