### PR TITLE
fix(analytics-core): add support for experiment plugin

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -47,8 +47,8 @@ import { autocapturePlugin } from '@amplitude/plugin-autocapture-browser';
 import { WebAttribution } from './attribution/web-attribution';
 
 /**
- * Exported for `@amplitude/unified`.
- * If you are instrumenting by `@amplitude/analytics-browser`, use `amplitude.init()` or `amplitude.createInstance()` instead.
+ * Exported for `@amplitude/unified` or integration with blade plugins.
+ * If you only use `@amplitude/analytics-browser`, use `amplitude.init()` or `amplitude.createInstance()` instead.
  */
 export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -21,7 +21,6 @@ import {
   BrowserOptions,
   BrowserConfig,
   BrowserClient,
-  Plugin,
 } from '@amplitude/analytics-core';
 import {
   getAttributionTrackingConfig,
@@ -47,27 +46,17 @@ import { createBrowserJoinedConfigGenerator } from './config/joined-config';
 import { autocapturePlugin } from '@amplitude/plugin-autocapture-browser';
 import { WebAttribution } from './attribution/web-attribution';
 
-interface PluginHost {
-  plugin(name: string): Plugin | undefined;
-}
-
-export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, PluginHost {
+/**
+ * Exported for `@amplitude/unified`.
+ * If you are instrumenting by `@amplitude/analytics-browser`, use `amplitude.init()` or `amplitude.createInstance()` instead.
+ */
+export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   config: BrowserConfig;
   previousSessionDeviceId: string | undefined;
   previousSessionUserId: string | undefined;
   webAttribution: WebAttribution | undefined;
-
-  plugin(name: string): Plugin | undefined {
-    const plugin = this.timeline.plugins.find((plugin) => plugin.name === name);
-    if (plugin === undefined) {
-      this.config.loggerProvider.debug(`Cannot find plugin with name ${name}`);
-      return undefined;
-    }
-
-    return plugin;
-  }
 
   init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {
     let userId: string | undefined;

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -23,6 +23,7 @@ export const {
   setUserId,
   track,
 } = client;
+export { AmplitudeBrowser } from './browser-client';
 export { runQueuedFunctions } from './utils/snippet-helper';
 export { Revenue, Identify } from '@amplitude/analytics-core';
 

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -23,6 +23,7 @@ import {
   setTransport,
   setUserId,
   track,
+  AmplitudeBrowser,
 } from '../src/index';
 
 describe('index', () => {
@@ -51,5 +52,6 @@ describe('index', () => {
     expect(typeof setTransport).toBe('function');
     expect(typeof setUserId).toBe('function');
     expect(typeof track).toBe('function');
+    expect(typeof AmplitudeBrowser).toBe('function');
   });
 });

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -23,6 +23,10 @@ import {
 import { buildResult } from './utils/result-builder';
 import { AmplitudeReturn, returnWrapper } from './utils/return-wrapper';
 
+interface PluginHost {
+  plugin(name: string): Plugin | undefined;
+}
+
 export interface CoreClient {
   /**
    * Adds a new plugin.
@@ -179,7 +183,7 @@ export interface CoreClient {
   flush(): AmplitudeReturn<void>;
 }
 
-export class AmplitudeCore implements CoreClient {
+export class AmplitudeCore implements CoreClient, PluginHost {
   protected initializing = false;
   protected name: string;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -418,5 +422,15 @@ export class AmplitudeCore implements CoreClient {
 
   flush() {
     return returnWrapper(this.timeline.flush());
+  }
+
+  plugin(name: string): Plugin | undefined {
+    const plugin = this.timeline.plugins.find((plugin) => plugin.name === name);
+    if (plugin === undefined) {
+      this.config.loggerProvider.debug(`Cannot find plugin with name ${name}`);
+      return undefined;
+    }
+
+    return plugin;
   }
 }

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -482,4 +482,28 @@ describe('core-client', () => {
       expect(flush).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('plugin', () => {
+    test('should return plugin by name', async () => {
+      const mockPlugin: Plugin = {
+        name: 'mock-plugin',
+      };
+      client.timeline.plugins.push(mockPlugin);
+
+      const result = client.plugin('mock-plugin');
+
+      expect(result).toBe(mockPlugin);
+
+      // Clean timeline plugins
+      client.timeline.plugins = [];
+    });
+
+    test('should return undefined when name does not exist', async () => {
+      client.config = mockConfig;
+      const result = client.plugin('mock-plugin');
+
+      expect(result).toBe(undefined);
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith('Cannot find plugin with name mock-plugin');
+    });
+  });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
This PR is made for the experiment plugin https://github.com/amplitude/experiment-js-client/pull/168

- Export class `AmplitudeBrowser` for experiment plugin integration
- Move `PluginHost` from `AmplitudeBrowser` to `AmplitudeCore`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
