### PR TITLE
feat(analytics-browser): set default for fetchRemoteConfig option to true

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -88,7 +88,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     },
     public transport: 'fetch' | 'xhr' | 'beacon' = 'fetch',
     public useBatch: boolean = false,
-    public fetchRemoteConfig: boolean = false,
+    public fetchRemoteConfig: boolean = true,
     userId?: string,
     pageCounter?: number,
     debugLogsEnabled?: boolean,

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -75,7 +75,7 @@ describe('config', () => {
         transport: 'fetch',
         transportProvider: new FetchTransport(),
         useBatch: false,
-        fetchRemoteConfig: false,
+        fetchRemoteConfig: true,
         version: VERSION,
       });
     });
@@ -133,7 +133,7 @@ describe('config', () => {
         transport: 'fetch',
         transportProvider: new FetchTransport(),
         useBatch: false,
-        fetchRemoteConfig: false,
+        fetchRemoteConfig: true,
         version: VERSION,
       });
       expect(getTopLevelDomain).toHaveBeenCalledTimes(1);
@@ -235,7 +235,7 @@ describe('config', () => {
         transport: 'fetch',
         transportProvider: new FetchTransport(),
         useBatch: false,
-        fetchRemoteConfig: false,
+        fetchRemoteConfig: true,
         version: VERSION,
       });
     });

--- a/packages/analytics-core/src/types/browser-config.ts
+++ b/packages/analytics-core/src/types/browser-config.ts
@@ -76,8 +76,9 @@ export interface ExternalBrowserConfig extends IConfig {
    */
   pageCounter?: number;
   /**
-   * Whether to fetch remote configuration.
-   * @defaultValue `false`
+   * Whether to fetch remote configuration. The remote configuration can be updated in the Amplitude platform here:
+   * https://app.amplitude.com/data/amplitude/{your_org_name}/settings/autocapture
+   * @defaultValue `true`
    */
   fetchRemoteConfig?: boolean;
 }


### PR DESCRIPTION
### Summary

This PR sets the default for the `fetchRemoteConfig` option to be `true`.
The goal of this is to allow more users, excluding those who have set it to false explicitly, to be able to control their SDK configuration through the Amplitude platform.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
