### PR TITLE
feat(session-replay-browser): ugc removal poc

### DIFF
--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -7,6 +7,7 @@ import {
   PrivacyConfig,
   SessionReplayPerformanceConfig,
   SessionReplayVersion,
+  UGCFilterRule,
 } from './types';
 import { SafeLoggerProvider } from '../logger';
 
@@ -30,6 +31,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   storeType: StoreType;
   performanceConfig?: SessionReplayPerformanceConfig;
   experimental?: { useWebWorker: boolean };
+  ugcFilterRules?: UGCFilterRule[];
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -53,6 +55,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     this.version = options.version;
     this.performanceConfig = options.performanceConfig;
     this.storeType = options.storeType ?? 'idb';
+    this.ugcFilterRules = options.ugcFilterRules;
 
     if (options.privacyConfig) {
       this.privacyConfig = options.privacyConfig;

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -50,6 +50,20 @@ export type PrivacyConfig = {
   unmaskSelector?: string[];
 };
 
+/**
+ * UGC filter rule.
+ */
+export type UGCFilterRule = {
+  /**
+   * The selector of the UGC element.
+   */
+  selector: string;
+  /**
+   * The replacement text for the UGC element.
+   */
+  replacement: string;
+};
+
 export interface SessionReplayLocalConfig extends IConfig {
   apiKey: string;
   loggerProvider: ILogger;
@@ -123,6 +137,10 @@ export interface SessionReplayLocalConfig extends IConfig {
      */
     useWebWorker: boolean;
   };
+  /**
+   * UGC filter rules.
+   */
+  ugcFilterRules?: UGCFilterRule[];
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -1,6 +1,6 @@
-import { getGlobalScope, ServerZone } from '@amplitude/analytics-core';
+import { getGlobalScope, ILogger, ServerZone } from '@amplitude/analytics-core';
 import { getInputType } from '@amplitude/rrweb-snapshot';
-import { DEFAULT_MASK_LEVEL, MaskLevel, PrivacyConfig, SessionReplayJoinedConfig } from './config/types';
+import { DEFAULT_MASK_LEVEL, MaskLevel, PrivacyConfig, SessionReplayJoinedConfig, UGCFilterRule } from './config/types';
 import {
   KB_SIZE,
   MASK_TEXT_CLASS,
@@ -141,6 +141,54 @@ export const getServerUrl = (serverZone?: keyof typeof ServerZone, trackServerUr
   }
 
   return SESSION_REPLAY_SERVER_URL;
+};
+
+const globToRegex = (glob: string): RegExp => {
+  // Escape special regex characters, then convert globs
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape regex specials
+    .replace(/\*/g, '.*') // Convert * to .*
+    .replace(/\?/g, '.'); // Convert ? to .
+
+  return new RegExp(`^${escaped}$`);
+};
+
+export const getPageUrl = (logger: ILogger, pageUrl: string, ugcFilterRules?: UGCFilterRule[]) => {
+  if (!ugcFilterRules) {
+    return pageUrl;
+  }
+
+  // validate ugcFilterRules
+  if (!ugcFilterRules.every((rule) => typeof rule.selector === 'string' && typeof rule.replacement === 'string')) {
+    logger.error('ugcFilterRules must be an array of objects with selector and replacement properties');
+    return pageUrl;
+  }
+
+  // validate ugcFilterRules are valid globs
+  if (
+    !ugcFilterRules.every((rule) => {
+      try {
+        new RegExp(rule.selector);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    })
+  ) {
+    logger.error('ugcFilterRules must be an array of objects with valid globs');
+    return pageUrl;
+  }
+
+  // apply ugcFilterRules, order is important, first rule wins
+  for (const rule of ugcFilterRules) {
+    const regex = globToRegex(rule.selector);
+
+    if (regex.test(pageUrl)) {
+      return pageUrl.replace(regex, rule.replacement);
+    }
+  }
+
+  return pageUrl;
 };
 
 export const getStorageSize = async (): Promise<StorageData> => {

--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -4,6 +4,7 @@ import { BeaconTransport } from '../beacon-transport';
 import { getGlobalScope } from '@amplitude/analytics-core';
 import { SessionReplayJoinedConfig } from '../config/types';
 import { SessionReplayDestinationSessionMetadata } from '../typings/session-replay';
+import { getPageUrl } from '../helpers';
 
 const { getWindowHeight, getWindowWidth } = utils;
 
@@ -35,19 +36,24 @@ export class ScrollWatcher {
   private _maxScrollWidth: number;
   private _maxScrollHeight: number;
   private readonly transport: BeaconTransport<ScrollEventPayload>;
+  private readonly config: Pick<SessionReplayJoinedConfig, 'loggerProvider' | 'ugcFilterRules'>;
 
   static default(
     context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>,
     config: SessionReplayJoinedConfig,
   ): ScrollWatcher {
-    return new ScrollWatcher(new BeaconTransport<ScrollEventPayload>(context, config));
+    return new ScrollWatcher(new BeaconTransport<ScrollEventPayload>(context, config), config);
   }
 
-  constructor(transport: BeaconTransport<ScrollEventPayload>) {
+  constructor(
+    transport: BeaconTransport<ScrollEventPayload>,
+    config: Pick<SessionReplayJoinedConfig, 'loggerProvider' | 'ugcFilterRules'>,
+  ) {
     this._maxScrollX = 0;
     this._maxScrollY = 0;
     this._maxScrollWidth = getWindowWidth();
     this._maxScrollHeight = getWindowHeight();
+    this.config = config;
 
     this.transport = transport;
   }
@@ -110,7 +116,7 @@ export class ScrollWatcher {
 
             viewportHeight: getWindowHeight(),
             viewportWidth: getWindowWidth(),
-            pageUrl: globalScope.location.href,
+            pageUrl: getPageUrl(this.config.loggerProvider, globalScope.location.href, this.config.ugcFilterRules),
             timestamp: this.timestamp,
             type: 'scroll',
           },

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -363,7 +363,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.networkObservers?.start((event: NetworkRequestEvent) => {
       void this.addCustomRRWebEvent(CustomRRwebEvent.FETCH_REQUEST, event);
     });
-    const { privacyConfig, interactionConfig, loggingConfig } = config;
+    const { privacyConfig, interactionConfig, loggingConfig, ugcFilterRules } = config;
 
     const hooks = interactionConfig?.enabled
       ? {
@@ -373,6 +373,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
               eventsManager: this.eventsManager,
               sessionId,
               deviceIdFn: this.getDeviceId.bind(this),
+              ugcFilterRules,
             }),
           scroll: this.scrollHook,
         }

--- a/packages/session-replay-browser/test/hooks/click.test.ts
+++ b/packages/session-replay-browser/test/hooks/click.test.ts
@@ -214,6 +214,38 @@ describe('click', () => {
         type: 'click',
       });
     });
+
+    test('add event on click event with scroll with UGC filter rules', () => {
+      const hookWithUGCFilterRules = clickHook(mockLoggerProvider, {
+        deviceIdFn: () => deviceId,
+        eventsManager: mockEventsManager,
+        sessionId: sessionId,
+        ugcFilterRules: [{ selector: 'http://localhost/user/*', replacement: 'http://localhost/user/user_id' }],
+      });
+      mockGlobalScope({
+        innerHeight: 768,
+        innerWidth: 1024,
+        location: {
+          href: 'http://localhost/user/123123',
+        } as any,
+      });
+      hookWithUGCFilterRules({
+        id: 1234,
+        type: MouseInteractions.Click,
+        x: 3,
+        y: 3,
+      });
+      expect(jest.spyOn(mockEventsManager, 'addEvent')).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(mockEventsManager.addEvent.mock.calls[0][0].event.data)).toStrictEqual({
+        x: 3,
+        y: 3,
+        viewportHeight: 768,
+        viewportWidth: 1024,
+        pageUrl: 'http://localhost/user/user_id',
+        timestamp: expect.any(Number),
+        type: 'click',
+      });
+    });
   });
 
   describe('clickBatcher', () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
This pull request introduces a new feature to support User-Generated Content (UGC) filtering in the Session Replay library. It includes changes to add UGC filter rules, apply them to page URLs, and validate their usage. The changes span across configuration, helper methods, hooks, and tests.

### UGC Filtering Feature Implementation

* **Configuration Updates**:
  - Added a new `UGCFilterRule` type to define UGC filter rules with `selector` and `replacement` properties. (`packages/session-replay-browser/src/config/types.ts`, [packages/session-replay-browser/src/config/types.tsR53-R66](diffhunk://#diff-3a86afe4928999add3708316114f2e24431702518dd9f124bee6b7df56299beaR53-R66))
  - Updated `SessionReplayLocalConfig` to include an optional `ugcFilterRules` property. (`packages/session-replay-browser/src/config/local-config.ts`, [[1]](diffhunk://#diff-b3985e000147ff08ef5d558589a5324db4905464ccf76e265ccf8eec81be9355R34) [[2]](diffhunk://#diff-b3985e000147ff08ef5d558589a5324db4905464ccf76e265ccf8eec81be9355R58)

* **Helper Functionality**:
  - Added `getPageUrl` helper to apply UGC filter rules to page URLs, with validation for rule structure and glob patterns. (`packages/session-replay-browser/src/helpers.ts`, [packages/session-replay-browser/src/helpers.tsR146-R193](diffhunk://#diff-0d86e594a4ecc24dccffd0a2a979b0904467a8a7c11d17b1dc9451c1b28a3530R146-R193))

* **Integration in Hooks**:
  - Updated `click` and `scroll` hooks to use `getPageUrl` for applying UGC filter rules to event data. (`packages/session-replay-browser/src/hooks/click.ts`, [[1]](diffhunk://#diff-d5419d6c240af4edb6c41bd0f11a1608663fa25f6fea9e3c4e9b1182848407cfR108-R117); `packages/session-replay-browser/src/hooks/scroll.ts`, [[2]](diffhunk://#diff-6701c003a923ff4315b6319297ddf6e8bfdecc5e60d8316e9c5ecb36397138b2L113-R119)

### Testing Enhancements

* **Unit Tests for `getPageUrl`**:
  - Validated scenarios such as no rules, invalid rules, and correct application of single/multiple rules. (`packages/session-replay-browser/test/helpers.test.ts`, [packages/session-replay-browser/test/helpers.test.tsR274-R373](diffhunk://#diff-654113a2278e3df354e180fdf4a8cf8872331058159f6c24c97e72850c969080R274-R373))

* **Integration Tests for Hooks**:
  - Ensured `click` and `scroll` events correctly apply UGC filter rules in various scenarios. (`packages/session-replay-browser/test/hooks/click.test.ts`, [[1]](diffhunk://#diff-b8dce375174146eab2ab8f528a6fbdecec905971bdffcf63205d0f3b5d07ac57R217-R248); `packages/session-replay-browser/test/hooks/scroll.test.ts`, [[2]](diffhunk://#diff-f447b26cebb602e4aaa13c839052771501e48afc2cebd9dc60ba62ce642b3502L99-R143)

These changes collectively enable UGC filtering for improved privacy and customization in session replay data.
<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
