### PR TITLE
feat(analytics-core): new plugin interfaces onXXXchanged()

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -188,6 +188,8 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, Pl
     this.config.loggerProvider.debug('function setUserId: ', userId);
     if (userId !== this.config.userId || userId === undefined) {
       this.config.userId = userId;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      this.timeline.onIdentityChanged({ userId: userId });
       setConnectorUserId(userId, this.config.instanceName);
     }
   }
@@ -202,8 +204,12 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, Pl
       return;
     }
     this.config.loggerProvider.debug('function setDeviceId: ', deviceId);
-    this.config.deviceId = deviceId;
-    setConnectorDeviceId(deviceId, this.config.instanceName);
+    if (deviceId !== this.config.deviceId) {
+      this.config.deviceId = deviceId;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      this.timeline.onIdentityChanged({ deviceId: deviceId });
+      setConnectorDeviceId(deviceId, this.config.instanceName);
+    }
   }
 
   reset() {
@@ -229,6 +235,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, Pl
     this.config.loggerProvider.debug('function setSessionId: ', sessionId);
 
     const previousSessionId = this.getSessionId();
+    if (previousSessionId !== sessionId) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      this.timeline.onSessionIdChanged(sessionId);
+    }
+
     const lastEventTime = this.config.lastEventTime;
     let lastEventId = this.config.lastEventId ?? -1;
 

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -2,8 +2,8 @@ import { Plugin } from './types/plugin';
 import { IConfig } from './config';
 import { BaseEvent, EventOptions } from './types/event/base-event';
 import { Result } from './types/result';
-import { Event } from './types/event/event';
-import { IIdentify } from './identify';
+import { Event, IdentifyOperation, SpecialEventType, UserProperties } from './types/event/event';
+import { IIdentify, OrderedIdentifyOperations } from './identify';
 import { IRevenue } from './revenue';
 import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from './types/messages';
 import { Timeline } from './timeline';
@@ -15,8 +15,7 @@ import {
   createTrackEvent,
 } from './utils/event-builder';
 import { buildResult } from './utils/result-builder';
-import { returnWrapper } from './utils/return-wrapper';
-import { AmplitudeReturn } from './utils/return-wrapper';
+import { AmplitudeReturn, returnWrapper } from './utils/return-wrapper';
 
 export interface CoreClient {
   /**
@@ -287,11 +286,92 @@ export class AmplitudeCore implements CoreClient {
     return this.process(event);
   }
 
+  /**
+   *
+   * This method applies identify operations to user properties and
+   * returns a single object representing the final user property state.
+   *
+   * This is a best-effort api that only supports $set, $clearAll, and $unset.
+   * Other operations are not supported and are ignored.
+   *
+   *
+   * @param userProperties The `event.userProperties` object from an Identify event.
+   * @returns A key-value object user properties without operations.
+   *
+   * @example
+   * Input:
+   * {
+   *   $set: { plan: 'premium' },
+   *   custom_flag: true
+   * }
+   *
+   * Output:
+   * {
+   *   plan: 'premium',
+   *   custom_flag: true
+   * }
+   */
+  getOperationAppliedUserProperties(userProperties: UserProperties | undefined): { [key: string]: any } {
+    const updatedProperties: { [key: string]: any } = {};
+
+    if (userProperties === undefined) {
+      return updatedProperties;
+    }
+
+    // Keep non-operation keys for later merge
+    const nonOpProperties: Record<string, any> = {};
+    for (const key in userProperties) {
+      if (!Object.values(IdentifyOperation).includes(key as IdentifyOperation)) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        nonOpProperties[key] = userProperties[key];
+      }
+    }
+
+    OrderedIdentifyOperations.forEach((operation) => {
+      if (!Object.keys(userProperties).includes(operation)) return;
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const opProperties = userProperties[operation];
+
+      switch (operation) {
+        case IdentifyOperation.CLEAR_ALL:
+          for (const prop in updatedProperties) {
+            // Due to operation order, the following line will never execute.
+            /* istanbul ignore next */
+            delete updatedProperties[prop];
+          }
+          break;
+        case IdentifyOperation.UNSET:
+          for (const prop in opProperties) {
+            delete updatedProperties[prop];
+          }
+          break;
+        case IdentifyOperation.SET:
+          Object.assign(updatedProperties, opProperties);
+          break;
+      }
+    });
+
+    // Merge non-operation properties.
+    // Custom properties should not be affected by operations.
+    // https://github.com/amplitude/nova/blob/343f678ded83c032e83b189796b3c2be161b48f5/src/main/java/com/amplitude/userproperty/model/ModifyUserPropertiesIdent.java#L79-L83
+    Object.assign(updatedProperties, nonOpProperties);
+
+    return updatedProperties;
+  }
+
   async process(event: Event): Promise<Result> {
     try {
       // skip event processing if opt out
       if (this.config.optOut) {
         return buildResult(event, 0, OPT_OUT_MESSAGE);
+      }
+
+      if (event.event_type === SpecialEventType.IDENTIFY) {
+        const userProperties = this.getOperationAppliedUserProperties(event.user_properties);
+        this.timeline.onIdentityChanged({ userProperties: userProperties });
       }
 
       const result = await this.timeline.push(event);

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -321,7 +321,11 @@ export class AmplitudeCore implements CoreClient {
   }
 
   _setOptOut(optOut: boolean) {
-    this.config.optOut = Boolean(optOut);
+    this.config.loggerProvider.debug(`function setOptOut(optOut: ${String(optOut)}), config.optOut: ${String(optOut)}`);
+    if (this.config.optOut !== optOut) {
+      this.timeline.onOptOutChanged(optOut);
+      this.config.optOut = Boolean(optOut);
+    }
   }
 
   flush() {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -321,7 +321,6 @@ export class AmplitudeCore implements CoreClient {
   }
 
   _setOptOut(optOut: boolean) {
-    this.config.loggerProvider.debug(`function setOptOut(optOut: ${String(optOut)}), config.optOut: ${String(optOut)}`);
     if (this.config.optOut !== optOut) {
       this.timeline.onOptOutChanged(optOut);
       this.config.optOut = Boolean(optOut);

--- a/packages/analytics-core/src/identify.ts
+++ b/packages/analytics-core/src/identify.ts
@@ -168,3 +168,19 @@ export enum IdentifyOperation {
   UNSET = '$unset',
   CLEAR_ALL = '$clearAll',
 }
+
+/**
+ * Note that the order of operations should align with https://github.com/amplitude/nova/blob/7701b5986b565d4b2fb53b99a9f2175df055dea8/src/main/java/com/amplitude/ingestion/core/UserPropertyUtils.java#L210
+ */
+export const OrderedIdentifyOperations = [
+  IdentifyOperation.CLEAR_ALL,
+  IdentifyOperation.UNSET,
+  IdentifyOperation.SET,
+  IdentifyOperation.SET_ONCE,
+  IdentifyOperation.ADD,
+  IdentifyOperation.APPEND,
+  IdentifyOperation.PREPEND,
+  IdentifyOperation.PREINSERT,
+  IdentifyOperation.POSTINSERT,
+  IdentifyOperation.REMOVE,
+];

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -158,18 +158,30 @@ export class Timeline {
 
   onIdentityChanged(identity: AnalyticsIdentity) {
     this.plugins.forEach((plugin) => {
+      // Intentionally to not await plugin.onIdentityChanged() for non-blocking.
+      // Ignore optional channing next line for test coverage.
+      // If the plugin doesn't implement it, it won't be called.
+      /* istanbul ignore next */
       void plugin.onIdentityChanged?.(identity);
     });
   }
 
   onSessionIdChanged(sessionId: number) {
     this.plugins.forEach((plugin) => {
+      // Intentionally to not await plugin.onSessionIdChanged() for non-blocking.
+      // Ignore optional channing next line for test coverage.
+      // If the plugin doesn't implement it, it won't be called.
+      /* istanbul ignore next */
       void plugin.onSessionIdChanged?.(sessionId);
     });
   }
 
   onOptOutChanged(optOut: boolean) {
     this.plugins.forEach((plugin) => {
+      // Intentionally to not await plugin.onOptOutChanged() for non-blocking.
+      // Ignore optional channing next line for test coverage.
+      // If the plugin doesn't implement it, it won't be called.
+      /* istanbul ignore next */
       void plugin.onOptOutChanged?.(optOut);
     });
   }

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -1,4 +1,4 @@
-import { BeforePlugin, DestinationPlugin, EnrichmentPlugin, Plugin } from './types/plugin';
+import { AnalyticsIdentity, BeforePlugin, DestinationPlugin, EnrichmentPlugin, Plugin } from './types/plugin';
 import { CoreClient } from './core-client';
 import { IConfig } from './config';
 import { EventCallback } from './types/event-callback';
@@ -154,5 +154,23 @@ export class Timeline {
     });
 
     await Promise.all(executeDestinations);
+  }
+
+  onIdentityChanged(identity: AnalyticsIdentity) {
+    this.plugins.forEach((plugin) => {
+      void plugin.onIdentityChanged?.(identity);
+    });
+  }
+
+  onSessionIdChanged(sessionId: number) {
+    this.plugins.forEach((plugin) => {
+      void plugin.onSessionIdChanged?.(sessionId);
+    });
+  }
+
+  onOptOutChanged(optOut: boolean) {
+    this.plugins.forEach((plugin) => {
+      void plugin.onOptOutChanged?.(optOut);
+    });
   }
 }

--- a/packages/analytics-core/src/types/event/event.ts
+++ b/packages/analytics-core/src/types/event/event.ts
@@ -52,6 +52,39 @@ export interface IdentifyUserProperties {
   [IdentifyOperation.REMOVE]?: BaseOperationConfig;
 }
 
+/**
+ * Represents the structure of user properties that can be sent with an Identify or GroupIdentify event.
+ *
+ * This type supports both:
+ *
+ * 1. Reserved Amplitude identify operations via `IdentifyUserProperties`:
+ *    These operations enable structured updates to user properties.
+ *
+ *    Example:
+ *    ```ts
+ *    {
+ *      $set: { plan: 'premium', login_count: 1 },
+ *      $add: { login_count: 1 },
+ *      $unset: { plan: '-' },
+ *      $clearAll: '-'
+ *    }
+ *    ```
+ *
+ * 2. Custom user-defined properties (excluding reserved operation keys):
+ *    Useful for assigning static properties without using Identify operations.
+ *
+ *    Example:
+ *    ```ts
+ *    {
+ *      custom_flag: true,
+ *      experiment_group: 'B',
+ *      favorite_color: 'blue'
+ *    }
+ *    ```
+ *
+ * This union ensures compatibility with Amplitude's identify semantics
+ * while allowing flexibility to define arbitrary non-reserved properties.
+ */
 export type UserProperties =
   | IdentifyUserProperties
   | {

--- a/packages/analytics-core/src/types/plugin.ts
+++ b/packages/analytics-core/src/types/plugin.ts
@@ -11,7 +11,6 @@ export type PluginType = PluginTypeBefore | PluginTypeEnrichment | PluginTypeDes
 export interface AnalyticsIdentity {
   deviceId?: string;
   userId?: string;
-  // TODO(xinyi): this is not supported right now
   userProperties?: { [key: string]: any };
 }
 
@@ -21,13 +20,16 @@ interface PluginBase<T = CoreClient, U = IConfig> {
   setup?(config: U, client: T): Promise<void>;
   teardown?(): Promise<void>;
   /**
-   * The function is called when identity is changed.
-   * Only available on Browser SDK.
-   * React Native and Node SDK don't support it now.
-   * @param identity Changed identity.
-   * If a filed doesn't exist, it means it's not changed.
-   * For example, {userId: undefined} means userId is changed to undefined
-   * and deviceId and userProperties are unchanged
+   * Called when the identity is changed. This is a **best-effort** API and may not be triggered in all scenarios.
+   *
+   * Currently supported only in the Browser SDK. Not supported in React Native or Node SDKs.
+   *
+   * @param identity The changed identity. If a field is missing, it means it has not changed.
+   * For example, `{ userId: undefined }` means the userId was explicitly changed to `undefined`,
+   * while deviceId and userProperties remain unchanged.
+   *
+   * Note: `onIdentityChanged()` will be triggered when a user logs in via `setUserId()`.
+   * It will not be triggered on subsequent page loads (e.g., when a user reopens the site in a new tab).
    */
   onIdentityChanged?(identity: AnalyticsIdentity): Promise<void>;
   onSessionIdChanged?(sessionId: number): Promise<void>;

--- a/packages/analytics-core/src/types/plugin.ts
+++ b/packages/analytics-core/src/types/plugin.ts
@@ -8,11 +8,30 @@ type PluginTypeEnrichment = 'enrichment';
 type PluginTypeDestination = 'destination';
 export type PluginType = PluginTypeBefore | PluginTypeEnrichment | PluginTypeDestination;
 
+export interface AnalyticsIdentity {
+  deviceId?: string;
+  userId?: string;
+  // TODO(xinyi): this is not supported right now
+  userProperties?: { [key: string]: any };
+}
+
 interface PluginBase<T = CoreClient, U = IConfig> {
   name?: string;
   type?: PluginType;
   setup?(config: U, client: T): Promise<void>;
   teardown?(): Promise<void>;
+  /**
+   * The function is called when identity is changed.
+   * Only available on Browser SDK.
+   * React Native and Node SDK don't support it now.
+   * @param identity Changed identity.
+   * If a filed doesn't exist, it means it's not changed.
+   * For example, {userId: undefined} means userId is changed to undefined
+   * and deviceId and userProperties are unchanged
+   */
+  onIdentityChanged?(identity: AnalyticsIdentity): Promise<void>;
+  onSessionIdChanged?(sessionId: number): Promise<void>;
+  onOptOutChanged?(optOut: boolean): Promise<void>;
 }
 
 export interface BeforePlugin<T = CoreClient, U = IConfig> extends PluginBase<T, U> {

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { Event } from '../src/types/event/event';
+import { Event, IdentifyEvent, SpecialEventType, UserProperties } from '../src/types/event/event';
 import { Plugin } from '../src/types/plugin';
 import { Status } from '../src/types/status';
 import { AmplitudeCore, Identify, Revenue } from '../src/index';
 import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from '../src/types/messages';
 import { useDefaultConfig } from './helpers/default';
+import { IdentifyOperation } from '../src/identify';
+import { UNSET_VALUE } from '../src/types/constants';
+import { BrowserConfig, LogLevel } from '@amplitude/analytics-types';
+
 async function runScheduleTimers() {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   await new Promise(process.nextTick);
@@ -21,6 +25,40 @@ describe('core-client', () => {
   const badRequest = { event: { event_type: 'sample' }, code: 400, message: Status.Invalid };
   const continueRequest = { event: { event_type: 'sample' }, code: 100, message: Status.Unknown };
   const client = new AmplitudeCore();
+  const mockLoggerProvider = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  const mockConfig: BrowserConfig = {
+    apiKey: 'static_key',
+    flushIntervalMillis: 0,
+    flushMaxRetries: 1,
+    flushQueueSize: 0,
+    logLevel: LogLevel.None,
+    loggerProvider: mockLoggerProvider,
+    optOut: false,
+    deviceId: '1a2b3c',
+    serverUrl: 'url',
+    serverZone: 'US',
+    useBatch: false,
+    sessionId: 123,
+    cookieExpiration: 365,
+    cookieSameSite: 'Lax',
+    cookieSecure: false,
+    cookieUpgrade: true,
+    disableCookies: false,
+    domain: '.amplitude.com',
+    sessionTimeout: 30 * 60 * 1000,
+    trackingOptions: {
+      ipAddress: true,
+      language: true,
+      platform: true,
+    },
+  } as unknown as BrowserConfig;
 
   beforeEach(() => {
     jest.useFakeTimers({ doNotFake: ['nextTick'] });
@@ -331,6 +369,84 @@ describe('core-client', () => {
       const result = await dispathPromise;
       expect(push).toHaveBeenCalledTimes(1);
       expect(result).toBe(success);
+    });
+  });
+
+  describe('getNoOperationFormattedUserProperties', () => {
+    test('should strip out identify operations $set', () => {
+      const client = new AmplitudeCore();
+      const userProperties: UserProperties = {
+        [IdentifyOperation.SET]: { key1: 'value1' },
+      };
+      const result = client.getOperationAppliedUserProperties(userProperties);
+      expect(result).toEqual({ key1: 'value1' });
+    });
+
+    test('should apply by order', () => {
+      const client = new AmplitudeCore();
+      const userProperties: UserProperties = {
+        [IdentifyOperation.CLEAR_ALL]: UNSET_VALUE,
+        [IdentifyOperation.SET]: { key1: 'value1', key2: 'value2' },
+        [IdentifyOperation.UNSET]: { key1: UNSET_VALUE },
+      };
+      const result = client.getOperationAppliedUserProperties(userProperties);
+      expect(result).toEqual({ key1: 'value1', key2: 'value2' });
+    });
+
+    test('should keep items without identify operations', () => {
+      const client = new AmplitudeCore();
+      const userProperties: UserProperties = { key1: 'value1', key2: 'value2' };
+      const result = client.getOperationAppliedUserProperties(userProperties);
+      expect(result).toEqual(userProperties);
+    });
+
+    test('should handle mixed user properties', () => {
+      const client = new AmplitudeCore();
+      const userProperties: UserProperties = {
+        [IdentifyOperation.CLEAR_ALL]: UNSET_VALUE,
+        [IdentifyOperation.SET]: { key1: 'value1', key2: 'value2' },
+        [IdentifyOperation.UNSET]: { key1: UNSET_VALUE },
+        key3: 'value3',
+      };
+      const result = client.getOperationAppliedUserProperties(userProperties);
+      expect(result).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+      });
+    });
+
+    test('should return empty object when user properties is undefined', () => {
+      const client = new AmplitudeCore();
+      expect(client.getOperationAppliedUserProperties(undefined)).toEqual({});
+    });
+  });
+
+  describe('process', () => {
+    test('should call onIdentifyChanged on identify events', async () => {
+      const client = new AmplitudeCore();
+      client.config = mockConfig;
+      const getOperationAppliedUserPropertiesSpy = jest.spyOn(
+        AmplitudeCore.prototype,
+        'getOperationAppliedUserProperties',
+      );
+      const onIdentityChanged = jest.spyOn(client.timeline, 'onIdentityChanged');
+      jest.spyOn(client.timeline, 'push').mockReturnValueOnce(
+        Promise.resolve({
+          event: { event_type: 'test' },
+          code: 200,
+          message: '',
+        }),
+      );
+
+      const identifyEvent: IdentifyEvent = {
+        user_properties: {},
+        event_type: SpecialEventType.IDENTIFY,
+      };
+      await client.process(identifyEvent);
+
+      expect(getOperationAppliedUserPropertiesSpy).toHaveBeenCalledTimes(1);
+      expect(onIdentityChanged).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -494,4 +494,61 @@ describe('timeline', () => {
       expect(flush).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('onIdentityChanged', () => {
+    test('should call onIdentityChanged() of each plugin', async () => {
+      const onIdentityChanged = jest.fn().mockReturnValue(Promise.resolve(undefined));
+      const plugin: EnrichmentPlugin = {
+        name: 'mock',
+        type: 'enrichment',
+        onIdentityChanged,
+      };
+      const mockIdentity = {
+        deviceId: 'test-device-id',
+        userId: 'test-user-id',
+      };
+      timeline.plugins.push(plugin);
+
+      timeline.onIdentityChanged(mockIdentity);
+
+      expect(onIdentityChanged).toHaveBeenCalledTimes(1);
+      expect(onIdentityChanged).toHaveBeenCalledWith(mockIdentity);
+    });
+  });
+
+  describe('onSessionIdChanged', () => {
+    test('should call onSessionIdChanged() of each plugin', async () => {
+      const onSessionIdChanged = jest.fn().mockReturnValue(Promise.resolve(undefined));
+      const plugin: EnrichmentPlugin = {
+        name: 'mock',
+        type: 'enrichment',
+        onSessionIdChanged,
+      };
+      const mockSessionId = 123;
+      timeline.plugins.push(plugin);
+
+      timeline.onSessionIdChanged?.(mockSessionId);
+
+      expect(onSessionIdChanged).toHaveBeenCalledTimes(1);
+      expect(onSessionIdChanged).toHaveBeenCalledWith(mockSessionId);
+    });
+  });
+
+  describe('onOptOutChanged', () => {
+    test('should call onOptOutChanged() of each plugin', async () => {
+      const onOptOutChanged = jest.fn().mockReturnValue(Promise.resolve(undefined));
+      const plugin: EnrichmentPlugin = {
+        name: 'mock',
+        type: 'enrichment',
+        onOptOutChanged,
+      };
+      const mockOptOut = true;
+      timeline.plugins.push(plugin);
+
+      timeline.onOptOutChanged?.(mockOptOut);
+
+      expect(onOptOutChanged).toHaveBeenCalledTimes(1);
+      expect(onOptOutChanged).toHaveBeenCalledWith(mockOptOut);
+    });
+  });
 });

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -72,6 +72,13 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
     }
   }
 
+  async onSessionIdChanged(sessionId: number): Promise<void> {
+    this.config.loggerProvider.debug(
+      `Analytics session id is changed to ${sessionId}, SR session id is ${String(sessionReplay.getSessionId())}.`,
+    );
+    await sessionReplay.setSessionId(sessionId).promise;
+  }
+
   async execute(event: Event) {
     try {
       if (this.options.customSessionId) {

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -306,7 +306,9 @@ describe('SessionReplayPlugin', () => {
       const sessionReplay = new SessionReplayPlugin({
         deviceId: customDeviceId,
       });
+      // First init() called
       await sessionReplay.setup?.(mockConfig, mockAmplitude);
+      // Second init() called
       await sessionReplay.onOptOutChanged?.(false);
 
       expect(init).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-126972](https://amplitude.atlassian.net/browse/AMP-126972)

Add three APIs to plugin. They are called when the corresponding property is changed. 
- onSessionIdChanged()
- onOptOutChanged()
- onIdentityChanged()

Adopt SR plugin to the first two.
- onSessionIdChanged()
  - update session replay instance's session id
- onOptOutChanged()
  - call session replay shutdown() or init() according to optOut

 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-126972]: https://amplitude.atlassian.net/browse/AMP-126972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ