### PR TITLE
chore: fix typo in tests

### DIFF
--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -138,7 +138,7 @@ describe('browser-client', () => {
       expect(client.getUserId()).toBe(undefined);
     });
 
-    test('should set initalize with undefined user id', async () => {
+    test('should set initialize with undefined user id', async () => {
       client.setOptOut(true);
       await client.init(apiKey, undefined).promise;
       expect(client.getUserId()).toBe(undefined);

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -191,7 +191,7 @@ describe('SessionReplayPlugin', () => {
       });
     });
 
-    test('should call initalize on session replay sdk', async () => {
+    test('should call initialize on session replay sdk', async () => {
       const sessionReplay = new SessionReplayPlugin({
         sampleRate: 0.4,
         privacyConfig: {
@@ -222,7 +222,7 @@ describe('SessionReplayPlugin', () => {
       });
     });
 
-    test('should call initalize on session replay sdk with custom server urls', async () => {
+    test('should call initialize on session replay sdk with custom server urls', async () => {
       const configServerUrl = 'http://localhost:3000';
       const trackServerUrl = 'http://localhost:3001';
 


### PR DESCRIPTION
## Summary
- correct `initialize` typos in tests

## Testing
- `npm test`