### PR TITLE
ci: remove ci nx on push to branches

### DIFF
--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -1,10 +1,6 @@
 name: Continuous Integration (NX)
 
 on:
-  push:
-    branches:
-      - main
-      - v1.x
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Remove `ci-nx` GHA on push to branches. It should only run on PRs. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
