### PR TITLE
fix(analytics-browser): support autocapture.networkTracking as object

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -159,7 +159,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
 
     // TODO: the "this.config.networkTrackingOptions" should be taken out once we have
     // beta tested network tracking
-    if (isNetworkTrackingEnabled(this.config.autocapture) && !!this.config.networkTrackingOptions) {
+    if (isNetworkTrackingEnabled(this.config.autocapture)) {
       this.config.loggerProvider.debug('Adding network tracking plugin');
       await this.add(networkCapturePlugin(getNetworkTrackingConfig(this.config))).promise;
     }

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -157,8 +157,6 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient {
       await this.add(autocapturePlugin(getElementInteractionsConfig(this.config))).promise;
     }
 
-    // TODO: the "this.config.networkTrackingOptions" should be taken out once we have
-    // beta tested network tracking
     if (isNetworkTrackingEnabled(this.config.autocapture)) {
       this.config.loggerProvider.debug('Adding network tracking plugin');
       await this.add(networkCapturePlugin(getNetworkTrackingConfig(this.config))).promise;

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -9,11 +9,20 @@ import {
   NetworkTrackingOptions,
 } from '@amplitude/analytics-core';
 
+type AutocaptureOptionsDefaultAvailable = Pick<
+  AutocaptureOptions,
+  'pageViews' |
+  'sessions' |
+  'fileDownloads' |
+  'formInteractions' |
+  'attribution'
+>;
+
 /**
  * Returns false if autocapture === false or if autocapture[event],
  * otherwise returns true
  */
-const isTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined, event: keyof AutocaptureOptions) => {
+const isTrackingEnabled = (autocapture: AutocaptureOptionsDefaultAvailable | boolean | undefined, event: keyof AutocaptureOptionsDefaultAvailable) => {
   if (typeof autocapture === 'boolean') {
     return autocapture;
   }
@@ -42,9 +51,8 @@ export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boole
 
 /**
  * Returns true if
- * 1. autocapture === true
- * 2. if autocapture.networkTracking === true
- * 3. if autocapture.networkTracking === object
+ * 1. if autocapture.networkTracking === true
+ * 2. if autocapture.networkTracking === object
  * otherwise returns false
  */
 export const isNetworkTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) => {

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -9,6 +9,10 @@ import {
   NetworkTrackingOptions,
 } from '@amplitude/analytics-core';
 
+/**
+ * A subset of AutocaptureOptions that includes the autocapture features that
+ * are made available to users by default (even if "config.autocapture === undefined")
+ */
 type AutocaptureOptionsDefaultAvailable = Pick<
   AutocaptureOptions,
   'pageViews' | 'sessions' | 'fileDownloads' | 'formInteractions' | 'attribution'
@@ -16,7 +20,7 @@ type AutocaptureOptionsDefaultAvailable = Pick<
 
 /**
  * Returns false if autocapture === false or if autocapture[event],
- * otherwise returns true
+ * otherwise returns true (even if "config.autocapture === undefined")
  */
 const isTrackingEnabled = (
   autocapture: AutocaptureOptionsDefaultAvailable | boolean | undefined,

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -11,18 +11,17 @@ import {
 
 type AutocaptureOptionsDefaultAvailable = Pick<
   AutocaptureOptions,
-  'pageViews' |
-  'sessions' |
-  'fileDownloads' |
-  'formInteractions' |
-  'attribution'
+  'pageViews' | 'sessions' | 'fileDownloads' | 'formInteractions' | 'attribution'
 >;
 
 /**
  * Returns false if autocapture === false or if autocapture[event],
  * otherwise returns true
  */
-const isTrackingEnabled = (autocapture: AutocaptureOptionsDefaultAvailable | boolean | undefined, event: keyof AutocaptureOptionsDefaultAvailable) => {
+const isTrackingEnabled = (
+  autocapture: AutocaptureOptionsDefaultAvailable | boolean | undefined,
+  event: keyof AutocaptureOptionsDefaultAvailable,
+) => {
   if (typeof autocapture === 'boolean') {
     return autocapture;
   }
@@ -56,10 +55,6 @@ export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boole
  * otherwise returns false
  */
 export const isNetworkTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) => {
-  if (typeof autocapture === 'boolean') {
-    return autocapture;
-  }
-
   if (
     typeof autocapture === 'object' &&
     (autocapture.networkTracking === true || typeof autocapture.networkTracking === 'object')
@@ -104,8 +99,12 @@ export const getElementInteractionsConfig = (config: BrowserOptions): ElementInt
 };
 
 export const getNetworkTrackingConfig = (config: BrowserOptions): NetworkTrackingOptions | undefined => {
-  if (isNetworkTrackingEnabled(config.autocapture) && config.networkTrackingOptions) {
-    return config.networkTrackingOptions;
+  if (isNetworkTrackingEnabled(config.autocapture)) {
+    if (typeof config.autocapture === 'object' && typeof config.autocapture.networkTracking === 'object') {
+      return config.autocapture.networkTracking;
+    } else if (config.networkTrackingOptions) {
+      return config.networkTrackingOptions;
+    }
   }
   return;
 };

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -400,11 +400,12 @@ describe('browser-client', () => {
       expect(autocapturePlugin).toHaveBeenCalledTimes(0);
     });
 
-    test('should use network tracking plugin when autocapture is on', async () => {
+    test('should use network tracking plugin when autocapture.networkTracking is on', async () => {
       const networkTrackingPlugin = jest.spyOn(networkCapturePlugin, 'plugin');
       await client.init(apiKey, userId, {
-        autocapture: true,
-        networkTrackingOptions: {}, // TODO: may not need this in the future?
+        autocapture: {
+          networkTracking: true,
+        },
       }).promise;
       expect(networkTrackingPlugin).toHaveBeenCalledTimes(1);
     });

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -174,27 +174,40 @@ describe('isNetworkTrackingEnabled', () => {
   test('should return false when autocapture is undefined', () => {
     expect(isNetworkTrackingEnabled(undefined)).toBe(false);
   });
-  test('should return true when autocapture is true', () => {
-    expect(isNetworkTrackingEnabled(true)).toBe(true);
+
+  test('should return false when autocapture is true (explicit opt-in)', () => {
+    expect(isNetworkTrackingEnabled(true)).toBe(false);
   });
-  test('should return true when autocapture is an object with networkTracking set to true', () => {
+
+  test('should return true when autocapture.networkTracking is true', () => {
     expect(
       isNetworkTrackingEnabled({
         networkTracking: true,
       }),
     ).toBe(true);
   });
-  test.todo('should return true when autocapture is an object with networkTracking set to an object');
-  test('should return false when autocapture is an object with networkTracking set to false', () => {
+
+  test('should return true when autocapture.networkTracking is an object', () => {
+    expect(
+      isNetworkTrackingEnabled({
+        networkTracking: {},
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false when autocapture.networkTracking is false', () => {
     expect(
       isNetworkTrackingEnabled({
         networkTracking: false,
       }),
     ).toBe(false);
   });
-  test('should return false when autocapture is an object with networkTracking set to undefined', () => {
+
+  test('should return false when autocapture.networkTracking is undefined', () => {
     expect(
       isNetworkTrackingEnabled({
+        sessions: true,
+        pageViews: true,
         networkTracking: undefined,
       }),
     ).toBe(false);

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -171,6 +171,10 @@ describe('isAttributionTrackingEnabled', () => {
 });
 
 describe('isNetworkTrackingEnabled', () => {
+  test('should return false when autocapture is false', () => {
+    expect(isNetworkTrackingEnabled(false)).toBe(false);
+  });
+
   test('should return false when autocapture is undefined', () => {
     expect(isNetworkTrackingEnabled(undefined)).toBe(false);
   });

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -295,9 +295,54 @@ describe('getAttributionTrackingConfig', () => {
 });
 
 describe('getNetworkTrackingConfig', () => {
-  test('should return undefined when networkTracking is not defined', () => {
+  test('should return autocapture.networkTracking if it is an object', () => {
+    const autocapture = {
+      networkTracking: {
+        ignoreAmplitudeRequests: true,
+        ignoreHosts: ['example.com'],
+        captureRules: [
+          {
+            hosts: ['example.com'],
+            statusCodeRange: '500-599',
+          },
+        ],
+      },
+    };
     const config = getNetworkTrackingConfig({
-      networkTrackingOptions: undefined,
+      autocapture,
+    });
+    expect(typeof config).toBe('object');
+    expect(config).toEqual(autocapture.networkTracking);
+  });
+
+  test('should return "networkTrackingOptions" if is defined and autocapture.networkTracking=true (deprecated)', () => {
+    const autocapture = {
+      networkTracking: true,
+    };
+    const networkTrackingOptions = {
+      ignoreAmplitudeRequests: true,
+      ignoreHosts: ['example.com'],
+      captureRules: [
+        {
+          hosts: ['example.com'],
+          statusCodeRange: '500-599',
+        },
+      ],
+    };
+    const config = getNetworkTrackingConfig({
+      autocapture,
+      networkTrackingOptions,
+    });
+    expect(typeof config).toBe('object');
+    expect(config).toEqual(networkTrackingOptions);
+  });
+
+  test('should return undefined when autocapture is not defined', () => {
+    const autocapture = undefined;
+    const networkTrackingOptions = {};
+    const config = getNetworkTrackingConfig({
+      autocapture,
+      networkTrackingOptions,
     });
     expect(config).toBeUndefined();
   });
@@ -320,33 +365,6 @@ describe('getNetworkTrackingConfig', () => {
       },
     });
     expect(config).toBeUndefined();
-  });
-
-  test('should return default config when networkTracking is true', () => {
-    const config = getNetworkTrackingConfig({
-      autocapture: {
-        networkTracking: true,
-      },
-      networkTrackingOptions: {
-        ignoreAmplitudeRequests: false,
-        ignoreHosts: ['example.com'],
-        captureRules: [
-          {
-            hosts: ['example.com'],
-            statusCodeRange: '500-599',
-          },
-        ],
-      },
-    });
-
-    expect(config?.ignoreAmplitudeRequests).toBe(false);
-    expect(config?.ignoreHosts).toEqual(['example.com']);
-    expect(config?.captureRules).toEqual([
-      {
-        hosts: ['example.com'],
-        statusCodeRange: '500-599',
-      },
-    ]);
   });
 });
 

--- a/packages/analytics-core/src/types/browser-config.ts
+++ b/packages/analytics-core/src/types/browser-config.ts
@@ -163,7 +163,7 @@ export interface AutocaptureOptions {
    * Enables/disables network request tracking.
    * @defaultValue `false`
    */
-  networkTracking?: boolean;
+  networkTracking?: boolean | NetworkTrackingOptions;
 }
 
 export interface TrackingOptions {

--- a/packages/analytics-core/src/types/browser-config.ts
+++ b/packages/analytics-core/src/types/browser-config.ts
@@ -85,6 +85,7 @@ export interface ExternalBrowserConfig extends IConfig {
   /**
    * Captures network requests and responses.
    * @defaultValue `undefined`
+   * @deprecated use autocapture.networkTracking instead
    */
   networkTrackingOptions?: NetworkTrackingOptions;
 }

--- a/test-server/browser-sdk/index.html
+++ b/test-server/browser-sdk/index.html
@@ -17,14 +17,16 @@
         import.meta.env.VITE_AMPLITUDE_API_KEY,
         import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
         {
-          autocapture: true,
-          networkTrackingOptions: {
-            ignoreAmplitudeRequests: false,
-            ignoreHosts: [],
-            captureRules: [
-              {hosts: ['*.amplitude.com'], statusCodeRange: '400-599'},
-              {hosts: ['httpstat.us'], statusCodeRange: '400-599'},
-            ],
+          autocapture: {
+            // networkTracking: true,
+            networkTracking: {
+              ignoreAmplitudeRequests: false,
+              ignoreHosts: [],
+              captureRules: [
+                {hosts: ['*.amplitude.com'], statusCodeRange: '400-599'},
+                {hosts: ['httpstat.us'], statusCodeRange: '400-599'},
+              ],
+            },
           },
         }
       );


### PR DESCRIPTION
### Summary

* Currently only "config.networkTrackingOptions" is used to defined network tracking. This PR adds "config.autocapture.networkTracking = {}" as an option too
* Also, this PR makes "autocapture.networkTracking" explicitly opt-in, meaning you have to set `autocapture.networkTracking` to `true` or an object for `networkTracking` to be enabled.

## Extra Change
* I also changed the type `isTrackingEnabled(autocapture: AutocaptureOptions, ...)` to `isTrackingEnabled(autocapture: AutocaptureOptionsDefaultAvailable, ...)`
  * `AutocaptureOptionsDefaultAvailable` is a new type that's a subset of AutocaptureOptions that only includes `'pageViews' | 'sessions' | 'fileDownloads' | 'formInteractions' | 'attribution'`
  * This is to prevent future autocapture features from calling "isTrackingEnabled" and being enabled when autocapture is undefined

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
