### PR TITLE
fix(analytics-browser): use performance.now in network capture

### DIFF
--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -22,10 +22,12 @@ const isTrackingEnabled = (
     return autocapture;
   }
 
-  if (autocapture?.[event] === false) {
-    return false;
-  } else if (autocapture && !autocapture?.[event]) {
-    return defaultValue;
+  if (typeof autocapture === 'object') {
+    if (autocapture[event] === false) {
+      return false;
+    } else if (!autocapture[event]) {
+      return defaultValue;
+    }
   }
 
   return true;

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -13,32 +13,38 @@ import {
  * Returns false if autocapture === false or if autocapture[event],
  * otherwise returns true
  */
-const isTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined, event: keyof AutocaptureOptions) => {
+const isTrackingEnabled = (
+  autocapture: AutocaptureOptions | boolean | undefined,
+  event: keyof AutocaptureOptions,
+  defaultValue = false,
+) => {
   if (typeof autocapture === 'boolean') {
     return autocapture;
   }
 
   if (autocapture?.[event] === false) {
     return false;
+  } else if (autocapture && !autocapture?.[event]) {
+    return defaultValue;
   }
 
   return true;
 };
 
 export const isAttributionTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
-  isTrackingEnabled(autocapture, 'attribution');
+  isTrackingEnabled(autocapture, 'attribution', true);
 
 export const isFileDownloadTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
-  isTrackingEnabled(autocapture, 'fileDownloads');
+  isTrackingEnabled(autocapture, 'fileDownloads', true);
 
 export const isFormInteractionTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
-  isTrackingEnabled(autocapture, 'formInteractions');
+  isTrackingEnabled(autocapture, 'formInteractions', true);
 
 export const isPageViewTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
-  isTrackingEnabled(autocapture, 'pageViews');
+  isTrackingEnabled(autocapture, 'pageViews', true);
 
 export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
-  isTrackingEnabled(autocapture, 'sessions');
+  isTrackingEnabled(autocapture, 'sessions', true);
 
 export const isNetworkTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
   isTrackingEnabled(autocapture, 'networkTracking');

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -10,22 +10,23 @@ import {
 } from '@amplitude/analytics-core';
 
 /**
- * Returns false if autocapture === false or if autocapture[event],
+ * Returns autocapture[event] if it is defined
+ * returns defaultValue if autocapture[event] is undefined
  * otherwise returns true
  */
 const isTrackingEnabled = (
   autocapture: AutocaptureOptions | boolean | undefined,
   event: keyof AutocaptureOptions,
-  defaultValue = false,
+  defaultValue: boolean,
 ) => {
   if (typeof autocapture === 'boolean') {
     return autocapture;
   }
 
-  if (typeof autocapture === 'object') {
+  if (autocapture !== null && typeof autocapture === 'object') {
     if (autocapture[event] === false) {
       return false;
-    } else if (!autocapture[event]) {
+    } else if (autocapture[event] === undefined) {
       return defaultValue;
     }
   }
@@ -49,7 +50,7 @@ export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boole
   isTrackingEnabled(autocapture, 'sessions', true);
 
 export const isNetworkTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) =>
-  isTrackingEnabled(autocapture, 'networkTracking');
+  isTrackingEnabled(autocapture, 'networkTracking', false);
 
 /**
  * Returns true if

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -299,7 +299,26 @@ describe('getNetworkTrackingConfig', () => {
     const config = getNetworkTrackingConfig({
       networkTrackingOptions: undefined,
     });
+    expect(config).toBeUndefined();
+  });
 
+  test('should return undefined when autocapture.networkTracking is undefined', () => {
+    const config = getNetworkTrackingConfig({
+      autocapture: {
+        elementInteractions: true,
+        sessions: true,
+      },
+      networkTrackingOptions: {
+        ignoreAmplitudeRequests: true,
+        ignoreHosts: ['example.com'],
+        captureRules: [
+          {
+            hosts: ['example.com'],
+            statusCodeRange: '500-599',
+          },
+        ],
+      },
+    });
     expect(config).toBeUndefined();
   });
 

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -149,7 +149,7 @@ export class NetworkObserver {
         const response = await originalFetch(input, init);
 
         requestEvent.status = response.status;
-        requestEvent.duration = performance.now() - durationStart;
+        requestEvent.duration = Math.floor(performance.now() - durationStart);
         requestEvent.startTime = startTime;
         requestEvent.endTime = Math.floor(startTime + requestEvent.duration);
 

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -133,7 +133,7 @@ export class NetworkObserver {
     const originalFetch = this.globalScope.fetch;
 
     this.globalScope.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const startTime = Date.now();
+      const startTime = performance.now();
       const requestEvent: NetworkRequestEvent = {
         timestamp: startTime,
         startTime,
@@ -146,7 +146,7 @@ export class NetworkObserver {
 
       try {
         const response = await originalFetch(input, init);
-        const endTime = Date.now();
+        const endTime = performance.now();
 
         requestEvent.status = response.status;
         requestEvent.duration = endTime - startTime;

--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -133,7 +133,8 @@ export class NetworkObserver {
     const originalFetch = this.globalScope.fetch;
 
     this.globalScope.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const startTime = performance.now();
+      const startTime = Date.now();
+      const durationStart = performance.now();
       const requestEvent: NetworkRequestEvent = {
         timestamp: startTime,
         startTime,
@@ -146,12 +147,11 @@ export class NetworkObserver {
 
       try {
         const response = await originalFetch(input, init);
-        const endTime = performance.now();
 
         requestEvent.status = response.status;
-        requestEvent.duration = endTime - startTime;
+        requestEvent.duration = performance.now() - durationStart;
         requestEvent.startTime = startTime;
-        requestEvent.endTime = endTime;
+        requestEvent.endTime = Math.floor(startTime + requestEvent.duration);
 
         // Convert Headers
         const headers: Record<string, string> = {};


### PR DESCRIPTION
### Summary

also, make it so `autocapture.networkTracking` defaults to `false`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
