### PR TITLE
fix(plugin-autocapture-browser): add autocapture.networkTracking

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -32,6 +32,7 @@ import {
   isFormInteractionTrackingEnabled,
   isElementInteractionsEnabled,
   isPageViewTrackingEnabled,
+  isNetworkTrackingEnabled,
 } from './default-tracking';
 import { convertProxyObjectToRealObject, isInstanceProxy } from './utils/snippet-helper';
 import { Context } from './plugins/context';
@@ -149,7 +150,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       await this.add(pageViewTrackingPlugin(getPageViewTrackingConfig(this.config))).promise;
     }
 
-    if (isElementInteractionsEnabled(this.config.autocapture)) {
+    if (isElementInteractionsEnabled(this.config.autocapture) || isNetworkTrackingEnabled(this.config.autocapture)) {
       this.config.loggerProvider.debug('Adding user interactions plugin (autocapture plugin)');
       await this.add(autocapturePlugin(getElementInteractionsConfig(this.config))).promise;
     }

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -61,6 +61,16 @@ export const isElementInteractionsEnabled = (autocapture: AutocaptureOptions | b
   return false;
 };
 
+export const isNetworkTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
+  if (typeof autocapture === 'boolean') {
+    return autocapture;
+  }
+  if (typeof autocapture === 'object' && autocapture.networkTracking) {
+    return true;
+  }
+  return false;
+};
+
 export const getElementInteractionsConfig = (config: BrowserOptions): ElementInteractionsOptions | undefined => {
   if (
     isElementInteractionsEnabled(config.autocapture) &&

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -8,6 +8,7 @@ import {
   isPageViewTrackingEnabled,
   isSessionTrackingEnabled,
   isElementInteractionsEnabled,
+  isNetworkTrackingEnabled,
 } from '../src/default-tracking';
 
 describe('isFileDownloadTrackingEnabled', () => {
@@ -163,6 +164,32 @@ describe('isAttributionTrackingEnabled', () => {
     expect(
       isAttributionTrackingEnabled({
         attribution: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isNetworkTrackingEnabled', () => {
+  test('should return true with true parameter', () => {
+    expect(isNetworkTrackingEnabled(true)).toBe(true);
+  });
+  test('should return false with undefined parameter', () => {
+    expect(isNetworkTrackingEnabled(undefined)).toBe(false);
+  });
+  test('should return false with false parameter', () => {
+    expect(isNetworkTrackingEnabled(false)).toBe(false);
+  });
+  test('should return true with object parameter', () => {
+    expect(
+      isNetworkTrackingEnabled({
+        networkTracking: true,
+      }),
+    ).toBe(true);
+  });
+  test('should return false with object parameter', () => {
+    expect(
+      isNetworkTrackingEnabled({
+        networkTracking: false,
       }),
     ).toBe(false);
   });

--- a/packages/analytics-core/src/types/browser-config.ts
+++ b/packages/analytics-core/src/types/browser-config.ts
@@ -159,6 +159,11 @@ export interface AutocaptureOptions {
    * @defaultValue `false`
    */
   elementInteractions?: boolean | ElementInteractionsOptions;
+  /**
+   * Enables/disables network request tracking.
+   * @defaultValue `false`
+   */
+  networkTracking?: boolean | NetworkTrackingOptions;
 }
 
 export interface TrackingOptions {

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -257,6 +257,16 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
       return;
     }
 
+    let isElementTrackingEnabled = false;
+    let isNetworkTrackingEnabled = false;
+    if (config.autocapture === true) {
+      isElementTrackingEnabled = true;
+      isNetworkTrackingEnabled = true;
+    } else if (typeof config.autocapture === 'object') {
+      isElementTrackingEnabled = !!config.autocapture.elementInteractions;
+      isNetworkTrackingEnabled = !!config.autocapture.networkTracking;
+    }
+
     // Create should track event functions the different allowlists
     const shouldTrackEvent = createShouldTrackEvent(
       options,
@@ -271,38 +281,42 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
     const allObservables = createObservables();
 
     // Create subscriptions
-    const clickTrackingSubscription = trackClicks({
-      allObservables,
-      options: options as AutoCaptureOptionsWithDefaults,
-      amplitude,
-      shouldTrackEvent: shouldTrackEvent,
-    });
-    subscriptions.push(clickTrackingSubscription);
+    if (isElementTrackingEnabled) {
+      const clickTrackingSubscription = trackClicks({
+        allObservables,
+        options: options as AutoCaptureOptionsWithDefaults,
+        amplitude,
+        shouldTrackEvent: shouldTrackEvent,
+      });
+      subscriptions.push(clickTrackingSubscription);
 
-    const changeSubscription = trackChange({
-      allObservables,
-      getEventProperties,
-      amplitude,
-      shouldTrackEvent: shouldTrackEvent,
-    });
-    subscriptions.push(changeSubscription);
+      const changeSubscription = trackChange({
+        allObservables,
+        getEventProperties,
+        amplitude,
+        shouldTrackEvent: shouldTrackEvent,
+      });
+      subscriptions.push(changeSubscription);
 
-    const actionClickSubscription = trackActionClick({
-      allObservables,
-      options: options as AutoCaptureOptionsWithDefaults,
-      getEventProperties,
-      amplitude,
-      shouldTrackEvent,
-      shouldTrackActionClick: shouldTrackActionClick,
-    });
-    subscriptions.push(actionClickSubscription);
+      const actionClickSubscription = trackActionClick({
+        allObservables,
+        options: options as AutoCaptureOptionsWithDefaults,
+        getEventProperties,
+        amplitude,
+        shouldTrackEvent,
+        shouldTrackActionClick: shouldTrackActionClick,
+      });
+      subscriptions.push(actionClickSubscription);
+    }
 
-    const networkRequestSubscription = trackNetworkEvents({
-      allObservables,
-      config,
-      amplitude,
-    });
-    subscriptions.push(networkRequestSubscription);
+    if (isNetworkTrackingEnabled) {
+      const networkRequestSubscription = trackNetworkEvents({
+        allObservables,
+        config,
+        amplitude,
+      });
+      subscriptions.push(networkRequestSubscription);
+    }
 
     /* istanbul ignore next */
     config?.loggerProvider?.log(`${name} has been successfully added.`);

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-action-clicks.test.ts
@@ -51,6 +51,7 @@ describe('action clicks:', () => {
     const config: Partial<BrowserConfig> = {
       defaultTracking: false,
       loggerProvider: loggerProvider as ILogger,
+      autocapture: true,
     };
 
     beforeEach(async () => {

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -66,6 +66,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider as ILogger,
+        autocapture: true,
       };
       const amplitude: Partial<BrowserClient> = {};
       await plugin?.setup?.(config as BrowserConfig, amplitude as BrowserClient);
@@ -90,6 +91,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider as ILogger,
+        autocapture: true,
       };
       const amplitude: Partial<BrowserClient> = {};
       await plugin?.setup?.(config as BrowserConfig, amplitude as BrowserClient);
@@ -155,6 +157,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -214,6 +217,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -272,6 +276,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -340,6 +345,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -403,6 +409,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -469,6 +476,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -536,6 +544,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -568,6 +577,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -604,6 +614,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider as ILogger,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -646,6 +657,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider as ILogger,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -678,6 +690,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -728,6 +741,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -763,6 +777,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -832,6 +847,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -852,6 +868,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -876,6 +893,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -902,6 +920,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider as ILogger,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -927,6 +946,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider as ILogger,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -947,6 +967,7 @@ describe('autoTrackingPlugin', () => {
       const config: Partial<BrowserConfig> = {
         defaultTracking: false,
         loggerProvider: loggerProvider as ILogger,
+        autocapture: true,
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -993,6 +1014,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -1049,6 +1071,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -1101,6 +1124,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -1154,6 +1178,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -1203,6 +1228,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -1224,6 +1250,7 @@ describe('autoTrackingPlugin', () => {
         const config: Partial<BrowserConfig> = {
           defaultTracking: false,
           loggerProvider: loggerProvider,
+          autocapture: true,
         };
         await plugin?.setup?.(config as BrowserConfig, instance);
 


### PR DESCRIPTION
### Summary

Add `autocapture.networkTracking` to this implementation. This is a config flag to determine if we should or should not do network tracking.

Currently, the "plugin-autocapture" only does element interactions. Adding network capture mixes network capturing with element interactions. This PR makes it so that element interactions only happen if the configuration is setup for it; and likewise with network tracking options.

### Question(s)
* The "setup" function was refactored so that element interactions are only going to be triggered when "config.autocomplete === true" or "!!!config.autocomplete.elementInteractions". I'm concerned this may be a breaking change?

### Comments
* The logic of "plugin-autocapture" is getting a lit bit unwieldy. I'd like to do a refactor afterwards to clean things up and have more separation between element interactions logic and network capture logic

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
