### PR TITLE
fix(analytics-core): cookie storage should delete duplicate

### DIFF
--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -49,8 +49,7 @@ export class CookieStorage<T> implements Storage<T> {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  /* istanbul ignore next */
   async getRaw(key: string): Promise<string | undefined> {
     const globalScope = getGlobalScope();
     const cookieString = globalScope?.document?.cookie ?? '';


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-125768]

The SDK, by default, creates cookies using a domain with a leading dot (e.g., .amplitude.com). However, some customers have reported cases where two cookies with the same name exist—one with a leading dot in the domain and one without. See an example screenshot in the linked ticket comment.

This PR fix the issue by detecting and deleting the duplicate cookie that does not have the leading dot, ensuring only one cookie remains.

Note: We use document.cookie here, which does not expose domain information. While the [CookieStore API](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore) would provide full access to domain-specific cookies, it is not yet widely supported across modern browsers.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-125768]: https://amplitude.atlassian.net/browse/AMP-125768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ