### PR TITLE
fix(session-replay-browser): reduces network calls to remote config from many to 1

### DIFF
--- a/packages/analytics-remote-config/src/remote-config.ts
+++ b/packages/analytics-remote-config/src/remote-config.ts
@@ -34,11 +34,10 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
     this.configKeys = configKeys;
   }
 
-  getRemoteConfig = async <K extends keyof RemoteConfig>(
+  getRemoteNamespaceConfig = async (
     configNamespace: string,
-    key: K,
     sessionId?: number | string,
-  ): Promise<RemoteConfig[K] | undefined> => {
+  ): Promise<RemoteConfig | undefined> => {
     const fetchStartTime = Date.now();
     // Finally fetch via API
     const configAPIResponse = await this.fetchWithTimeout(sessionId);
@@ -46,11 +45,20 @@ export class RemoteConfigFetch<RemoteConfig extends { [key: string]: object }>
       const remoteConfig = configAPIResponse.configs && configAPIResponse.configs[configNamespace];
       if (remoteConfig) {
         this.metrics.fetchTimeAPISuccess = Date.now() - fetchStartTime;
-        return remoteConfig[key];
+        return remoteConfig;
       }
     }
     this.metrics.fetchTimeAPIFail = Date.now() - fetchStartTime;
     return undefined;
+  };
+
+  getRemoteConfig = async <K extends keyof RemoteConfig>(
+    configNamespace: string,
+    key: K,
+    sessionId?: number | string,
+  ): Promise<RemoteConfig[K] | undefined> => {
+    const namespaceConfig = await this.getRemoteNamespaceConfig(configNamespace, sessionId);
+    return namespaceConfig?.[key];
   };
 
   getServerUrl() {

--- a/packages/analytics-remote-config/src/types.ts
+++ b/packages/analytics-remote-config/src/types.ts
@@ -16,6 +16,7 @@ export interface BaseRemoteConfigFetch<T> {
     key: K,
     sessionId?: number | string,
   ) => Promise<T[K] | undefined>;
+  getRemoteNamespaceConfig: (configNamespace: string, sessionId?: number | string) => Promise<T | undefined>;
 }
 
 export interface RemoteConfigFetch<T> extends BaseRemoteConfigFetch<T> {

--- a/packages/analytics-remote-config/test/remote-config.test.ts
+++ b/packages/analytics-remote-config/test/remote-config.test.ts
@@ -76,6 +76,9 @@ describe('RemoteConfigFetch', () => {
       storeRemoteConfig: jest.fn(),
       getLastFetchedSessionId: jest.fn().mockResolvedValue(123),
       getRemoteConfig: jest.fn().mockResolvedValue(samplingConfig.sr_sampling_config),
+      getRemoteNamespaceConfig: jest.fn().mockResolvedValue({
+        sr_sampling_config: samplingConfig.sr_sampling_config,
+      }),
       remoteConfigHasValues: jest.fn().mockResolvedValue(true),
     };
     localConfig = new Config({

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -56,43 +56,29 @@ export class SessionReplayJoinedConfigGenerator {
     config.captureEnabled = true;
     let remoteConfig: SessionReplayRemoteConfig | undefined;
     try {
-      const samplingConfig = await this.remoteConfigFetch.getRemoteConfig(
-        'sessionReplay',
-        'sr_sampling_config',
-        sessionId,
-      );
+      const namespaceConfig = await this.remoteConfigFetch.getRemoteNamespaceConfig('sessionReplay', sessionId);
+      if (namespaceConfig) {
+        const samplingConfig = namespaceConfig.sr_sampling_config;
+        const privacyConfig = namespaceConfig.sr_privacy_config;
 
-      const privacyConfig = await this.remoteConfigFetch.getRemoteConfig(
-        'sessionReplay',
-        'sr_privacy_config',
-        sessionId,
-      );
-
-      const ugcFilterRules = config.interactionConfig?.ugcFilterRules;
-      // This is intentionally forced to only be set through the remote config.
-      config.interactionConfig = await this.remoteConfigFetch.getRemoteConfig(
-        'sessionReplay',
-        'sr_interaction_config',
-        sessionId,
-      );
-      if (config.interactionConfig && ugcFilterRules) {
-        config.interactionConfig.ugcFilterRules = ugcFilterRules;
-      }
-
-      // This is intentionally forced to only be set through the remote config.
-      config.loggingConfig = await this.remoteConfigFetch.getRemoteConfig(
-        'sessionReplay',
-        'sr_logging_config',
-        sessionId,
-      );
-
-      if (samplingConfig || privacyConfig) {
-        remoteConfig = {};
-        if (samplingConfig) {
-          remoteConfig.sr_sampling_config = samplingConfig;
+        const ugcFilterRules = config.interactionConfig?.ugcFilterRules;
+        // This is intentionally forced to only be set through the remote config.
+        config.interactionConfig = namespaceConfig.sr_interaction_config;
+        if (config.interactionConfig && ugcFilterRules) {
+          config.interactionConfig.ugcFilterRules = ugcFilterRules;
         }
-        if (privacyConfig) {
-          remoteConfig.sr_privacy_config = privacyConfig;
+
+        // This is intentionally forced to only be set through the remote config.
+        config.loggingConfig = namespaceConfig.sr_logging_config;
+
+        if (samplingConfig || privacyConfig) {
+          remoteConfig = {};
+          if (samplingConfig) {
+            remoteConfig.sr_sampling_config = samplingConfig;
+          }
+          if (privacyConfig) {
+            remoteConfig.sr_privacy_config = privacyConfig;
+          }
         }
       }
     } catch (err: unknown) {

--- a/packages/session-replay-browser/test/__mocks__/@amplitude/analytics-remote-config.ts
+++ b/packages/session-replay-browser/test/__mocks__/@amplitude/analytics-remote-config.ts
@@ -1,0 +1,55 @@
+import { RemoteConfigFetch } from '@amplitude/analytics-remote-config';
+import { SessionReplayRemoteConfig } from '../../../src/config/types';
+import { RemoteConfigMetric } from '@amplitude/analytics-remote-config/lib/esm/types';
+
+let _namespaceConfig: SessionReplayRemoteConfig = {
+  sr_sampling_config: {
+    capture_enabled: true,
+    sample_rate: 100,
+  },
+};
+
+let _shouldThrowError = false;
+
+class AnalyticsRemoteConfigMock implements RemoteConfigFetch<SessionReplayRemoteConfig> {
+  metrics: RemoteConfigMetric = {
+    fetchTimeAPISuccess: 0,
+    fetchTimeAPIFail: 0,
+  };
+  getRemoteConfig: <K extends keyof SessionReplayRemoteConfig>(
+    configNamespace: string,
+    key: K,
+    sessionId?: number | string,
+  ) => Promise<SessionReplayRemoteConfig[K] | undefined> = (_, key) => {
+    if (_shouldThrowError) {
+      throw new Error('test error');
+    }
+    return Promise.resolve(_namespaceConfig[key]);
+  };
+  getRemoteNamespaceConfig: (
+    configNamespace: string,
+    sessionId?: number | string,
+  ) => Promise<SessionReplayRemoteConfig | undefined> = () => {
+    if (_shouldThrowError) {
+      throw new Error('test error');
+    }
+    return Promise.resolve(_namespaceConfig);
+  };
+}
+
+const analyticsRemoteConfigMock = new AnalyticsRemoteConfigMock();
+
+export const __setNamespaceConfig = (namespaceConfig: SessionReplayRemoteConfig) => {
+  _namespaceConfig = namespaceConfig;
+};
+
+export const __setShouldThrowError = (shouldThrowError: boolean) => {
+  _shouldThrowError = shouldThrowError;
+};
+
+export const createRemoteConfigFetch = async () => {
+  return Promise.resolve(analyticsRemoteConfigMock);
+};
+export const metrics = analyticsRemoteConfigMock.metrics;
+export const getRemoteConfig = analyticsRemoteConfigMock.getRemoteConfig;
+export const getRemoteNamespaceConfig = analyticsRemoteConfigMock.getRemoteNamespaceConfig;

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -98,6 +98,28 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           captureEnabled: samplingConfig.capture_enabled,
         });
       });
+
+      test.each([
+        { 샘플링_설정: { 캡처_활성화: true } },
+        { sr_foo: 'invalid' },
+        { sr_foo: 1 },
+        { sr_foo: false },
+        { sr_foo: undefined },
+        { sr_foo: null },
+        { sr_foo: {} },
+        { sr_foo: [] },
+      ])('should ignore improper config keys', async (inputConfig) => {
+        __setNamespaceConfig(inputConfig);
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig(123);
+        expect(config).toStrictEqual({
+          ...mockLocalConfig,
+          captureEnabled: true,
+          optOut: mockLocalConfig.optOut,
+          interactionConfig: undefined,
+          loggingConfig: undefined,
+        });
+      });
+
       test('should use sample_rate only from API', async () => {
         __setNamespaceConfig({
           sr_sampling_config: { sample_rate: samplingConfig.sample_rate },

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as AnalyticsCore from '@amplitude/analytics-core';
-import * as RemoteConfigFetch from '@amplitude/analytics-remote-config';
 import { LogLevel, ILogger, ServerZone } from '@amplitude/analytics-core';
 import * as RRWeb from '@amplitude/rrweb-record';
 import { IDBFactory } from 'fake-indexeddb';
@@ -16,6 +15,7 @@ jest.mock('idb-keyval');
 type MockedLogger = jest.Mocked<ILogger>;
 jest.mock('@amplitude/rrweb-record');
 type MockedRRWeb = jest.Mocked<typeof import('@amplitude/rrweb-record')>;
+jest.mock('@amplitude/analytics-remote-config');
 
 const mockEvent = {
   type: 4,
@@ -66,13 +66,7 @@ describe('module level integration', () => {
     sessionId: 123,
     serverZone: ServerZone.EU,
   };
-  let getRemoteConfigMock: jest.Mock;
   beforeEach(() => {
-    getRemoteConfigMock = jest.fn();
-    jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
-      getRemoteConfig: getRemoteConfigMock,
-      metrics: {},
-    });
     jest.spyOn(SessionReplayIDB.SessionReplayEventsIDBStore, 'new');
     jest.useFakeTimers();
     originalFetch = global.fetch;

--- a/packages/session-replay-browser/test/session-replay-factory.test.ts
+++ b/packages/session-replay-browser/test/session-replay-factory.test.ts
@@ -1,16 +1,9 @@
-import * as RemoteConfigFetch from '@amplitude/analytics-remote-config';
 import { SessionReplay } from '../src/session-replay';
 import { getLogConfig } from '../src/session-replay-factory';
 
+jest.mock('@amplitude/analytics-remote-config');
+
 describe('session replay factory', () => {
-  let getRemoteConfigMock: jest.Mock;
-  beforeEach(() => {
-    getRemoteConfigMock = jest.fn();
-    jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
-      getRemoteConfig: getRemoteConfigMock,
-      metrics: {},
-    });
-  });
   describe('getLogConfig', () => {
     test('return the log config if config defined on session replay', async () => {
       const sessionReplay = new SessionReplay();

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -123,6 +123,7 @@ describe('SessionReplay', () => {
     getRemoteConfigMock = jest.fn().mockResolvedValue(samplingConfig);
     jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
       getRemoteConfig: getRemoteConfigMock,
+      getRemoteNamespaceConfig: getRemoteConfigMock,
       metrics: {},
     });
     jest.spyOn(SessionReplayIDB, 'createStore');
@@ -190,6 +191,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -212,6 +214,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -247,6 +250,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -282,6 +286,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -453,6 +458,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
       await sessionReplay.init(apiKey, {
@@ -500,6 +506,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
       await sessionReplay.init(apiKey, {
@@ -915,6 +922,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
       await sessionReplay.init(apiKey, {
@@ -1257,6 +1265,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -1291,6 +1300,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -1317,6 +1327,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -1342,6 +1353,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 
@@ -1371,6 +1383,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1407,6 +1420,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1444,6 +1458,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1482,6 +1497,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1521,6 +1537,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1559,6 +1576,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1596,6 +1614,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1636,6 +1655,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1675,6 +1695,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -1722,6 +1743,7 @@ describe('SessionReplay', () => {
           });
         jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
           getRemoteConfig: getRemoteConfigMock,
+          getRemoteNamespaceConfig: getRemoteConfigMock,
           metrics: {},
         });
 
@@ -2069,6 +2091,7 @@ describe('SessionReplay', () => {
       });
       jest.spyOn(RemoteConfigFetch, 'createRemoteConfigFetch').mockResolvedValue({
         getRemoteConfig: getRemoteConfigMock,
+        getRemoteNamespaceConfig: getRemoteConfigMock,
         metrics: {},
       });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We were previously making a remote call for each key of the config. This changes it to only look up the namespace and fetch the keys in JS.

Tested using tampermonkey:

![image](https://github.com/user-attachments/assets/519163f3-a890-479b-8410-67fca9e31afd)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
