### PR TITLE
fix: Add missing dependency to @amplitude/analytics-connector

### DIFF
--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -35,6 +35,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
+    "@amplitude/analytics-connector": "^1.6.4",
     "tslib": "^2.4.1"
   },
   "files": [


### PR DESCRIPTION
### Summary

This PR adds `@amplitude/analytics-connector` to the dependencies list in the `package.json` file.

Reason:  [this](https://github.com/amplitude/Amplitude-TypeScript/commit/1746ae5efb1ecd0e7586bc22ff8a704a6928c26a) commit added the `analytics-connector.ts` file which imports from `@amplitude/analytics-connector` but the dependency isn't added to the dependencies list of the package.json.

Discovered: I was working on adding "Amplitude Session Replay" by following [this](https://amplitude.com/docs/session-replay/session-replay-integration-with-segment) doc. This failed running locally, since `@amplitude/analytics-connector` package was missing. The error lead me to the `analytics-connector.ts` file. I resolved this locally by installing the `@amplitude/analytics-connector` to my app. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
