### PR TITLE
fix(session-replay): map the type to the correct sdk plugin

### DIFF
--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -158,7 +158,7 @@ export interface SessionReplayMetadata {
   sessionId: string | number | undefined;
   hashValue?: number;
   sampleRate: number;
-  replaySDKType: string;
+  replaySDKType: string | null;
   replaySDKVersion: string | undefined;
   standaloneSDKType: string;
   standaloneSDKVersion: string | undefined;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -105,7 +105,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
     );
     this.config = joinedConfig;
 
-    this.setMetadata(options.sessionId, joinedConfig, localConfig, remoteConfig, options.version?.version, VERSION);
+    this.setMetadata(
+      options.sessionId,
+      joinedConfig,
+      localConfig,
+      remoteConfig,
+      options.version?.version,
+      VERSION,
+      options.version?.type,
+    );
 
     if (options.sessionId && this.config.interactionConfig?.enabled) {
       const scrollWatcher = ScrollWatcher.default(
@@ -524,6 +532,18 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.sendEvents();
   }
 
+  private mapSDKType(sdkType: string | undefined) {
+    if (sdkType === 'plugin') {
+      return '@amplitude/plugin-session-replay-browser';
+    }
+
+    if (sdkType === 'segment') {
+      return '@amplitude/segment-session-replay-plugin';
+    }
+
+    return null;
+  }
+
   private setMetadata(
     sessionId: string | number | undefined,
     joinedConfig: SessionReplayJoinedConfig,
@@ -531,6 +551,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     remoteConfig: SessionReplayRemoteConfig | undefined,
     replaySDKVersion: string | undefined,
     standaloneSDKVersion: string | undefined,
+    sdkType: string | undefined,
   ) {
     const hashValue = sessionId?.toString() ? generateHashCode(sessionId.toString()) : undefined;
 
@@ -541,7 +562,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       sessionId,
       hashValue,
       sampleRate: joinedConfig.sampleRate,
-      replaySDKType: '@amplitude/plugin-session-replay-browser',
+      replaySDKType: this.mapSDKType(sdkType),
       replaySDKVersion,
       standaloneSDKType: '@amplitude/session-replay-browser',
       standaloneSDKVersion,

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1481,5 +1481,14 @@ describe('SessionReplay', () => {
       const metadata = (sessionReplay as any).metadata;
       expect(metadata?.replaySDKVersion).toBe(customVersion);
     });
+
+    test('should set replaySDKType to @amplitude/segment-session-replay-plugin if type is segment', async () => {
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        version: { version: '1.8.7', type: 'segment' },
+      }).promise;
+      const metadata = (sessionReplay as any).metadata;
+      expect(metadata?.replaySDKType).toBe('@amplitude/segment-session-replay-plugin');
+    });
   });
 });


### PR DESCRIPTION
### Summary

Correct type mapping for SDK Plugins that are not Amplitude specific such as Segment.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
