### PR TITLE
docs(session-replay-browser): adding documentation for options in the standalone sdk

### DIFF
--- a/packages/plugin-session-replay-browser/README.md
+++ b/packages/plugin-session-replay-browser/README.md
@@ -55,7 +55,15 @@ const sessionReplayTracking = sessionReplayPlugin({
 |-|-|-|-|-|
 |`sampleRate`|`number`|`undefined`|Yes|Use this option to control how many sessions will be selected for replay collection. A selected session will be collected for replay, while sessions that are not selected will not.  <br></br>The number should be a decimal between 0 and 1, ie `0.01`, representing the fraction of sessions you would like to have randomly selected for replay collection. Over a large number of sessions, `0.01` would select `1%` of those sessions.|
 |`privacyConfig`|`object`|`undefined`|No| Supports advanced masking configs with CSS selectors.|
+|`forceSessionTracking`|`boolean`|`false`|No|If this is enabled we will force the browser SDK to also send start and end session events.|
 |`debugMode`|`boolean`|`false`|No| Adds additional debug event property to help debug instrumentation issues (such as mismatching apps). Only recommended for debugging initial setup, and not recommended for production.|
+|`configServerUrl`|`string`|No|`undefined`|Specifies the endpoint URL to fetch remote configuration. If provided, it overrides the default server zone configuration.|
+|`trackServerUrl`|`string`|No|`undefined`|Specifies the endpoint URL for sending session replay data. If provided, it overrides the default server zone configuration.|
+|`shouldInlineStylesheet`|`boolean`|No|`true`|If stylesheets are inlined, the contents of the stylesheet will be stored. During replay, the stored stylesheet will be used instead of attempting to fetch it remotely. This prevents replays from appearing broken due to missing stylesheets. Note: Inlining stylesheets may not work in all cases. If this is `undefined` stylesheets will be inlined.|
+|`storeType`|`string`|No|`idb`|Specifies how replay events should be stored. `idb` uses IndexedDB to persist replay events when all events cannot be sent during capture. `memory` stores replay events only in memory, meaning events are lost when the page is closed. If IndexedDB is unavailable, the system falls back to `memory`.|
+|`performanceConfig.enabled`|`boolean`|No|`false`|If enabled, event compression will be deferred to occur during the browser's idle periods.|
+|`performanceConfig.timeout`|`number`|No|`undefined`|Optional timeout in milliseconds for the `requestIdleCallback` API. If specified, this value will be used to set a maximum time for the browser to wait before executing the deferred compression task, even if the browser is not idle.|
+|`experimental.useWebWorker`|`boolean`|No|`false`|If the SDK should compress the replay events using a webworker.|
 
 ### 3. Install plugin to Amplitude SDK
 

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,5 +1,9 @@
 import { Event } from '@amplitude/analytics-types';
-import { StoreType } from '@amplitude/session-replay-browser';
+import {
+  StoreType,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type SessionReplayOptions as StandaloneSessionReplayOptions, // used for documentation
+} from '@amplitude/session-replay-browser';
 
 export type MaskLevel =
   | 'light' // only mask a subset of inputs that’s deemed sensitive - password, credit card, telephone #, email. These are information we never want to capture.
@@ -19,17 +23,55 @@ export interface SessionReplayPerformanceConfig {
 }
 
 export interface SessionReplayOptions {
+  /**
+   * @see {@link StandaloneSessionReplayOptions.sampleRate}
+   */
   sampleRate?: number;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.privacyConfig}
+   */
   privacyConfig?: SessionReplayPrivacyConfig;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.debugMode}
+   */
   debugMode?: boolean;
+  /**
+   * If this is enabled we will force the browser SDK to also send start and end session events.
+   */
   forceSessionTracking?: boolean;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.configServerUrl}
+   */
   configServerUrl?: string;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.trackServerUrl}
+   */
   trackServerUrl?: string;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.shouldInlineStylesheet}
+   */
   shouldInlineStylesheet?: boolean;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.performanceConfig}
+   */
   performanceConfig?: SessionReplayPerformanceConfig;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.storeType}
+   */
   storeType?: StoreType;
+  /**
+   * Override the device ID for session replay.
+   */
   deviceId?: string;
+  /**
+   * Dynamically overrides the session ID for replay. Ensure stability to avoid frequent restarts.
+   * @param event Browser SDK event
+   * @returns The session ID for the session replay.
+   */
   customSessionId?: (event: Event) => string | undefined;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.experimental}
+   */
   experimental?: {
     useWebWorker: boolean;
   };

--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -81,12 +81,19 @@ sessionReplay.shutdown()
 |`sessionId`|`number`|Yes|`undefined`|Sets an identifier for the users current session. The value must be in milliseconds since epoch (Unix Timestamp).|
 |`sampleRate`|`number`|No|`0`|Use this option to control how many sessions will be selected for replay collection. A selected session will be collected for replay, while sessions that are not selected will not.  <br></br>The number should be a decimal between 0 and 1, ie `0.01`, representing the fraction of sessions you would like to have randomly selected for replay collection. Over a large number of sessions, `0.01` would select `1%` of those sessions.|
 |`optOut`|`boolean`|No|`false`|Sets permission to collect replays for sessions. Setting a value of true prevents Amplitude from collecting session replays.|
-|`flushMaxRetries`|`number`|No|`5`|Sets the maximum number of retries for failed upload attempts. This is only applicable to retryable errors.|
+|`flushMaxRetries`|`number`|No|`2`|Sets the maximum number of retries for failed upload attempts. This is only applicable to retryable errors.|
 |`logLevel`|`number`|No|`LogLevel.Warn`|`LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. Sets the log level.|
 |`loggerProvider`|`Logger`|No|`Logger`|Sets a custom loggerProvider class from the Logger to emit log messages to desired destination.|
 |`serverZone`|`string`|No|`US`|EU or US. Sets the Amplitude server zone. Set this to EU for Amplitude projects created in EU data center.|
-|`privacyConfig`|`object`|No|`undefined`| Supports advanced masking configs with CSS selectors.|
-|`debugMode`|`boolean`|No|`false`| Adds additional debug event property to help debug instrumentation issues (such as mismatching apps). Only recommended for debugging initial setup, and not recommended for production.|
+|`privacyConfig`|`object`|No|`undefined`|Supports advanced masking configs with CSS selectors.|
+|`debugMode`|`boolean`|No|`false`|Adds additional debug event property to help debug instrumentation issues (such as mismatching apps). Only recommended for debugging initial setup, and not recommended for production.|
+|`configServerUrl`|`string`|No|`undefined`|Specifies the endpoint URL to fetch remote configuration. If provided, it overrides the default server zone configuration.|
+|`trackServerUrl`|`string`|No|`undefined`|Specifies the endpoint URL for sending session replay data. If provided, it overrides the default server zone configuration.|
+|`shouldInlineStylesheet`|`boolean`|No|`true`|If stylesheets are inlined, the contents of the stylesheet will be stored. During replay, the stored stylesheet will be used instead of attempting to fetch it remotely. This prevents replays from appearing broken due to missing stylesheets. Note: Inlining stylesheets may not work in all cases. If this is `undefined` stylesheets will be inlined.|
+|`storeType`|`string`|No|`idb`|Specifies how replay events should be stored. `idb` uses IndexedDB to persist replay events when all events cannot be sent during capture. `memory` stores replay events only in memory, meaning events are lost when the page is closed. If IndexedDB is unavailable, the system falls back to `memory`.|
+|`performanceConfig.enabled`|`boolean`|No|`false`|If enabled, event compression will be deferred to occur during the browser's idle periods.|
+|`performanceConfig.timeout`|`number`|No|`undefined`|Optional timeout in milliseconds for the `requestIdleCallback` API. If specified, this value will be used to set a maximum time for the browser to wait before executing the deferred compression task, even if the browser is not idle.|
+|`experimental.useWebWorker`|`boolean`|No|`false`|If the SDK should compress the replay events using a webworker.|
 
 ## Privacy
 By default, the session replay will mask all inputs, meaning the text in inputs will appear in a session replay as asterisks: `***`. You may require more specific masking controls based on your use case, so we offer the following controls:

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -53,23 +53,74 @@ export type PrivacyConfig = {
 export interface SessionReplayLocalConfig extends Config {
   apiKey: string;
   loggerProvider: Logger;
+  /**
+   * LogLevel.None or LogLevel.Error or LogLevel.Warn or LogLevel.Verbose or LogLevel.Debug.
+   * Sets the log level.
+   *
+   * @defaultValue LogLevel.Warn
+   */
   logLevel: LogLevel;
+  /**
+   * The maximum number of retries allowed for sending replay events.
+   * Once this limit is reached, failed events will no longer be sent.
+   *
+   * @defaultValue 2
+   */
   flushMaxRetries: number;
+  /**
+   * Use this option to control how many sessions to select for replay collection.
+   * The number should be a decimal between 0 and 1, for example 0.4, representing
+   * the fraction of sessions to have randomly selected for replay collection.
+   * Over a large number of sessions, 0.4 would select 40% of those sessions.
+   * Sample rates as small as six decimal places (0.000001) are supported.
+   *
+   * @defaultValue 0
+   */
   sampleRate: number;
   privacyConfig?: PrivacyConfig;
+  /**
+   * Adds additional debug event property to help debug instrumentation issues
+   * (such as mismatching apps). Only recommended for debugging initial setup,
+   * and not recommended for production.
+   */
   debugMode?: boolean;
-  // This will control which endpoint is used for remote config.
-  // This will override server zone if specified.
+  /**
+   * Specifies the endpoint URL to fetch remote configuration.
+   * If provided, it overrides the default server zone configuration.
+   */
   configServerUrl?: string;
-  // This will control which endpoint is used for session replay track calls.
-  // This will override server zone if specified.
+  /**
+   * Specifies the endpoint URL for sending session replay data.
+   * If provided, it overrides the default server zone configuration.
+   */
   trackServerUrl?: string;
+  /**
+   * If stylesheets are inlined, the contents of the stylesheet will be stored.
+   * During replay, the stored stylesheet will be used instead of attempting to fetch it remotely.
+   * This prevents replays from appearing broken due to missing stylesheets.
+   * Note: Inlining stylesheets may not work in all cases.
+   */
   shouldInlineStylesheet?: boolean;
   version?: SessionReplayVersion;
+  /**
+   * Performance configuration config. If enabled, we will defer compression
+   * to be done during the browser's idle periods.
+   */
   performanceConfig?: SessionReplayPerformanceConfig;
+  /**
+   * Specifies how replay events should be stored. `idb` uses IndexedDB to persist replay events
+   * when all events cannot be sent during capture. `memory` stores replay events only in memory,
+   * meaning events are lost when the page is closed. If IndexedDB is unavailable, the system falls back to `memory`.
+   */
   storeType: StoreType;
 
+  /**
+   * Experimental features.
+   */
   experimental?: {
+    /**
+     * If the SDK should compress the replay events using a webworker.
+     */
     useWebWorker: boolean;
   };
 }
@@ -96,8 +147,19 @@ export interface SessionReplayVersion {
   type: SessionReplayType;
 }
 
+/**
+ * Configuration options for session replay performance.
+ */
 export interface SessionReplayPerformanceConfig {
+  /**
+   * If enabled, event compression will be deferred to occur during the browser's idle periods.
+   */
   enabled: boolean;
+  /**
+   * Optional timeout in milliseconds for the `requestIdleCallback` API.
+   * If specified, this value will be used to set a maximum time for the browser to wait
+   * before executing the deferred compression task, even if the browser is not idle.
+   */
   timeout?: number;
 }
 

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -75,7 +75,13 @@ export interface EventsStore<KeyType> {
   cleanUpSessionEventsStore(sessionId: string | number, sequenceId?: KeyType): Promise<void>;
 }
 export interface SessionIdentifiers {
+  /**
+   * Sets an identifier for the device running your application.
+   */
   deviceId?: string;
+  /**
+   * Sets an identifier for the users current session. The value must be in milliseconds since epoch (Unix Timestamp).
+   */
   sessionId?: string | number;
   sessionReplayId?: string;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Documenting additional SDK parameters.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
