### PR TITLE
fix: guard globalScope missing "addEventListener"

### DIFF
--- a/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
@@ -13,7 +13,7 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   let eventListeners: EventListener[] = [];
 
   const addNetworkListener = (type: 'online' | 'offline', handler: () => void) => {
-    if (globalScope) {
+    if (globalScope && 'addEventListener' in globalScope && typeof globalScope.addEventListener === 'function') {
       globalScope.addEventListener(type, handler);
       eventListeners.push({
         type,
@@ -24,7 +24,11 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
 
   const removeNetworkListeners = () => {
     eventListeners.forEach(({ type, handler }) => {
-      if (globalScope) {
+      if (
+        globalScope &&
+        'removeEventListener' in globalScope &&
+        typeof globalScope.removeEventListener === 'function'
+      ) {
         globalScope.removeEventListener(type, handler);
       }
     });

--- a/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
@@ -1,5 +1,4 @@
-import { getGlobalScope, BeforePlugin, BrowserClient } from '@amplitude/analytics-core';
-import { BrowserConfig } from 'src/config';
+import { getGlobalScope, BeforePlugin, BrowserClient, BrowserConfig } from '@amplitude/analytics-core';
 
 interface EventListener {
   type: 'online' | 'offline';
@@ -13,8 +12,9 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   let eventListeners: EventListener[] = [];
 
   const addNetworkListener = (type: 'online' | 'offline', handler: () => void) => {
-    if (globalScope && 'addEventListener' in globalScope && typeof globalScope.addEventListener === 'function') {
-      globalScope.addEventListener(type, handler);
+    /* istanbul ignore next */
+    if (globalScope?.addEventListener) {
+      globalScope?.addEventListener(type, handler);
       eventListeners.push({
         type,
         handler,
@@ -24,13 +24,8 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
 
   const removeNetworkListeners = () => {
     eventListeners.forEach(({ type, handler }) => {
-      if (
-        globalScope &&
-        'removeEventListener' in globalScope &&
-        typeof globalScope.removeEventListener === 'function'
-      ) {
-        globalScope.removeEventListener(type, handler);
-      }
+      /* istanbul ignore next */
+      globalScope?.removeEventListener(type, handler);
     });
     eventListeners = [];
   };

--- a/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
@@ -2,6 +2,7 @@
 
 import { createAmplitudeMock, createConfigurationMock } from '../helpers/mock';
 import { networkConnectivityCheckerPlugin } from '../../src/plugins/network-connectivity-checker';
+import * as AnalyticsCore from '@amplitude/analytics-core';
 
 describe('networkConnectivityCheckerPlugin', () => {
   const amplitude = createAmplitudeMock();
@@ -55,5 +56,17 @@ describe('networkConnectivityCheckerPlugin', () => {
     expect(config.offline).toEqual(false);
     expect(addEventListenerSpy).not.toHaveBeenCalled();
     addEventListenerSpy.mockRestore();
+  });
+
+  test('should not throw if addEventListener is not a function', async () => {
+    const getGlobalScopeMock = jest
+      .spyOn(AnalyticsCore, 'getGlobalScope')
+      .mockReturnValue({} as unknown as typeof globalThis);
+    const plugin = networkConnectivityCheckerPlugin();
+
+    await expect(plugin.setup?.(config, amplitude)).resolves.not.toThrow();
+    await expect(plugin.teardown?.()).resolves.not.toThrow();
+
+    getGlobalScopeMock.mockRestore();
   });
 });

--- a/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
@@ -69,4 +69,11 @@ describe('networkConnectivityCheckerPlugin', () => {
 
     getGlobalScopeMock.mockRestore();
   });
+
+  test('should not throw if globalScope.addEventListener is not available', async () => {
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({} as unknown as typeof globalThis);
+    const plugin = networkConnectivityCheckerPlugin();
+
+    await expect(plugin.setup?.(config, amplitude)).resolves.not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- guard against missing global `addEventListener`
- update teardown to match
- add regression test

## Testing
- `npx eslint packages/analytics-browser/src/plugins/network-connectivity-checker.ts packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts`
- `npx lerna run test --scope @amplitude/analytics-browser --stream`

------
https://chatgpt.com/codex/tasks/task_b_684b49f89a5c832bb70657c9cdae92a7