### PR TITLE
fix(analytics-browser): re-export enums from analytics-types

### DIFF
--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -89,13 +89,13 @@ export namespace Types {
   export type BrowserOptions = BrowserOptionsType;
   export type Config = IConfigType;
   export type Event = EventType;
-  export type IdentifyOperation = IdentifyOperationType;
-  export type SpecialEventType = SpecialEventTypeType;
+  export const IdentifyOperation = IdentifyOperationType;
+  export const SpecialEventType = SpecialEventTypeType;
   export type Identify = IIdentifyType;
   export type Revenue = IRevenueType;
-  export type RevenueProperty = RevenuePropertyType;
+  export const RevenueProperty = RevenuePropertyType;
   export type Logger = ILoggerType;
-  export type LogLevel = LogLevelType;
+  export const LogLevel = LogLevelType;
   export type Plugin = PluginType;
   export type BeforePlugin = BeforePluginType;
   export type EnrichmentPlugin = EnrichmentPluginType;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix https://github.com/amplitude/Amplitude-TypeScript/issues/1004
Follow up PR of https://github.com/amplitude/Amplitude-TypeScript/pull/993. 
Enums are essentially constants. So export them as const rather than type under the namespace `Types`. Keep re-exported interfaces as type.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
