### PR TITLE
docs: add Cursor rules for development standards

### DIFF
--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -1,0 +1,99 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Code Style Guidelines
+
+This document outlines the code style and conventions for the Amplitude TypeScript SDK monorepo.
+
+## TypeScript Conventions
+
+### General Rules
+- Use TypeScript strict mode with all compiler checks enabled as defined in [tsconfig.json](mdc:tsconfig.json)
+- Always define explicit return types for public methods and functions
+- Use meaningful variable and function names that clearly describe their purpose
+- Prefer `const` over `let` when variables won't be reassigned
+- Use template literals instead of string concatenation
+- Avoid `any` type - use proper typing or generic constraints instead
+
+### Interface and Type Definitions
+- Use `interface` for object shapes that might be extended
+- Use `type` for unions, intersections, and computed types
+- Export types that are used across package boundaries
+- Use PascalCase for interfaces and type names (e.g., `EventType`, `BrowserConfig`)
+
+### Function and Method Conventions
+- Use camelCase for function and method names
+- Use async/await instead of raw Promises for better readability
+- Keep functions focused on a single responsibility
+- Use proper JSDoc comments for public APIs
+
+### Import/Export Standards
+- Use named imports/exports over default exports for better tree-shaking
+- Group imports in this order: external libraries, internal packages, relative imports
+- Use absolute imports for cross-package references in the monorepo
+- Consistent barrel exports in `index.ts` files
+
+## Code Organization
+
+### File Structure
+- Follow the established pattern from [packages/analytics-browser/src](mdc:packages/analytics-browser/src)
+- Group related functionality in dedicated directories (config, plugins, utils, etc.)
+- Use descriptive file names that match their primary export
+
+### Class Organization
+- Private methods and properties should be prefixed with underscore
+- Group methods logically: constructor, public methods, private methods
+- Use readonly properties where appropriate
+- Implement proper error handling and validation
+
+## Formatting Rules
+
+The project uses Prettier with the following configuration from [.prettierrc.json](mdc:.prettierrc.json):
+- Line width: 120 characters
+- Single quotes for strings
+- Trailing commas in all contexts
+- Proper prose wrapping for markdown
+
+## Linting Standards
+
+Follow the ESLint configuration defined in [.eslintrc.js](mdc:.eslintrc.js):
+- No unused variables (except function parameters)
+- Require explicit return types for TypeScript functions
+- No multiple empty lines
+- End files with newline
+- Avoid unsafe global access (window, globalThis, self) except in test files
+
+## Package-Specific Conventions
+
+### Browser Packages
+- Use feature detection instead of user agent sniffing
+- Implement proper error boundaries for browser APIs
+- Follow the established plugin architecture pattern
+- Ensure backwards compatibility with older browser versions
+
+### Node.js Packages  
+- Use appropriate Node.js APIs and avoid browser-specific code
+- Implement proper error handling for server environments
+- Follow semantic versioning for breaking changes
+
+## Testing Conventions
+- Use Jest for unit testing as configured in [jest.config.js](mdc:jest.config.js)
+- Follow the naming pattern `*.test.ts` for test files
+- Write descriptive test names that explain the expected behavior
+- Use proper mocking for external dependencies
+- Maintain high test coverage for public APIs
+
+## Error Handling
+- Use custom error classes with descriptive messages
+- Implement proper error boundaries in browser environments
+- Log errors with appropriate context for debugging
+- Provide meaningful error messages for developers
+
+## Performance Guidelines
+- Avoid blocking operations in browser environments
+- Use lazy loading for optional features
+- Implement proper caching strategies
+- Consider bundle size impact for browser packages
+- Use tree-shaking friendly exports

--- a/.cursor/rules/commit-and-pr-guidelines.mdc
+++ b/.cursor/rules/commit-and-pr-guidelines.mdc
@@ -1,0 +1,115 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Commit and Pull Request Guidelines
+
+This document outlines the commit message standards and pull request guidelines for the Amplitude TypeScript SDK.
+
+## Commit Message Standards
+
+Follow the [Conventional Commits](mdc:https:/www.conventionalcommits.org) specification as outlined in [CONTRIBUTING.md](mdc:CONTRIBUTING.md).
+
+### Commit Types
+- **feat**: New features (triggers minor release)
+- **fix**: Bug fixes (triggers patch release)  
+- **docs**: Documentation updates
+- **style**: Code style changes (formatting, missing semi-colons, etc.)
+- **refactor**: Code changes that neither fix bugs nor add features
+- **perf**: Performance improvements
+- **test**: Adding or updating tests
+- **build**: Changes to build system or dependencies
+- **ci**: Changes to CI configuration
+- **chore**: Other changes that don't modify src or test files
+- **revert**: Revert previous commits
+
+### Breaking Changes
+- Any commit with `BREAKING CHANGE` in the body triggers a major release
+- Use `!` after the type/scope for breaking changes: `feat!: remove deprecated API`
+- Clearly document migration path in commit body
+
+### Scope Guidelines
+Use package names as scopes when changes are package-specific:
+- `feat(analytics-browser): add new tracking method`
+- `fix(analytics-node): resolve memory leak issue`
+- `docs(session-replay): update installation guide`
+
+### Examples of Good Commit Messages
+
+```
+feat(analytics-browser): add support for custom user properties
+
+This change allows users to set custom properties that persist
+across all events in a session.
+
+BREAKING CHANGE: The setUserProperties method now requires
+an explicit flush parameter. Use setUserProperties(props, true)
+to maintain previous behavior.
+
+Closes #123
+```
+
+```
+fix(analytics-core): prevent duplicate event submission
+
+Added deduplication logic to prevent the same event from being
+sent multiple times when network issues cause retries.
+
+Fixes #456
+```
+
+```
+docs: update installation instructions for v2
+
+- Added Node.js version requirements
+- Updated package installation commands
+- Added migration guide from v1
+```
+
+## Pull Request Guidelines
+
+### PR Title Standards
+- Use the same format as commit messages
+- Title should be descriptive and concise
+- Include scope when PR affects specific package
+- Examples:
+  - `feat(analytics-browser): implement session tracking`
+  - `fix: resolve TypeScript compilation errors`
+  - `docs: update API documentation examples`
+
+### PR Description Template
+Include the following sections in your PR description:
+
+```markdown
+## Summary
+Brief description of what this PR accomplishes.
+
+## Changes
+- List of specific changes made
+- New features added
+- Bugs fixed
+- Dependencies updated
+
+## Testing
+- [ ] Unit tests added/updated
+- [ ] Integration tests pass
+- [ ] Manual testing completed
+- [ ] Browser compatibility verified (if applicable)
+
+## Breaking Changes
+Describe any breaking changes and migration steps required.
+
+## Related Issues
+- Closes #123
+- Related to #456
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Self-review of code completed
+- [ ] Documentation updated
+- [ ] Tests added for new functionality
+- [ ] All tests pass
+- [ ] No new ESLint warnings
+```
+


### PR DESCRIPTION
## Summary
Adds comprehensive Cursor rules documentation to improve development workflow and maintain consistency across Amplitude-TypeScript.

Example usage:
type `commit and create a pr following @commit-and-pr-guidelines.mdc` in Cursor and it will automatically commit and create a PR with title and description. You can change them later. You have to install [Browser MCP](https://chromewebstore.google.com/detail/browser-mcp-automate-your/bjfgambnhccakkhmkepdoekmckoijdlc) first to allow Cursor interact with your browser. 

## Changes
- Added commit and PR guidelines following conventional commits
- Added code style and formatting rules