### PR TITLE
fix(analytics-browser): default values for config were not being used for fetchRemoteConfig

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -85,7 +85,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     let browserOptions = await useBrowserConfig(options.apiKey, options, this);
     // Step 2: Create browser config
-    if (options.fetchRemoteConfig) {
+    if (browserOptions.fetchRemoteConfig) {
       const joinedConfigGenerator = await createBrowserJoinedConfigGenerator(browserOptions);
       browserOptions = await joinedConfigGenerator.generateJoinedConfig();
     }

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -102,7 +102,7 @@ describe('browser-client', () => {
   describe('init', () => {
     test('should use remote config by default', async () => {
       await client.init(apiKey).promise;
-      expect(RemoteConfig.createBrowserJoinedConfigGenerator).not.toHaveBeenCalled();
+      expect(RemoteConfig.createBrowserJoinedConfigGenerator).toHaveBeenCalled();
     });
 
     test('should use remote config when fetchRemoteConfig is true', async () => {
@@ -116,7 +116,7 @@ describe('browser-client', () => {
       await client.init(apiKey, {
         fetchRemoteConfig: false,
       }).promise;
-      expect(RemoteConfig.createBrowserJoinedConfigGenerator).toHaveBeenCalled();
+      expect(RemoteConfig.createBrowserJoinedConfigGenerator).not.toHaveBeenCalled();
     });
 
     test('should initialize client', async () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -52,6 +52,7 @@ describe('browser-client', () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
     // clean up cookies
     document.cookie = `AMP_${apiKey}=null; expires=-1`;
   });

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -100,7 +100,7 @@ describe('browser-client', () => {
   });
 
   describe('init', () => {
-    test('should NOT use remote config by default', async () => {
+    test('should use remote config by default', async () => {
       await client.init(apiKey).promise;
       expect(RemoteConfig.createBrowserJoinedConfigGenerator).not.toHaveBeenCalled();
     });
@@ -108,6 +108,13 @@ describe('browser-client', () => {
     test('should use remote config when fetchRemoteConfig is true', async () => {
       await client.init(apiKey, {
         fetchRemoteConfig: true,
+      }).promise;
+      expect(RemoteConfig.createBrowserJoinedConfigGenerator).toHaveBeenCalled();
+    });
+
+    test('should use remote config when fetchRemoteConfig is false', async () => {
+      await client.init(apiKey, {
+        fetchRemoteConfig: false,
       }).promise;
       expect(RemoteConfig.createBrowserJoinedConfigGenerator).toHaveBeenCalled();
     });


### PR DESCRIPTION

### Summary
A previous change (#1008) set the default value of fetchRemoteConfig to be `true`, but this default was not being used which resulted in fetchRemoteConfig defaulting to `undefined`.

This change fixes it by referencing the correct browserOptions variable which includes the default values

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
