### PR TITLE
fix(analytics-react-native): country uppercase with existing Kotlin version

### DIFF
--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AndroidContextProvider.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AndroidContextProvider.kt
@@ -115,7 +115,7 @@ class AndroidContextProvider(private val context: Context, shouldTrackAdid: Bool
           if (manager.phoneType != TelephonyManager.PHONE_TYPE_CDMA) {
             val country = manager.networkCountryIso
             if (country != null) {
-              return country.toUpperCase(Locale.US)
+              return country.uppercase(Locale.US)
             }
           }
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- keep Kotlin at 1.7.0
- use `uppercase` instead of deprecated `toUpperCase`
- fix #1188

## Testing
- manually tested with RN version 0.80 and 0.75

------
https://chatgpt.com/codex/tasks/task_b_686d4efa82988320aa7960f35f85a327