### PR TITLE
fix(plugin-autocapture-browser): remove cursor pointer

### DIFF
--- a/packages/plugin-autocapture-browser/src/frustration-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/frustration-plugin.ts
@@ -87,8 +87,8 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions): Brow
     }
 
     // Create should track event functions for the different allowlists
-    const shouldTrackRageClick = createShouldTrackEvent(options, rageCssSelectors, true);
-    const shouldTrackDeadClick = createShouldTrackEvent(options, deadCssSelectors, true);
+    const shouldTrackRageClick = createShouldTrackEvent(options, rageCssSelectors);
+    const shouldTrackDeadClick = createShouldTrackEvent(options, deadCssSelectors);
 
     // Create observables for events on the window
     const allObservables = createObservables();


### PR DESCRIPTION
### Summary

Remove the feature of capturing dead clicks and rage clicks when the element being hovered over has a cursor = pointer.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
