### PR TITLE
fix: truncate GitHub issue titles for Jira ticket creation

### DIFF
--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -46,6 +46,20 @@ jobs:
         with:
           string: ${{ inputs.label }}
 
+      - name: Truncate Issue Title
+        id: truncate
+        run: |
+          # Calculate max length for title (255 - length of prefix - length of ellipsis)
+          PREFIX="[SDK - ${{ inputs.label }}] "
+          ELLIPSIS="..."
+          MAX_TITLE_LENGTH=$((255 - ${#PREFIX} - ${#ELLIPSIS}))
+          # Truncate title if needed
+          TITLE="${{ github.event.issue.title }}"
+          if [ ${#TITLE} -gt $MAX_TITLE_LENGTH ]; then
+            TITLE="${TITLE:0:$MAX_TITLE_LENGTH}..."
+          fi
+          echo "truncated_title=$TITLE" >> $GITHUB_OUTPUT
+
       - name: Create issue
         id: create
         uses: atlassian/gajira-create@master
@@ -53,7 +67,7 @@ jobs:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: Task
           summary: |
-            [SDK - ${{ inputs.label }}] ${{ github.event.issue.title }}
+            [SDK - ${{ inputs.label }}] ${{ steps.truncate.outputs.truncated_title }}
           description: |
             ${{ github.event.issue.html_url }}
           fields: '{


### PR DESCRIPTION
### Summary

GitHub issues with long titles were causing Jira ticket creation to fail because the combined length of the prefix `[SDK - {label}]` and the GitHub issue title could exceed Jira's 255-character limit for summaries. While GitHub has a 256-character limit for issue titles, this doesn't account for the additional characters added by our prefix format.

- Added a truncation step that calculates the maximum allowed title length, accounting for:
  - The prefix length (`[SDK - {label}] `)
  - The ellipsis length (`...`)
  - The remaining space for the actual title
- Truncates the GitHub issue title if needed, preserving the prefix format
- Adds ellipsis (...) to indicate when a title has been truncated

This will impact all repos that depend on this workflow, e.g. [Amplitude-Flutter](https://github.com/amplitude/Amplitude-Flutter/blob/main/.github/workflows/jira-issue-create.yml)

Testing (once merged)
1. Create a GitHub issue with a title longer than 255 characters
2. Verify the Jira ticket is created successfully
3. Confirm the summary is properly truncated and includes the ellipsis
4. Verify the total length of the summary (including prefix and ellipsis) is ≤ 255 characters

### Checklist

* [✅ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no

Jira: https://amplitude.atlassian.net/browse/AMP-128684
