### PR TITLE
Fix cookie parsing without spaces

### DIFF
--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -51,7 +51,8 @@ export class CookieStorage<T> implements Storage<T> {
 
   async getRaw(key: string): Promise<string | undefined> {
     const globalScope = getGlobalScope();
-    const cookie = globalScope?.document?.cookie.split('; ') ?? [];
+    const cookieStr = globalScope?.document?.cookie ?? '';
+    const cookie = cookieStr.split(/;\s*/);
     const match = cookie.find((c) => c.indexOf(key + '=') === 0);
     if (!match) {
       return undefined;

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -57,6 +57,16 @@ describe('cookies', () => {
       await cookies.remove('hello');
     });
 
+    test('should parse cookies without spaces', async () => {
+      const cookies = new CookieStorage();
+      const value = { b: 2 };
+      const encodedValue = btoa(encodeURIComponent(JSON.stringify(value)));
+      jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValueOnce({
+        document: { cookie: `hello=${encodedValue};hello2=${encodedValue}` },
+      } as unknown as typeof globalThis);
+      expect(await cookies.get('hello2')).toEqual(value);
+    });
+
     test('should return undefined when global scope is not defined', async () => {
       const cookies = new CookieStorage<number[]>();
       await cookies.set('hello', [1]);


### PR DESCRIPTION
## Summary
- handle cookies without spaces between entries
- add regression test for cookie parsing

## Testing
- `yarn test:unit`