### PR TITLE
chore: publish lerna from-package temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "lerna run watch --parallel",
     "clean": "lerna run clean --stream && rimraf node_modules docs",
     "deploy:version": "lerna version",
-    "deploy:publish": "lerna publish",
+    "deploy:publish": "lerna publish from-package",
     "dev": "concurrently \"npm run watch\" \"vite dev --open\"",
     "docs": "typedoc",
     "docs:check": "typedoc --emit none",


### PR DESCRIPTION
### Summary

TEMPORARILY switching to "from-package" in Lerna so that we can publish packages that failed to publish. Revert this once that's done.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
