### PR TITLE
fix(unified): rename sr to sessionReplay

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -14,7 +14,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
   config: BrowserConfig;
   options: SessionReplayOptions;
   srInitOptions: sessionReplay.SessionReplayOptions;
-  sr: AmplitudeSessionReplay = {
+  sessionReplay: AmplitudeSessionReplay = {
     flush: sessionReplay.flush,
     getSessionId: sessionReplay.getSessionId,
     getSessionReplayProperties: sessionReplay.getSessionReplayProperties,
@@ -79,7 +79,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         experimental: this.options.experimental,
       };
 
-      await this.sr.init(config.apiKey, this.srInitOptions).promise;
+      await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;
     } catch (error) {
       /* istanbul ignore next */
       config?.loggerProvider.error(`Session Replay: Failed to initialize due to ${(error as Error).message}`);
@@ -88,9 +88,9 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
 
   async onSessionIdChanged(sessionId: number): Promise<void> {
     this.config.loggerProvider.debug(
-      `Analytics session id is changed to ${sessionId}, SR session id is ${String(this.sr.getSessionId())}.`,
+      `Analytics session id is changed to ${sessionId}, SR session id is ${String(this.sessionReplay.getSessionId())}.`,
     );
-    await this.sr.setSessionId(sessionId).promise;
+    await this.sessionReplay.setSessionId(sessionId).promise;
   }
 
   async onOptOutChanged(optOut: boolean): Promise<void> {
@@ -99,12 +99,12 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         optOut ? 'sessionReplay.shutdown()' : 'sessionReplay.init()'
       }.`,
     );
-    // TODO: compare optOut with this.sr.getOptOut().
+    // TODO: compare optOut with this.sessionReplay.getOptOut().
     // Need to add getOptOut() to the interface AmplitudeSessionReplay first.
     if (optOut) {
-      this.sr.shutdown();
+      this.sessionReplay.shutdown();
     } else {
-      await this.sr.init(this.config.apiKey, this.srInitOptions).promise;
+      await this.sessionReplay.init(this.config.apiKey, this.srInitOptions).promise;
     }
   }
 
@@ -115,11 +115,11 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         if (sessionId) {
           // On event, synchronize the session id to the custom session id from the event. This may
           // suffer from offline/delayed events messing up the state stored
-          if (sessionId !== this.sr.getSessionId()) {
-            await this.sr.setSessionId(sessionId).promise;
+          if (sessionId !== this.sessionReplay.getSessionId()) {
+            await this.sessionReplay.setSessionId(sessionId).promise;
           }
 
-          const sessionRecordingProperties = this.sr.getSessionReplayProperties();
+          const sessionRecordingProperties = this.sessionReplay.getSessionReplayProperties();
           event.event_properties = {
             ...event.event_properties,
             ...sessionRecordingProperties,
@@ -130,14 +130,14 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         // Choosing not to read from event object here, concerned about offline/delayed events messing up the state stored
         // in SR.
         const sessionId: string | number | undefined = this.config.sessionId;
-        if (sessionId && sessionId !== this.sr.getSessionId()) {
-          await this.sr.setSessionId(sessionId).promise;
+        if (sessionId && sessionId !== this.sessionReplay.getSessionId()) {
+          await this.sessionReplay.setSessionId(sessionId).promise;
         }
 
         // Treating config.sessionId as source of truth, if the event's session id doesn't match, the
         // event is not of the current session (offline/late events). In that case, don't tag the events
         if (sessionId && sessionId === event.session_id) {
-          const sessionRecordingProperties = this.sr.getSessionReplayProperties();
+          const sessionRecordingProperties = this.sessionReplay.getSessionReplayProperties();
           event.event_properties = {
             ...event.event_properties,
             ...sessionRecordingProperties,
@@ -155,7 +155,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
 
   async teardown(): Promise<void> {
     try {
-      this.sr.shutdown();
+      this.sessionReplay.shutdown();
       // the following are initialized in setup() which will always be called first
       // here we reset them to null to prevent memory leaks
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -168,7 +168,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
   }
 
   getSessionReplayProperties() {
-    return this.sr.getSessionReplayProperties();
+    return this.sessionReplay.getSessionReplayProperties();
   }
 }
 

--- a/packages/unified/README.md
+++ b/packages/unified/README.md
@@ -45,7 +45,7 @@ initAll('YOUR_API_KEY', {
   },
   
   // Session Replay options
-  sr: {
+  sessionReplay: {
     // Session Replay configuration options
   },
   
@@ -65,7 +65,7 @@ import {
   track, 
   identify, 
   experiment, 
-  sr 
+  sessionReplay 
 } from '@amplitude/unified';
 
 // Track events
@@ -78,7 +78,7 @@ identify(new Identify().set('userType', 'premium'));
 const variant = await experiment.fetch('experiment-key');
 
 // Access Session Replay features
-sr.startRecording();
+sessionReplay.flush();
 ```
 
 ## Configuration Options

--- a/packages/unified/src/index.ts
+++ b/packages/unified/src/index.ts
@@ -4,7 +4,7 @@ export { createInstance } from './unified-client-factory';
 export const {
   initAll,
   experiment,
-  sr,
+  sessionReplay,
   add,
   extendSession,
   flush,

--- a/packages/unified/src/unified-client-factory.ts
+++ b/packages/unified/src/unified-client-factory.ts
@@ -5,7 +5,7 @@ export const createInstance = (): UnifiedClient => {
   const client = new AmplitudeUnified();
   return {
     experiment: client.experiment,
-    sr: client.sr,
+    sessionReplay: client.sessionReplay,
     initAll: debugWrapper(
       client.initAll.bind(client),
       'initAll',

--- a/packages/unified/src/unified.ts
+++ b/packages/unified/src/unified.ts
@@ -21,20 +21,20 @@ export interface UnifiedSharedOptions {
 
 export type UnifiedOptions = UnifiedSharedOptions & {
   analytics?: BrowserOptions;
-  sr?: Omit<SessionReplayOptions, keyof UnifiedSharedOptions>;
+  sessionReplay?: Omit<SessionReplayOptions, keyof UnifiedSharedOptions>;
   experiment?: Omit<ExperimentPluginConfig, keyof UnifiedSharedOptions>;
 };
 
 export interface UnifiedClient extends BrowserClient {
   initAll(apiKey: string, unifiedOptions?: UnifiedOptions): Promise<void>;
-  sr: AmplitudeSessionReplay;
+  sessionReplay: AmplitudeSessionReplay;
   experiment: IExperimentClient | undefined;
 }
 
 export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  sr: AmplitudeSessionReplay;
+  sessionReplay: AmplitudeSessionReplay;
 
   get experiment(): IExperimentClient | undefined {
     // Return when init() or initAll() is not called
@@ -70,7 +70,7 @@ export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient 
     super.add(libraryPlugin());
     await super.init(apiKey, { ...unifiedOptions?.analytics, ...sharedOptions }).promise;
 
-    await super.add(sessionReplayPlugin({ ...unifiedOptions?.sr, ...sharedOptions })).promise;
+    await super.add(sessionReplayPlugin({ ...unifiedOptions?.sessionReplay, ...sharedOptions })).promise;
 
     await super.add(experimentPlugin({ ...unifiedOptions?.experiment, ...sharedOptions })).promise;
 
@@ -78,7 +78,7 @@ export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient 
     if (srPlugin === undefined) {
       this.config.loggerProvider.debug(`${SessionReplayPlugin.pluginName} plugin is not found.`);
     } else {
-      this.sr = (srPlugin as SessionReplayPlugin).sr;
+      this.sessionReplay = (srPlugin as SessionReplayPlugin).sessionReplay;
     }
   }
 

--- a/packages/unified/test/unified-client-factory.test.ts
+++ b/packages/unified/test/unified-client-factory.test.ts
@@ -2,7 +2,7 @@ import instance from '../src/unified-client-factory';
 
 test('should create a UnifiedClient instance with expected methods', () => {
   expect(instance).toHaveProperty('experiment');
-  expect(instance).toHaveProperty('sr');
+  expect(instance).toHaveProperty('sessionReplay');
   expect(typeof instance.initAll).toBe('function');
   expect(typeof instance.init).toBe('function');
   expect(typeof instance.add).toBe('function');

--- a/packages/unified/test/unified.test.ts
+++ b/packages/unified/test/unified.test.ts
@@ -27,12 +27,12 @@ describe('AmplitudeUnified', () => {
       undefined,
     ])('should initialize all plugins and assign sr and experiment properties', async (unifiedOptions) => {
       const client = new AmplitudeUnified();
-      expect(client.sr).toBeUndefined();
+      expect(client.sessionReplay).toBeUndefined();
       expect(client.experiment).toBeUndefined();
 
       await client.initAll('test-api-key', unifiedOptions);
 
-      expect(client.sr).toBeDefined();
+      expect(client.sessionReplay).toBeDefined();
       expect(client.experiment).toBeDefined();
     });
 
@@ -43,7 +43,7 @@ describe('AmplitudeUnified', () => {
         if (name === SessionReplayPlugin.pluginName) return undefined;
         return originalPlugin(name);
       });
-      expect(client.sr).toBeUndefined();
+      expect(client.sessionReplay).toBeUndefined();
       expect(client.experiment).toBeUndefined();
 
       await client.initAll('test-api-key', {
@@ -52,7 +52,7 @@ describe('AmplitudeUnified', () => {
         },
       });
 
-      expect(client.sr).toBeUndefined();
+      expect(client.sessionReplay).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${SessionReplayPlugin.pluginName} plugin is not found.`);
       expect(client.experiment).toBeDefined();
     });
@@ -62,7 +62,7 @@ describe('AmplitudeUnified', () => {
       jest.spyOn(client, 'plugins').mockImplementation((_) => {
         return [];
       });
-      expect(client.sr).toBeUndefined();
+      expect(client.sessionReplay).toBeUndefined();
       expect(client.experiment).toBeUndefined();
 
       await client.initAll('test-api-key', {
@@ -71,7 +71,7 @@ describe('AmplitudeUnified', () => {
         },
       });
 
-      expect(client.sr).toBeDefined();
+      expect(client.sessionReplay).toBeDefined();
       expect(client.experiment).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${ExperimentPlugin.pluginName} plugin is not found.`);
     });
@@ -81,7 +81,7 @@ describe('AmplitudeUnified', () => {
       jest.spyOn(client, 'plugins').mockImplementation((_) => {
         return [];
       });
-      expect(client.sr).toBeUndefined();
+      expect(client.sessionReplay).toBeUndefined();
       expect(client.experiment).toBeUndefined();
 
       await client.initAll('test-api-key', {
@@ -90,7 +90,7 @@ describe('AmplitudeUnified', () => {
         },
       });
 
-      expect(client.sr).toBeDefined();
+      expect(client.sessionReplay).toBeDefined();
       expect(client.experiment).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${ExperimentPlugin.pluginName} plugin is not found.`);
     });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Rename `sr` to `sessionReplay` in unified SDK. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
