### PR TITLE
feat(session-replay-browser): allows users to omit scripts and comments from being captured

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -77,6 +77,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         performanceConfig: this.options.performanceConfig,
         storeType: this.options.storeType,
         experimental: this.options.experimental,
+        omitElementTags: this.options.omitElementTags,
         applyBackgroundColorToBlockedElements: this.options.applyBackgroundColorToBlockedElements,
         interactionConfig: this.options.interactionConfig,
       };

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -100,6 +100,13 @@ export interface SessionReplayOptions {
     useWebWorker: boolean;
   };
   /**
+   * @see {@link StandaloneSessionReplayOptions.omitElementTags}
+   */
+  omitElementTags?: {
+    script?: boolean;
+    comment?: boolean;
+  };
+  /**
    * If true, applies a background color to blocked elements for visual masking. Defaults to false.
    */
   applyBackgroundColorToBlockedElements?: boolean;

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -32,6 +32,10 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   performanceConfig?: SessionReplayPerformanceConfig;
   experimental?: { useWebWorker: boolean };
   applyBackgroundColorToBlockedElements?: boolean;
+  omitElementTags?: {
+    script?: boolean;
+    comment?: boolean;
+  };
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -73,6 +77,9 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     }
     if (options.experimental) {
       this.experimental = options.experimental;
+    }
+    if (options.omitElementTags) {
+      this.omitElementTags = options.omitElementTags;
     }
   }
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -143,6 +143,20 @@ export interface SessionReplayLocalConfig extends IConfig {
   };
 
   /**
+   * Remove certain parts of the DOM from being captured. These are typically ignored when blocking by selectors.
+   */
+  omitElementTags?: {
+    /**
+     * If true, removes script tags from the DOM, but not noscript tags.
+     */
+    script?: boolean;
+    /**
+     * If true, removes comment tags from the DOM.
+     */
+    comment?: boolean;
+  };
+
+  /**
    * If true, applies a background color to blocked elements in the replay.
    * This helps visualize which elements are blocked from being captured.
    */

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -471,6 +471,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
         maskTextFn: maskFn('text', privacyConfig),
         maskTextSelector: this.getMaskTextSelectors(),
         recordCanvas: false,
+        slimDOMOptions: {
+          script: config.omitElementTags?.script,
+          comment: config.omitElementTags?.comment,
+        },
         errorHandler: (error: unknown) => {
           const typedError = error as Error & { _external_?: boolean };
 

--- a/packages/session-replay-browser/src/utils/rrweb.ts
+++ b/packages/session-replay-browser/src/utils/rrweb.ts
@@ -67,6 +67,10 @@ export type RecordFunction = {
     maskTextFn?: (text: string, element: HTMLElement | null) => string;
     maskTextSelector?: string;
     recordCanvas?: boolean;
+    slimDOMOptions?: {
+      script?: boolean;
+      comment?: boolean;
+    };
     errorHandler?: (error: unknown) => boolean;
     plugins?: any[];
     applyBackgroundColorToBlockedElements?: boolean;

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1178,6 +1178,13 @@ describe('SessionReplay', () => {
       expect(errorHandlerReturn).toBe(true);
     });
 
+    test('should add slim dom options', async () => {
+      await sessionReplay.init(apiKey, { ...mockOptions, omitElementTags: { script: true, comment: true } }).promise;
+      await sessionReplay.recordEvents();
+      const recordArg = mockRecordFunction.mock.calls[0][0];
+      expect(recordArg?.slimDOMOptions).toEqual({ script: true, comment: true });
+    });
+
     test('should rethrow CSSStylesheet errors', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, mockOptions).promise;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Currently in shadow root contexts script tags may show "SCRIPT_PLACEHOLDER" which is not ideal. This is due to `<script>` tags being captured and replaced with this text. On replay rrweb injects `display: none !important`, but is not added to shadow roots sometimes causing the text to appear.

This can be fixed in the player too, but it's good to have this option if we need it later on. I changed the name of the option on our side since I thought it was clearer, but happy to discuss that one!

[SR-1374](https://amplitude.atlassian.net/browse/SR-1374)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No


[SR-1374]: https://amplitude.atlassian.net/browse/SR-1374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ