### PR TITLE
feat(session-replay-browser): migrate to core v2.x

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -4,7 +4,7 @@ export { Revenue, IRevenue, RevenueProperty } from './revenue';
 export { Destination } from './plugins/destination';
 export { IdentityEventSender } from './plugins/identity';
 export { IConfig, Config, RequestMetadata } from './config';
-export { Logger, ILogger } from './logger';
+export { Logger, ILogger, LogConfig } from './logger';
 export { getGlobalScope } from './global-scope';
 export { getAnalyticsConnector, setConnectorDeviceId, setConnectorUserId } from './analytics-connector';
 export { isNewSession } from './session';

--- a/packages/analytics-core/src/types/server-zone.ts
+++ b/packages/analytics-core/src/types/server-zone.ts
@@ -4,6 +4,10 @@
 export enum ServerZone {
   US = 'US',
   EU = 'EU',
+  /**
+   * Add for session-replay-browser migration from analytics-type v1.x.
+   */
+  STAGING = 'STAGING',
 }
 
 export type ServerZoneType = 'US' | 'EU';

--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -38,9 +38,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": ">=1 <2",
-    "@amplitude/analytics-core": ">=1 <2",
-    "@amplitude/analytics-types": ">=1 <2",
+    "@amplitude/analytics-core": "^2.8.1",
     "@amplitude/session-replay-browser": "^1.20.2",
     "idb-keyval": "^6.2.1",
     "tslib": "^2.4.1"

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,9 +1,9 @@
-import { BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-core';
+import { BrowserClient, BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-core';
 import * as sessionReplay from '@amplitude/session-replay-browser';
 import { SessionReplayOptions } from './typings/session-replay';
 import { VERSION } from './version';
 
-export class SessionReplayPlugin implements EnrichmentPlugin {
+export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, BrowserConfig> {
   name = '@amplitude/plugin-session-replay-browser';
   type = 'enrichment' as const;
   // this.config is defined in setup() which will always be called first
@@ -16,7 +16,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin {
     this.options = { forceSessionTracking: false, ...options };
   }
 
-  async setup(config: BrowserConfig) {
+  async setup(config: BrowserConfig, _client: BrowserClient) {
     try {
       /* istanbul ignore next */
       config?.loggerProvider.log(`Installing @amplitude/plugin-session-replay, version ${VERSION}.`);

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,4 +1,4 @@
-import { BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-types';
+import { BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-core';
 import * as sessionReplay from '@amplitude/session-replay-browser';
 import { SessionReplayOptions } from './typings/session-replay';
 import { VERSION } from './version';

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,4 +1,4 @@
-import { Event } from '@amplitude/analytics-types';
+import { Event } from '@amplitude/analytics-core';
 import {
   StoreType,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -93,7 +93,7 @@ describe('SessionReplayPlugin', () => {
       const sessionReplay = new SessionReplayPlugin({
         deviceId: customDeviceId,
       });
-      await sessionReplay.setup(mockConfig);
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
       expect(sessionReplay.config.serverUrl).toBe('url');
       expect(sessionReplay.config.flushMaxRetries).toBe(1);
       expect(sessionReplay.config.flushQueueSize).toBe(0);
@@ -105,28 +105,37 @@ describe('SessionReplayPlugin', () => {
     describe('defaultTracking', () => {
       test('should not change defaultTracking forceSessionTracking is not defined', async () => {
         const sessionReplay = new SessionReplayPlugin();
-        await sessionReplay.setup({
-          ...mockConfig,
-          defaultTracking: true,
-        });
+        await sessionReplay.setup?.(
+          {
+            ...mockConfig,
+            defaultTracking: true,
+          },
+          mockAmplitude,
+        );
         expect(sessionReplay.config.defaultTracking).toBe(true);
       });
 
       test('should not change defaultTracking if its set to true', async () => {
         const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: true });
-        await sessionReplay.setup({
-          ...mockConfig,
-          defaultTracking: true,
-        });
+        await sessionReplay.setup?.(
+          {
+            ...mockConfig,
+            defaultTracking: true,
+          },
+          mockAmplitude,
+        );
         expect(sessionReplay.config.defaultTracking).toBe(true);
       });
 
       test('should modify defaultTracking to enable sessions if its set to false', async () => {
         const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: true });
-        await sessionReplay.setup({
-          ...mockConfig,
-          defaultTracking: false,
-        });
+        await sessionReplay.setup?.(
+          {
+            ...mockConfig,
+            defaultTracking: false,
+          },
+          mockAmplitude,
+        );
         expect(sessionReplay.config.defaultTracking).toEqual({
           pageViews: false,
           formInteractions: false,
@@ -137,12 +146,15 @@ describe('SessionReplayPlugin', () => {
 
       test('should modify defaultTracking to enable sessions if it is an object', async () => {
         const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: true });
-        await sessionReplay.setup({
-          ...mockConfig,
-          defaultTracking: {
-            pageViews: false,
+        await sessionReplay.setup?.(
+          {
+            ...mockConfig,
+            defaultTracking: {
+              pageViews: false,
+            },
           },
-        });
+          mockAmplitude,
+        );
         expect(sessionReplay.config.defaultTracking).toEqual({
           pageViews: false,
           sessions: true,
@@ -151,21 +163,27 @@ describe('SessionReplayPlugin', () => {
 
       test('should not modify defaultTracking to enable sessions if session tracking is disbled', async () => {
         const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: false });
-        await sessionReplay.setup({
-          ...mockConfig,
-          defaultTracking: false,
-        });
+        await sessionReplay.setup?.(
+          {
+            ...mockConfig,
+            defaultTracking: false,
+          },
+          mockAmplitude,
+        );
         expect(sessionReplay.config.defaultTracking).toEqual(false);
       });
 
       test('should not modify defaultTracking object to enable sessions if session tracking is disbled', async () => {
         const sessionReplay = new SessionReplayPlugin({ forceSessionTracking: false });
-        await sessionReplay.setup({
-          ...mockConfig,
-          defaultTracking: {
-            pageViews: false,
+        await sessionReplay.setup?.(
+          {
+            ...mockConfig,
+            defaultTracking: {
+              pageViews: false,
+            },
           },
-        });
+          mockAmplitude,
+        );
         expect(sessionReplay.config.defaultTracking).toEqual({
           pageViews: false,
         });
@@ -179,7 +197,7 @@ describe('SessionReplayPlugin', () => {
           blockSelector: ['#id'],
         },
       });
-      await sessionReplay.setup(mockConfig);
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
 
       expect(init).toHaveBeenCalledTimes(1);
 
@@ -215,7 +233,7 @@ describe('SessionReplayPlugin', () => {
         configServerUrl,
         trackServerUrl,
       });
-      await sessionReplay.setup(mockConfig);
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
 
       expect(init).toHaveBeenCalledTimes(1);
 
@@ -248,7 +266,7 @@ describe('SessionReplayPlugin', () => {
         init.mockImplementation(() => {
           throw new Error('Mock Error');
         });
-        await sessionReplay.setup(mockConfig);
+        await sessionReplay.setup?.(mockConfig, mockAmplitude);
       }).not.toThrow();
     });
   });
@@ -256,7 +274,7 @@ describe('SessionReplayPlugin', () => {
   describe('execute', () => {
     test('should add event property for [Amplitude] Session Replay ID', async () => {
       const sessionReplay = sessionReplayPlugin();
-      await sessionReplay.setup({ ...mockConfig });
+      await sessionReplay.setup?.({ ...mockConfig }, mockAmplitude);
       getSessionReplayProperties.mockReturnValueOnce({
         '[Amplitude] Session Replay ID': '123',
       });
@@ -269,7 +287,7 @@ describe('SessionReplayPlugin', () => {
         session_id: 123,
       };
 
-      const enrichedEvent = await sessionReplay.execute(event);
+      const enrichedEvent = await sessionReplay.execute?.(event);
       expect(enrichedEvent?.event_properties).toEqual({
         property_a: true,
         property_b: 123,
@@ -279,7 +297,7 @@ describe('SessionReplayPlugin', () => {
 
     test('should not add event property for for event with mismatching session id.', async () => {
       const sessionReplay = sessionReplayPlugin();
-      await sessionReplay.setup({ ...mockConfig });
+      await sessionReplay.setup?.({ ...mockConfig }, mockAmplitude);
       getSessionReplayProperties.mockReturnValueOnce({
         '[Amplitude] Session Replay ID': '123',
       });
@@ -291,7 +309,7 @@ describe('SessionReplayPlugin', () => {
         },
         session_id: 124,
       };
-      const enrichedEvent = await sessionReplay.execute(event);
+      const enrichedEvent = await sessionReplay.execute?.(event);
 
       expect(enrichedEvent?.event_properties).toEqual({
         property_a: true,
@@ -301,7 +319,7 @@ describe('SessionReplayPlugin', () => {
 
     test('should update the session id on any event', async () => {
       const sessionReplay = new SessionReplayPlugin();
-      await sessionReplay.setup({ ...mockConfig, sessionId: 123 });
+      await sessionReplay.setup?.({ ...mockConfig, sessionId: 123 }, mockAmplitude);
 
       const newEvent = {
         event_type: 'session_start',
@@ -314,20 +332,20 @@ describe('SessionReplayPlugin', () => {
 
     test('should not update if session id unchanged', async () => {
       const sessionReplay = new SessionReplayPlugin();
-      await sessionReplay.setup({ ...mockConfig, sessionId: 123 });
+      await sessionReplay.setup?.({ ...mockConfig, sessionId: 123 }, mockAmplitude);
       getSessionId.mockReturnValueOnce(123);
 
       const event = {
         event_type: 'page view',
         session_id: 123,
       };
-      await sessionReplay.execute(event);
+      await sessionReplay.execute?.(event);
       expect(setSessionId).not.toHaveBeenCalled();
     });
 
     test('should return original event in case of errors', async () => {
       const sessionReplay = sessionReplayPlugin();
-      await sessionReplay.setup({ ...mockConfig });
+      await sessionReplay.setup?.({ ...mockConfig }, mockAmplitude);
       getSessionReplayProperties.mockImplementation(() => {
         throw new Error('Mock error');
       });
@@ -340,7 +358,7 @@ describe('SessionReplayPlugin', () => {
         session_id: 123,
       };
 
-      const enrichedEvent = await sessionReplay.execute(event);
+      const enrichedEvent = await sessionReplay.execute?.(event);
       expect(enrichedEvent).toEqual(event);
     });
   });
@@ -348,7 +366,7 @@ describe('SessionReplayPlugin', () => {
   describe('teardown', () => {
     test('should call session replay teardown', async () => {
       const sessionReplay = sessionReplayPlugin();
-      await sessionReplay.setup(mockConfig);
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
       await sessionReplay.teardown?.();
       expect(shutdown).toHaveBeenCalled();
     });
@@ -356,7 +374,7 @@ describe('SessionReplayPlugin', () => {
     test('internal errors should not be thrown', async () => {
       expect(async () => {
         const sessionReplay = sessionReplayPlugin();
-        await sessionReplay.setup(mockConfig);
+        await sessionReplay.setup?.(mockConfig, mockAmplitude);
 
         // Mock the shutdown function to throw an error
         shutdown.mockImplementation(() => {
@@ -376,7 +394,7 @@ describe('SessionReplayPlugin', () => {
           return event_properties['custom_session_id'] as string | undefined;
         },
       });
-      await sessionReplay.setup({ ...mockConfig });
+      await sessionReplay.setup?.({ ...mockConfig }, mockAmplitude);
       getSessionId.mockReturnValueOnce('test_122');
       const event = {
         event_type: 'event_type',
@@ -388,7 +406,7 @@ describe('SessionReplayPlugin', () => {
         session_id: 124,
       };
 
-      await sessionReplay.execute(event);
+      await sessionReplay.execute?.(event);
       expect(setSessionId).toHaveBeenCalledTimes(1);
       expect(setSessionId).toHaveBeenCalledWith('test_123');
     });
@@ -403,7 +421,7 @@ describe('SessionReplayPlugin', () => {
           return event_properties['custom_session_id'] as string | undefined;
         },
       });
-      await sessionReplay.setup({ ...mockConfig });
+      await sessionReplay.setup?.({ ...mockConfig }, mockAmplitude);
       getSessionId.mockReturnValueOnce('test_123');
       const event = {
         event_type: 'event_type',
@@ -415,7 +433,7 @@ describe('SessionReplayPlugin', () => {
         session_id: 124,
       };
 
-      await sessionReplay.execute(event);
+      await sessionReplay.execute?.(event);
       expect(setSessionId).not.toHaveBeenCalled();
     });
 
@@ -429,7 +447,7 @@ describe('SessionReplayPlugin', () => {
           return event_properties['custom_session_id'] as string | undefined;
         },
       });
-      await sessionReplay.setup({ ...mockConfig });
+      await sessionReplay.setup?.({ ...mockConfig }, mockAmplitude);
       const event = {
         event_type: 'event_type',
         event_properties: {
@@ -439,7 +457,7 @@ describe('SessionReplayPlugin', () => {
         session_id: 124,
       };
 
-      const enrichedEvent = await sessionReplay.execute(event);
+      const enrichedEvent = await sessionReplay.execute?.(event);
       expect(setSessionId).not.toHaveBeenCalled();
       expect(enrichedEvent).toEqual(event);
     });
@@ -448,7 +466,7 @@ describe('SessionReplayPlugin', () => {
   describe('getSessionReplayProperties', () => {
     test('should return session replay properties', async () => {
       const sessionReplay = sessionReplayPlugin() as SessionReplayPlugin;
-      await sessionReplay.setup(mockConfig);
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
       getSessionReplayProperties.mockReturnValueOnce({
         '[Amplitude] Session Recorded': true,
         '[Amplitude] Session Replay ID': '123/456',

--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -38,10 +38,8 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^1.1.3",
-    "@amplitude/analytics-core": ">=1 <2",
+    "@amplitude/analytics-core": "^2.8.1",
     "@amplitude/analytics-remote-config": "^0.6.1",
-    "@amplitude/analytics-types": ">=1 <2",
     "@amplitude/rrweb": "2.0.0-alpha.29",
     "@amplitude/rrweb-packer": "2.0.0-alpha.29",
     "@amplitude/rrweb-plugin-console-record": "2.0.0-alpha.29",

--- a/packages/session-replay-browser/src/beacon-transport.ts
+++ b/packages/session-replay-browser/src/beacon-transport.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import { SessionReplayJoinedConfig } from './config/types';
 import { SessionReplayDestinationSessionMetadata } from './typings/session-replay';
 import { getServerUrl } from './helpers';

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -1,5 +1,5 @@
 import { RemoteConfigFetch, createRemoteConfigFetch } from '@amplitude/analytics-remote-config';
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 import { getDebugConfig } from '../helpers';
 import { SessionReplayOptions } from '../typings/session-replay';
 import { SessionReplayLocalConfig } from './local-config';
@@ -10,7 +10,7 @@ import {
   SessionReplayRemoteConfig,
 } from './types';
 
-export const removeInvalidSelectorsFromPrivacyConfig = (privacyConfig: PrivacyConfig, loggerProvider: Logger) => {
+export const removeInvalidSelectorsFromPrivacyConfig = (privacyConfig: PrivacyConfig, loggerProvider: ILogger) => {
   // This allows us to not search the DOM.
   const fragment = document.createDocumentFragment();
 

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -1,6 +1,4 @@
-import { FetchTransport } from '@amplitude/analytics-client-common';
-import { Config, Logger } from '@amplitude/analytics-core';
-import { LogLevel } from '@amplitude/analytics-types';
+import { Config, Logger, FetchTransport, LogLevel } from '@amplitude/analytics-core';
 import { DEFAULT_SAMPLE_RATE, DEFAULT_SERVER_ZONE } from '../constants';
 import { SessionReplayOptions, StoreType } from '../typings/session-replay';
 import {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -1,4 +1,4 @@
-import { Config, LogLevel, Logger } from '@amplitude/analytics-types';
+import { IConfig, LogLevel, ILogger } from '@amplitude/analytics-core';
 import { StoreType, ConsoleLogLevel } from '../typings/session-replay';
 
 export interface SamplingConfig {
@@ -50,9 +50,9 @@ export type PrivacyConfig = {
   unmaskSelector?: string[];
 };
 
-export interface SessionReplayLocalConfig extends Config {
+export interface SessionReplayLocalConfig extends IConfig {
   apiKey: string;
-  loggerProvider: Logger;
+  loggerProvider: ILogger;
   /**
    * LogLevel.None or LogLevel.Error or LogLevel.Warn or LogLevel.Verbose or LogLevel.Debug.
    * Sets the log level.

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -1,5 +1,4 @@
-import { AMPLITUDE_PREFIX } from '@amplitude/analytics-core';
-import { ServerZone } from '@amplitude/analytics-types';
+import { AMPLITUDE_PREFIX, ServerZone } from '@amplitude/analytics-core';
 
 export const DEFAULT_EVENT_PROPERTY_PREFIX = '[Amplitude]';
 

--- a/packages/session-replay-browser/src/events/base-events-store.ts
+++ b/packages/session-replay-browser/src/events/base-events-store.ts
@@ -1,16 +1,16 @@
 import { MAX_EVENT_LIST_SIZE_IN_BYTES, MAX_INTERVAL, MIN_INTERVAL } from '../constants';
 import { Events, EventsStore, SendingSequencesReturn } from '../typings/session-replay';
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 
 export type InstanceArgs = {
-  loggerProvider: Logger;
+  loggerProvider: ILogger;
   minInterval?: number;
   maxInterval?: number;
   maxPersistedEventsSize?: number;
 };
 
 export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
-  protected readonly loggerProvider: Logger;
+  protected readonly loggerProvider: ILogger;
   private minInterval = MIN_INTERVAL;
   private maxInterval = MAX_INTERVAL;
   private maxPersistedEventsSize = MAX_EVENT_LIST_SIZE_IN_BYTES;

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import { pack } from '@amplitude/rrweb-packer';
 import type { eventWithTime } from '@amplitude/rrweb-types';
 import { SessionReplayJoinedConfig } from 'src/config/types';

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -1,5 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { STORAGE_PREFIX } from '@amplitude/analytics-core';
+import { STORAGE_PREFIX, getGlobalScope } from '@amplitude/analytics-core';
 import { DBSchema, IDBPDatabase, openDB } from 'idb';
 import { STORAGE_FAILURE } from '../messages';
 import { EventType, Events, SendingSequencesReturn } from '../typings/session-replay';

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -1,5 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { ServerZone } from '@amplitude/analytics-types';
+import { getGlobalScope, ServerZone } from '@amplitude/analytics-core';
 import { getInputType } from '@amplitude/rrweb-snapshot';
 import { DEFAULT_MASK_LEVEL, MaskLevel, PrivacyConfig, SessionReplayJoinedConfig } from './config/types';
 import {

--- a/packages/session-replay-browser/src/hooks/click.ts
+++ b/packages/session-replay-browser/src/hooks/click.ts
@@ -3,8 +3,7 @@ import { record, utils } from '@amplitude/rrweb';
 import { SessionReplayEventsManager as AmplitudeSessionReplayEventsManager } from '../typings/session-replay';
 import { PayloadBatcher } from 'src/track-destination';
 import { finder } from '../libs/finder';
-import { getGlobalScope } from '@amplitude/analytics-client-common';
-import type { Logger } from '@amplitude/analytics-types';
+import { getGlobalScope, ILogger } from '@amplitude/analytics-core';
 
 // exported for testing
 export type ClickEvent = {
@@ -68,7 +67,7 @@ export const clickBatcher: PayloadBatcher = ({ version, events }) => {
   return { version, events: Object.values(reduced) };
 };
 
-export const clickHook: (logger: Logger, options: Options) => mouseInteractionCallBack =
+export const clickHook: (logger: ILogger, options: Options) => mouseInteractionCallBack =
   (logger, { eventsManager, sessionId, deviceIdFn }) =>
   (e) => {
     if (e.type !== MouseInteractions.Click) {

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -1,7 +1,7 @@
 import { utils } from '@amplitude/rrweb';
 import { scrollCallback, scrollPosition } from '@amplitude/rrweb-types';
 import { BeaconTransport } from '../beacon-transport';
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 import { SessionReplayJoinedConfig } from '../config/types';
 import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';
 

--- a/packages/session-replay-browser/src/logger.ts
+++ b/packages/session-replay-browser/src/logger.ts
@@ -1,4 +1,4 @@
-import { Logger as ILogger, LogLevel } from '@amplitude/analytics-types';
+import { ILogger, LogLevel } from '@amplitude/analytics-core';
 
 export class SafeLoggerProvider implements ILogger {
   private logger: ILogger;

--- a/packages/session-replay-browser/src/observers.ts
+++ b/packages/session-replay-browser/src/observers.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-core';
 
 export interface NetworkRequestEvent {
   timestamp: number;

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -1,5 +1,4 @@
-import { debugWrapper } from '@amplitude/analytics-core';
-import { LogConfig } from '@amplitude/analytics-types';
+import { debugWrapper, LogConfig } from '@amplitude/analytics-core';
 import { getDefaultConfig } from './config/local-config';
 import { SessionReplay } from './session-replay';
 import { AmplitudeSessionReplay } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -1,6 +1,11 @@
-import { getAnalyticsConnector, getGlobalScope } from '@amplitude/analytics-client-common';
-import { Logger, returnWrapper } from '@amplitude/analytics-core';
-import { Logger as ILogger, LogLevel } from '@amplitude/analytics-types';
+import {
+  Logger,
+  returnWrapper,
+  getAnalyticsConnector,
+  getGlobalScope,
+  ILogger,
+  LogLevel,
+} from '@amplitude/analytics-core';
 import { record } from '@amplitude/rrweb';
 import { scrollCallback } from '@amplitude/rrweb-types';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -1,5 +1,4 @@
-import { BaseTransport } from '@amplitude/analytics-core';
-import { Logger as ILogger, Status } from '@amplitude/analytics-types';
+import { BaseTransport, ILogger, Status } from '@amplitude/analytics-core';
 import { getCurrentUrl, getServerUrl } from './helpers';
 import {
   MAX_RETRIES_EXCEEDED_MESSAGE,

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,4 +1,4 @@
-import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-types';
+import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-core';
 import { SessionReplayJoinedConfig, SessionReplayLocalConfig, SessionReplayVersion } from '../config/types';
 
 export type StorageData = {

--- a/packages/session-replay-browser/test/base-events-store.test.ts
+++ b/packages/session-replay-browser/test/base-events-store.test.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 import { InMemoryEventsStore } from '../src/events/events-memory-store';
 
 describe('BaseEventsStore', () => {
@@ -6,7 +6,7 @@ describe('BaseEventsStore', () => {
     jest.useRealTimers();
   });
 
-  const mockLoggerProvider: Logger = {
+  const mockLoggerProvider: ILogger = {
     error: jest.fn(),
     log: jest.fn(),
     disable: jest.fn(),

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -1,5 +1,5 @@
 import * as RemoteConfigFetch from '@amplitude/analytics-remote-config';
-import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
+import { LogLevel, ILogger, ServerZone } from '@amplitude/analytics-core';
 import { SessionReplayOptions } from 'src/typings/session-replay';
 import {
   SessionReplayJoinedConfigGenerator,
@@ -10,7 +10,7 @@ import { SessionReplayLocalConfig } from '../../src/config/local-config';
 import { PrivacyConfig, SessionReplayRemoteConfig } from '../../src/config/types';
 import { createRemoteConfigFetch } from '@amplitude/analytics-remote-config';
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 const samplingConfig = {
   sample_rate: 0.4,
   capture_enabled: true,

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
 import { EventCompressor } from '../src/events/event-compressor';
 import { createEventsManager } from '../src/events/events-manager';
@@ -11,7 +11,7 @@ const mockEvent = {
   timestamp: 1687358660935,
 };
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 
 describe('EventCompressor', () => {
   let eventsManager: SessionReplayEventsManager<'replay' | 'interaction', string>;

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 import { IDBPDatabase, openDB } from 'idb';
 import * as EventsIDBStore from '../src/events/events-idb-store';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import { SessionReplayDB, SessionReplayEventsIDBStore } from '../src/events/events-idb-store';
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 
 const apiKey = 'static_key';
 const mockEvent = {
@@ -422,21 +422,21 @@ describe('SessionReplayEventsIDBStore', () => {
         loggerProvider: mockLoggerProvider,
       });
 
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(mockGlobalScope);
 
       await eventsStorage?.transitionFromKeyValStore();
       expect(mockLoggerProvider.warn).toHaveBeenCalled();
     });
 
     test('should reject when global scope is undefined', async () => {
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
 
       await expect(EventsIDBStore.keyValDatabaseExists()).rejects.toThrow('Global scope not found');
     });
 
     test('should reject when indexedDB does not exist', async () => {
       const mockGlobalScope = {} as Omit<typeof globalThis, 'indexedDB'>;
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope as typeof globalThis);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(mockGlobalScope as typeof globalThis);
 
       await expect(EventsIDBStore.keyValDatabaseExists()).rejects.toThrow('Session Replay: cannot find indexedDB');
     });
@@ -450,7 +450,7 @@ describe('SessionReplayEventsIDBStore', () => {
         },
       } as unknown as typeof globalThis;
 
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(mockGlobalScope);
 
       await expect(EventsIDBStore.keyValDatabaseExists()).rejects.toThrow('Test error');
     });

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
 import * as SessionReplayIDB from '../src/events/events-idb-store';
 import { createEventsManager } from '../src/events/events-manager';
@@ -11,7 +11,7 @@ import * as helpers from '../src/helpers';
 jest.mock('idb-keyval');
 jest.mock('../src/track-destination');
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 
 const mockEvent = {
   type: 4,

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -1,9 +1,9 @@
 // We don't want to call expects in conditions and typescript doesn't take these checks into account.
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Logger } from '@amplitude/analytics-types';
+import { ILogger } from '@amplitude/analytics-core';
 import { InMemoryEventsStore } from '../src/events/events-memory-store';
 
-const mockLoggerProvider: Logger = {
+const mockLoggerProvider: ILogger = {
   error: jest.fn(),
   log: jest.fn(),
   disable: jest.fn(),

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -6,9 +6,9 @@ import {
   SESSION_REPLAY_STAGING_URL,
   UNMASK_TEXT_CLASS,
 } from '../src/constants';
-import { ServerZone } from '@amplitude/analytics-types';
+import { ServerZone } from '@amplitude/analytics-core';
 import { generateHashCode, getServerUrl, getStorageSize, isSessionInSample, maskFn } from '../src/helpers';
-import * as clientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 
 describe('SessionReplayPlugin helpers', () => {
   describe('maskFn -- input', () => {
@@ -228,12 +228,12 @@ describe('SessionReplayPlugin helpers', () => {
 
   describe('getStorageSize', () => {
     test('should return a default set of data if global scope is not defined', async () => {
-      jest.spyOn(clientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
       const storageSize = await getStorageSize();
       expect(storageSize).toEqual({ totalStorageSize: 0, percentOfQuota: 0, usageDetails: '' });
     });
     test('should return formatted storage size data', async () => {
-      jest.spyOn(clientCommon, 'getGlobalScope').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         navigator: {
           storage: {
             estimate: async () => {
@@ -252,7 +252,7 @@ describe('SessionReplayPlugin helpers', () => {
       expect(storageSize).toEqual({ totalStorageSize: 209, percentOfQuota: 0.005, usageDetails: '{"indexedDB":10}' });
     });
     test('should return a default set of data if values within navigator are not defined', async () => {
-      jest.spyOn(clientCommon, 'getGlobalScope').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         navigator: {
           storage: {
             estimate: async () => {

--- a/packages/session-replay-browser/test/hooks/beacon.test.ts
+++ b/packages/session-replay-browser/test/hooks/beacon.test.ts
@@ -1,4 +1,4 @@
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import { SessionReplayJoinedConfig } from 'src/config/types';
 import { BeaconTransport } from '../../src/beacon-transport';
 import { randomUUID } from 'crypto';
@@ -8,14 +8,12 @@ type TestEvent = {
   Field2: number;
 };
 
-jest.mock('@amplitude/analytics-client-common');
-
 describe('beacon', () => {
   const mockGlobalScope = (globalScope?: Partial<typeof globalThis>): typeof globalThis => {
-    const mockedGlobalScope = jest.spyOn(AnalyticsClientCommon, 'getGlobalScope');
+    const mockedGlobalScope = jest.spyOn(AnalyticsCore, 'getGlobalScope');
     mockedGlobalScope.mockReturnValue(globalScope as typeof globalThis);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return AnalyticsClientCommon.getGlobalScope()!;
+    return AnalyticsCore.getGlobalScope()!;
   };
 
   describe('BeaconTransport', () => {

--- a/packages/session-replay-browser/test/hooks/click.test.ts
+++ b/packages/session-replay-browser/test/hooks/click.test.ts
@@ -2,20 +2,20 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import { MouseInteractions } from '@amplitude/rrweb-types';
 import { SessionReplayEventsManager } from '../../src/typings/session-replay';
 import { UUID } from '@amplitude/analytics-core';
 import { ClickEvent, ClickEventWithCount, clickBatcher, clickHook, clickNonBatcher } from '../../src/hooks/click';
 import { record, utils } from '@amplitude/rrweb';
-import type { Logger } from '@amplitude/analytics-types';
+import type { ILogger } from '@amplitude/analytics-core';
 import { finder } from '../../src/libs/finder';
 
 jest.mock('@amplitude/rrweb');
 jest.mock('../../src/libs/finder');
 
 describe('click', () => {
-  const mockLoggerProvider: Logger = {
+  const mockLoggerProvider: ILogger = {
     error: jest.fn(),
     log: jest.fn(),
     disable: jest.fn(),
@@ -43,7 +43,7 @@ describe('click', () => {
     };
 
     const mockGlobalScope = (globalScope?: Partial<typeof globalThis>) => {
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
     };
 
     const mockWindowScroll = (left = 0, top = 0) => {

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectMaxScrolls"] }] */
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import { BeaconTransport } from '../../src/beacon-transport';
 import { ScrollEventPayload, ScrollWatcher } from '../../src/hooks/scroll';
 import { utils } from '@amplitude/rrweb';
@@ -11,7 +11,7 @@ jest.mock('../../src/beacon-transport');
 
 describe('scroll', () => {
   const mockGlobalScope = (globalScope?: Partial<typeof globalThis>) => {
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
   };
 
   const mockWindowScroll = (left = 0, top = 0) => {

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import * as RemoteConfigFetch from '@amplitude/analytics-remote-config';
-import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
+import { LogLevel, ILogger, ServerZone } from '@amplitude/analytics-core';
 import * as RRWeb from '@amplitude/rrweb';
 import { IDBFactory } from 'fake-indexeddb';
 import { EventType, SessionReplayOptions } from 'src/typings/session-replay';
@@ -13,7 +13,7 @@ import { UNEXPECTED_ERROR_MESSAGE } from '../src/messages';
 import { SessionReplay } from '../src/session-replay';
 
 jest.mock('idb-keyval');
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 jest.mock('@amplitude/rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
 
@@ -81,7 +81,7 @@ describe('module level integration', () => {
         status: 200,
       }),
     ) as jest.Mock;
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(mockGlobalScope);
   });
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import * as RemoteConfigFetch from '@amplitude/analytics-remote-config';
-import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
+import { LogLevel, ILogger, ServerZone } from '@amplitude/analytics-core';
 import * as RRWeb from '@amplitude/rrweb';
 import { IDBFactory } from 'fake-indexeddb';
 import { SessionReplayOptions } from 'src/typings/session-replay';
@@ -14,7 +14,7 @@ import * as Helpers from '../../src/helpers';
 import { SessionReplay } from '../../src/session-replay';
 import { SESSION_ID_IN_20_SAMPLE } from '../test-data';
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 jest.mock('@amplitude/rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
 
@@ -92,7 +92,7 @@ describe('module level integration', () => {
         status: 200,
       }),
     ) as jest.Mock;
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(mockGlobalScope);
   });
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/session-replay-browser/test/logger.test.ts
+++ b/packages/session-replay-browser/test/logger.test.ts
@@ -1,8 +1,8 @@
-import { Logger, LogLevel } from '@amplitude/analytics-types';
+import { ILogger, LogLevel } from '@amplitude/analytics-core';
 import { SafeLoggerProvider } from '../src/logger';
 
 describe('SafeLoggerProvider', () => {
-  let mockLogger: jest.Mocked<Logger>;
+  let mockLogger: jest.Mocked<ILogger>;
   let logSpy: jest.SpyInstance;
   let warnSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;

--- a/packages/session-replay-browser/test/observers.test.ts
+++ b/packages/session-replay-browser/test/observers.test.ts
@@ -1,6 +1,5 @@
 import { NetworkObservers, NetworkRequestEvent } from '../src/observers';
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
-
+import * as AnalyticsCore from '@amplitude/analytics-core';
 type PartialGlobal = Pick<typeof globalThis, 'fetch'>;
 
 // Test subclass to access protected methods
@@ -22,7 +21,7 @@ describe('NetworkObservers', () => {
     mockFetch = jest.fn();
     globalScope = { fetch: mockFetch };
 
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
 
     networkObservers = new TestNetworkObservers();
   });
@@ -152,7 +151,7 @@ describe('NetworkObservers', () => {
     });
 
     it('should handle missing global scope', () => {
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
 
       networkObservers.start(callback);
 
@@ -161,7 +160,7 @@ describe('NetworkObservers', () => {
 
     it('should handle missing fetch', () => {
       const scopeWithoutFetch = {} as typeof globalThis;
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(scopeWithoutFetch);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scopeWithoutFetch);
 
       networkObservers.start(callback);
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 import * as RemoteConfigFetch from '@amplitude/analytics-remote-config';
-import { LogLevel, Logger, ServerZone } from '@amplitude/analytics-types';
+import { LogLevel, ILogger, ServerZone } from '@amplitude/analytics-core';
 import * as RRWeb from '@amplitude/rrweb';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
 import { NetworkObservers } from '../src/observers';
@@ -27,7 +27,7 @@ import { SessionReplayOptions } from '../src/typings/session-replay';
 jest.mock('@amplitude/rrweb');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb')>;
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 
 const mockEvent = {
   type: 4,
@@ -132,7 +132,7 @@ describe('SessionReplay', () => {
         callback();
       }, (options?.timeout as number) || 0);
     });
-    globalSpy = jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(mockGlobalScope);
+    globalSpy = jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(mockGlobalScope);
   });
   afterEach(() => {
     jest.resetAllMocks();
@@ -249,7 +249,7 @@ describe('SessionReplay', () => {
 
     test('should invoke page leave listeners', async () => {
       const invokeEventMap = new Map<string, any>();
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         document: {
           hasFocus: () => false,
         },
@@ -288,7 +288,7 @@ describe('SessionReplay', () => {
     });
 
     test('fallback to memory store if no indexeddb', async () => {
-      globalSpy = jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+      globalSpy = jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         ...mockGlobalScope,
         indexedDB: null as any,
       });
@@ -302,7 +302,7 @@ describe('SessionReplay', () => {
     });
 
     test('fallback to memory store if no global scope', async () => {
-      globalSpy = jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      globalSpy = jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
       await sessionReplay.init(apiKey, {
         ...mockOptions,
         sampleRate: 0.5,
@@ -477,7 +477,7 @@ describe('SessionReplay', () => {
     });
     test('it should not call initialize if the document does not have focus', () => {
       const initialize = jest.spyOn(sessionReplay, 'initialize');
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         document: {
           hasFocus: () => false,
         },
@@ -626,7 +626,7 @@ describe('SessionReplay', () => {
     });
 
     test('should ignore focus handler when debug mode is on.', async () => {
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         ...mockGlobalScope,
         document: {
           hasFocus: () => false,
@@ -795,7 +795,7 @@ describe('SessionReplay', () => {
       expect(sessionReplay.shouldOptOut()).toEqual(undefined);
     });
     test('should return opt out from identity store if set', async () => {
-      jest.spyOn(AnalyticsClientCommon, 'getAnalyticsConnector').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getAnalyticsConnector').mockReturnValue({
         identityStore: {
           getIdentity: () => {
             return {
@@ -803,12 +803,12 @@ describe('SessionReplay', () => {
             };
           },
         },
-      } as unknown as ReturnType<typeof AnalyticsClientCommon.getAnalyticsConnector>);
+      } as unknown as ReturnType<typeof AnalyticsCore.getAnalyticsConnector>);
       await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance' }).promise;
       expect(sessionReplay.shouldOptOut()).toEqual(true);
     });
     test('should return opt out from identity store even if set to false', async () => {
-      jest.spyOn(AnalyticsClientCommon, 'getAnalyticsConnector').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getAnalyticsConnector').mockReturnValue({
         identityStore: {
           getIdentity: () => {
             return {
@@ -816,7 +816,7 @@ describe('SessionReplay', () => {
             };
           },
         },
-      } as unknown as ReturnType<typeof AnalyticsClientCommon.getAnalyticsConnector>);
+      } as unknown as ReturnType<typeof AnalyticsCore.getAnalyticsConnector>);
       await sessionReplay.init(apiKey, { ...mockOptions, instanceName: 'my_instance', optOut: true }).promise;
       expect(sessionReplay.shouldOptOut()).toEqual(false);
     });
@@ -1154,7 +1154,7 @@ describe('SessionReplay', () => {
     });
 
     test('should remove event listeners with pagehide', async () => {
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         ...mockGlobalScope,
         self: {
           onpagehide: (() => {

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1,10 +1,10 @@
-import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
-import { Logger, ServerZone } from '@amplitude/analytics-types';
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import { ILogger, ServerZone } from '@amplitude/analytics-core';
 import { SessionReplayDestinationContext } from 'src/typings/session-replay';
 import { SessionReplayTrackDestination } from '../src/track-destination';
 import { VERSION } from '../src/version';
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 const mockEvent = {
   type: 4,
   data: { href: 'https://analytics.amplitude.com/', width: 1728, height: 154 },
@@ -42,7 +42,7 @@ describe('SessionReplayTrackDestination', () => {
       }),
     ) as jest.Mock;
 
-    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue({} as unknown as typeof globalThis);
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({} as unknown as typeof globalThis);
   });
   afterEach(() => {
     jest.resetAllMocks();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@amplitude/analytics-client-common@>=1 <2", "@amplitude/analytics-client-common@^1.1.3":
+"@amplitude/analytics-client-common@>=1 <2":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-1.2.3.tgz#13c31681ee84e4519f66a0451e6014351c20df53"
   integrity sha512-J/RlOmzvrhhLkk5HhpYlV83SGnli+IRWzHaWPV5Dhg1yieaMZlGPkyoS26gyMMPBIv9fcoG6b4LptO9pbMbjSg==
@@ -13,9 +13,9 @@
     tslib "^2.4.1"
 
 "@amplitude/analytics-connector@^1.4.8":
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.8.tgz#dd801303db2662bc51be7e0194eeb8bd72267c42"
-  integrity sha512-dFW7c7Wb6Ng7vbmzwbaXZSpqfBx37ukamJV9ErFYYS8vGZK/Hkbt3M7fZHBI4WFU6CCwakr2ZXPme11uGPYWkQ==
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz#8a811ff5c8ee46bdfea0e8f61c7578769b5778ed"
+  integrity sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==
 
 "@amplitude/analytics-connector@^1.5.0":
   version "1.6.3"
@@ -13005,16 +13005,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13046,7 +13037,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13066,13 +13057,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -13952,7 +13936,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13965,15 +13949,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,29 +2,12 @@
 # yarn lockfile v1
 
 
-"@amplitude/analytics-client-common@>=1 <2":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-1.2.3.tgz#13c31681ee84e4519f66a0451e6014351c20df53"
-  integrity sha512-J/RlOmzvrhhLkk5HhpYlV83SGnli+IRWzHaWPV5Dhg1yieaMZlGPkyoS26gyMMPBIv9fcoG6b4LptO9pbMbjSg==
-  dependencies:
-    "@amplitude/analytics-connector" "^1.5.0"
-    "@amplitude/analytics-core" "^1.2.5"
-    "@amplitude/analytics-types" "^1.3.4"
-    tslib "^2.4.1"
-
 "@amplitude/analytics-connector@^1.4.8":
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz#8a811ff5c8ee46bdfea0e8f61c7578769b5778ed"
   integrity sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==
 
-"@amplitude/analytics-connector@^1.5.0":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.3.tgz#0879fede6835fd288974b6697eaf4b8d1bce6569"
-  integrity sha512-ms/G/hT/KYrJ+czdYFEbk/nmYLYkln89HmegJHcV+8L++UOh8mW8hYfZKbBTw5YyB1PKxUbBZum5n2I3hNMd2A==
-  dependencies:
-    "@amplitude/experiment-core" "^0.11.0"
-
-"@amplitude/analytics-core@>=1 <2", "@amplitude/analytics-core@^1.2.5":
+"@amplitude/analytics-core@>=1 <2":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-1.2.5.tgz#f5fc39d93920f3e5447956b9a7525b924b5c0791"
   integrity sha512-V7CVlHVN+1diKiOpdp2bCPZ0mbS4CmUYF+v+eXDwVfJL3M/t3sVcT1apXnmVYGYi14cGu9hQOD11rD6qKbUOsw==
@@ -46,13 +29,6 @@
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-1.3.4.tgz#9142a893313cc28a9c7a7a3e3360c33636fc9b7d"
   integrity sha512-tR70gzqFkEzX9QpxvWYMfLCledT7vMhgd3d4/bkp3nnGXTOORaVUOCcSgOyxyuFdSx84T61aP/eZPKIcZcaP+A==
-
-"@amplitude/experiment-core@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.11.0.tgz#a4aa408b0f2f087dbaaa0452eb8e91591f03a5a1"
-  integrity sha512-egqb/eWFUU+gn6w3t9/L8PHpivAZrIVOX6dTk0NUVNfG3jeN4VuB77BOvu51xxfNF3Hvs6J49do9hRtE/LdvSw==
-  dependencies:
-    js-base64 "^3.7.5"
 
 "@amplitude/rrdom@^2.0.0-alpha.29":
   version "2.0.0-alpha.29"
@@ -9269,11 +9245,6 @@ joi@^17.2.1:
     "@sideway/address" "^4.1.3"
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
-
-js-base64@^3.7.5:
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
-  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
 
 js-sdsl@^4.1.4:
   version "4.2.0"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Migrate `session-replay-browser` and `plugin-session-replay-browser` to the latest `analytics-core` v2.x and remove analytics-types and analytics-client-common.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
