### PR TITLE
fix(unified): update version library to enrichment type

### DIFF
--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/unified",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.2",
   "description": "Official Amplitude SDK for Web analytics, experiment, session replay, and more.",
   "keywords": [
     "amplitude",

--- a/packages/unified/src/index.ts
+++ b/packages/unified/src/index.ts
@@ -1,6 +1,6 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import client from './unified-client-factory';
 export { createInstance } from './unified-client-factory';
-// eslint-disable-next-line @typescript-eslint/unbound-method
 export const {
   initAll,
   experiment,

--- a/packages/unified/src/library.ts
+++ b/packages/unified/src/library.ts
@@ -3,9 +3,9 @@ import { VERSION } from './version';
 
 const LIBPREFIX = 'amplitude-ts-unified';
 
-export const libraryPlugin = (): Types.BeforePlugin => {
+export const libraryPlugin = (): Types.EnrichmentPlugin => {
   return {
-    type: 'before',
+    type: 'enrichment',
     name: '@amplitude/unified-library-plugin',
     async execute(event: Types.Event): Promise<Types.Event | null> {
       event.library = `${LIBPREFIX}/${VERSION}-${event.library ?? ''}`;

--- a/packages/unified/src/unified.ts
+++ b/packages/unified/src/unified.ts
@@ -67,8 +67,8 @@ export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient 
       instanceName: unifiedOptions?.instanceName,
     };
 
-    await super.init(apiKey, { ...unifiedOptions?.analytics, ...sharedOptions }).promise;
     super.add(libraryPlugin());
+    await super.init(apiKey, { ...unifiedOptions?.analytics, ...sharedOptions }).promise;
 
     await super.add(sessionReplayPlugin({ ...unifiedOptions?.sr, ...sharedOptions })).promise;
 

--- a/packages/unified/src/version.ts
+++ b/packages/unified/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.0.0-beta.0';
+export const VERSION = '1.0.0-beta.2';

--- a/packages/unified/test/library.test.ts
+++ b/packages/unified/test/library.test.ts
@@ -23,7 +23,7 @@ describe('libraryPlugin', () => {
   it('should have the correct plugin type and name', () => {
     const plugin = libraryPlugin();
 
-    expect(plugin.type).toBe('before');
+    expect(plugin.type).toBe('enrichment');
     expect(plugin.name).toBe('@amplitude/unified-library-plugin');
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

When dogfood the unified SDK on corp site, the event library was not changed and remained to be `amplitude-ts/2.17.6`. This PR changes the unified version library to enrichment type to be processed later than the version library of the browser sdk. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
