### PR TITLE
chore: fix documentation + remove unused code

### DIFF
--- a/packages/plugin-network-capture-browser/README.md
+++ b/packages/plugin-network-capture-browser/README.md
@@ -10,7 +10,7 @@
 
 ## TODO: Re-write this README.md to match plugin-network-capture
 
-Browser SDK plugin for autocapture.
+Browser SDK plugin for network capture.
 
 ## Installation
 
@@ -26,9 +26,9 @@ yarn add @amplitude/plugin-network-capture-browser@beta
 
 ## Usage
 
-This plugin works on top of the Amplitude Browser SDK, generating auto-tracked events and sending to Amplitude.
+This plugin works on top of the Amplitude Browser SDK, and tracks network request events
 
-To use this plugin, you need to install `@amplitude/analytics-browser` version `v1.9.1` or later.
+To use this plugin, you need to install `@amplitude/plugin-network-capture-browser`
 
 ### 1. Import Amplitude packages
 

--- a/packages/plugin-network-capture-browser/src/network-capture-plugin.ts
+++ b/packages/plugin-network-capture-browser/src/network-capture-plugin.ts
@@ -3,7 +3,6 @@ import {
   BrowserClient,
   BrowserConfig,
   EnrichmentPlugin,
-  ElementInteractionsOptions,
   NetworkRequestEvent,
   networkObserver,
   NetworkEventCallback,
@@ -22,11 +21,6 @@ declare global {
 }
 
 export type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
-
-export type AutoCaptureOptionsWithDefaults = Required<
-  Pick<ElementInteractionsOptions, 'debounceTime' | 'cssSelectorAllowlist' | 'actionClickAllowlist'>
-> &
-  ElementInteractionsOptions;
 
 export enum ObservablesEnum {
   NetworkObservable = 'networkObservable',


### PR DESCRIPTION
resulting from copy-pasting autocapture to network capture


### Summary

This plugin was created by copying autocapture-browser and then renaming some stuff and re-writing. Some of the docoumentation wasn't updated properly. And there was a bit of unused code.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
