### PR TITLE
fix: use sliding window to capture rage clicks

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
@@ -73,7 +73,7 @@ export function trackRageClicks({
         // add the current click to the window
         clickWindow.push(click);
 
-        // if there's not trailing clicks to be a rage click, return null
+        // if there's not enough clicks to be a rage click, return null
         if (clickWindow.length < RAGE_CLICK_THRESHOLD) {
           return null;
         }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
@@ -54,7 +54,10 @@ export function trackRageClicks({
 
         // if the current click isn't on the same element as the most recent click,
         // clear the sliding window and start over
-        if (clickWindow.length > 0 && clickWindow[clickWindow.length - 1].event.target !== click.event.target) {
+        if (
+          clickWindow.length > 0 &&
+          clickWindow[clickWindow.length - 1].closestTrackedAncestor !== click.closestTrackedAncestor
+        ) {
           clickWindow.splice(0, clickWindow.length);
         }
 
@@ -92,6 +95,9 @@ export function trackRageClicks({
           '[Amplitude] Click Count': clickWindow.length,
           ...firstClick.targetElementProperties,
         };
+
+        // restart the sliding window
+        clickWindow.splice(0, clickWindow.length);
 
         return { rageClickEvent, time: firstClick.timestamp };
       }),

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
@@ -14,11 +14,6 @@ describe('trackRageClicks', () => {
   let allObservables: AllWindowObservables;
   let shouldTrackRageClick: jest.Mock;
 
-  beforeAll(() => {
-    // reduce the rage click window to 5ms to speed up the test
-    //_overrideRageClickConfig(5, 5);
-  });
-
   beforeEach(() => {
     mockAmplitude = {
       track: jest.fn(),

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
@@ -4,7 +4,7 @@
 
 import { Subject } from 'rxjs';
 import { BrowserClient } from '@amplitude/analytics-core';
-import { _overrideRageClickConfig, trackRageClicks } from '../../src/autocapture/track-rage-click';
+import { trackRageClicks } from '../../src/autocapture/track-rage-click';
 import { AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT } from '../../src/constants';
 import { AllWindowObservables, ObservablesEnum } from '../../src/autocapture-plugin';
 
@@ -16,7 +16,7 @@ describe('trackRageClicks', () => {
 
   beforeAll(() => {
     // reduce the rage click window to 5ms to speed up the test
-    _overrideRageClickConfig(5, 5);
+    //_overrideRageClickConfig(5, 5);
   });
 
   beforeEach(() => {
@@ -67,7 +67,7 @@ describe('trackRageClicks', () => {
       expect(mockAmplitude.track).toHaveBeenCalledWith(
         AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
         expect.objectContaining({
-          '[Amplitude] Click Count': 5,
+          '[Amplitude] Click Count': 4,
           '[Amplitude] Clicks': expect.arrayContaining([
             expect.objectContaining({
               X: 100,
@@ -93,8 +93,8 @@ describe('trackRageClicks', () => {
     // Create a mock element
     const mockElement = document.createElement('div');
 
-    // Simulate only 4 clicks (below threshold)
-    for (let i = 0; i < 4; i++) {
+    // Simulate only 3 clicks (below threshold)
+    for (let i = 0; i < 3; i++) {
       clickObservable.next({
         event: {
           target: mockElement,

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -257,7 +257,9 @@
       window.amplitude = amplitude;
       const frustrationInteractions = {
         deadClicks: true,
-        rageClicks: true,
+        rageClicks: {
+          cssSelectorAllowlist: ['input'],
+        },
       };
       amplitude.add(frustrationPlugin(frustrationInteractions));
       amplitude.init(

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -257,9 +257,7 @@
       window.amplitude = amplitude;
       const frustrationInteractions = {
         deadClicks: true,
-        rageClicks: {
-          cssSelectorAllowlist: ['input'],
-        },
+        rageClicks: true,
       };
       amplitude.add(frustrationPlugin(frustrationInteractions));
       amplitude.init(


### PR DESCRIPTION
### Summary

Use a sliding window for rage click instead of a buffer.

Previously, it used a buffer, which has an edge case where 3 events could happen in one window and then another 3 events could happen in the next window, and it could miss a rage click if the buffer time elapsed between the calls.

This PR fixes it so that it just adds clicks to a sliding window, where the clicks expire after a certain time, and the window gets cleared if the next clicked element is not the same as the previously clicked on element.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Yes
