### PR TITLE
fix: use correct logger

### DIFF
--- a/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
+++ b/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.1.0'
+  s.dependency 'AmplitudeSessionReplay', '>=0.4.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/plugin-session-replay-react-native/ios/ConsoleLogger.swift
+++ b/packages/plugin-session-replay-react-native/ios/ConsoleLogger.swift
@@ -12,7 +12,7 @@ public enum LogLevelEnum: Int {
     case DEBUG
 }
 
-public class ConsoleLogger: AmplitudeSessionReplay.Logger {
+public class ConsoleLogger: CoreLogger {
     public typealias LogLevel = LogLevelEnum
 
     public var logLevel: Int


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Session Replay no longer provides a logger, it uses the version from core.
Also, update min version of sr to the unified release.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
