### PR TITLE
fix(docs): correct installation command syntax in README for segment-session-replay-plugin

### DIFF
--- a/packages/segment-session-replay-plugin/README.md
+++ b/packages/segment-session-replay-plugin/README.md
@@ -16,10 +16,10 @@ Replay SDK is included in this package, and does not need to be installed separa
 
 ```sh
 # npm
-npm install @amplitude/segment-session-replay-plugin" --save
+npm install @amplitude/segment-session-replay-plugin --save
 
 # yarn
-yarn add @amplitude/segment-session-replay-plugin"
+yarn add @amplitude/segment-session-replay-plugin
 ```
 
 ## Usage


### PR DESCRIPTION
### Summary

Correct installation command syntax in README for segment-session-replay-plugin.  Previously there was an unclosed quote which caused issues when copying and pasting the command.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No, docs change.
