### PR TITLE
fix(plugin-network-capture-browser): default status=undefined as 0

### DIFF
--- a/packages/analytics-core/src/network-request-event.ts
+++ b/packages/analytics-core/src/network-request-event.ts
@@ -310,7 +310,7 @@ export class NetworkRequestEvent {
     public readonly startTime: number,
     public readonly url?: string,
     public readonly requestWrapper?: IRequestWrapper,
-    public readonly status?: number,
+    public readonly status: number = 0,
     public readonly duration?: number,
     public readonly responseWrapper?: IResponseWrapper,
     public readonly error?: {

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -380,6 +380,7 @@ describe('NetworkObserver', () => {
         method: 'GET',
         url: 'https://api.example.com/data',
         startTime: Date.now(),
+        status: 200,
         toSerializable: () => ({ ...mockEvent }),
       };
 
@@ -830,5 +831,12 @@ describe('RequestWrapperFetch', () => {
 describe('networkObserver', () => {
   test('singleton should be an instance of NetworkObserver', () => {
     expect(networkObserver).toBeInstanceOf(NetworkObserver);
+  });
+});
+
+describe('NetworkRequestEvent', () => {
+  test('status should be 0 if not set', () => {
+    const event = new NetworkRequestEvent('xhr', 'GET', 0, 0, 'https://api.example.com/data');
+    expect(event.status).toBe(0);
   });
 });

--- a/packages/plugin-network-capture-browser/test/autocapture-plugin/track-network-event.test.ts
+++ b/packages/plugin-network-capture-browser/test/autocapture-plugin/track-network-event.test.ts
@@ -281,6 +281,22 @@ describe('track-network-event', () => {
   });
 
   describe('shouldTrackNetworkEvent returns false when', () => {
+    test('status code is empty', () => {
+      const networkEvent = new NetworkRequestEvent(
+        'fetch',
+        'POST',
+        0,
+        0,
+        'https://example.com/track',
+        // leave status empty
+      );
+      const result = shouldTrackNetworkEvent(
+        networkEvent,
+        localConfig.networkTrackingOptions as NetworkTrackingOptions,
+      );
+      expect(result).toBe(false);
+    });
+
     test('domain is amplitude.com', () => {
       networkEvent.url = 'https://api.amplitude.com/track';
       expect(shouldTrackNetworkEvent(networkEvent)).toBe(false);

--- a/test-server/browser-sdk/fetch.html
+++ b/test-server/browser-sdk/fetch.html
@@ -17,7 +17,9 @@
         import.meta.env.VITE_AMPLITUDE_API_KEY,
         import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
         {
-          autocapture: true,
+          autocapture: {
+            networkTracking: true,
+          },
           networkTrackingOptions: {
             ignoreAmplitudeRequests: false,
             ignoreHosts: [],


### PR DESCRIPTION
### Summary

If NetworkRequestEvent encounters status=undefined in it's constructor, set it to 0 by default. Status 0 is a default status meaning that no response came back.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
