### PR TITLE
fix(react-native-session-replay): prevent crash on Android with old architecture 

### DIFF
--- a/packages/plugin-session-replay-react-native/android/src/main/java/com/amplitude/pluginsessionreplayreactnative/PluginSessionReplayReactNativeModule.kt
+++ b/packages/plugin-session-replay-react-native/android/src/main/java/com/amplitude/pluginsessionreplayreactnative/PluginSessionReplayReactNativeModule.kt
@@ -109,6 +109,8 @@ class PluginSessionReplayReactNativeModule(private val reactContext: ReactApplic
   }
 
   override fun invalidate() {
-    sessionReplay.shutdown()
+    if (::sessionReplay.isInitialized) {
+      sessionReplay.shutdown()
+    }
   }
 }


### PR DESCRIPTION
This change adds compatibility checks to prevent crashes when the plugin is used with apps running on the old React Native architecture instead of the new architecture. Ensures the plugin works reliably across different React Native configurations.

Fixes https://github.com/amplitude/Amplitude-TypeScript/issues/1028

### Summary

Fixes https://github.com/amplitude/Amplitude-TypeScript/issues/1028

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
