### PR TITLE
feat(analytics-core): add plugins to look up plugin by class type

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -25,6 +25,7 @@ import { AmplitudeReturn, returnWrapper } from './utils/return-wrapper';
 
 interface PluginHost {
   plugin(name: string): Plugin | undefined;
+  plugins<T extends Plugin>(pluginClass: new (...args: any[]) => T): T[];
 }
 
 export interface CoreClient {
@@ -432,5 +433,9 @@ export class AmplitudeCore implements CoreClient, PluginHost {
     }
 
     return plugin;
+  }
+
+  plugins<T extends Plugin>(pluginClass: { new (...args: any[]): T }): T[] {
+    return this.timeline.plugins.filter((plugin) => plugin instanceof pluginClass) as T[];
   }
 }

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, IdentifyEvent, SpecialEventType, UserProperties } from '../src/types/event/event';
-import { Plugin } from '../src/types/plugin';
+import { Plugin, EnrichmentPlugin } from '../src/types/plugin';
 import { Status } from '../src/types/status';
 import { AmplitudeCore, Identify, Revenue } from '../src/index';
 import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from '../src/types/messages';
@@ -504,6 +504,40 @@ describe('core-client', () => {
 
       expect(result).toBe(undefined);
       expect(mockLoggerProvider.debug).toHaveBeenCalledWith('Cannot find plugin with name mock-plugin');
+    });
+  });
+
+  describe('plugins', () => {
+    class TestPlugin implements EnrichmentPlugin {
+      name = 'test-plugin';
+      setup = jest.fn();
+      execute = jest.fn();
+    }
+
+    test('should return plugins of a specific class', async () => {
+      const testPlugin1 = new TestPlugin();
+      const testPlugin2 = new TestPlugin();
+      const otherPlugin: Plugin = {
+        name: 'other-plugin',
+        setup: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      client.timeline.plugins.push(testPlugin1, otherPlugin, testPlugin2);
+
+      const result = client.plugins(TestPlugin);
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain(testPlugin1);
+      expect(result).toContain(testPlugin2);
+
+      // Clean up
+      client.timeline.plugins = [];
+    });
+
+    test('should return empty array if no plugins of the class exist', () => {
+      const result = client.plugins(TestPlugin);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/unified/test/unified.test.ts
+++ b/packages/unified/test/unified.test.ts
@@ -1,7 +1,7 @@
 import { AmplitudeUnified } from '../src/unified';
 import { ILogger } from '@amplitude/analytics-core';
 import { SessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
-import { ExperimentPlugin } from '@amplitude/plugin-experiment-browser';
+import { experimentPlugin, ExperimentPlugin } from '@amplitude/plugin-experiment-browser';
 import * as libraryModule from '../src/library';
 
 type MockedLogger = jest.Mocked<ILogger>;
@@ -59,10 +59,27 @@ describe('AmplitudeUnified', () => {
 
     test('should log when experiment plugin is not found', async () => {
       const client = new AmplitudeUnified();
-      const originalPlugin = client.plugin.bind(client);
-      jest.spyOn(client, 'plugin').mockImplementation((name) => {
-        if (name === ExperimentPlugin.pluginName) return undefined;
-        return originalPlugin(name);
+      jest.spyOn(client, 'plugins').mockImplementation((_) => {
+        return [];
+      });
+      expect(client.sr).toBeUndefined();
+      expect(client.experiment).toBeUndefined();
+
+      await client.initAll('test-api-key', {
+        analytics: {
+          loggerProvider: mockLoggerProvider,
+        },
+      });
+
+      expect(client.sr).toBeDefined();
+      expect(client.experiment).toBeUndefined();
+      expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${ExperimentPlugin.pluginName} plugin is not found.`);
+    });
+
+    test('should log when multiple experiment instances are not found', async () => {
+      const client = new AmplitudeUnified();
+      jest.spyOn(client, 'plugins').mockImplementation((_) => {
+        return [];
       });
       expect(client.sr).toBeUndefined();
       expect(client.experiment).toBeUndefined();
@@ -96,6 +113,24 @@ describe('AmplitudeUnified', () => {
         loggerProvider: mockLoggerProvider,
       });
       expect(res).toBeDefined();
+    });
+  });
+
+  describe('get experiment', () => {
+    test('should return undefined and log when multiple experiment instances', async () => {
+      const client = new AmplitudeUnified();
+      const experimentPlugin2 = experimentPlugin();
+      // Have to change name because plugin with existing name will be ignored at registration
+      experimentPlugin2.name = '@amplitude/experiment-analytics-plugin-2';
+
+      await client.initAll('test-api-key');
+      await client.add(experimentPlugin2).promise;
+
+      expect(client.plugin('@amplitude/experiment-analytics-plugin-2')).toBeDefined();
+      expect(mockLoggerProviderDebug).toHaveBeenCalledWith(
+        `Multiple instances of ${ExperimentPlugin.pluginName} are found.`,
+      );
+      expect(client.experiment).toBeUndefined();
     });
   });
 });

--- a/packages/unified/test/unified.test.ts
+++ b/packages/unified/test/unified.test.ts
@@ -123,14 +123,18 @@ describe('AmplitudeUnified', () => {
       // Have to change name because plugin with existing name will be ignored at registration
       experimentPlugin2.name = '@amplitude/experiment-analytics-plugin-2';
 
-      await client.initAll('test-api-key');
+      await client.initAll('test-api-key', {
+        analytics: {
+          loggerProvider: mockLoggerProvider,
+        },
+      });
       await client.add(experimentPlugin2).promise;
 
       expect(client.plugin('@amplitude/experiment-analytics-plugin-2')).toBeDefined();
+      expect(client.experiment).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(
         `Multiple instances of ${ExperimentPlugin.pluginName} are found.`,
       );
-      expect(client.experiment).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Add a new API `plugins()` to `PluginHost` to support the case that multiple product experiment (experiment-js-client) instances can be attached to one analytics client instance. 

reference: https://github.com/amplitude/AmplitudeCore-Swift/pull/27

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
