### PR TITLE
fix(plugin-network-capture): fix bug that fails to capture relative URLs

### DIFF
--- a/packages/plugin-network-capture-browser/test/autocapture-plugin/track-network-event.test.ts
+++ b/packages/plugin-network-capture-browser/test/autocapture-plugin/track-network-event.test.ts
@@ -131,7 +131,7 @@ describe('track-network-event', () => {
       const [eventName, eventProperties] = networkEventCall;
       expect(eventName).toBe(AMPLITUDE_NETWORK_REQUEST_EVENT);
       expect(eventProperties).toEqual({
-        '[Amplitude] URL': 'https://example.com/track?hello=world#hash',
+        '[Amplitude] URL': 'https://example.com/track',
         '[Amplitude] URL Query': 'hello=world',
         '[Amplitude] URL Fragment': 'hash',
         '[Amplitude] Request Method': 'POST',
@@ -164,7 +164,7 @@ describe('track-network-event', () => {
       const [eventName, eventProperties] = networkEventCall;
       expect(eventName).toBe(AMPLITUDE_NETWORK_REQUEST_EVENT);
       expect(eventProperties).toEqual({
-        '[Amplitude] URL': 'https://example.com/track?hello=world#hash',
+        '[Amplitude] URL': 'https://example.com/track',
         '[Amplitude] URL Query': 'hello=world',
         '[Amplitude] URL Fragment': 'hash',
         '[Amplitude] Request Method': 'POST',
@@ -304,6 +304,30 @@ describe('track-network-event', () => {
   });
 
   describe('shouldTrackNetworkEvent returns true when', () => {
+    const defaultHref = window.location.href;
+
+    beforeAll(() => {
+      window.location.href = 'https://example.com';
+    });
+
+    afterAll(() => {
+      window.location.href = defaultHref;
+    });
+
+    test('url omits baseURL and window.location.href is not ignored', () => {
+      networkEvent.url = '/some/url';
+      networkEvent.status = 500;
+      const result = shouldTrackNetworkEvent(networkEvent, localConfig.networkTrackingOptions);
+      expect(result).toBe(true);
+    });
+
+    test('url is a relative URL and location.href is not ignored', () => {
+      networkEvent.url = 'relativeurl';
+      networkEvent.status = 500;
+      const result = shouldTrackNetworkEvent(networkEvent, localConfig.networkTrackingOptions);
+      expect(result).toBe(true);
+    });
+
     test('domain is api.amplitude.com and ignoreAmplitudeRequests is false', () => {
       localConfig.networkTrackingOptions = { ignoreAmplitudeRequests: false };
       networkEvent.url = 'https://api.amplitude.com/track';


### PR DESCRIPTION
### Summary

Calls to "fetch" with a relative URL were not being captured and causing an exception to be thrown because [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) doesn't parse and throws an exception if you pass it a relative URL without a base URL.

Added a helper function that parses the URL with the base URL, and also catches the exception and returns undefined if it breaks.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
