### PR TITLE
feat(analytics-browser): allow initialization of remote config property pageUrlAllowlistRegex

### DIFF
--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -76,10 +76,15 @@ export class BrowserJoinedConfigGenerator {
             const transformedRcElementInteractions = transformedAutocaptureRemoteConfig.elementInteractions;
 
             const exactAllowList = transformedRcElementInteractions.pageUrlAllowlist ?? [];
-            // Convert string patterns to RegExp objects
-            const regexList = remoteConfig.autocapture.elementInteractions.pageUrlAllowlistRegex.map(
-              (pattern) => new RegExp(pattern),
-            );
+            // Convert string patterns to RegExp objects, warn on invalid patterns and skip them
+            const regexList = [];
+            for (const pattern of remoteConfig.autocapture.elementInteractions.pageUrlAllowlistRegex) {
+              try {
+                regexList.push(new RegExp(pattern));
+              } catch (regexError) {
+                this.config.loggerProvider.warn(`Invalid regex pattern: ${pattern}`, regexError);
+              }
+            }
 
             const combinedPageUrlAllowlist = exactAllowList.concat(regexList);
 

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -65,10 +65,10 @@ export class BrowserJoinedConfigGenerator {
             this.config.autocapture = remoteConfig.autocapture;
           }
 
-          // Handle pageUrlAllowlistRegex conversion to RegExp objects
+          // Handle Element Interactions config initialization
           if (
             typeof remoteConfig.autocapture.elementInteractions === 'object' &&
-            remoteConfig.autocapture.elementInteractions?.pageUrlAllowlistRegex?.length
+            remoteConfig.autocapture.elementInteractions.pageUrlAllowlistRegex?.length
           ) {
             transformedAutocaptureRemoteConfig.elementInteractions = {
               ...remoteConfig.autocapture.elementInteractions,
@@ -77,8 +77,9 @@ export class BrowserJoinedConfigGenerator {
 
             const exactAllowList = transformedRcElementInteractions.pageUrlAllowlist ?? [];
             // Convert string patterns to RegExp objects
-            const regexList =
-              transformedRcElementInteractions.pageUrlAllowlistRegex?.map((pattern) => new RegExp(pattern)) ?? [];
+            const regexList = remoteConfig.autocapture.elementInteractions.pageUrlAllowlistRegex.map(
+              (pattern) => new RegExp(pattern),
+            );
 
             const combinedPageUrlAllowlist = exactAllowList.concat(regexList);
 

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -59,6 +59,7 @@ export class BrowserJoinedConfigGenerator {
         }
 
         if (typeof remoteConfig.autocapture === 'object') {
+          const transformedAutocaptureRemoteConfig = { ...remoteConfig.autocapture };
           if (this.config.autocapture === undefined) {
             this.config.autocapture = remoteConfig.autocapture;
           }
@@ -68,16 +69,21 @@ export class BrowserJoinedConfigGenerator {
             typeof remoteConfig.autocapture.elementInteractions === 'object' &&
             remoteConfig.autocapture.elementInteractions?.pageUrlAllowlistRegex?.length
           ) {
-            const exactAllowList = remoteConfig.autocapture.elementInteractions.pageUrlAllowlist ?? [];
+            transformedAutocaptureRemoteConfig.elementInteractions = {
+              ...remoteConfig.autocapture.elementInteractions,
+            };
+
+            const exactAllowList = transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlist ?? [];
             // Convert string patterns to RegExp objects
-            const regexList = remoteConfig.autocapture.elementInteractions.pageUrlAllowlistRegex.map(
-              (pattern) => new RegExp(pattern),
-            );
+            const regexList =
+              transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlistRegex?.map(
+                (pattern) => new RegExp(pattern),
+              ) ?? [];
 
             const combinedPageUrlAllowlist = exactAllowList.concat(regexList);
 
-            remoteConfig.autocapture.elementInteractions.pageUrlAllowlist = combinedPageUrlAllowlist;
-            delete remoteConfig.autocapture.elementInteractions.pageUrlAllowlistRegex;
+            transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlist = combinedPageUrlAllowlist;
+            delete transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlistRegex;
           }
 
           if (typeof this.config.autocapture === 'boolean') {
@@ -88,14 +94,14 @@ export class BrowserJoinedConfigGenerator {
               pageViews: this.config.autocapture,
               sessions: this.config.autocapture,
               elementInteractions: this.config.autocapture,
-              ...remoteConfig.autocapture,
+              ...transformedAutocaptureRemoteConfig,
             };
           }
 
           if (typeof this.config.autocapture === 'object') {
             this.config.autocapture = {
               ...this.config.autocapture,
-              ...remoteConfig.autocapture,
+              ...transformedAutocaptureRemoteConfig,
             };
           }
         }

--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -60,6 +60,7 @@ export class BrowserJoinedConfigGenerator {
 
         if (typeof remoteConfig.autocapture === 'object') {
           const transformedAutocaptureRemoteConfig = { ...remoteConfig.autocapture };
+
           if (this.config.autocapture === undefined) {
             this.config.autocapture = remoteConfig.autocapture;
           }
@@ -72,18 +73,17 @@ export class BrowserJoinedConfigGenerator {
             transformedAutocaptureRemoteConfig.elementInteractions = {
               ...remoteConfig.autocapture.elementInteractions,
             };
+            const transformedRcElementInteractions = transformedAutocaptureRemoteConfig.elementInteractions;
 
-            const exactAllowList = transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlist ?? [];
+            const exactAllowList = transformedRcElementInteractions.pageUrlAllowlist ?? [];
             // Convert string patterns to RegExp objects
             const regexList =
-              transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlistRegex?.map(
-                (pattern) => new RegExp(pattern),
-              ) ?? [];
+              transformedRcElementInteractions.pageUrlAllowlistRegex?.map((pattern) => new RegExp(pattern)) ?? [];
 
             const combinedPageUrlAllowlist = exactAllowList.concat(regexList);
 
-            transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlist = combinedPageUrlAllowlist;
-            delete transformedAutocaptureRemoteConfig.elementInteractions.pageUrlAllowlistRegex;
+            transformedRcElementInteractions.pageUrlAllowlist = combinedPageUrlAllowlist;
+            delete transformedRcElementInteractions.pageUrlAllowlistRegex;
           }
 
           if (typeof this.config.autocapture === 'boolean') {

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -430,7 +430,6 @@ describe('joined-config', () => {
       });
 
       test('should not fail or override pageUrlAllowlist when pageUrlAllowlistRegex is undefined', async () => {
-        // Arrange: Set up the local configuration and the BrowserJoinedConfigGenerator
         localConfig = createConfigurationMock({});
         generator = new BrowserJoinedConfigGenerator(localConfig);
 
@@ -443,13 +442,11 @@ describe('joined-config', () => {
           },
         };
 
-        // Mock the remote configuration fetch to return the defined remoteConfig
         mockRemoteConfigFetch = {
           getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
           metrics: metrics,
         };
 
-        // Mock the createRemoteConfigFetch function to return our mocked remoteConfigFetch object
         (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
           mockRemoteConfigFetch,
         );

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -5,11 +5,23 @@ import {
   BrowserRemoteConfig,
 } from '../../src/config/joined-config';
 import { createConfigurationMock } from '../helpers/mock';
-import { RequestMetadata, BrowserConfig as IBrowserConfig } from '@amplitude/analytics-core';
+import {
+  RequestMetadata,
+  BrowserConfig as IBrowserConfig,
+  type BrowserConfig,
+  type ElementInteractionsOptions,
+} from '@amplitude/analytics-core';
 
 jest.mock('@amplitude/analytics-remote-config', () => ({
   createRemoteConfigFetch: jest.fn(),
 }));
+
+function expectIsAutocaptureObjectWithElementInteractions(config: BrowserConfig): asserts config is BrowserConfig & {
+  autocapture: BrowserConfig['autocapture'] & { elementInteractions: ElementInteractionsOptions };
+} {
+  expect(config).toHaveProperty('autocapture');
+  expect(config.autocapture).toHaveProperty('elementInteractions');
+}
 
 describe('joined-config', () => {
   let localConfig: IBrowserConfig;
@@ -326,6 +338,143 @@ describe('joined-config', () => {
         );
         expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_API_fail).toBe(100);
         expect(joinedConfig.requestMetadata?.sdk.metrics.histogram.remote_config_fetch_time_IDB).toBe(undefined);
+      });
+
+      test('should convert pageUrlAllowlistRegex strings to RegExp objects and combine with pageUrlAllowlist', async () => {
+        localConfig = createConfigurationMock(createConfigurationMock({}));
+        generator = new BrowserJoinedConfigGenerator(localConfig);
+
+        const remoteConfig = {
+          autocapture: {
+            elementInteractions: {
+              pageUrlAllowlist: ['exact-match.com', 'another-exact-match.com'],
+              pageUrlAllowlistRegex: ['^https://.*\\.example\\.com$', '.*\\.amplitude\\.com$'],
+            },
+          },
+        };
+
+        mockRemoteConfigFetch = {
+          getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
+          metrics: metrics,
+        };
+
+        (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
+          mockRemoteConfigFetch,
+        );
+
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+
+        // Verify the combined pageUrlAllowlist contains both exact matches and RegExp objects
+        expectIsAutocaptureObjectWithElementInteractions(joinedConfig);
+        const elementInteractions = joinedConfig.autocapture?.elementInteractions;
+
+        const pageUrlAllowlist = elementInteractions.pageUrlAllowlist;
+        expect(Array.isArray(pageUrlAllowlist)).toBe(true);
+        expect(pageUrlAllowlist?.length).toBe(4);
+
+        // First two items should be strings
+        expect(pageUrlAllowlist?.[0]).toBe('exact-match.com');
+        expect(pageUrlAllowlist?.[1]).toBe('another-exact-match.com');
+
+        // Last two items should be RegExp objects
+        expect(pageUrlAllowlist?.[2]).toBeInstanceOf(RegExp);
+        expect(pageUrlAllowlist?.[3]).toBeInstanceOf(RegExp);
+        expect(pageUrlAllowlist?.[2].toString()).toBe(new RegExp('^https://.*\\.example\\.com$').toString());
+        expect(pageUrlAllowlist?.[3].toString()).toBe(new RegExp('.*\\.amplitude\\.com$').toString());
+
+        // pageUrlAllowlistRegex should have been removed
+        expect(elementInteractions).not.toHaveProperty('pageUrlAllowlistRegex');
+      });
+
+      test('should handle empty pageUrlAllowlist when pageUrlAllowlistRegex is provided', async () => {
+        localConfig = createConfigurationMock(createConfigurationMock({}));
+        generator = new BrowserJoinedConfigGenerator(localConfig);
+
+        const remoteConfig = {
+          autocapture: {
+            elementInteractions: {
+              pageUrlAllowlistRegex: ['^https://.*\\.example\\.com$', '.*\\.amplitude\\.com$'],
+            },
+          },
+        };
+
+        mockRemoteConfigFetch = {
+          getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
+          metrics: metrics,
+        };
+
+        (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
+          mockRemoteConfigFetch,
+        );
+
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+
+        // Verify the pageUrlAllowlist contains only RegExp objects
+        expectIsAutocaptureObjectWithElementInteractions(joinedConfig);
+        const elementInteractions = joinedConfig.autocapture?.elementInteractions;
+
+        const pageUrlAllowlist = elementInteractions.pageUrlAllowlist;
+        expect(Array.isArray(pageUrlAllowlist)).toBe(true);
+        expect(pageUrlAllowlist?.length).toBe(2);
+
+        // Both items should be RegExp objects
+        expect(pageUrlAllowlist?.[0]).toBeInstanceOf(RegExp);
+        expect(pageUrlAllowlist?.[1]).toBeInstanceOf(RegExp);
+        expect(pageUrlAllowlist?.[0].toString()).toBe(new RegExp('^https://.*\\.example\\.com$').toString());
+        expect(pageUrlAllowlist?.[1].toString()).toBe(new RegExp('.*\\.amplitude\\.com$').toString());
+
+        // pageUrlAllowlistRegex should have been removed
+        expect(elementInteractions).not.toHaveProperty('pageUrlAllowlistRegex');
+      });
+
+      test('should not fail or override pageUrlAllowlist when pageUrlAllowlistRegex is undefined', async () => {
+        // Arrange: Set up the local configuration and the BrowserJoinedConfigGenerator
+        localConfig = createConfigurationMock({});
+        generator = new BrowserJoinedConfigGenerator(localConfig);
+
+        // Define the remote configuration with an existing exact match allowlist and pageUrlAllowlistRegex as undefined
+        const remoteConfig = {
+          autocapture: {
+            elementInteractions: {
+              pageUrlAllowlist: ['existing-domain.com', 'another-domain.net'],
+            },
+          },
+        };
+
+        // Mock the remote configuration fetch to return the defined remoteConfig
+        mockRemoteConfigFetch = {
+          getRemoteConfig: jest.fn().mockResolvedValue(remoteConfig),
+          metrics: metrics,
+        };
+
+        // Mock the createRemoteConfigFetch function to return our mocked remoteConfigFetch object
+        (createRemoteConfigFetch as jest.MockedFunction<typeof createRemoteConfigFetch>).mockResolvedValue(
+          mockRemoteConfigFetch,
+        );
+
+        // Act: Initialize the generator and generate the joined configuration
+        await generator.initialize();
+        const joinedConfig = await generator.generateJoinedConfig();
+
+        // Assert: Verify that the original pageUrlAllowlist remains unchanged
+        // Ensure the autocapture and elementInteractions objects exist in the joined config
+        expectIsAutocaptureObjectWithElementInteractions(joinedConfig);
+        const elementInteractions = joinedConfig.autocapture?.elementInteractions;
+        expect(elementInteractions).toBeDefined();
+
+        const pageUrlAllowlist = elementInteractions.pageUrlAllowlist;
+        expect(Array.isArray(pageUrlAllowlist)).toBe(true);
+        // Expect the list to have the original exact match strings
+        expect(pageUrlAllowlist?.length).toBe(2);
+
+        // Verify that the elements in the allowlist are the original strings
+        expect(pageUrlAllowlist?.[0]).toBe('existing-domain.com');
+        expect(pageUrlAllowlist?.[1]).toBe('another-domain.net');
+
+        // Assert: Verify that the pageUrlAllowlistRegex property has been removed (even if it was undefined)
+        expect(elementInteractions).not.toHaveProperty('pageUrlAllowlistRegex');
       });
     });
   });


### PR DESCRIPTION
### Summary

- Updated types of `BrowserRemoteConfig` to reflect the addition of the pageUrlAllowlistRegex property inside `elementInteractions`
- Updated `generateJoinedConfig()` to also initialize those strings from `pageUrlAllowlistRegex` as RegExp objects and append them to the original

[Jira](https://amplitude.atlassian.net/browse/AMP-127542)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
