### PR TITLE
chore: update Node version in pre-release workflow

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        node-version: [18.15.x]
+        node-version: [18.17.x]
 
     steps:
       - name: Get branch name


### PR DESCRIPTION
### Summary

Bump the version of NodeJS that the pre-release workflow uses so that it's the same as v2 release.

This was done because an [attempt to do the pre-release](https://github.com/amplitude/Amplitude-TypeScript/actions/runs/14653457044/job/41124195039) due to a dependency required Node >= 18.17 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
