### PR TITLE
feat(plugin-session-replay-browser): add an sr instance property

### DIFF
--- a/packages/plugin-session-replay-browser/src/index.ts
+++ b/packages/plugin-session-replay-browser/src/index.ts
@@ -1,1 +1,2 @@
-export { sessionReplayPlugin as plugin, sessionReplayPlugin } from './session-replay';
+export { sessionReplayPlugin as plugin, sessionReplayPlugin, SessionReplayPlugin } from './session-replay';
+export { AmplitudeSessionReplay } from '@amplitude/session-replay-browser';

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -93,6 +93,8 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         optOut ? 'sessionReplay.shutdown()' : 'sessionReplay.init()'
       }.`,
     );
+    // TODO: compare optOut with this.sr.getOptOut().
+    // Need to add getOptOut() to the interface AmplitudeSessionReplay first.
     if (optOut) {
       this.sr.shutdown();
     } else {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -14,8 +14,14 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
   config: BrowserConfig;
   options: SessionReplayOptions;
   srInitOptions: sessionReplay.SessionReplayOptions;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
-  sr: AmplitudeSessionReplay = sessionReplay.createInstance();
+  sr: AmplitudeSessionReplay = {
+    flush: sessionReplay.flush,
+    getSessionId: sessionReplay.getSessionId,
+    getSessionReplayProperties: sessionReplay.getSessionReplayProperties,
+    init: sessionReplay.init,
+    setSessionId: sessionReplay.setSessionId,
+    shutdown: sessionReplay.shutdown,
+  };
 
   constructor(options?: SessionReplayOptions) {
     this.options = { forceSessionTracking: false, ...options };

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -1,8 +1,8 @@
 import { getGlobalScope } from '@amplitude/analytics-core';
 import { pack } from '@amplitude/rrweb-packer';
 import type { eventWithTime } from '@amplitude/rrweb-types';
-import { SessionReplayJoinedConfig } from 'src/config/types';
-import { SessionReplayEventsManager } from 'src/typings/session-replay';
+import { SessionReplayJoinedConfig } from '../config/types';
+import { SessionReplayEventsManager } from '../typings/session-replay';
 
 interface TaskQueue {
   event: eventWithTime;

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,5 +1,4 @@
 import sessionReplay from './session-replay-factory';
-export { createInstance } from './session-replay-factory';
 export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
 export { SessionReplayOptions, StoreType } from './typings/session-replay';
 export { SafeLoggerProvider } from './logger';

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,4 +1,6 @@
 import sessionReplay from './session-replay-factory';
+export { createInstance } from './session-replay-factory';
 export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
 export { SessionReplayOptions, StoreType } from './typings/session-replay';
 export { SafeLoggerProvider } from './logger';
+export { AmplitudeSessionReplay } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -12,7 +12,7 @@ export const getLogConfig = (sessionReplay: SessionReplay) => (): LogConfig => {
   };
 };
 
-const createInstance: () => AmplitudeSessionReplay = () => {
+export const createInstance: () => AmplitudeSessionReplay = () => {
   const sessionReplay = new SessionReplay();
   return {
     init: debugWrapper(sessionReplay.init.bind(sessionReplay), 'init', getLogConfig(sessionReplay)),

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -12,7 +12,7 @@ export const getLogConfig = (sessionReplay: SessionReplay) => (): LogConfig => {
   };
 };
 
-export const createInstance: () => AmplitudeSessionReplay = () => {
+const createInstance: () => AmplitudeSessionReplay = () => {
   const sessionReplay = new SessionReplay();
   return {
     init: debugWrapper(sessionReplay.init.bind(sessionReplay), 'init', getLogConfig(sessionReplay)),


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Add a class property `sr` to `SessionReplayPlugin` class
- Export `SessionReplayPlugin` class 

Will create a PR to add this example to `examples/browser/react-app/` in another PR. https://github.com/amplitude/Amplitude-TypeScript/commit/dfded000878b45a1245fc84cf3738fc834d29a97

Local test: 
Analytics and SR work: 
![image](https://github.com/user-attachments/assets/ffbcea48-f10b-43ab-bfc8-edca6a7767a0)

```ts
const client: AmplitudeBrowser = new amplitude.AmplitudeBrowser();
client.init('5b9a9510e261f9ead90865bbc5a7ad1d', 'user@company.com', {
  logLevel: amplitude.Types.LogLevel.Debug,
}).promise.then((_) => {
  client.add(sessionReplayPlugin({debugMode: true})).promise.then((_) => {
    // Add SR plugin to existing Amplitude analytics SDK
    // and call SR APIs.
    // SR APIs are only available when
    // 1. Amplitude instance has successfully setup
    // 2. SR plugin has been installed successfully
    console.log(`client.sr.getSessionId(): ${client.sr.getSessionId()}`);
    console.log(`client.sr.getSessionReplayProperties(): ${client.sr.getSessionReplayProperties()}`);
  });
});
```
![image](https://github.com/user-attachments/assets/e17e0b7b-d703-4b1b-bf9a-7e6a671af1e8)


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
