### PR TITLE
fix(analytics-core): remote config use new schema & config group

### DIFF
--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -29,14 +29,6 @@ export const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_TIMEOUT = 1000;
 // TODO(xinyi)
 // const DEFAULT_MIN_TIME_BETWEEN_FETCHES = 5 * 60 * 1000; // 5 minutes
-export const FETCHED_KEYS = [
-  'analyticsSDK.browserSDK',
-  'sessionReplay.sr_interaction_config',
-  'sessionReplay.sr_logging_config',
-  'sessionReplay.sr_privacy_config',
-  'sessionReplay.sr_sampling_config',
-  'sessionReplay.sr_targeting_config',
-];
 
 export interface RemoteConfig {
   [key: string]: any;
@@ -109,6 +101,8 @@ export interface IRemoteConfigClient {
 }
 
 export class RemoteConfigClient implements IRemoteConfigClient {
+  static readonly CONFIG_GROUP = 'browser';
+
   readonly apiKey: string;
   readonly serverUrl: string;
   readonly logger: ILogger;
@@ -303,9 +297,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     const encodedApiKey = encodeURIComponent(this.apiKey);
 
     const urlParams = new URLSearchParams();
-    FETCHED_KEYS.forEach((key) => {
-      urlParams.append('config_keys', key);
-    });
+    urlParams.append('config_group', RemoteConfigClient.CONFIG_GROUP);
 
     return `${this.serverUrl}/${encodedApiKey}?${urlParams.toString()}`;
   }

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -527,28 +527,14 @@ describe('RemoteConfigClient', () => {
 
   describe('getUrlParams', () => {
     test('should generate correct US URL', () => {
-      const expectedUrl =
-        `https://sr-client-cfg.amplitude.com/config/test-api-key?` +
-        `config_keys=analyticsSDK.browserSDK&` +
-        `config_keys=sessionReplay.sr_interaction_config&` +
-        `config_keys=sessionReplay.sr_logging_config&` +
-        `config_keys=sessionReplay.sr_privacy_config&` +
-        `config_keys=sessionReplay.sr_sampling_config&` +
-        `config_keys=sessionReplay.sr_targeting_config`;
+      const expectedUrl = `https://sr-client-cfg.amplitude.com/config/test-api-key?config_group=browser`;
       const url = client.getUrlParams();
       expect(url).toBe(expectedUrl);
     });
 
     test('should generate correct EU URL', () => {
       client = new RemoteConfigClient(mockApiKey, mockLogger, 'EU');
-      const expectedUrl =
-        `https://sr-client-cfg.eu.amplitude.com/config/test-api-key?` +
-        `config_keys=analyticsSDK.browserSDK&` +
-        `config_keys=sessionReplay.sr_interaction_config&` +
-        `config_keys=sessionReplay.sr_logging_config&` +
-        `config_keys=sessionReplay.sr_privacy_config&` +
-        `config_keys=sessionReplay.sr_sampling_config&` +
-        `config_keys=sessionReplay.sr_targeting_config`;
+      const expectedUrl = `https://sr-client-cfg.eu.amplitude.com/config/test-api-key?config_group=browser`;
       const url = client.getUrlParams();
       expect(url).toBe(expectedUrl);
     });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-133689]
```
// Before
// api_key as url param
https://sr-client-cfg.amplitude.com/config?api_key=xxxx&config_keys=analyticsSDK.browserSDK

// After
// api_key in url path
https://sr-client-cfg.amplitude.com/config/xxxxx?config_keys=analyticsSDK.browserSDK
```

[AMP-134103]
Replace fetched keys with config group which can be dynamically set in dyconf. See the jira ticket for how to set it in dyconf. 

Example 
![image](https://github.com/user-attachments/assets/1275855c-16d9-4c1b-8b13-5787f6702384)



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-133689]: https://amplitude.atlassian.net/browse/AMP-133689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMP-134103]: https://amplitude.atlassian.net/browse/AMP-134103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ