### PR TITLE
chore: Revert "fix: truncate GitHub issue titles for Jira ticket creation"

### DIFF
--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -46,20 +46,6 @@ jobs:
         with:
           string: ${{ inputs.label }}
 
-      - name: Truncate Issue Title
-        id: truncate
-        run: |
-          # Calculate max length for title (255 - length of prefix - length of ellipsis)
-          PREFIX="[SDK - ${{ inputs.label }}] "
-          ELLIPSIS="..."
-          MAX_TITLE_LENGTH=$((255 - ${#PREFIX} - ${#ELLIPSIS}))
-          # Truncate title if needed
-          TITLE="${{ github.event.issue.title }}"
-          if [ ${#TITLE} -gt $MAX_TITLE_LENGTH ]; then
-            TITLE="${TITLE:0:$MAX_TITLE_LENGTH}..."
-          fi
-          echo "truncated_title=$TITLE" >> $GITHUB_OUTPUT
-
       - name: Create issue
         id: create
         uses: atlassian/gajira-create@master
@@ -67,7 +53,7 @@ jobs:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: Task
           summary: |
-            [SDK - ${{ inputs.label }}] ${{ steps.truncate.outputs.truncated_title }}
+            [SDK - ${{ inputs.label }}] ${{ github.event.issue.title }}
           description: |
             ${{ github.event.issue.html_url }}
           fields: '{


### PR DESCRIPTION
Did not work on first run, will look into trying to manually test this elsewhere first then recreate 
Reverts amplitude/Amplitude-TypeScript#1023