### PR TITLE
chore(segment-session-replay-plugin): set publishConfig and remove private status in package.json

### DIFF
--- a/packages/segment-session-replay-plugin/package.json
+++ b/packages/segment-session-replay-plugin/package.json
@@ -18,10 +18,12 @@
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
-  "private": true,
   "files": [
     "lib"
   ],


### PR DESCRIPTION
### Summary

PR updates `package.json` for `segment-session-replay-plugin` to allow the package to be published to NPM.
- Removes the private status
- Adds a `publishConfig`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
