### PR TITLE
 fix(plugin-page-view-tracking-browser): do not restore history.pushState on teardown

### DIFF
--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -537,7 +537,7 @@ describe('pageViewTrackingPlugin', () => {
       expect(history.pushState).not.toBe(originalPushState);
       await plugin.teardown?.();
       expect(history.pushState).not.toBe(originalPushState);
-      // eslint-enable @typescript-eslint/unbound-method
+      /* eslint-enable @typescript-eslint/unbound-method */
     });
   });
 

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -524,6 +524,21 @@ describe('pageViewTrackingPlugin', () => {
       await plugin.teardown?.();
       expect(removeEventListener).toHaveBeenCalledTimes(1);
     });
+
+    test('should not restore history.pushState after teardown', async () => {
+      /* eslint-disable @typescript-eslint/unbound-method */
+      const history = window.history;
+      const originalPushState = history.pushState;
+      const plugin = pageViewTrackingPlugin({
+        trackHistoryChanges: 'all',
+      });
+      expect(history.pushState).toBe(originalPushState);
+      await plugin.setup?.(mockConfig, createInstance());
+      expect(history.pushState).not.toBe(originalPushState);
+      await plugin.teardown?.();
+      expect(history.pushState).not.toBe(originalPushState);
+      // eslint-enable @typescript-eslint/unbound-method
+    });
   });
 
   test('shouldTrackHistoryPageView pathOnly option', () => {

--- a/test-server/browser-sdk/page-view-history.html
+++ b/test-server/browser-sdk/page-view-history.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/amplitude.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page View with History Push State tracking</title>
+  </head>
+  <body>
+    <h1>Page One</h1>
+    <div id="app">
+      Page View with History Push State tracking
+    </div>
+    <div>
+      When clicking on the button below, it will change the URL to /new-page,
+      without reloading the page. The page view plugin will track this change
+      and send an event to Amplitude with the new URL.
+    </div>
+    <button id="navigate">Go to /new-page</button>
+    <div style="margin-top: 20px;">
+      Clicking the button below will tear down the page view plugin. So that
+      if you visit /new-page again, it will not track the page view.
+    </div>
+    <button id="teardown">Tear down page view plugin</button>
+
+    <script>
+      document.getElementById('navigate').addEventListener('click', function() {
+        const newUrl = '/new-page';
+        
+        // Push new state to the browser history
+        history.pushState({ page: 'new-page' }, 'New Page', newUrl);
+  
+        // Optionally, update the content without reloading
+        document.querySelector('h1').innerText = 'Page 2: ' + location.pathname;
+  
+        // Dispatch a popstate event if your routing or tracking system needs it
+        const popStateEvent = new PopStateEvent('popstate', { state: { page: 'new-page' } });
+        dispatchEvent(popStateEvent);
+      });
+    </script>
+    <script type="module">
+      import * as amplitude from '@amplitude/analytics-browser';
+      import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
+      window.amplitude = amplitude;
+      const pageViewPlugin = pageViewTrackingPlugin({
+        trackHistoryChanges: 'all',
+      });
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY,
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
+      );
+      amplitude.add(pageViewPlugin);
+
+      document.getElementById('teardown').addEventListener('click', function() {
+        // Remove the page view plugin
+        pageViewPlugin.teardown();
+        console.log('Page view plugin removed');
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Summary

When we cal teardown on page view plugin, `window.history.pushState` is restored to whatever it was before we overwrote it. The problem with this is that if another plugin also overwrites `window.history.pushState` after we do, and then we restore it, their implementation will get overwritten to.

This PR stops the restoration of `pushState` and what it does instead is adds a flag `isTracking` that needs to be `true` for page tracking to work. So when "setup" is called, `isTracking=true`. When "teardown" is called", "isTracking=false" again and then the `history.pushState` callback becomes essentially a "no-op"

Also added a page to test-server that lets you manually test this.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
