### PR TITLE
chore: Revert: "fix(analytics-browser): default values for config were not being used for fetchRemoteConfig"

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -85,7 +85,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     let browserOptions = await useBrowserConfig(options.apiKey, options, this);
     // Step 2: Create browser config
-    if (browserOptions.fetchRemoteConfig) {
+    if (options.fetchRemoteConfig) {
       const joinedConfigGenerator = await createBrowserJoinedConfigGenerator(browserOptions);
       browserOptions = await joinedConfigGenerator.generateJoinedConfig();
     }

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -52,7 +52,6 @@ describe('browser-client', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
     // clean up cookies
     document.cookie = `AMP_${apiKey}=null; expires=-1`;
   });
@@ -101,9 +100,9 @@ describe('browser-client', () => {
   });
 
   describe('init', () => {
-    test('should use remote config by default', async () => {
+    test('should NOT use remote config by default', async () => {
       await client.init(apiKey).promise;
-      expect(RemoteConfig.createBrowserJoinedConfigGenerator).toHaveBeenCalled();
+      expect(RemoteConfig.createBrowserJoinedConfigGenerator).not.toHaveBeenCalled();
     });
 
     test('should use remote config when fetchRemoteConfig is true', async () => {
@@ -111,13 +110,6 @@ describe('browser-client', () => {
         fetchRemoteConfig: true,
       }).promise;
       expect(RemoteConfig.createBrowserJoinedConfigGenerator).toHaveBeenCalled();
-    });
-
-    test('should use remote config when fetchRemoteConfig is false', async () => {
-      await client.init(apiKey, {
-        fetchRemoteConfig: false,
-      }).promise;
-      expect(RemoteConfig.createBrowserJoinedConfigGenerator).not.toHaveBeenCalled();
     });
 
     test('should initialize client', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
Reverts #1037 

This breaks some tests that are non-trivial to fix, reverting change for now

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
