### PR TITLE
chore(plugin-session-replay-browser): clean analytics-types in tests

### DIFF
--- a/packages/plugin-session-replay-browser/test/integration/browser-sdk-integration.test.ts
+++ b/packages/plugin-session-replay-browser/test/integration/browser-sdk-integration.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as amplitude from '@amplitude/analytics-browser';
 import { sessionReplayPlugin } from '../../src/session-replay';
-import { Event } from '@amplitude/analytics-types';
+import { Event } from '@amplitude/analytics-core';
 import { server } from './mockAPIHandlers';
 import { matchRequestUrl } from 'msw';
 

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -1,4 +1,4 @@
-import { BrowserClient, BrowserConfig, LogLevel, Logger, Plugin, Event } from '@amplitude/analytics-types';
+import { BrowserClient, BrowserConfig, LogLevel, ILogger, Plugin, Event } from '@amplitude/analytics-core';
 import * as sessionReplayBrowser from '@amplitude/session-replay-browser';
 import { SessionReplayPlugin, sessionReplayPlugin } from '../src/session-replay';
 import { VERSION } from '../src/version';
@@ -7,7 +7,7 @@ import { randomUUID } from 'crypto';
 jest.mock('@amplitude/session-replay-browser');
 type MockedSessionReplayBrowser = jest.Mocked<typeof import('@amplitude/session-replay-browser')>;
 
-type MockedLogger = jest.Mocked<Logger>;
+type MockedLogger = jest.Mocked<ILogger>;
 
 type MockedBrowserClient = jest.Mocked<BrowserClient>;
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Clean left analytics-types in tests! 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
