### PR TITLE
chore: make a re-usable version of the Network Observer

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -59,3 +59,5 @@ export {
   AttributionOptions,
 } from './types/browser-config';
 export { BrowserClient } from './types/browser-client';
+
+export { NetworkObserver, NetworkRequestEvent, NetworkEventCallback } from './network-observer';

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -40,9 +40,6 @@ export interface FormDataBrowser {
 export type FetchRequestBody = string | Blob | ArrayBuffer | FormDataBrowser | URLSearchParams | null | undefined;
 
 export function getRequestBodyLength(body: FetchRequestBody | null | undefined): number | undefined {
-  if (body === null || body === undefined) {
-    return;
-  }
   const global = getGlobalScope();
   /* istanbul ignore next */
   if (!global?.TextEncoder) {

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -1,0 +1,182 @@
+import { getGlobalScope, UUID } from '@amplitude/analytics-core';
+
+export interface NetworkRequestMethod {
+  GET: 'GET';
+  POST: 'POST';
+  PUT: 'PUT';
+  DELETE: 'DELETE';
+  PATCH: 'PATCH';
+  OPTIONS: 'OPTIONS';
+  HEAD: 'HEAD';
+}
+
+export interface NetworkRequestEvent {
+  timestamp: number;
+  type: 'fetch';
+  method: string;
+  url: string;
+  status?: number;
+  duration?: number;
+  requestBodySize?: number;
+  requestHeaders?: Record<string, string>;
+  responseBodySize?: number;
+  responseHeaders?: Record<string, string>;
+  error?: {
+    name: string;
+    message: string;
+  };
+  startTime?: number;
+  endTime?: number; // TODO: check what timestamp being used?
+  // TODO: add errorCode Question: what is error code?
+}
+
+interface FormDataBrowser extends FormData {
+  entries(): IterableIterator<[string, FormDataEntryValue]>;
+}
+
+export function getRequestBodyLength(body: BodyInit | null | undefined): number | undefined {
+  if (body === null || body === undefined) {
+    return;
+  }
+  const global = getGlobalScope();
+  /* istanbul ignore next */
+  if (!global?.TextEncoder) {
+    return;
+  }
+  const { TextEncoder } = global;
+
+  if (typeof body === 'string') {
+    return new TextEncoder().encode(body).length;
+  } else if (body instanceof Blob) {
+    return body.size;
+  } else if (body instanceof URLSearchParams) {
+    return new TextEncoder().encode(body.toString()).length;
+  } else if (body instanceof ArrayBuffer) {
+    return body.byteLength;
+  } else if (ArrayBuffer.isView(body)) {
+    return body.byteLength;
+  } else if (body instanceof FormData) {
+    // Estimating only for text parts; not accurate for files
+    // TODO: get consensus before deciding if we do this
+    const formData = body as FormDataBrowser;
+    let total = 0;
+    for (const [key, value] of formData.entries()) {
+      if (typeof value === 'string') {
+        total += new TextEncoder().encode(key + '=' + value).length;
+      } else {
+        // if we encounter a "File" type, we should not count it and just return undefined
+        // TODO: research how FormData works, and if this is the best practice, and what a File type is on a browser
+        return;
+      }
+    }
+    return total;
+  }
+  // Stream or unknown
+  return;
+}
+
+export type NetworkEventCallbackFn = (event: NetworkRequestEvent) => void;
+
+export class NetworkEventCallback {
+  constructor(public readonly callback: (event: NetworkRequestEvent) => void, public readonly id: string = UUID()) {}
+}
+
+export class NetworkObserver {
+  private restoreNativeFetch: (() => void) | null = null;
+  private eventCallbacks: Map<string, NetworkEventCallback> = new Map();
+  private isObserving = false;
+
+  constructor() {
+    if (!NetworkObserver.isSupported()) {
+      throw new Error('Fetch API is not supported in this environment.');
+    }
+  }
+
+  static isSupported(): boolean {
+    const globalScope = getGlobalScope();
+    return !!globalScope && !!globalScope.fetch;
+  }
+
+  subscribe(eventCallback: NetworkEventCallback) {
+    this.eventCallbacks.set(eventCallback.id, eventCallback);
+    if (!this.isObserving) {
+      this.observeFetch();
+      this.isObserving = true;
+    }
+  }
+
+  unsubscribe(eventCallback: NetworkEventCallback) {
+    this.eventCallbacks.delete(eventCallback.id);
+    if (this.eventCallbacks.size === 0 && this.isObserving) {
+      this.restoreNativeFetch?.();
+      this.isObserving = false;
+    }
+  }
+
+  protected triggerEventCallbacks(event: NetworkRequestEvent) {
+    this.eventCallbacks.forEach((callback) => {
+      callback.callback(event);
+    });
+  }
+
+  private observeFetch() {
+    const globalScope = getGlobalScope();
+    if (!globalScope) return;
+
+    const originalFetch = globalScope.fetch;
+
+    globalScope.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const startTime = Date.now();
+      const requestEvent: NetworkRequestEvent = {
+        timestamp: startTime,
+        type: 'fetch',
+        method: init?.method || 'GET', // Fetch API defaults to GET when no method is provided
+        url: input.toString(),
+        requestHeaders: init?.headers as Record<string, string>,
+        requestBodySize: getRequestBodyLength(init?.body),
+      };
+
+      try {
+        const response = await originalFetch(input, init);
+        const endTime = Date.now();
+
+        requestEvent.status = response.status;
+        requestEvent.duration = endTime - startTime;
+        requestEvent.startTime = startTime;
+        requestEvent.endTime = endTime;
+
+        // Convert Headers
+        const headers: Record<string, string> = {};
+        let contentLength: number | undefined = undefined;
+        response.headers.forEach((value: string, key: string) => {
+          headers[key] = value;
+          if (key === 'content-length') {
+            contentLength = parseInt(value, 10) || undefined;
+          }
+        });
+        requestEvent.responseHeaders = headers;
+        requestEvent.responseBodySize = contentLength;
+
+        this.triggerEventCallbacks(requestEvent);
+        return response;
+      } catch (error) {
+        const endTime = Date.now();
+        requestEvent.duration = endTime - startTime;
+
+        // Capture error information
+        const typedError = error as Error;
+        requestEvent.error = {
+          name: typedError.name || 'UnknownError',
+          message: typedError.message || 'An unknown error occurred',
+        };
+
+        this.triggerEventCallbacks(requestEvent);
+        throw error;
+      }
+    };
+
+    this.restoreNativeFetch = () => {
+      globalScope.fetch = originalFetch;
+    };
+  }
+}

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -69,9 +69,6 @@ export function getRequestBodyLength(body: FetchRequestBody | null | undefined):
       } else if ((value as Blob).size) {
         // if we encounter a "File" type, we should not count it and just return undefined
         total += (value as Blob).size;
-      } else {
-        // if we encounter some non-string or non-blob type, we should not count it and just return undefined
-        return;
       }
     }
     return total;

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope, UUID } from '@amplitude/analytics-core';
+import { getGlobalScope, UUID } from '../src/';
 
 export interface NetworkRequestMethod {
   GET: 'GET';

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -252,9 +252,15 @@ describe('NetworkObserver', () => {
       // Mock the global scope to not have fetch
       const scopeWithoutFetch = {} as typeof globalThis;
       jest.spyOn(Global, 'getGlobalScope').mockReturnValue(scopeWithoutFetch);
-      expect(() => {
-        new NetworkObserver();
-      }).toThrow();
+      const localLogger = {
+        error: jest.fn(),
+        disable: jest.fn(),
+        enable: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+        log: jest.fn(),
+      };
+      new NetworkObserver(localLogger);
     });
 
     it('should only restore globalScope.fetch when all subscriptions are unsubscribed', async () => {

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -1,10 +1,5 @@
-import {
-  FormDataBrowser,
-  getRequestBodyLength,
-  NetworkEventCallback,
-  NetworkObserver,
-  NetworkRequestEvent,
-} from '../src/network-observer';
+import { NetworkEventCallback, NetworkObserver, NetworkRequestEvent } from '../src/index';
+import { FormDataBrowser, getRequestBodyLength } from '../src/network-observer';
 import * as AnalyticsCore from '@amplitude/analytics-core';
 import { TextEncoder } from 'util';
 import * as streams from 'stream/web';

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -228,10 +228,6 @@ describe('NetworkObserver', () => {
         const body = undefined;
         expect(getRequestBodyLength(body)).toBeUndefined();
       });
-      it('body is null', () => {
-        const body = null;
-        expect(getRequestBodyLength(body)).toBeUndefined();
-      });
       it('TextEncoder is not available', () => {
         try {
           Object.defineProperty(globalScope, 'TextEncoder', {

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -244,6 +244,11 @@ describe('NetworkObserver', () => {
           });
         }
       });
+      it('globalScope is not available', () => {
+        jest.spyOn(Global, 'getGlobalScope').mockReturnValue(undefined);
+        const body = 'Hello World!';
+        expect(getRequestBodyLength(body)).toBeUndefined();
+      });
     });
   });
 

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -1,0 +1,344 @@
+import {
+  getRequestBodyLength,
+  NetworkEventCallback,
+  NetworkObserver,
+  NetworkRequestEvent,
+} from '../src/network-observer';
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import { TextEncoder } from 'util';
+import * as streams from 'stream/web';
+type PartialGlobal = Pick<typeof globalThis, 'fetch'>;
+
+// Test subclass to access protected methods
+class TestNetworkObserver extends NetworkObserver {
+  public testNotifyEvent(event: NetworkRequestEvent) {
+    this.triggerEventCallbacks(event);
+  }
+}
+
+describe('NetworkObserver', () => {
+  let networkObserver: TestNetworkObserver;
+  let originalFetchMock: jest.Mock;
+  let events: NetworkRequestEvent[] = [];
+  let globalScope: PartialGlobal;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    events = [];
+    originalFetchMock = jest.fn();
+    globalScope = {
+      ...globalThis,
+      fetch: originalFetchMock,
+      TextEncoder,
+      ReadableStream: streams.ReadableStream,
+    } as PartialGlobal;
+
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
+
+    networkObserver = new TestNetworkObserver();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const callback = (event: NetworkRequestEvent) => {
+    events.push(event);
+  };
+
+  describe('successful requests', () => {
+    it('should track successful fetch requests with headers', async () => {
+      // Create a simple mock response
+      const headers = new Headers();
+      headers.set('content-type', 'application/json');
+      headers.set('content-length', '20');
+      headers.set('server', 'test-server');
+      const mockResponse = {
+        status: 200,
+        headers,
+      };
+      originalFetchMock.mockResolvedValue(mockResponse);
+
+      networkObserver.subscribe(new NetworkEventCallback(callback));
+
+      const requestHeaders = {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token123',
+      };
+
+      await globalScope.fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: requestHeaders,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'fetch',
+        method: 'POST',
+        url: 'https://api.example.com/data',
+        status: 200,
+        requestHeaders,
+        responseHeaders: {
+          'content-type': 'application/json',
+          server: 'test-server',
+        },
+        responseBodySize: 20,
+      });
+      expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should track successful fetch requests without headers', async () => {
+      const mockResponse = {
+        status: 200,
+        headers: {
+          forEach: jest.fn(), // Mock function that does nothing
+        },
+      };
+      originalFetchMock.mockResolvedValue(mockResponse);
+
+      networkObserver.subscribe(new NetworkEventCallback(callback));
+
+      await globalScope.fetch('https://api.example.com/data');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'fetch',
+        method: 'GET',
+        url: 'https://api.example.com/data',
+        status: 200,
+        requestHeaders: undefined,
+        responseHeaders: {},
+      });
+      expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    });
+
+    describe('.responseBodySize', () => {
+      it('should not be captured if content-length is not present in headers', async () => {
+        const headers = new Headers();
+        headers.set('content-type', 'application/json');
+        const mockResponse = {
+          status: 200,
+          headers,
+        };
+        originalFetchMock.mockResolvedValue(mockResponse);
+        networkObserver.subscribe(new NetworkEventCallback(callback));
+        await globalScope.fetch('https://api.example.com/data');
+        expect(events).toHaveLength(1);
+        expect(events[0].responseBodySize).toBeUndefined();
+      });
+
+      it('should not be captured if content-length is not a valid number', async () => {
+        const headers = new Headers();
+        headers.set('content-type', 'application/json');
+        headers.set('content-length', 'invalid-number');
+        const mockResponse = {
+          status: 200,
+          headers,
+        };
+        originalFetchMock.mockResolvedValue(mockResponse);
+        networkObserver.subscribe(new NetworkEventCallback(callback));
+        await globalScope.fetch('https://api.example.com/data');
+        expect(events).toHaveLength(1);
+        expect(events[0].responseBodySize).toBeUndefined();
+      });
+    });
+  });
+
+  describe('failed requests', () => {
+    it('should track network errors', async () => {
+      const networkError = new TypeError('Failed to fetch');
+      originalFetchMock.mockRejectedValue(networkError);
+
+      networkObserver.subscribe(new NetworkEventCallback(callback));
+
+      await expect(globalScope.fetch('https://api.example.com/data')).rejects.toThrow('Failed to fetch');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'fetch',
+        method: 'GET',
+        url: 'https://api.example.com/data',
+        error: {
+          name: 'TypeError',
+          message: 'Failed to fetch',
+        },
+      });
+      expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle non-Error throws', async () => {
+      originalFetchMock.mockRejectedValue('string error');
+      const cb = new NetworkEventCallback(callback);
+      networkObserver.subscribe(cb);
+
+      await expect(globalScope.fetch('https://api.example.com/data')).rejects.toBe('string error');
+
+      expect(events).toHaveLength(1);
+      expect(events[0].error).toEqual({
+        name: 'UnknownError',
+        message: 'An unknown error occurred',
+      });
+    });
+  });
+
+  describe('.getRequestBodyLength()', () => {
+    describe('it should return the body length when the body is of type', () => {
+      it('string', () => {
+        const body = 'Hello World!';
+        expect(getRequestBodyLength(body)).toBe(body.length);
+      });
+      it('Blob', () => {
+        const blob = new Blob(['Hello World!']);
+        expect(getRequestBodyLength(blob)).toBe(blob.size);
+      });
+      it('ArrayBuffer', () => {
+        const buffer = new ArrayBuffer(8);
+        expect(getRequestBodyLength(buffer)).toBe(buffer.byteLength);
+      });
+
+      it('ArrayBufferView', () => {
+        const buffer = new ArrayBuffer(8);
+        const arr = new Uint8Array(buffer);
+        expect(getRequestBodyLength(arr)).toBe(arr.byteLength);
+      });
+      it('FormData', () => {
+        const formData = new FormData();
+        const val = 'value';
+        formData.append('key', val);
+        const blob = new Blob(['Hello World!']);
+        formData.append('file', blob);
+        const expectedSize = 'key='.length + val.length + 'file='.length + blob.size + 1;
+        expect(getRequestBodyLength(formData)).toBe(expectedSize);
+      });
+      it('URLSearchParams', () => {
+        const params = new URLSearchParams();
+        const val = 'value';
+        params.append('key', val);
+        const val2 = 'value2';
+        params.append('key2', val2);
+        const expectedSize = 'key='.length + val.length + '&key2='.length + val2.length;
+        expect(getRequestBodyLength(params)).toBe(expectedSize);
+      });
+    });
+
+    describe('it should not return the body length when', () => {
+      it('body is a ReadableStream', () => {
+        const stream = new streams.ReadableStream();
+        expect(getRequestBodyLength(stream as ReadableStream)).toBeUndefined();
+      });
+      it('body is undefined', () => {
+        const body = undefined;
+        expect(getRequestBodyLength(body)).toBeUndefined();
+      });
+      it('body is null', () => {
+        const body = null;
+        expect(getRequestBodyLength(body)).toBeUndefined();
+      });
+      it('TextEncoder is not available', () => {
+        try {
+          Object.defineProperty(globalScope, 'TextEncoder', {
+            value: undefined,
+            configurable: true,
+            writable: true,
+          });
+          expect(getRequestBodyLength('Hello World!')).toBeUndefined();
+        } finally {
+          Object.defineProperty(globalScope, 'TextEncoder', {
+            value: TextEncoder,
+            configurable: true,
+            writable: true,
+          });
+        }
+      });
+    });
+  });
+
+  describe('observer lifecycle', () => {
+    it('should throw an exception if fetch is not supported', async () => {
+      // Mock the global scope to not have fetch
+      const scopeWithoutFetch = {} as typeof globalThis;
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scopeWithoutFetch);
+      expect(() => {
+        new NetworkObserver();
+      }).toThrow();
+    });
+
+    it('should only restore globalScope.fetch when all subscriptions are unsubscribed', async () => {
+      const cb1 = new NetworkEventCallback(callback);
+      const cb2 = new NetworkEventCallback(callback);
+      networkObserver.subscribe(cb1);
+      networkObserver.subscribe(cb2);
+      networkObserver.unsubscribe(cb1);
+
+      // cb1 unsubscribed, but cb2 is still subscribed so fetch should be overridden
+      expect(globalScope.fetch).not.toBe(originalFetchMock);
+
+      // cb1 and cb2 unsubscribed, fetch should be restored
+      networkObserver.unsubscribe(cb2);
+      expect(globalScope.fetch).toBe(originalFetchMock);
+    });
+
+    it('should stop tracking when no event subscriptions are left', async () => {
+      const cb = new NetworkEventCallback(callback);
+      networkObserver.subscribe(cb);
+      networkObserver.unsubscribe(cb);
+
+      expect(globalScope.fetch).toBe(originalFetchMock);
+
+      await originalFetchMock('https://api.example.com/data');
+      expect(events).toHaveLength(0);
+    });
+
+    it('should handle missing global scope', () => {
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(undefined);
+      const cb = new NetworkEventCallback(callback);
+      networkObserver.subscribe(cb);
+
+      expect(() => networkObserver.unsubscribe(cb)).not.toThrow();
+    });
+
+    it('should call eventCallback with request event data', async () => {
+      const mockCallback = jest.fn();
+      const mockResponse = {
+        status: 200,
+        headers: {
+          forEach: (callback: (value: string, key: string) => void) => {
+            callback('application/json', 'content-type');
+          },
+        },
+      };
+      originalFetchMock.mockResolvedValue(mockResponse);
+      const cb = new NetworkEventCallback(mockCallback);
+      networkObserver.subscribe(cb);
+
+      await globalScope.fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle notifyEvent with optional chaining', async () => {
+      const mockEvent = {
+        timestamp: Date.now(),
+        type: 'fetch' as const,
+        method: 'GET',
+        url: 'https://api.example.com/data',
+      };
+
+      // Test with callback
+      const mockCallback = jest.fn();
+      const cb = new NetworkEventCallback(mockCallback);
+      networkObserver.subscribe(cb);
+      networkObserver.testNotifyEvent(mockEvent);
+      expect(mockCallback).toHaveBeenCalledWith(mockEvent);
+
+      // Test without callback
+      networkObserver.unsubscribe(cb);
+      networkObserver.testNotifyEvent(mockEvent);
+      expect(mockCallback).toHaveBeenCalledTimes(1); // Still only called once
+    });
+  });
+});

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -155,7 +155,6 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     // Initialize network observers if logging is enabled
     if (this.config.loggingConfig?.network?.enabled) {
-      this.config;
       this.networkObservers = new NetworkObservers();
     }
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -155,6 +155,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     // Initialize network observers if logging is enabled
     if (this.config.loggingConfig?.network?.enabled) {
+      this.config;
       this.networkObservers = new NetworkObservers();
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
* copied Jesse's implementation of [network observer](https://github.com/amplitude/Amplitude-TypeScript/blob/AMP-125616/add-autocomplete/packages/session-replay-browser/src/observers.ts#L25) to be a singleton class in "analytics-core"
* changed methods from "start" and "stop" to "subscribe" and "unsubscribe" and made it so that it can be subscribed to multiple times
* added requestBodySize and responseBodySize to network events and added functions to calculate the size of those
* note that this is unused (hence why it's a "chore"). The next stages will be to
  * make the network request autocapture
  * port over "observer.ts" to use this

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
