### PR TITLE
feat(analytics-browser): plugin host

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -21,6 +21,7 @@ import {
   BrowserOptions,
   BrowserConfig,
   BrowserClient,
+  Plugin,
 } from '@amplitude/analytics-core';
 import {
   getAttributionTrackingConfig,
@@ -46,13 +47,21 @@ import { createBrowserJoinedConfigGenerator } from './config/joined-config';
 import { autocapturePlugin } from '@amplitude/plugin-autocapture-browser';
 import { WebAttribution } from './attribution/web-attribution';
 
-export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
+interface PluginHost {
+  plugin(name: string): Plugin | undefined;
+}
+
+export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, PluginHost {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   config: BrowserConfig;
   previousSessionDeviceId: string | undefined;
   previousSessionUserId: string | undefined;
   webAttribution: WebAttribution | undefined;
+
+  plugin(name: string): Plugin | undefined {
+    return this.timeline.plugins.find((plugin) => plugin.name === name);
+  }
 
   init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {
     let userId: string | undefined;

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -60,7 +60,13 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, Pl
   webAttribution: WebAttribution | undefined;
 
   plugin(name: string): Plugin | undefined {
-    return this.timeline.plugins.find((plugin) => plugin.name === name);
+    const plugin = this.timeline.plugins.find((plugin) => plugin.name === name);
+    if (plugin === undefined) {
+      this.config.loggerProvider.debug(`Cannot find plugin with name ${name}`);
+      return undefined;
+    }
+
+    return plugin;
   }
 
   init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -25,8 +25,6 @@ export const {
 } = client;
 export { runQueuedFunctions } from './utils/snippet-helper';
 export { Revenue, Identify } from '@amplitude/analytics-core';
-// Export for prototype augmentation
-export { AmplitudeBrowser } from './browser-client';
 
 import {
   AmplitudeReturn as AmplitudeReturnType,

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -25,6 +25,8 @@ export const {
 } = client;
 export { runQueuedFunctions } from './utils/snippet-helper';
 export { Revenue, Identify } from '@amplitude/analytics-core';
+// Export for prototype augmentation
+export { AmplitudeBrowser } from './browser-client';
 
 import {
   AmplitudeReturn as AmplitudeReturnType,

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -56,6 +56,49 @@ describe('browser-client', () => {
     document.cookie = `AMP_${apiKey}=null; expires=-1`;
   });
 
+  describe('plugin', () => {
+    test('should return plugin by name', async () => {
+      const fileDownloadTrackingPlugin = jest.spyOn(fileDownloadTracking, 'fileDownloadTracking');
+      await client.init(apiKey, userId, {
+        optOut: false,
+        defaultTracking: {
+          ...defaultTracking,
+          fileDownloads: true,
+        },
+      }).promise;
+      const result = client.plugin('@amplitude/plugin-file-download-tracking-browser');
+      // result should be fileDownloadTrackingPlugin
+      // comparing with the first call to the spy
+      expect(result).toBe(fileDownloadTrackingPlugin.mock.results[0].value);
+    });
+
+    test('should return undefined when name doesn not exist', async () => {
+      const loggerProvider = {
+        log: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        enable: jest.fn(),
+        disable: jest.fn(),
+      };
+      await client.init(apiKey, userId, {
+        optOut: false,
+        defaultTracking: {
+          ...defaultTracking,
+          fileDownloads: true,
+        },
+        loggerProvider: loggerProvider,
+      }).promise;
+      const result = client.plugin('plugin-file-download-tracking-browser');
+      // result should be fileDownloadTrackingPlugin
+      // comparing with the first call to the spy
+      expect(result).toBe(undefined);
+      expect(loggerProvider.debug).toHaveBeenCalledWith(
+        'Cannot find plugin with name plugin-file-download-tracking-browser',
+      );
+    });
+  });
+
   describe('init', () => {
     test('should NOT use remote config by default', async () => {
       await client.init(apiKey).promise;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-126972](https://amplitude.atlassian.net/browse/AMP-126972)

This PR adds an interface `PluginHost` with a method `plugin()` which returns the plugin instance by name string. 
This PR supports installing experiment as a plugin https://github.com/amplitude/experiment-js-client/pull/168

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-126972]: https://amplitude.atlassian.net/browse/AMP-126972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ