### PR TITLE
chore: enhance publish workflow with from-package option

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -85,7 +85,7 @@ jobs:
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version
-        if: env.PUBLISH_FROM != 'from-package'
+        if: ${{ env.PUBLISH_FROM != 'from-package' }}
         run: |
           echo "Running lerna version..."
           OUTPUT=$(GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --create-release github 2>&1)


### PR DESCRIPTION
### Summary

- Force to fail the job when there is no changed package to version 
- Adds `publishFrom` input parameter to support both `from-git` (default) and `from-package` publishing modes. The version creation step is now conditional and only runs for `from-git` mode.

### Checklist
* [x] Does your PR title have the correct title format?
* [ ] * Does your PR have a breaking change?: No