### PR TITLE
chore(session replay): add metadata and config to rrweb events

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -6,6 +6,7 @@ import { SessionReplayLocalConfig } from './local-config';
 import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
   PrivacyConfig,
+  SessionReplayConfigs,
   SessionReplayJoinedConfig,
   SessionReplayRemoteConfig,
 } from './types';
@@ -46,7 +47,7 @@ export class SessionReplayJoinedConfigGenerator {
     this.remoteConfigFetch = remoteConfigFetch;
   }
 
-  async generateJoinedConfig(sessionId?: string | number): Promise<SessionReplayJoinedConfig> {
+  async generateJoinedConfig(sessionId?: string | number): Promise<SessionReplayConfigs> {
     const config: SessionReplayJoinedConfig = { ...this.localConfig };
     // Special case here as optOut is implemented via getter/setter
     config.optOut = this.localConfig.optOut;
@@ -97,7 +98,11 @@ export class SessionReplayJoinedConfigGenerator {
     }
 
     if (!remoteConfig) {
-      return config;
+      return {
+        localConfig: this.localConfig,
+        joinedConfig: config,
+        remoteConfig,
+      };
     }
 
     const { sr_sampling_config: samplingConfig, sr_privacy_config: remotePrivacyConfig } = remoteConfig;
@@ -188,7 +193,11 @@ export class SessionReplayJoinedConfigGenerator {
       JSON.stringify({ name: 'session replay joined config', config: getDebugConfig(config) }, null, 2),
     );
 
-    return config;
+    return {
+      localConfig: this.localConfig,
+      joinedConfig: config,
+      remoteConfig,
+    };
   }
 }
 

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -36,7 +36,7 @@ export interface SessionReplayRemoteConfigAPIResponse {
 }
 
 export type MaskLevel =
-  | 'light' // only mask a subset of inputs that’s deemed sensitive - password, credit card, telephone #, email. These are information we never want to capture.
+  | 'light' // only mask a subset of inputs that's deemed sensitive - password, credit card, telephone #, email. These are information we never want to capture.
   | 'medium' // mask all inputs
   | 'conservative'; // mask all inputs and all texts
 
@@ -138,8 +138,23 @@ export interface SessionReplayRemoteConfigFetch {
   getRemoteConfig: (sessionId?: number) => Promise<SessionReplayRemoteConfig | void>;
 }
 
+export interface SessionReplayConfigs {
+  localConfig: SessionReplayLocalConfig;
+  joinedConfig: SessionReplayJoinedConfig;
+  remoteConfig: SessionReplayRemoteConfig | undefined;
+}
 export interface SessionReplayJoinedConfigGenerator {
-  generateJoinedConfig: (sessionId?: string | number) => Promise<SessionReplayJoinedConfig>;
+  generateJoinedConfig: (sessionId?: string | number) => Promise<SessionReplayConfigs>;
+}
+
+export interface SessionReplayMetadata {
+  remoteConfig: SessionReplayRemoteConfig | undefined;
+  localConfig: SessionReplayLocalConfig;
+  joinedConfig: SessionReplayJoinedConfig;
+  framework?: {
+    name: string;
+    version: string;
+  };
 }
 
 export interface SessionReplayVersion {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -156,7 +156,7 @@ export interface SessionReplayMetadata {
     version: string;
   };
   sessionId: string | number | undefined;
-  hash?: number;
+  hashValue?: number;
   sampleRate: number;
   replaySDKType: string;
   replaySDKVersion: string | undefined;

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -155,6 +155,9 @@ export interface SessionReplayMetadata {
     name: string;
     version: string;
   };
+  sessionId: string | number | undefined;
+  hash?: number;
+  sampleRate: number;
 }
 
 export interface SessionReplayVersion {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -158,6 +158,10 @@ export interface SessionReplayMetadata {
   sessionId: string | number | undefined;
   hash?: number;
   sampleRate: number;
+  replaySDKType: string;
+  replaySDKVersion: string | undefined;
+  standaloneSDKType: string;
+  standaloneSDKVersion: string | undefined;
 }
 
 export interface SessionReplayVersion {

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -30,4 +30,5 @@ export enum CustomRRwebEvent {
   GET_SR_PROPS = 'get-sr-props',
   DEBUG_INFO = 'debug-info',
   FETCH_REQUEST = 'fetch-request',
+  METADATA = 'metadata',
 }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -250,7 +250,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   focusListener = () => {
     // Restart recording on focus to ensure that when user
     // switches tabs, we take a full snapshot
-    void this.recordEvents();
+    void this.recordEvents(false);
   };
 
   /**
@@ -373,7 +373,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     return plugins.length > 0 ? plugins : undefined;
   }
 
-  async recordEvents() {
+  async recordEvents(shouldLogMetadata = true) {
     const config = this.config;
     const shouldRecord = this.getShouldRecord();
     const sessionId = this.identifiers?.sessionId;
@@ -451,11 +451,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
       });
 
       void this.addCustomRRWebEvent(CustomRRwebEvent.DEBUG_INFO);
-      void this.addCustomRRWebEvent(CustomRRwebEvent.METADATA, this.metadata);
-
+      if (shouldLogMetadata) {
+        void this.addCustomRRWebEvent(CustomRRwebEvent.METADATA, this.metadata);
+      }
     } catch (error) {
       this.loggerProvider.warn('Failed to initialize session replay:', error);
     }
+
   }
 
   addCustomRRWebEvent = async (

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -532,14 +532,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
     replaySDKVersion: string | undefined,
     standaloneSDKVersion: string | undefined,
   ) {
-    const hash = sessionId?.toString() ? generateHashCode(sessionId.toString()) : undefined;
+    const hashValue = sessionId?.toString() ? generateHashCode(sessionId.toString()) : undefined;
 
     this.metadata = {
       joinedConfig,
       localConfig,
       remoteConfig,
       sessionId,
-      hash,
+      hashValue,
       sampleRate: joinedConfig.sampleRate,
       replaySDKType: '@amplitude/plugin-session-replay-browser',
       replaySDKVersion,

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -95,7 +95,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     describe('with successful sampling config fetch', () => {
       test('should use sample_rate and capture_enabled from API', async () => {
         getRemoteConfigMockImplementation({ samplingConfig });
-        const config = await joinedConfigGenerator.generateJoinedConfig(123);
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig(123);
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
@@ -105,7 +105,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
       });
       test('should use sample_rate only from API', async () => {
         getRemoteConfigMockImplementation({ samplingConfig: { sample_rate: samplingConfig.sample_rate } });
-        const config = await joinedConfigGenerator.generateJoinedConfig(123);
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig(123);
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
@@ -115,7 +115,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
       });
       test('should use capture_enabled only from API', async () => {
         getRemoteConfigMockImplementation({ samplingConfig: { capture_enabled: false } });
-        const config = await joinedConfigGenerator.generateJoinedConfig(123);
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig(123);
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
@@ -124,7 +124,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
       });
       test('should set captureEnabled to true if no values returned from API', async () => {
         getRemoteConfigMockImplementation({ samplingConfig: {} });
-        const config = await joinedConfigGenerator.generateJoinedConfig(123);
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig(123);
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
@@ -135,7 +135,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     describe('with unsuccessful sampling config fetch', () => {
       test('should set captureEnabled to true', async () => {
         getRemoteConfigMock.mockRejectedValue({});
-        const config = await joinedConfigGenerator.generateJoinedConfig(123);
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig(123);
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
@@ -159,7 +159,8 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         });
         remoteConfigFetch.getRemoteConfig = getRemoteConfigMock;
         new SessionReplayJoinedConfigGenerator(remoteConfigFetch, mockLocalConfig);
-        return configGenerator.generateJoinedConfig(123);
+        const { joinedConfig } = await configGenerator.generateJoinedConfig(123);
+        return joinedConfig;
       };
 
       test('should join string block selector from API', async () => {
@@ -264,7 +265,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         getRemoteConfigMockImplementation({ privacyConfig });
         mockRemoteConfigFetch.getRemoteConfig = getRemoteConfigMock;
         const configGenerator = new SessionReplayJoinedConfigGenerator(mockRemoteConfigFetch, mockLocalConfig);
-        const config = await configGenerator.generateJoinedConfig(123);
+        const { joinedConfig: config } = await configGenerator.generateJoinedConfig(123);
         expect(config).toEqual({
           ...mockLocalConfig,
           captureEnabled: true,


### PR DESCRIPTION
### Summary

Adding metadata event that propagates as an rrweb event. This will be processed to be used later as metadata information including versions and debugging. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
