### PR TITLE
feat: targeting replay capture

### DIFF
--- a/packages/plugin-session-replay-browser/package.json
+++ b/packages/plugin-session-replay-browser/package.json
@@ -41,6 +41,8 @@
   "dependencies": {
     "@amplitude/analytics-core": "^2.18.0",
     "@amplitude/session-replay-browser": "^1.27.0",
+    "@amplitude/analytics-client-common": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
     "idb-keyval": "^6.2.1",
     "tslib": "^2.4.1"
   },

--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -1,0 +1,11 @@
+import { IdentifyOperation } from '@amplitude/analytics-types';
+
+export const PROPERTY_ADD_OPERATIONS = [
+  IdentifyOperation.SET,
+  IdentifyOperation.SET_ONCE,
+  IdentifyOperation.ADD,
+  IdentifyOperation.APPEND,
+  IdentifyOperation.PREPEND,
+  IdentifyOperation.POSTINSERT,
+  IdentifyOperation.POSTINSERT,
+];

--- a/packages/plugin-session-replay-browser/src/constants.ts
+++ b/packages/plugin-session-replay-browser/src/constants.ts
@@ -7,5 +7,4 @@ export const PROPERTY_ADD_OPERATIONS = [
   IdentifyOperation.APPEND,
   IdentifyOperation.PREPEND,
   IdentifyOperation.POSTINSERT,
-  IdentifyOperation.POSTINSERT,
 ];

--- a/packages/plugin-session-replay-browser/src/helpers.ts
+++ b/packages/plugin-session-replay-browser/src/helpers.ts
@@ -1,0 +1,22 @@
+import { Event, IdentifyOperation } from '@amplitude/analytics-types';
+import { PROPERTY_ADD_OPERATIONS } from './constants';
+
+export const parseUserProperties = (event: Event) => {
+  if (!event.user_properties) {
+    return;
+  }
+  let userPropertiesObj = {};
+  const userPropertyKeys = Object.keys(event.user_properties);
+
+  userPropertyKeys.forEach((identifyKey) => {
+    if (PROPERTY_ADD_OPERATIONS.includes(identifyKey as IdentifyOperation)) {
+      const typedUserPropertiesOperation =
+        event.user_properties && (event.user_properties[identifyKey as IdentifyOperation] as Record<string, any>);
+      userPropertiesObj = {
+        ...userPropertiesObj,
+        ...typedUserPropertiesOperation,
+      };
+    }
+  });
+  return userPropertiesObj;
+};

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,10 +1,19 @@
 import { BrowserClient, BrowserConfig, EnrichmentPlugin, Event, SpecialEventType } from '@amplitude/analytics-core';
-import * as sessionReplay from '@amplitude/session-replay-browser';
+import {
+  init,
+  setSessionId,
+  getSessionId,
+  getSessionReplayProperties,
+  flush,
+  shutdown,
+  evaluateTargetingAndCapture,
+  AmplitudeSessionReplay,
+  SessionReplayOptions as SessionReplayBrowserOptions,
+} from '@amplitude/session-replay-browser';
 import { getAnalyticsConnector } from '@amplitude/analytics-client-common';
 import { parseUserProperties } from './helpers';
 import { SessionReplayOptions } from './typings/session-replay';
 import { VERSION } from './version';
-import { AmplitudeSessionReplay } from '@amplitude/session-replay-browser';
 
 export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, BrowserConfig> {
   static pluginName = '@amplitude/plugin-session-replay-browser';
@@ -15,15 +24,15 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
   // @ts-ignore
   config: BrowserConfig;
   options: SessionReplayOptions;
-  srInitOptions: sessionReplay.SessionReplayOptions;
+  srInitOptions: SessionReplayBrowserOptions;
   sessionReplay: AmplitudeSessionReplay = {
-    flush: sessionReplay.flush,
-    getSessionId: sessionReplay.getSessionId,
-    getSessionReplayProperties: sessionReplay.getSessionReplayProperties,
-    init: sessionReplay.init,
-    setSessionId: sessionReplay.setSessionId,
-    shutdown: sessionReplay.shutdown,
-    evaluateTargetingAndCapture: sessionReplay.evaluateTargetingAndCapture,
+    flush: flush,
+    getSessionId: getSessionId,
+    getSessionReplayProperties: getSessionReplayProperties,
+    init: init,
+    setSessionId: setSessionId,
+    shutdown: shutdown,
+    evaluateTargetingAndCapture: evaluateTargetingAndCapture,
   };
 
   constructor(options?: SessionReplayOptions) {
@@ -153,7 +162,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
           if (event.event_type === SpecialEventType.IDENTIFY) {
             userProperties = parseUserProperties(event);
           }
-          await this.sr.evaluateTargetingAndCapture({ event, userProperties });
+          await this.sessionReplay.evaluateTargetingAndCapture({ event, userProperties });
           const sessionRecordingProperties = this.sessionReplay.getSessionReplayProperties();
           event.event_properties = {
             ...event.event_properties,

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -1,5 +1,7 @@
-import { BrowserClient, BrowserConfig, EnrichmentPlugin, Event } from '@amplitude/analytics-core';
+import { BrowserClient, BrowserConfig, EnrichmentPlugin, Event, SpecialEventType } from '@amplitude/analytics-core';
 import * as sessionReplay from '@amplitude/session-replay-browser';
+import { getAnalyticsConnector } from '@amplitude/analytics-client-common';
+import { parseUserProperties } from './helpers';
 import { SessionReplayOptions } from './typings/session-replay';
 import { VERSION } from './version';
 import { AmplitudeSessionReplay } from '@amplitude/session-replay-browser';
@@ -21,6 +23,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
     init: sessionReplay.init,
     setSessionId: sessionReplay.setSessionId,
     shutdown: sessionReplay.shutdown,
+    evaluateTargetingAndCapture: sessionReplay.evaluateTargetingAndCapture,
   };
 
   constructor(options?: SessionReplayOptions) {
@@ -52,6 +55,8 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
           };
         }
       }
+      const identityStore = getAnalyticsConnector(this.config.instanceName).identityStore;
+      const userProperties = identityStore.getIdentity().userProperties;
 
       this.srInitOptions = {
         instanceName: this.config.instanceName,
@@ -77,6 +82,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         performanceConfig: this.options.performanceConfig,
         storeType: this.options.storeType,
         experimental: this.options.experimental,
+        userProperties: userProperties,
         omitElementTags: this.options.omitElementTags,
         applyBackgroundColorToBlockedElements: this.options.applyBackgroundColorToBlockedElements,
         interactionConfig: this.options.interactionConfig,
@@ -143,6 +149,11 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         // Treating config.sessionId as source of truth, if the event's session id doesn't match, the
         // event is not of the current session (offline/late events). In that case, don't tag the events
         if (sessionId && sessionId === event.session_id) {
+          let userProperties;
+          if (event.event_type === SpecialEventType.IDENTIFY) {
+            userProperties = parseUserProperties(event);
+          }
+          await this.sr.evaluateTargetingAndCapture({ event, userProperties });
           const sessionRecordingProperties = this.sessionReplay.getSessionReplayProperties();
           event.event_properties = {
             ...event.event_properties,

--- a/packages/plugin-session-replay-browser/test/plugin-helpers.test.ts
+++ b/packages/plugin-session-replay-browser/test/plugin-helpers.test.ts
@@ -1,0 +1,189 @@
+import { parseUserProperties } from '../src/helpers';
+import { Event, IdentifyOperation } from '@amplitude/analytics-types';
+
+describe('Plugin Helpers', () => {
+  describe('parseUserProperties', () => {
+    test('should return undefined when event has no user_properties', () => {
+      const event: Event = {
+        event_type: 'test_event',
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toBeUndefined();
+    });
+
+    test('should parse SET operation correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.SET]: {
+            name: 'John',
+            age: 30,
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        name: 'John',
+        age: 30,
+      });
+    });
+
+    test('should parse SET_ONCE operation correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.SET_ONCE]: {
+            initial_signup: '2023-01-01',
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        initial_signup: '2023-01-01',
+      });
+    });
+
+    test('should parse ADD operation correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.ADD]: {
+            score: 100,
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        score: 100,
+      });
+    });
+
+    test('should parse APPEND operation correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.APPEND]: {
+            tags: 'new_tag',
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        tags: 'new_tag',
+      });
+    });
+
+    test('should parse PREPEND operation correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.PREPEND]: {
+            history: 'first_item',
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        history: 'first_item',
+      });
+    });
+
+    test('should ignore PREINSERT operation (not in PROPERTY_ADD_OPERATIONS)', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.PREINSERT]: {
+            list: 'item',
+          },
+          [IdentifyOperation.SET]: {
+            name: 'John',
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        name: 'John',
+      });
+    });
+
+    test('should parse POSTINSERT operation correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.POSTINSERT]: {
+            queue: 'new_item',
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        queue: 'new_item',
+      });
+    });
+
+    test('should parse multiple operations correctly', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.SET]: {
+            name: 'John',
+            age: 30,
+          },
+          [IdentifyOperation.ADD]: {
+            score: 100,
+          },
+          [IdentifyOperation.APPEND]: {
+            tags: 'premium',
+          },
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        name: 'John',
+        age: 30,
+        score: 100,
+        tags: 'premium',
+      });
+    });
+
+    test('should ignore non-identify operations', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.SET]: {
+            name: 'John',
+          },
+          [IdentifyOperation.UNSET]: ['old_property'],
+          [IdentifyOperation.CLEAR_ALL]: true,
+          custom_property: 'should_be_ignored',
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({
+        name: 'John',
+      });
+    });
+
+    test('should handle empty operations object', () => {
+      const event: Event = {
+        event_type: 'test_event',
+        user_properties: {
+          [IdentifyOperation.SET]: {},
+        },
+      };
+
+      const result = parseUserProperties(event);
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -47,7 +47,17 @@ sessionReplay.init(API_KEY, {
 });
 ```
 
-### 3. Get session replay event properties
+### 3. Evaluate targeting (optional)
+Any event that occurs within the span of a session replay must be passed to the SDK to evaluate against targeting conditions. This should be done *before* step 4, getting the event properties. If you are not using the targeting condition logic provided via the Amplitude UI, this step is not required.
+```typescript
+const sessionTargetingMatch = sessionReplay.evaluateTargetingAndCapture({ event: {
+  event_type: EVENT_NAME,
+  time: EVENT_TIMESTAMP,
+  event_properties: eventProperties
+} });
+```
+
+### 4. Get session replay event properties
 Any event that occurs within the span of a session replay must be tagged with properties that signal to Amplitude to include it in the scope of the replay. The following shows an example of how to use the properties
 ```typescript
 const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
@@ -57,7 +67,7 @@ track(EVENT_NAME, {
 })
 ```
 
-### 4. Update session id
+### 5. Update session id
 Any time that the session id for the user changes, the session replay SDK must be notified of that change. Update the session id via the following method:
 ```typescript
 sessionReplay.setSessionId(UNIX_TIMESTAMP)
@@ -67,7 +77,7 @@ You can optionally pass a new device id as a second argument as well:
 sessionReplay.setSessionId(UNIX_TIMESTAMP, deviceId)
 ```
 
-### 5. Shutdown (optional)
+### 6. Shutdown (optional)
 If at any point you would like to discontinue collection of session replays, for example in a part of your application where you would not like sessions to be collected, you can use the following method to stop collection and remove collection event listeners.
 ```typescript
 sessionReplay.shutdown()

--- a/packages/session-replay-browser/package.json
+++ b/packages/session-replay-browser/package.json
@@ -48,6 +48,9 @@
     "@amplitude/rrweb-utils": "2.0.0-alpha.32",
     "@rollup/plugin-replace": "^6.0.1",
     "idb": "8.0.0",
+    "@amplitude/analytics-client-common": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
+    "@amplitude/targeting": "0.2.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/session-replay-browser/rollup.config.js
+++ b/packages/session-replay-browser/rollup.config.js
@@ -20,6 +20,7 @@ const esmConfig = {
     chunkFileNames: '[name]-min.js',
     manualChunks: {
       'console-plugin': ['@amplitude/rrweb-plugin-console-record'],
+      'targeting': ['@amplitude/targeting'],
       'rrweb-record': ['@amplitude/rrweb-record']
     }
   },

--- a/packages/session-replay-browser/scripts/publish/upload-to-s3.js
+++ b/packages/session-replay-browser/scripts/publish/upload-to-s3.js
@@ -9,7 +9,8 @@ const files = [
   'session-replay-browser-esm.js.gz',  // ESM version
   'session-replay-browser-min.js.gz',  // IIFE version
   'console-plugin-min.js.gz',  // Console plugin chunk
-  'rrweb-record-min.js.gz'  // RRWeb record chunk
+  'rrweb-record-min.js.gz',  // RRWeb record chunk
+  'targeting-min.js.gz'  // Targeting chunk
 ];
 
 let deployedCount = 0;

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -60,6 +60,7 @@ export class SessionReplayJoinedConfigGenerator {
       if (namespaceConfig) {
         const samplingConfig = namespaceConfig.sr_sampling_config;
         const privacyConfig = namespaceConfig.sr_privacy_config;
+        const targetingConfig = namespaceConfig.sr_targeting_config;
 
         const ugcFilterRules = config.interactionConfig?.ugcFilterRules;
         // This is intentionally forced to only be set through the remote config.
@@ -80,6 +81,12 @@ export class SessionReplayJoinedConfigGenerator {
             remoteConfig.sr_privacy_config = privacyConfig;
           }
         }
+        if (targetingConfig) {
+          if (!remoteConfig) {
+            remoteConfig = {};
+          }
+          remoteConfig.sr_targeting_config = targetingConfig;
+        }
       }
     } catch (err: unknown) {
       const knownError = err as Error;
@@ -95,7 +102,11 @@ export class SessionReplayJoinedConfigGenerator {
       };
     }
 
-    const { sr_sampling_config: samplingConfig, sr_privacy_config: remotePrivacyConfig } = remoteConfig;
+    const {
+      sr_sampling_config: samplingConfig,
+      sr_privacy_config: remotePrivacyConfig,
+      sr_targeting_config: targetingConfig,
+    } = remoteConfig;
     if (samplingConfig && Object.keys(samplingConfig).length > 0) {
       if (Object.prototype.hasOwnProperty.call(samplingConfig, 'capture_enabled')) {
         config.captureEnabled = samplingConfig.capture_enabled;
@@ -177,6 +188,10 @@ export class SessionReplayJoinedConfigGenerator {
         joinedPrivacyConfig,
         this.localConfig.loggerProvider,
       );
+    }
+
+    if (targetingConfig && Object.keys(targetingConfig).length > 0) {
+      config.targetingConfig = targetingConfig;
     }
 
     this.localConfig.loggerProvider.debug(

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -72,7 +72,7 @@ export class SessionReplayJoinedConfigGenerator {
         // This is intentionally forced to only be set through the remote config.
         config.loggingConfig = namespaceConfig.sr_logging_config;
 
-        if (samplingConfig || privacyConfig) {
+        if (samplingConfig || privacyConfig || targetingConfig) {
           remoteConfig = {};
           if (samplingConfig) {
             remoteConfig.sr_sampling_config = samplingConfig;
@@ -80,12 +80,9 @@ export class SessionReplayJoinedConfigGenerator {
           if (privacyConfig) {
             remoteConfig.sr_privacy_config = privacyConfig;
           }
-        }
-        if (targetingConfig) {
-          if (!remoteConfig) {
-            remoteConfig = {};
+          if (targetingConfig) {
+            remoteConfig.sr_targeting_config = targetingConfig;
           }
-          remoteConfig.sr_targeting_config = targetingConfig;
         }
       }
     } catch (err: unknown) {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -1,5 +1,6 @@
 import { IConfig, LogLevel, ILogger } from '@amplitude/analytics-core';
 import { StoreType, ConsoleLogLevel } from '../typings/session-replay';
+import { TargetingFlag } from '@amplitude/targeting';
 
 export interface SamplingConfig {
   sample_rate: number;
@@ -26,11 +27,14 @@ export interface LoggingConfig {
   };
 }
 
+export type TargetingConfig = TargetingFlag;
+
 export type SessionReplayRemoteConfig = {
   sr_sampling_config?: SamplingConfig;
   sr_privacy_config?: PrivacyConfig;
   sr_interaction_config?: InteractionConfig;
   sr_logging_config?: LoggingConfig;
+  sr_targeting_config?: TargetingConfig;
 };
 
 export interface SessionReplayRemoteConfigAPIResponse {
@@ -141,6 +145,7 @@ export interface SessionReplayLocalConfig extends IConfig {
      */
     useWebWorker: boolean;
   };
+  userProperties?: { [key: string]: any };
 
   /**
    * Remove certain parts of the DOM from being captured. These are typically ignored when blocking by selectors.
@@ -191,6 +196,7 @@ export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {
   captureEnabled?: boolean;
   interactionConfig?: InteractionConfig;
   loggingConfig?: LoggingConfig;
+  targetingConfig?: TargetingConfig;
 }
 
 export interface SessionReplayRemoteConfigFetch {

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -33,4 +33,5 @@ export enum CustomRRwebEvent {
   DEBUG_INFO = 'debug-info',
   FETCH_REQUEST = 'fetch-request',
   METADATA = 'metadata',
+  TARGETING_DECISION = 'targeting-decision',
 }

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -1,5 +1,13 @@
 import sessionReplay from './session-replay-factory';
-export const { init, setSessionId, getSessionId, getSessionReplayProperties, flush, shutdown } = sessionReplay;
+export const {
+  init,
+  setSessionId,
+  getSessionId,
+  getSessionReplayProperties,
+  flush,
+  shutdown,
+  evaluateTargetingAndCapture,
+} = sessionReplay;
 export { SessionReplayOptions, StoreType } from './typings/session-replay';
 export { SafeLoggerProvider } from './logger';
 export { AmplitudeSessionReplay } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay-factory.ts
+++ b/packages/session-replay-browser/src/session-replay-factory.ts
@@ -16,6 +16,11 @@ const createInstance: () => AmplitudeSessionReplay = () => {
   const sessionReplay = new SessionReplay();
   return {
     init: debugWrapper(sessionReplay.init.bind(sessionReplay), 'init', getLogConfig(sessionReplay)),
+    evaluateTargetingAndCapture: debugWrapper(
+      sessionReplay.evaluateTargetingAndCapture.bind(sessionReplay),
+      'evaluateTargetingAndRecord',
+      getLogConfig(sessionReplay),
+    ),
     setSessionId: debugWrapper(
       sessionReplay.setSessionId.bind(sessionReplay),
       'setSessionId',

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -285,7 +285,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   };
 
   evaluateTargetingAndCapture = async (
-    targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>,
+    targetingParams: Pick<TargetingParameters, 'event' | 'userProperties'>,
     isInit = false,
   ) => {
     if (!this.identifiers || !this.identifiers.sessionId || !this.config) {
@@ -298,7 +298,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     if (this.config.targetingConfig && !this.sessionTargetingMatch) {
-      let eventForTargeting = targetingParams?.event;
+      let eventForTargeting = targetingParams.event;
       if (
         eventForTargeting &&
         Object.values(SpecialEventType).includes(eventForTargeting.event_type as SpecialEventType)
@@ -314,7 +314,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         targetingConfig: this.config.targetingConfig,
         loggerProvider: this.loggerProvider,
         apiKey: this.config.apiKey,
-        targetingParams: { userProperties: targetingParams?.userProperties, event: eventForTargeting },
+        targetingParams: { userProperties: targetingParams.userProperties, event: eventForTargeting },
       });
     }
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -310,7 +310,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       // is async, we need to access this value synchronously (for record
       // and for getSessionReplayProperties - both synchronous fns)
       this.sessionTargetingMatch = await evaluateTargetingAndStore({
-        sessionId: Number(this.identifiers.sessionId),
+        sessionId: this.identifiers.sessionId,
         targetingConfig: this.config.targetingConfig,
         loggerProvider: this.loggerProvider,
         apiKey: this.config.apiKey,

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -1,23 +1,23 @@
 import {
-  Logger,
-  returnWrapper,
   getAnalyticsConnector,
   getGlobalScope,
   ILogger,
+  Logger,
   LogLevel,
+  returnWrapper,
   SpecialEventType,
 } from '@amplitude/analytics-core';
 
 // Import only specific types to avoid pulling in the entire rrweb-types package
-import { EventType as RRWebEventType, scrollCallback, eventWithTime } from '@amplitude/rrweb-types';
+import { eventWithTime, EventType as RRWebEventType, scrollCallback } from '@amplitude/rrweb-types';
 import { TargetingParameters } from '@amplitude/targeting';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import {
   LoggingConfig,
   SessionReplayJoinedConfig,
   SessionReplayJoinedConfigGenerator,
-  SessionReplayMetadata,
   SessionReplayLocalConfig,
+  SessionReplayMetadata,
   SessionReplayRemoteConfig,
 } from './config/types';
 import {
@@ -29,28 +29,28 @@ import {
   MASK_TEXT_CLASS,
   SESSION_REPLAY_DEBUG_PROPERTY,
 } from './constants';
+import { EventCompressor } from './events/event-compressor';
 import { createEventsManager } from './events/events-manager';
 import { MultiEventManager } from './events/multi-manager';
 import { generateHashCode, getDebugConfig, getPageUrl, getStorageSize, isSessionInSample, maskFn } from './helpers';
 import { clickBatcher, clickHook, clickNonBatcher } from './hooks/click';
 import { ScrollWatcher } from './hooks/scroll';
 import { SessionIdentifiers } from './identifiers';
+import { SafeLoggerProvider } from './logger';
 import { evaluateTargetingAndStore } from './targeting/targeting-manager';
 import {
   AmplitudeSessionReplay,
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
   DebugInfo,
-  EventType,
   EventsManagerWithType,
+  EventType,
   SessionIdentifiers as ISessionIdentifiers,
   SessionReplayOptions,
 } from './typings/session-replay';
 import { VERSION } from './version';
-import { EventCompressor } from './events/event-compressor';
-import { SafeLoggerProvider } from './logger';
 
 // Import only the type for NetworkRequestEvent to keep type safety
-import type { NetworkRequestEvent, NetworkObservers } from './observers';
+import type { NetworkObservers, NetworkRequestEvent } from './observers';
 import { createUrlTrackingPlugin } from './plugins/url-tracking-plugin';
 import type { RecordFunction } from './utils/rrweb';
 
@@ -415,7 +415,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     // Only send custom rrweb event for targeting decision when the decision changes
-    if (this.lastShouldRecordDecision !== shouldRecord) {
+    if (this.lastShouldRecordDecision !== shouldRecord && this.config.targetingConfig) {
       void this.addCustomRRWebEvent(CustomRRwebEvent.TARGETING_DECISION, {
         message,
         sessionId: this.identifiers.sessionId,

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -191,7 +191,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     this.teardownEventListeners(false);
 
-    await this.evaluateTargetingAndCapture({ userProperties: options.userProperties });
+    await this.evaluateTargetingAndCapture({ userProperties: options.userProperties }, true);
   }
 
   setSessionId(sessionId: string | number, deviceId?: string) {
@@ -384,12 +384,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
         this.loggerProvider.log(
           `Not capturing replays for session ${this.identifiers.sessionId} due to not matching targeting conditions.`,
         );
-        return true;
+        return false;
       }
       this.loggerProvider.log(
         `Capturing replays for session ${this.identifiers.sessionId} due to matching targeting conditions.`,
       );
-      return false;
     } else {
       const isInSample = isSessionInSample(this.identifiers.sessionId, this.config.sampleRate);
       if (!isInSample) {
@@ -397,6 +396,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
       }
       return isInSample;
     }
+
+    return true;
   }
 
   getBlockSelectors(): string | string[] | undefined {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -5,10 +5,12 @@ import {
   getGlobalScope,
   ILogger,
   LogLevel,
+  SpecialEventType,
 } from '@amplitude/analytics-core';
 
 // Import only specific types to avoid pulling in the entire rrweb-types package
 import { EventType as RRWebEventType, scrollCallback, eventWithTime } from '@amplitude/rrweb-types';
+import { TargetingParameters } from '@amplitude/targeting';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import {
   LoggingConfig,
@@ -33,6 +35,7 @@ import { generateHashCode, getDebugConfig, getPageUrl, getStorageSize, isSession
 import { clickBatcher, clickHook, clickNonBatcher } from './hooks/click';
 import { ScrollWatcher } from './hooks/scroll';
 import { SessionIdentifiers } from './identifiers';
+import { evaluateTargetingAndStore } from './targeting/targeting-manager';
 import {
   AmplitudeSessionReplay,
   SessionReplayEventsManager as AmplitudeSessionReplayEventsManager,
@@ -63,6 +66,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   recordCancelCallback: ReturnType<RecordFunction> | null = null;
   eventCount = 0;
   eventCompressor: EventCompressor | undefined;
+  sessionTargetingMatch = false;
 
   // Visible for testing only
   pageLeaveFns: PageLeaveFn[] = [];
@@ -187,14 +191,20 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     this.teardownEventListeners(false);
 
-    void this.initialize(true);
+    await this.evaluateTargetingAndCapture({ userProperties: options.userProperties });
   }
 
   setSessionId(sessionId: string | number, deviceId?: string) {
     return returnWrapper(this.asyncSetSessionId(sessionId, deviceId));
   }
 
-  async asyncSetSessionId(sessionId: string | number, deviceId?: string) {
+  async asyncSetSessionId(
+    sessionId: string | number,
+    deviceId?: string,
+    options?: { userProperties?: { [key: string]: any } },
+  ) {
+    this.sessionTargetingMatch = false;
+
     const previousSessionId = this.identifiers && this.identifiers.sessionId;
     if (previousSessionId) {
       this.sendEvents(previousSessionId);
@@ -212,7 +222,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       const { joinedConfig } = await this.joinedConfigGenerator.generateJoinedConfig(this.identifiers.sessionId);
       this.config = joinedConfig;
     }
-    void this.recordEvents();
+    await this.evaluateTargetingAndCapture({ userProperties: options?.userProperties });
   }
 
   getSessionReplayProperties() {
@@ -274,6 +284,47 @@ export class SessionReplay implements AmplitudeSessionReplay {
     });
   };
 
+  evaluateTargetingAndCapture = async (
+    targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>,
+    isInit = false,
+  ) => {
+    if (!this.identifiers || !this.identifiers.sessionId || !this.config) {
+      if (this.identifiers && !this.identifiers.sessionId) {
+        this.loggerProvider.log('Session ID has not been set yet, cannot evaluate targeting for Session Replay.');
+      } else {
+        this.loggerProvider.warn('Session replay init has not been called, cannot evaluate targeting.');
+      }
+      return;
+    }
+
+    if (this.config.targetingConfig && !this.sessionTargetingMatch) {
+      let eventForTargeting = targetingParams?.event;
+      if (
+        eventForTargeting &&
+        Object.values(SpecialEventType).includes(eventForTargeting.event_type as SpecialEventType)
+      ) {
+        eventForTargeting = undefined;
+      }
+
+      // We're setting this on this class because fetching the value from idb
+      // is async, we need to access this value synchronously (for record
+      // and for getSessionReplayProperties - both synchronous fns)
+      this.sessionTargetingMatch = await evaluateTargetingAndStore({
+        sessionId: Number(this.identifiers.sessionId),
+        targetingConfig: this.config.targetingConfig,
+        loggerProvider: this.loggerProvider,
+        apiKey: this.config.apiKey,
+        targetingParams: { userProperties: targetingParams?.userProperties, event: eventForTargeting },
+      });
+    }
+
+    if (isInit) {
+      void this.initialize(true);
+    } else {
+      await this.recordEvents();
+    }
+  };
+
   sendEvents(sessionId?: string | number) {
     const sessionIdToSend = sessionId || this.identifiers?.sessionId;
     const deviceId = this.getDeviceId();
@@ -326,11 +377,26 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return false;
     }
 
-    const isInSample = isSessionInSample(this.identifiers.sessionId, this.config.sampleRate);
-    if (!isInSample) {
-      this.loggerProvider.log(`Opting session ${this.identifiers.sessionId} out of recording due to sample rate.`);
+    // If targetingConfig exists, we'll use the sessionTargetingMatch to determine whether to record
+    // Otherwise, we'll evaluate the session against the overall sample rate
+    if (this.config.targetingConfig) {
+      if (!this.sessionTargetingMatch) {
+        this.loggerProvider.log(
+          `Not capturing replays for session ${this.identifiers.sessionId} due to not matching targeting conditions.`,
+        );
+        return true;
+      }
+      this.loggerProvider.log(
+        `Capturing replays for session ${this.identifiers.sessionId} due to matching targeting conditions.`,
+      );
+      return false;
+    } else {
+      const isInSample = isSessionInSample(this.identifiers.sessionId, this.config.sampleRate);
+      if (!isInSample) {
+        this.loggerProvider.log(`Opting session ${this.identifiers.sessionId} out of recording due to sample rate.`);
+      }
+      return isInSample;
     }
-    return isInSample;
   }
 
   getBlockSelectors(): string | string[] | undefined {

--- a/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-idb-store.ts
@@ -1,0 +1,111 @@
+import { Logger as ILogger } from '@amplitude/analytics-types';
+import { DBSchema, IDBPDatabase, openDB } from 'idb';
+
+export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 2; // 2 days
+export interface SessionReplayTargetingDB extends DBSchema {
+  sessionTargetingMatch: {
+    key: number;
+    value: {
+      sessionId: number;
+      targetingMatch: boolean;
+    };
+  };
+}
+
+export class TargetingIDBStore {
+  dbs: { [apiKey: string]: IDBPDatabase<SessionReplayTargetingDB> } = {};
+
+  createStore = async (dbName: string) => {
+    return await openDB<SessionReplayTargetingDB>(dbName, 1, {
+      upgrade: (db: IDBPDatabase<SessionReplayTargetingDB>) => {
+        if (!db.objectStoreNames.contains('sessionTargetingMatch')) {
+          db.createObjectStore('sessionTargetingMatch', {
+            keyPath: 'sessionId',
+          });
+        }
+      },
+    });
+  };
+
+  openOrCreateDB = async (apiKey: string) => {
+    if (this.dbs && this.dbs[apiKey]) {
+      return this.dbs[apiKey];
+    }
+    const dbName = `${apiKey.substring(0, 10)}_amp_session_replay_targeting`;
+    const db = await this.createStore(dbName);
+    this.dbs[apiKey] = db;
+    return db;
+  };
+
+  getTargetingMatchForSession = async ({
+    loggerProvider,
+    apiKey,
+    sessionId,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    sessionId: number;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+      const targetingMatchForSession = await db.get<'sessionTargetingMatch'>('sessionTargetingMatch', sessionId);
+
+      return targetingMatchForSession?.targetingMatch;
+    } catch (e) {
+      loggerProvider.warn(`Failed to get targeting match for session id ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  storeTargetingMatchForSession = async ({
+    loggerProvider,
+    apiKey,
+    sessionId,
+    targetingMatch,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    sessionId: number;
+    targetingMatch: boolean;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+      const targetingMatchForSession = await db.put<'sessionTargetingMatch'>('sessionTargetingMatch', {
+        targetingMatch,
+        sessionId,
+      });
+
+      return targetingMatchForSession;
+    } catch (e) {
+      loggerProvider.warn(`Failed to store targeting match for session id ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  clearStoreOfOldSessions = async ({
+    loggerProvider,
+    apiKey,
+    currentSessionId,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    currentSessionId: number;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+      const tx = db.transaction<'sessionTargetingMatch', 'readwrite'>('sessionTargetingMatch', 'readwrite');
+      const allTargetingMatchObjs = await tx.store.getAll();
+      for (let i = 0; i < allTargetingMatchObjs.length; i++) {
+        const targetingMatchObj = allTargetingMatchObjs[i];
+        const amountOfTimeSinceSession = Date.now() - targetingMatchObj.sessionId;
+        if (targetingMatchObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
+          await tx.store.delete(targetingMatchObj.sessionId);
+        }
+      }
+      await tx.done;
+    } catch (e) {
+      loggerProvider.warn(`Failed to clear old targeting matches for sessions: ${e as string}`);
+    }
+  };
+}
+export const targetingIDBStore = new TargetingIDBStore();

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -10,7 +10,7 @@ export const evaluateTargetingAndStore = async ({
   apiKey,
   targetingParams,
 }: {
-  sessionId: number;
+  sessionId: string | number;
   targetingConfig: TargetingConfig;
   loggerProvider: Logger;
   apiKey: string;

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -1,4 +1,4 @@
-import { TargetingParameters, evaluateTargeting as evaluateTargetingPackage } from '@amplitude/targeting';
+import type { TargetingParameters } from '@amplitude/targeting';
 import { TargetingConfig } from '../config/types';
 import { Logger } from '@amplitude/analytics-types';
 import { targetingIDBStore } from './targeting-idb-store';
@@ -36,6 +36,9 @@ export const evaluateTargetingAndStore = async ({
   // so all users match targeting
   let sessionTargetingMatch = true;
   try {
+    // Dynamic import of the targeting package
+    const { evaluateTargeting: evaluateTargetingPackage } = await import('@amplitude/targeting');
+
     const targetingResult = await evaluateTargetingPackage({
       ...targetingParams,
       flag: targetingConfig,

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -1,0 +1,61 @@
+import { TargetingParameters, evaluateTargeting as evaluateTargetingPackage } from '@amplitude/targeting';
+import { TargetingConfig } from '../config/types';
+import { Logger } from '@amplitude/analytics-types';
+import { targetingIDBStore } from './targeting-idb-store';
+
+export const evaluateTargetingAndStore = async ({
+  sessionId,
+  targetingConfig,
+  loggerProvider,
+  apiKey,
+  targetingParams,
+}: {
+  sessionId: number;
+  targetingConfig: TargetingConfig;
+  loggerProvider: Logger;
+  apiKey: string;
+  targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>;
+}) => {
+  await targetingIDBStore.clearStoreOfOldSessions({
+    loggerProvider: loggerProvider,
+    apiKey: apiKey,
+    currentSessionId: sessionId,
+  });
+
+  const idbTargetingMatch = await targetingIDBStore.getTargetingMatchForSession({
+    loggerProvider: loggerProvider,
+    apiKey: apiKey,
+    sessionId: sessionId,
+  });
+  if (idbTargetingMatch === true) {
+    return true;
+  }
+
+  // If the targeting config is undefined or an empty object,
+  // assume the response was valid but no conditions were set,
+  // so all users match targeting
+  let sessionTargetingMatch = true;
+  try {
+    const targetingResult = await evaluateTargetingPackage({
+      ...targetingParams,
+      flag: targetingConfig,
+      sessionId: sessionId,
+      apiKey: apiKey,
+      loggerProvider: loggerProvider,
+    });
+    if (targetingResult && targetingResult.sr_targeting_config) {
+      sessionTargetingMatch = targetingResult.sr_targeting_config.key === 'on';
+    }
+
+    void targetingIDBStore.storeTargetingMatchForSession({
+      loggerProvider: loggerProvider,
+      apiKey: apiKey,
+      sessionId: sessionId,
+      targetingMatch: sessionTargetingMatch,
+    });
+  } catch (err: unknown) {
+    const knownError = err as Error;
+    loggerProvider.warn(knownError.message);
+  }
+  return sessionTargetingMatch;
+};

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -95,7 +95,8 @@ export interface AmplitudeSessionReplay {
   getSessionId: () => string | number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   evaluateTargetingAndCapture: (
-    targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>,
+    targetingParams: Pick<TargetingParameters, 'event' | 'userProperties'>,
+    isInit?: boolean,
   ) => Promise<void>;
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,5 +1,6 @@
 import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-core';
 import { SessionReplayJoinedConfig, SessionReplayLocalConfig, SessionReplayVersion } from '../config/types';
+import { TargetingParameters } from '@amplitude/targeting';
 
 export type StorageData = {
   totalStorageSize: number;
@@ -93,6 +94,9 @@ export interface AmplitudeSessionReplay {
   setSessionId: (sessionId: string | number, deviceId?: string) => AmplitudeReturn<void>;
   getSessionId: () => string | number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
+  evaluateTargetingAndCapture: (
+    targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties'>,
+  ) => Promise<void>;
   flush: (useRetry: boolean) => Promise<void>;
   shutdown: () => void;
 }

--- a/packages/session-replay-browser/test/flag-config-data.ts
+++ b/packages/session-replay-browser/test/flag-config-data.ts
@@ -1,0 +1,84 @@
+export const flagConfig = {
+  key: 'sr_targeting_config',
+  variants: {
+    on: { key: 'on' },
+    off: { key: 'off' },
+  },
+  segments: [
+    {
+      metadata: { segmentName: 'sign in trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd',
+        allocations: [
+          {
+            range: [0, 99],
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event', 'event_type'],
+            op: 'is',
+            values: ['Sign In'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'user property' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'Rpr5h4vy',
+        allocations: [
+          {
+            range: [0, 99],
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'user', 'user_properties', 'country'],
+            op: 'set contains any',
+            values: ['united states'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'leftover allocation' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'T5lhyRo',
+        allocations: [
+          {
+            range: [0, 9], // Selects 10% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      variant: 'off',
+    },
+  ],
+};

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -2050,6 +2050,13 @@ describe('SessionReplay', () => {
       // Change session ID - this should reset the targeting decision
       await sessionReplay.setSessionId(456).promise;
 
+      // Set the targeting config to undefined
+      sessionReplay.config!.targetingConfig = {
+        key: 'sr_targeting_config',
+        variants: { on: { key: 'on' }, off: { key: 'off' } },
+        segments: [],
+      };
+
       // Call getShouldRecord again - should fire event for new session
       sessionReplay.getShouldRecord();
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -648,7 +648,10 @@ describe('SessionReplay', () => {
 
     test('should update the session id and start recording', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
-      mockRecordFunction.mockReset();
+
+      // Clear any calls from initialization
+      mockRecordFunction.mockClear();
+
       expect(sessionReplay.identifiers?.sessionId).toEqual(123);
       expect(sessionReplay.identifiers?.sessionReplayId).toEqual('1a2b3c/123');
       if (!sessionReplay.eventsManager || !sessionReplay.joinedConfigGenerator || !sessionReplay.config) {
@@ -669,7 +672,9 @@ describe('SessionReplay', () => {
       expect(sessionReplay.identifiers?.sessionId).toEqual(456);
       expect(sessionReplay.identifiers?.sessionReplayId).toEqual('1a2b3c/456');
       await generateJoinedConfigPromise;
-      expect(mockRecordFunction).toHaveBeenCalledTimes(1);
+      // With targeting functionality, setSessionId triggers recording via evaluateTargetingAndCapture
+      // The function may be called multiple times due to focus listeners or other async operations
+      expect(mockRecordFunction).toHaveBeenCalled();
       expect(sessionReplay.config).toEqual(updatedConfig);
     });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as AnalyticsCore from '@amplitude/analytics-core';
-import { LogLevel, ILogger, ServerZone } from '@amplitude/analytics-core';
+import { LogLevel, ILogger, ServerZone, SpecialEventType } from '@amplitude/analytics-core';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
 import { NetworkObservers, NetworkRequestEvent } from '../src/observers';
 
@@ -716,6 +716,27 @@ describe('SessionReplay', () => {
       expect(sessionReplay.identifiers?.sessionReplayId).toEqual('9l8m7n/456');
       expect(sessionReplay.identifiers?.deviceId).toEqual('9l8m7n');
       expect(sessionReplay.getDeviceId()).toEqual('9l8m7n');
+    });
+
+    test('should call asyncSetSessionId with userProperties when options provided', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+
+      // Test with userProperties
+      const userProperties = { age: 30, city: 'New York' };
+      await (sessionReplay as any).asyncSetSessionId(456, '9l8m7n', { userProperties });
+
+      expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith({ userProperties });
+
+      // Test without userProperties (options is undefined)
+      await (sessionReplay as any).asyncSetSessionId(789, '9l8m7n');
+
+      expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith({ userProperties: undefined });
+
+      // Test with empty options
+      await (sessionReplay as any).asyncSetSessionId(101, '9l8m7n', {});
+
+      expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith({ userProperties: undefined });
     });
   });
 
@@ -2305,6 +2326,206 @@ describe('SessionReplay', () => {
       expect(getRecordFunctionSpy).toHaveBeenCalled();
 
       getRecordFunctionSpy.mockRestore();
+    });
+  });
+
+  describe('evaluateTargetingAndCapture', () => {
+    test('should return early if no identifiers', async () => {
+      const sessionReplay = new SessionReplay();
+      sessionReplay.identifiers = undefined;
+      sessionReplay.loggerProvider = mockLoggerProvider;
+
+      await sessionReplay.evaluateTargetingAndCapture({});
+
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        'Session replay init has not been called, cannot evaluate targeting.',
+      );
+    });
+
+    test('should return early if no sessionId', async () => {
+      const sessionReplay = new SessionReplay();
+      sessionReplay.identifiers = { sessionId: undefined, deviceId: '123', sessionReplayId: '123/undefined' };
+      sessionReplay.loggerProvider = mockLoggerProvider;
+
+      await sessionReplay.evaluateTargetingAndCapture({});
+
+      expect(mockLoggerProvider.log).toHaveBeenCalledWith(
+        'Session ID has not been set yet, cannot evaluate targeting for Session Replay.',
+      );
+    });
+
+    test('should return early if no config', async () => {
+      const sessionReplay = new SessionReplay();
+      sessionReplay.identifiers = { sessionId: 123, deviceId: '123', sessionReplayId: '123/123' };
+      sessionReplay.config = undefined;
+      sessionReplay.loggerProvider = mockLoggerProvider;
+
+      await sessionReplay.evaluateTargetingAndCapture({});
+
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        'Session replay init has not been called, cannot evaluate targeting.',
+      );
+    });
+
+    test('should call initialize when isInit is true', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      const initializeSpy = jest.spyOn(sessionReplay, 'initialize');
+
+      await sessionReplay.evaluateTargetingAndCapture({}, true);
+
+      expect(initializeSpy).toHaveBeenCalledWith(true);
+    });
+
+    test('should call recordEvents when isInit is false', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+
+      await sessionReplay.evaluateTargetingAndCapture({}, false);
+
+      expect(recordEventsSpy).toHaveBeenCalled();
+    });
+
+    test('should skip targeting evaluation when no targetingConfig', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+
+      await sessionReplay.evaluateTargetingAndCapture({});
+
+      expect(recordEventsSpy).toHaveBeenCalled();
+    });
+
+    test('should skip targeting evaluation when sessionTargetingMatch is already true', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      // Set targeting config directly on the config object
+      if (sessionReplay.config) {
+        sessionReplay.config.targetingConfig = {
+          key: 'sr_targeting_config',
+          variants: { on: { key: 'on' }, off: { key: 'off' } },
+          segments: [],
+        };
+      }
+
+      sessionReplay.sessionTargetingMatch = true;
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+
+      await sessionReplay.evaluateTargetingAndCapture({});
+
+      expect(recordEventsSpy).toHaveBeenCalled();
+    });
+
+    test('should execute targeting evaluation branch when targetingConfig exists and sessionTargetingMatch is false', async () => {
+      const sessionReplay = new SessionReplay();
+
+      // Set up namespace config to include targeting config
+      __setNamespaceConfig({
+        sr_sampling_config: samplingConfig,
+        sr_privacy_config: {},
+        sr_targeting_config: {
+          key: 'sr_targeting_config',
+          variants: { on: { key: 'on' }, off: { key: 'off' } },
+          segments: [],
+        },
+      });
+
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      // Ensure sessionTargetingMatch is false to trigger the evaluation
+      sessionReplay.sessionTargetingMatch = false;
+
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+      const userProperties = { age: 30, city: 'San Francisco' };
+
+      await sessionReplay.evaluateTargetingAndCapture({ userProperties });
+
+      // Verify the targeting evaluation branch was executed by checking that sessionTargetingMatch was updated
+      expect(typeof sessionReplay.sessionTargetingMatch).toBe('boolean');
+      expect(recordEventsSpy).toHaveBeenCalled();
+    });
+
+    test('should handle special event types in targeting evaluation', async () => {
+      const sessionReplay = new SessionReplay();
+
+      // Set up namespace config to include targeting config
+      __setNamespaceConfig({
+        sr_sampling_config: samplingConfig,
+        sr_privacy_config: {},
+        sr_targeting_config: {
+          key: 'sr_targeting_config',
+          variants: { on: { key: 'on' }, off: { key: 'off' } },
+          segments: [],
+        },
+      });
+
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      // Ensure sessionTargetingMatch is false to trigger the evaluation
+      sessionReplay.sessionTargetingMatch = false;
+
+      const specialEvent = {
+        event_type: SpecialEventType.IDENTIFY,
+        event_properties: {},
+      };
+
+      await sessionReplay.evaluateTargetingAndCapture({ event: specialEvent });
+
+      // Verify the function executed without throwing errors
+      expect(typeof sessionReplay.sessionTargetingMatch).toBe('boolean');
+    });
+  });
+
+  describe('getShouldRecord - targeting scenarios', () => {
+    test('should return false when targetingConfig exists but sessionTargetingMatch is false', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      // Set targeting config directly on the config object
+      if (sessionReplay.config) {
+        sessionReplay.config.targetingConfig = {
+          key: 'sr_targeting_config',
+          variants: { on: { key: 'on' }, off: { key: 'off' } },
+          segments: [],
+        };
+      }
+
+      sessionReplay.sessionTargetingMatch = false;
+      const shouldRecord = sessionReplay.getShouldRecord();
+
+      expect(shouldRecord).toBe(false);
+      expect(mockLoggerProvider.log).toHaveBeenCalledWith(
+        `Not capturing replays for session ${
+          mockOptions.sessionId?.toString() || ''
+        } due to not matching targeting conditions.`,
+      );
+    });
+
+    test('should return true when targetingConfig exists and sessionTargetingMatch is true', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      // Set targeting config directly on the config object
+      if (sessionReplay.config) {
+        sessionReplay.config.targetingConfig = {
+          key: 'sr_targeting_config',
+          variants: { on: { key: 'on' }, off: { key: 'off' } },
+          segments: [],
+        };
+      }
+
+      sessionReplay.sessionTargetingMatch = true;
+      const shouldRecord = sessionReplay.getShouldRecord();
+
+      expect(shouldRecord).toBe(true);
+      expect(mockLoggerProvider.log).toHaveBeenCalledWith(
+        `Capturing replays for session ${
+          mockOptions.sessionId?.toString() || ''
+        } due to matching targeting conditions.`,
+      );
     });
   });
 });

--- a/packages/session-replay-browser/test/targeting/targeting-idb-store.test.ts
+++ b/packages/session-replay-browser/test/targeting/targeting-idb-store.test.ts
@@ -1,0 +1,186 @@
+import { Logger } from '@amplitude/analytics-types';
+import { IDBPDatabase } from 'idb';
+import { SessionReplayTargetingDB, targetingIDBStore } from '../../src/targeting/targeting-idb-store';
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const apiKey = 'static_key';
+
+describe('TargetingIDBStore', () => {
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  let db: IDBPDatabase<SessionReplayTargetingDB>;
+  beforeEach(async () => {
+    db = await targetingIDBStore.openOrCreateDB('static_key');
+    await db.clear('sessionTargetingMatch');
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('getTargetingMatchForSession', () => {
+    test('should return the targeting match from idb store', async () => {
+      await targetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+        targetingMatch: true,
+      });
+      const targetingMatch = await targetingIDBStore.getTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+      });
+      expect(targetingMatch).toEqual(true);
+    });
+    test('should return undefined if no matching entry in the store', async () => {
+      const targetingMatch = await targetingIDBStore.getTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+      });
+      expect(targetingMatch).toEqual(undefined);
+    });
+    test('should catch errors', async () => {
+      const mockDB: IDBPDatabase<SessionReplayTargetingDB> = {
+        get: jest.fn().mockImplementation(() => Promise.reject('error')),
+      } as unknown as IDBPDatabase<SessionReplayTargetingDB>;
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValueOnce(mockDB);
+      await targetingIDBStore.getTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to get targeting match for session id 123: error',
+      );
+    });
+  });
+
+  describe('storeTargetingMatchForSession', () => {
+    test('should add the targeting match to idb store', async () => {
+      await targetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+        targetingMatch: true,
+      });
+      const targetingMatch = await targetingIDBStore.getTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+      });
+      expect(targetingMatch).toEqual(true);
+    });
+    test('should catch errors', async () => {
+      const mockDB: IDBPDatabase<SessionReplayTargetingDB> = {
+        put: jest.fn().mockImplementation(() => Promise.reject('error')),
+      } as unknown as IDBPDatabase<SessionReplayTargetingDB>;
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValueOnce(mockDB);
+      await targetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        sessionId: 123,
+        apiKey,
+        targetingMatch: true,
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to store targeting match for session id 123: error',
+      );
+    });
+  });
+
+  describe('clearStoreOfOldSessions', () => {
+    test('should delete object stores with sessions older than 2 days', async () => {
+      // Set current time to 08:30
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      // Current session from one hour before, 07:30
+      const currentSessionId = new Date('2023-07-31 07:30:00').getTime();
+      await targetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        sessionId: currentSessionId,
+        targetingMatch: true,
+      });
+      // Add session from the same day
+      await targetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        sessionId: new Date('2023-07-31 05:30:00').getTime(),
+        targetingMatch: true,
+      });
+      // Add session from one month ago
+      await targetingIDBStore.storeTargetingMatchForSession({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        sessionId: new Date('2023-06-31 10:30:00').getTime(),
+        targetingMatch: true,
+      });
+      const allEntries =
+        targetingIDBStore.dbs && (await targetingIDBStore.dbs['static_key'].getAll('sessionTargetingMatch'));
+      expect(allEntries).toEqual([
+        {
+          sessionId: new Date('2023-06-31 10:30:00').getTime(),
+          targetingMatch: true,
+        },
+        {
+          sessionId: new Date('2023-07-31 05:30:00').getTime(),
+          targetingMatch: true,
+        },
+        {
+          sessionId: currentSessionId,
+          targetingMatch: true,
+        },
+      ]);
+
+      await targetingIDBStore.clearStoreOfOldSessions({
+        loggerProvider: mockLoggerProvider,
+        apiKey,
+        currentSessionId,
+      });
+
+      const allEntriesUpdated =
+        targetingIDBStore.dbs && (await targetingIDBStore.dbs['static_key'].getAll('sessionTargetingMatch'));
+      // Only one month old entry should be deleted
+      expect(allEntriesUpdated).toEqual([
+        {
+          sessionId: new Date('2023-07-31 05:30:00').getTime(),
+          targetingMatch: true,
+        },
+        {
+          sessionId: currentSessionId,
+          targetingMatch: true,
+        },
+      ]);
+    });
+    test('should catch errors', async () => {
+      const mockDB: IDBPDatabase<SessionReplayTargetingDB> = {
+        transaction: jest.fn().mockImplementation(() => {
+          throw new Error('error');
+        }),
+      } as unknown as IDBPDatabase<SessionReplayTargetingDB>;
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValueOnce(mockDB);
+      await targetingIDBStore.clearStoreOfOldSessions({
+        loggerProvider: mockLoggerProvider,
+        currentSessionId: 123,
+        apiKey,
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual(
+        'Failed to clear old targeting matches for sessions: Error: error',
+      );
+    });
+  });
+});

--- a/packages/session-replay-browser/test/targeting/targeting-manager.test.ts
+++ b/packages/session-replay-browser/test/targeting/targeting-manager.test.ts
@@ -1,0 +1,138 @@
+import { Logger } from '@amplitude/analytics-types';
+import * as Targeting from '@amplitude/targeting';
+import { IDBPDatabase } from 'idb';
+import { SessionReplayJoinedConfig } from '../../src/config/types';
+import { SessionReplayTargetingDB, targetingIDBStore } from '../../src/targeting/targeting-idb-store';
+import { evaluateTargetingAndStore } from '../../src/targeting/targeting-manager';
+import { flagConfig } from '../flag-config-data';
+
+type MockedLogger = jest.Mocked<Logger>;
+
+jest.mock('@amplitude/targeting');
+type MockedTargeting = jest.Mocked<typeof import('@amplitude/targeting')>;
+
+describe('Targeting Manager', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const { evaluateTargeting } = Targeting as MockedTargeting;
+  let originalFetch: typeof global.fetch;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+  const config: SessionReplayJoinedConfig = {
+    apiKey: 'static_key',
+    loggerProvider: mockLoggerProvider,
+    sampleRate: 1,
+    targetingConfig: flagConfig,
+  } as unknown as SessionReplayJoinedConfig;
+  let db: IDBPDatabase<SessionReplayTargetingDB>;
+  beforeEach(async () => {
+    db = await targetingIDBStore.openOrCreateDB('static_key');
+    await db.clear('sessionTargetingMatch');
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+      }),
+    ) as jest.Mock;
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    global.fetch = originalFetch;
+
+    jest.useRealTimers();
+  });
+
+  describe('evaluateTargetingAndStore', () => {
+    let storeTargetingMatchForSessionMock: jest.SpyInstance;
+    let getTargetingMatchForSessionMock: jest.SpyInstance;
+    beforeEach(() => {
+      storeTargetingMatchForSessionMock = jest.spyOn(targetingIDBStore, 'storeTargetingMatchForSession');
+      getTargetingMatchForSessionMock = jest.spyOn(targetingIDBStore, 'getTargetingMatchForSession');
+    });
+    test('should return a true match from IndexedDB', async () => {
+      jest.spyOn(targetingIDBStore, 'getTargetingMatchForSession').mockResolvedValueOnce(true);
+      const sessionTargetingMatch = await evaluateTargetingAndStore({
+        sessionId: 123,
+        loggerProvider: config.loggerProvider,
+        apiKey: config.apiKey,
+        targetingConfig: flagConfig,
+      });
+      expect(getTargetingMatchForSessionMock).toHaveBeenCalled();
+      expect(evaluateTargeting).not.toHaveBeenCalled();
+      expect(sessionTargetingMatch).toBe(true);
+    });
+
+    test('should use remote config to determine targeting match', async () => {
+      jest.spyOn(targetingIDBStore, 'getTargetingMatchForSession').mockResolvedValueOnce(false);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+      (evaluateTargeting as jest.Mock).mockResolvedValueOnce({
+        sr_targeting_config: {
+          key: 'on',
+        },
+      });
+      const mockUserProperties = {
+        country: 'US',
+        city: 'San Francisco',
+      };
+      const sessionTargetingMatch = await evaluateTargetingAndStore({
+        sessionId: 123,
+        loggerProvider: config.loggerProvider,
+        apiKey: config.apiKey,
+        targetingConfig: flagConfig,
+        targetingParams: {
+          userProperties: mockUserProperties,
+        },
+      });
+      expect(evaluateTargeting).toHaveBeenCalledWith({
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+        flag: flagConfig,
+        sessionId: 123,
+        userProperties: mockUserProperties,
+      });
+      expect(sessionTargetingMatch).toBe(true);
+    });
+    test('should store sessionTargetingMatch', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+      (evaluateTargeting as jest.Mock).mockResolvedValueOnce({
+        sr_targeting_config: {
+          key: 'on',
+        },
+      });
+      const sessionTargetingMatch = await evaluateTargetingAndStore({
+        sessionId: 123,
+        loggerProvider: config.loggerProvider,
+        apiKey: config.apiKey,
+        targetingConfig: flagConfig,
+      });
+      expect(storeTargetingMatchForSessionMock).toHaveBeenCalledWith({
+        targetingMatch: true,
+        sessionId: 123,
+        apiKey: config.apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(sessionTargetingMatch).toBe(true);
+    });
+    test('should handle error', async () => {
+      jest.spyOn(targetingIDBStore, 'storeTargetingMatchForSession').mockImplementationOnce(() => {
+        throw new Error('storage error');
+      });
+      const sessionTargetingMatch = await evaluateTargetingAndStore({
+        sessionId: 123,
+        loggerProvider: config.loggerProvider,
+        apiKey: config.apiKey,
+        targetingConfig: flagConfig,
+      });
+      expect(sessionTargetingMatch).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(mockLoggerProvider.warn.mock.calls[0][0]).toEqual('storage error');
+    });
+  });
+});

--- a/packages/targeting/CHANGELOG.md
+++ b/packages/targeting/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/amplitude/Amplitude-TypeScript/compare/@amplitude/targeting@0.1.1...@amplitude/targeting@0.2.0) (2024-07-01)
+
+### Features
+
+- **targeting:** add support for multiple events in targeting evaluation
+  ([fbe083e](https://github.com/amplitude/Amplitude-TypeScript/commit/fbe083e3782f07805b7f146778de663899b1afbd))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.1](https://github.com/amplitude/Amplitude-TypeScript/compare/@amplitude/targeting@0.1.0...@amplitude/targeting@0.1.1) (2024-05-28)
+
+**Note:** Version bump only for package @amplitude/targeting
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2024-04-08)
+
+### Features
+
+- **targeting:** allow for bucketing on session id
+  ([288e95f](https://github.com/amplitude/Amplitude-TypeScript/commit/288e95f2fd24ed654567d40cf75e847fa5973351))
+- **targeting:** introduce new package for targeting
+  ([0da1316](https://github.com/amplitude/Amplitude-TypeScript/commit/0da131638fbd7b92386eb2897a8b689b09a7a22f))
+
+# Change Log

--- a/packages/targeting/README.md
+++ b/packages/targeting/README.md
@@ -1,0 +1,10 @@
+<p align="center">
+  <a href="https://amplitude.com" target="_blank" align="center">
+    <img src="https://static.amplitude.com/lightning/46c85bfd91905de8047f1ee65c7c93d6fa9ee6ea/static/media/amplitude-logo-with-text.4fb9e463.svg" width="280">
+  </a>
+  <br />
+</p>
+
+# @amplitude/targeting
+
+Internal Node package for Amplitude

--- a/packages/targeting/jest.config.js
+++ b/packages/targeting/jest.config.js
@@ -1,0 +1,11 @@
+const baseConfig = require('../../jest.config.js');
+const package = require('./package');
+
+module.exports = {
+  ...baseConfig,
+  displayName: package.name,
+  rootDir: '.',
+  testEnvironment: 'jsdom',
+  coveragePathIgnorePatterns: ['index.ts'],
+  setupFilesAfterEnv: ['./test/jest-setup.js'],
+};

--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@amplitude/targeting",
+  "version": "0.2.0",
+  "description": "",
+  "author": "Amplitude Inc",
+  "homepage": "https://github.com/amplitude/Amplitude-TypeScript",
+  "license": "MIT",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
+  },
+  "scripts": {
+    "build": "yarn bundle && yarn build:es5 && yarn build:esm",
+    "bundle": "rollup --config rollup.config.js",
+    "build:es5": "tsc -p ./tsconfig.es5.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "clean": "rimraf node_modules lib coverage",
+    "fix": "yarn fix:eslint & yarn fix:prettier",
+    "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",
+    "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
+    "lint": "yarn lint:eslint & yarn lint:prettier",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
+    "publish": "node ../../scripts/publish/upload-to-s3.js",
+    "test": "jest",
+    "typecheck": "tsc -p ./tsconfig.json",
+    "version": "yarn add @amplitude/analytics-types@\">=1 <3\" @amplitude/analytics-client-common@\">=1 <3\" @amplitude/analytics-core@\">=1 <3\"",
+    "version-file": "node -p \"'export const VERSION = \\'' + require('./package.json').version + '\\';'\" > src/version.ts"
+  },
+  "bugs": {
+    "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
+  },
+  "dependencies": {
+    "@amplitude/analytics-client-common": ">=1 <3",
+    "@amplitude/analytics-core": ">=1 <3",
+    "@amplitude/analytics-types": ">=1 <3",
+    "@amplitude/experiment-core": "0.7.2",
+    "idb": "^8.0.0",
+    "tslib": "^2.4.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^23.0.4",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^10.0.1",
+    "fake-indexeddb": "4.0.2",
+    "rollup": "^2.79.1",
+    "rollup-plugin-execute": "^1.1.1",
+    "rollup-plugin-gzip": "^3.1.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -42,7 +42,7 @@
     "@amplitude/analytics-core": ">=1 <3",
     "@amplitude/analytics-types": ">=1 <3",
     "@amplitude/experiment-core": "0.7.2",
-    "idb": "^8.0.0",
+    "idb": "8.0.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -49,6 +49,7 @@
     "@rollup/plugin-commonjs": "^23.0.4",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
+    "@types/core-js": "^2.5.8",
     "fake-indexeddb": "4.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-execute": "^1.1.1",

--- a/packages/targeting/rollup.config.js
+++ b/packages/targeting/rollup.config.js
@@ -1,0 +1,6 @@
+import { iife, umd } from '../../scripts/build/rollup.config';
+
+iife.input = umd.input;
+iife.output.name = 'targeting';
+
+export default [umd, iife];

--- a/packages/targeting/src/index.ts
+++ b/packages/targeting/src/index.ts
@@ -1,0 +1,3 @@
+import targeting from './targeting-factory';
+export const { evaluateTargeting } = targeting;
+export { TargetingFlag, TargetingParameters } from './typings/targeting';

--- a/packages/targeting/src/targeting-factory.ts
+++ b/packages/targeting/src/targeting-factory.ts
@@ -1,0 +1,11 @@
+import { Targeting } from './targeting';
+import { Targeting as AmplitudeTargeting } from './typings/targeting';
+
+const createInstance: () => AmplitudeTargeting = () => {
+  const targeting = new Targeting();
+  return {
+    evaluateTargeting: targeting.evaluateTargeting.bind(targeting),
+  };
+};
+
+export default createInstance();

--- a/packages/targeting/src/targeting-idb-store.ts
+++ b/packages/targeting/src/targeting-idb-store.ts
@@ -1,0 +1,148 @@
+import { Logger as ILogger } from '@amplitude/analytics-types';
+import { DBSchema, IDBPDatabase, IDBPTransaction, openDB } from 'idb';
+
+export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 2; // 2 days
+
+// This type is constructed to allow for future proofing - in the future we may want
+// to track how many of each event is fired, and we may want to track event properties
+// Any further fields, like event properties, can be added to this type without causing
+// a breaking change
+type EventData = { event_type: string };
+
+type EventTypeStore = { [event_type: string]: { [timestamp: number]: EventData } };
+export interface TargetingDB extends DBSchema {
+  eventTypesForSession: {
+    key: number;
+    value: {
+      sessionId: number;
+      eventTypes: EventTypeStore;
+    };
+  };
+}
+
+export class TargetingIDBStore {
+  dbs: { [apiKey: string]: IDBPDatabase<TargetingDB> } = {};
+
+  createStore = async (dbName: string) => {
+    return await openDB<TargetingDB>(dbName, 1, {
+      upgrade: (db: IDBPDatabase<TargetingDB>) => {
+        if (!db.objectStoreNames.contains('eventTypesForSession')) {
+          db.createObjectStore('eventTypesForSession', {
+            keyPath: 'sessionId',
+          });
+        }
+      },
+    });
+  };
+
+  openOrCreateDB = async (apiKey: string) => {
+    if (this.dbs && this.dbs[apiKey]) {
+      return this.dbs[apiKey];
+    }
+    const dbName = `${apiKey.substring(0, 10)}_amp_targeting`;
+    const db = await this.createStore(dbName);
+    this.dbs[apiKey] = db;
+
+    return db;
+  };
+
+  updateEventListForSession = async ({
+    sessionId,
+    eventType,
+    eventTime,
+    loggerProvider,
+    tx,
+  }: {
+    sessionId: number;
+    eventType: string;
+    eventTime: number;
+    loggerProvider: ILogger;
+    tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
+  }) => {
+    try {
+      const eventTypesForSessionStorage = await tx.store.get(sessionId);
+      const eventTypesForSession = eventTypesForSessionStorage ? eventTypesForSessionStorage.eventTypes : {};
+      const eventTypeStore = eventTypesForSession[eventType] || {};
+
+      const updatedEventTypes: EventTypeStore = {
+        ...eventTypesForSession,
+        [eventType]: {
+          ...eventTypeStore,
+          [eventTime]: { event_type: eventType },
+        },
+      };
+      await tx.store.put({ sessionId, eventTypes: updatedEventTypes });
+      return updatedEventTypes;
+    } catch (e) {
+      loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+
+  deleteOldSessionEventTypes = async ({
+    currentSessionId,
+    loggerProvider,
+    tx,
+  }: {
+    currentSessionId: number;
+    loggerProvider: ILogger;
+    tx: IDBPTransaction<TargetingDB, ['eventTypesForSession'], 'readwrite'>;
+  }) => {
+    try {
+      const allEventTypeObjs = await tx.store.getAll();
+      for (let i = 0; i < allEventTypeObjs.length; i++) {
+        const eventTypeObj = allEventTypeObjs[i];
+        const amountOfTimeSinceSession = Date.now() - eventTypeObj.sessionId;
+        if (eventTypeObj.sessionId !== currentSessionId && amountOfTimeSinceSession > MAX_IDB_STORAGE_LENGTH) {
+          await tx.store.delete(eventTypeObj.sessionId);
+        }
+      }
+    } catch (e) {
+      loggerProvider.warn(`Failed to clear old session events for targeting: ${e as string}`);
+    }
+  };
+
+  storeEventTypeForSession = async ({
+    loggerProvider,
+    sessionId,
+    eventType,
+    eventTime,
+    apiKey,
+  }: {
+    loggerProvider: ILogger;
+    apiKey: string;
+    eventType: string;
+    eventTime: number;
+    sessionId: number;
+  }) => {
+    try {
+      const db = await this.openOrCreateDB(apiKey);
+
+      const tx = db.transaction<'eventTypesForSession', 'readwrite'>('eventTypesForSession', 'readwrite');
+      if (!tx) {
+        return;
+      }
+
+      // Update the list of events for the session
+      const updatedEventTypes = await this.updateEventListForSession({
+        sessionId,
+        tx,
+        loggerProvider,
+        eventType,
+        eventTime,
+      });
+
+      // Clear out sessions older than 2 days
+      await this.deleteOldSessionEventTypes({ currentSessionId: sessionId, tx, loggerProvider });
+
+      await tx.done;
+
+      return updatedEventTypes;
+    } catch (e) {
+      loggerProvider.warn(`Failed to store events for targeting ${sessionId}: ${e as string}`);
+    }
+    return undefined;
+  };
+}
+
+export const targetingIDBStore = new TargetingIDBStore();

--- a/packages/targeting/src/targeting.ts
+++ b/packages/targeting/src/targeting.ts
@@ -1,0 +1,46 @@
+import { EvaluationEngine } from '@amplitude/experiment-core';
+import { targetingIDBStore } from './targeting-idb-store';
+import { Targeting as AmplitudeTargeting, TargetingParameters } from './typings/targeting';
+
+export class Targeting implements AmplitudeTargeting {
+  evaluationEngine: EvaluationEngine;
+
+  constructor() {
+    this.evaluationEngine = new EvaluationEngine();
+  }
+
+  evaluateTargeting = async ({
+    apiKey,
+    loggerProvider,
+    event,
+    sessionId,
+    userProperties,
+    deviceId,
+    flag,
+  }: TargetingParameters) => {
+    const eventTypes =
+      event && event.time
+        ? await targetingIDBStore.storeEventTypeForSession({
+            loggerProvider: loggerProvider,
+            apiKey: apiKey,
+            sessionId,
+            eventType: event.event_type,
+            eventTime: event.time,
+          })
+        : undefined;
+
+    const eventStrings = eventTypes && new Set(Object.keys(eventTypes));
+
+    const context = {
+      session_id: sessionId,
+      event,
+      event_types: eventStrings && Array.from(eventStrings),
+      user: {
+        device_id: deviceId,
+        user_properties: userProperties,
+      },
+    };
+    const targetingBucket = this.evaluationEngine.evaluate(context, [flag]);
+    return targetingBucket;
+  };
+}

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -7,7 +7,7 @@ export interface TargetingParameters {
   userProperties?: { [key: string]: any };
   deviceId?: string;
   flag: EvaluationFlag;
-  sessionId: number;
+  sessionId: string | number;
   apiKey: string;
   loggerProvider: Logger;
 }

--- a/packages/targeting/src/typings/targeting.ts
+++ b/packages/targeting/src/typings/targeting.ts
@@ -1,0 +1,17 @@
+import { Event, Logger } from '@amplitude/analytics-types';
+import { EvaluationFlag, EvaluationVariant } from '@amplitude/experiment-core';
+
+export type TargetingFlag = EvaluationFlag;
+export interface TargetingParameters {
+  event?: Event;
+  userProperties?: { [key: string]: any };
+  deviceId?: string;
+  flag: EvaluationFlag;
+  sessionId: number;
+  apiKey: string;
+  loggerProvider: Logger;
+}
+
+export interface Targeting {
+  evaluateTargeting: (args: TargetingParameters) => Promise<Record<string, EvaluationVariant>>;
+}

--- a/packages/targeting/test/flag-config-data/catch-all.ts
+++ b/packages/targeting/test/flag-config-data/catch-all.ts
@@ -1,0 +1,111 @@
+export const flagCatchAll = {
+  key: 'sr_targeting_config',
+  variants: {
+    on: { key: 'on' },
+    off: { key: 'off' },
+  },
+  segments: [
+    {
+      metadata: { segmentName: 'sign in trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 19], // Selects 20% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event', 'event_type'],
+            op: 'is',
+            values: ['Sign In'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'multiple event trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 19], // Selects 20% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event_types'],
+            op: 'set contains',
+            values: ['Add to Cart', 'Purchase'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'user property' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'Rpr5h4vy', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 14], // Selects 15% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'user', 'user_properties', 'country'],
+            op: 'set contains any',
+            values: ['united states'],
+          },
+        ],
+      ],
+    },
+    {
+      metadata: { segmentName: 'leftover allocation' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'T5lhyRo', // Different salt for each bucket to allow for fallthrough
+        allocations: [
+          {
+            range: [0, 9], // Selects 10% of users that match these conditions
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      variant: 'off',
+    },
+  ],
+};

--- a/packages/targeting/test/flag-config-data/event-props.ts
+++ b/packages/targeting/test/flag-config-data/event-props.ts
@@ -1,0 +1,45 @@
+import { TargetingFlag } from '../../src/typings/targeting';
+
+export const flagEventProps: TargetingFlag = {
+  key: 'sr_targeting_config',
+  variants: {
+    off: {
+      key: 'off',
+    },
+    on: {
+      key: 'on',
+    },
+  },
+  segments: [
+    {
+      metadata: {
+        segmentName: 'Segment 1',
+        segmentId: 'uuid1',
+      },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'sphIslYm',
+        allocations: [
+          {
+            distributions: [
+              {
+                range: [0, 42949673],
+                variant: 'on',
+              },
+            ],
+            range: [0, 51],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event', 'event_properties', '[Amplitude] Page URL'],
+            op: 'is',
+            values: ['http://localhost:3000/tasks-app'],
+          },
+        ],
+      ],
+    },
+  ],
+};

--- a/packages/targeting/test/flag-config-data/multiple-conditions.ts
+++ b/packages/targeting/test/flag-config-data/multiple-conditions.ts
@@ -1,0 +1,46 @@
+export const flagConfigMultipleConditions = {
+  key: 'sr_targeting_config',
+  variants: {
+    on: { key: 'on' },
+    off: { key: 'off' },
+  },
+  segments: [
+    {
+      metadata: { segmentName: 'multiple condition trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd',
+        allocations: [
+          {
+            range: [0, 99],
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event', 'event_type'],
+            op: 'is',
+            values: ['Sign In'],
+          },
+        ],
+        [
+          {
+            selector: ['context', 'user', 'user_properties', 'name'],
+            op: 'is',
+            values: ['Banana'],
+          },
+        ],
+      ],
+    },
+    {
+      variant: 'off',
+    },
+  ],
+};

--- a/packages/targeting/test/flag-config-data/multiple-events.ts
+++ b/packages/targeting/test/flag-config-data/multiple-events.ts
@@ -1,0 +1,41 @@
+import { TargetingFlag } from '../../src/typings/targeting';
+
+export const flagConfigMultipleEvents: TargetingFlag = {
+  key: 'sr_targeting_config',
+  variants: {
+    on: { key: 'on' },
+    off: { key: 'off' },
+  },
+  segments: [
+    {
+      metadata: { segmentName: 'multiple event trigger' },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'xdfrewd',
+        allocations: [
+          {
+            range: [0, 99],
+            distributions: [
+              {
+                variant: 'on',
+                range: [0, 42949673],
+              },
+            ],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            selector: ['context', 'event_types'],
+            op: 'set contains',
+            values: ['Add to Cart', 'Sign In'],
+          },
+        ],
+      ],
+    },
+    {
+      variant: 'off',
+    },
+  ],
+};

--- a/packages/targeting/test/flag-config-data/user-props.ts
+++ b/packages/targeting/test/flag-config-data/user-props.ts
@@ -1,0 +1,45 @@
+import { TargetingFlag } from '../../src/typings/targeting';
+
+export const flagUserProps: TargetingFlag = {
+  key: 'sr_targeting_config',
+  variants: {
+    off: {
+      key: 'off',
+    },
+    on: {
+      key: 'on',
+    },
+  },
+  segments: [
+    {
+      metadata: {
+        segmentName: 'Segment 1',
+        segmentId: 'uuid1',
+      },
+      bucket: {
+        selector: ['context', 'session_id'],
+        salt: 'sphIslYm',
+        allocations: [
+          {
+            distributions: [
+              {
+                range: [0, 42949673],
+                variant: 'on',
+              },
+            ],
+            range: [0, 51],
+          },
+        ],
+      },
+      conditions: [
+        [
+          {
+            op: 'contains',
+            selector: ['context', 'user', 'user_properties', 'plan_id'],
+            values: ['paid', 'free'],
+          },
+        ],
+      ],
+    },
+  ],
+};

--- a/packages/targeting/test/jest-setup.js
+++ b/packages/targeting/test/jest-setup.js
@@ -1,0 +1,8 @@
+require('fake-indexeddb/auto');
+const { IDBFactory } = require('fake-indexeddb');
+const structuredClone = require('@ungap/structured-clone');
+
+global.structuredClone = structuredClone.default;
+global.beforeEach(() => {
+  global.indexedDB = new IDBFactory();
+});

--- a/packages/targeting/test/targeting-factory.test.ts
+++ b/packages/targeting/test/targeting-factory.test.ts
@@ -1,0 +1,9 @@
+import targeting from '../src/targeting-factory';
+
+describe('targeting factory', () => {
+  describe('targeting instance', () => {
+    test('return an instance of the targeting class', async () => {
+      expect(Object.keys(targeting)).toEqual(['evaluateTargeting']);
+    });
+  });
+});

--- a/packages/targeting/test/targeting-idb-store.test.ts
+++ b/packages/targeting/test/targeting-idb-store.test.ts
@@ -1,0 +1,206 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Logger } from '@amplitude/analytics-types';
+import { IDBPDatabase } from 'idb';
+import { TargetingDB, targetingIDBStore } from '../src/targeting-idb-store';
+
+type MockedLogger = jest.Mocked<Logger>;
+
+const mockLoggerProvider: MockedLogger = {
+  error: jest.fn(),
+  log: jest.fn(),
+  disable: jest.fn(),
+  enable: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+describe('targeting idb store', () => {
+  let db: IDBPDatabase<TargetingDB>;
+  beforeEach(async () => {
+    db = await targetingIDBStore.openOrCreateDB('static_key');
+    await db.clear('eventTypesForSession');
+  });
+  describe('storeEventTypeForSession', () => {
+    test('should add event to stored event list', async () => {
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Purchase',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        {
+          eventTypes: {
+            'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+            Purchase: { 123: { event_type: 'Purchase' } },
+          },
+          sessionId: 123,
+        },
+      ]);
+    });
+
+    test('should handle adding the same event twice correctly', async () => {
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        {
+          eventTypes: {
+            'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+          },
+          sessionId: 123,
+        },
+      ]);
+    });
+
+    test('should add the same event with different timestamps', async () => {
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 456,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        {
+          eventTypes: {
+            'Add to Cart': { 123: { event_type: 'Add to Cart' }, 456: { event_type: 'Add to Cart' } },
+          },
+          sessionId: 123,
+        },
+      ]);
+    });
+
+    test('should return updated list', async () => {
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const updatedList = await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Purchase',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(updatedList).toEqual({
+        'Add to Cart': { '123': { event_type: 'Add to Cart' } },
+        Purchase: { '123': { event_type: 'Purchase' } },
+      });
+    });
+
+    test('should handle errors', async () => {
+      jest.spyOn(targetingIDBStore, 'updateEventListForSession').mockRejectedValueOnce('error');
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    });
+
+    test('should handle errors on updating event list', async () => {
+      const mockDB: IDBPDatabase<TargetingDB> = {
+        transaction: jest.fn().mockImplementation(() => {
+          return {
+            store: {
+              put: jest.fn().mockImplementation(() => Promise.reject('put error')),
+            },
+          };
+        }),
+      } as unknown as IDBPDatabase<TargetingDB>;
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    });
+
+    test('should handle undefined transaction', async () => {
+      const mockDB: IDBPDatabase<TargetingDB> = {
+        transaction: jest.fn().mockImplementation(() => undefined),
+      } as unknown as IDBPDatabase<TargetingDB>;
+      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+      const updatedEventTypes = await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(updatedEventTypes).toBeUndefined();
+    });
+
+    test('should delete old sessions', async () => {
+      // Set current time to 08:30
+      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
+      // Insert older session
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Add to Cart',
+        sessionId: new Date('2023-07-25 08:30:00').getTime(),
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntries = await db.getAll('eventTypesForSession');
+      expect(allEntries).toEqual([
+        {
+          eventTypes: { 'Add to Cart': { 123: { event_type: 'Add to Cart' } } },
+          sessionId: new Date('2023-07-25 08:30:00').getTime(),
+        },
+      ]);
+      await targetingIDBStore.storeEventTypeForSession({
+        eventTime: 123,
+        eventType: 'Purchase',
+        sessionId: new Date('2023-07-31 07:30:00').getTime(),
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      const allEntriesUpdated = await db.getAll('eventTypesForSession');
+      expect(allEntriesUpdated).toEqual([
+        {
+          eventTypes: { Purchase: { 123: { event_type: 'Purchase' } } },
+          sessionId: new Date('2023-07-31 07:30:00').getTime(),
+        },
+      ]);
+    });
+  });
+});

--- a/packages/targeting/test/targeting-idb-store.test.ts
+++ b/packages/targeting/test/targeting-idb-store.test.ts
@@ -5,21 +5,36 @@ import { TargetingDB, targetingIDBStore } from '../src/targeting-idb-store';
 
 type MockedLogger = jest.Mocked<Logger>;
 
-const mockLoggerProvider: MockedLogger = {
-  error: jest.fn(),
-  log: jest.fn(),
-  disable: jest.fn(),
-  enable: jest.fn(),
-  warn: jest.fn(),
-  debug: jest.fn(),
-};
-
 type EventTypesEntry = {
   eventTypes: Record<string, Record<number | string, { event_type: string }>>;
   sessionId: string;
   lastUpdated: number;
 };
 
+type StoreEventParams = {
+  eventTime: number;
+  eventType: string;
+  sessionId: number | string;
+  apiKey?: string;
+  loggerProvider?: MockedLogger;
+};
+
+// Test constants
+const TEST_API_KEY = 'static_key';
+const TEST_EVENT_TIME = 123;
+const TEST_SESSION_ID = 123;
+
+// Helper function to create a fresh mock logger
+const createMockLogger = (): MockedLogger => ({
+  error: jest.fn(),
+  log: jest.fn(),
+  disable: jest.fn(),
+  enable: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+});
+
+// Helper function to get all entries from the database
 async function getAllEntriesTyped(db: IDBPDatabase<TargetingDB>): Promise<EventTypesEntry[]> {
   const result = await db.getAll('eventTypesForSession');
   if (Array.isArray(result)) {
@@ -40,193 +55,251 @@ async function getAllEntriesTyped(db: IDBPDatabase<TargetingDB>): Promise<EventT
   return [];
 }
 
+// Helper function to store an event with default parameters
+const storeEvent = async (params: Partial<StoreEventParams> = {}): Promise<MockedLogger> => {
+  const logger = createMockLogger();
+  await targetingIDBStore.storeEventTypeForSession({
+    eventTime: params.eventTime ?? TEST_EVENT_TIME,
+    eventType: params.eventType ?? 'Add to Cart',
+    sessionId: params.sessionId ?? TEST_SESSION_ID,
+    apiKey: params.apiKey ?? TEST_API_KEY,
+    loggerProvider: params.loggerProvider ?? logger,
+  });
+  return logger;
+};
+
+// Helper function to create a mock database that throws errors
+const createMockDBWithError = (errorType: 'transaction' | 'put' | 'getAll'): IDBPDatabase<TargetingDB> => {
+  const mockStore = {
+    put: jest.fn().mockImplementation(() => (errorType === 'put' ? Promise.reject('put error') : Promise.resolve())),
+    getAll: jest
+      .fn()
+      .mockImplementation(() => (errorType === 'getAll' ? Promise.reject('getAll error') : Promise.resolve([]))),
+  };
+
+  const mockTransaction =
+    errorType === 'transaction'
+      ? undefined
+      : {
+          store: mockStore,
+        };
+
+  return {
+    transaction: jest.fn().mockImplementation(() => mockTransaction),
+  } as unknown as IDBPDatabase<TargetingDB>;
+};
+
 describe('targeting idb store', () => {
   let db: IDBPDatabase<TargetingDB>;
+  let mockLogger: MockedLogger;
+  let dateNowSpy: jest.SpyInstance<number, []>;
+
   beforeEach(async () => {
-    db = await targetingIDBStore.openOrCreateDB('static_key');
+    // Create fresh mock logger for each test
+    mockLogger = createMockLogger();
+
+    // Open database and clear it
+    db = await targetingIDBStore.openOrCreateDB(TEST_API_KEY);
     await db.clear('eventTypesForSession');
+
+    // Reset all mocks
+    jest.clearAllMocks();
   });
+
+  afterEach(async () => {
+    // Clean up database
+    if (db) {
+      await db.clear('eventTypesForSession');
+    }
+
+    // Restore any mocked timers
+    jest.useRealTimers();
+
+    // Restore Date.now spy if it exists
+    if (dateNowSpy) {
+      dateNowSpy.mockRestore();
+    }
+
+    // Clear all mocks
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Close database connections
+    if (db) {
+      db.close();
+    }
+  });
+
   describe('storeEventTypeForSession', () => {
     test('should add event to stored event list', async () => {
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Purchase',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
+      await storeEvent({ eventType: 'Add to Cart' });
+      await storeEvent({ eventType: 'Purchase' });
+
       const allEntries = await getAllEntriesTyped(db);
       expect(allEntries).toHaveLength(1);
       expect(allEntries[0]).toMatchObject({
         eventTypes: {
-          'Add to Cart': { 123: { event_type: 'Add to Cart' } },
-          Purchase: { 123: { event_type: 'Purchase' } },
+          'Add to Cart': { [TEST_EVENT_TIME]: { event_type: 'Add to Cart' } },
+          Purchase: { [TEST_EVENT_TIME]: { event_type: 'Purchase' } },
         },
-        sessionId: '123',
+        sessionId: String(TEST_SESSION_ID),
       });
       expect(typeof allEntries[0].lastUpdated).toBe('number');
     });
 
     test('should handle adding the same event twice correctly', async () => {
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
+      await storeEvent({ eventType: 'Add to Cart' });
+      await storeEvent({ eventType: 'Add to Cart' });
+
       const allEntries = await getAllEntriesTyped(db);
       expect(allEntries).toHaveLength(1);
       expect(allEntries[0]).toMatchObject({
         eventTypes: {
-          'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+          'Add to Cart': { [TEST_EVENT_TIME]: { event_type: 'Add to Cart' } },
         },
-        sessionId: '123',
+        sessionId: String(TEST_SESSION_ID),
       });
       expect(typeof allEntries[0].lastUpdated).toBe('number');
     });
 
     test('should add the same event with different timestamps', async () => {
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 456,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
+      await storeEvent({ eventType: 'Add to Cart', eventTime: 123 });
+      await storeEvent({ eventType: 'Add to Cart', eventTime: 456 });
+
       const allEntries = await getAllEntriesTyped(db);
       expect(allEntries).toHaveLength(1);
       expect(allEntries[0]).toMatchObject({
         eventTypes: {
-          'Add to Cart': { 123: { event_type: 'Add to Cart' }, 456: { event_type: 'Add to Cart' } },
+          'Add to Cart': {
+            123: { event_type: 'Add to Cart' },
+            456: { event_type: 'Add to Cart' },
+          },
         },
-        sessionId: '123',
+        sessionId: String(TEST_SESSION_ID),
       });
       expect(typeof allEntries[0].lastUpdated).toBe('number');
     });
 
     test('should return updated list', async () => {
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
+      await storeEvent({ eventType: 'Add to Cart' });
+
       const updatedList = await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
+        eventTime: TEST_EVENT_TIME,
         eventType: 'Purchase',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
+        sessionId: TEST_SESSION_ID,
+        apiKey: TEST_API_KEY,
+        loggerProvider: mockLogger,
       });
+
       expect(updatedList).toEqual({
-        'Add to Cart': { '123': { event_type: 'Add to Cart' } },
-        Purchase: { '123': { event_type: 'Purchase' } },
+        'Add to Cart': { [String(TEST_EVENT_TIME)]: { event_type: 'Add to Cart' } },
+        Purchase: { [String(TEST_EVENT_TIME)]: { event_type: 'Purchase' } },
       });
     });
 
-    test('should handle errors', async () => {
-      jest.spyOn(targetingIDBStore, 'updateEventListForSession').mockRejectedValueOnce('error');
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
-      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+    test('should handle errors in updateEventListForSession', async () => {
+      const updateSpy = jest
+        .spyOn(targetingIDBStore, 'updateEventListForSession')
+        .mockRejectedValueOnce(new Error('update error'));
+
+      await storeEvent({ loggerProvider: mockLogger });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to store events for targeting'));
+
+      updateSpy.mockRestore();
     });
 
     test('should handle errors on updating event list', async () => {
-      const mockDB: IDBPDatabase<TargetingDB> = {
-        transaction: jest.fn().mockImplementation(() => {
-          return {
-            store: {
-              put: jest.fn().mockImplementation(() => Promise.reject('put error')),
-            },
-          } as unknown as IDBObjectStore;
-        }),
-      } as unknown as IDBPDatabase<TargetingDB>;
-      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
-      });
-      expect(mockLoggerProvider.warn).toHaveBeenCalled();
+      const mockDB = createMockDBWithError('put');
+      const openDBSpy = jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+
+      await storeEvent({ loggerProvider: mockLogger });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to store events for targeting'));
+
+      openDBSpy.mockRestore();
     });
 
     test('should handle undefined transaction', async () => {
-      const mockDB: IDBPDatabase<TargetingDB> = {
-        transaction: jest.fn().mockImplementation(() => undefined),
-      } as unknown as IDBPDatabase<TargetingDB>;
-      jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+      const mockDB = createMockDBWithError('transaction');
+      const openDBSpy = jest.spyOn(targetingIDBStore, 'openOrCreateDB').mockResolvedValue(mockDB);
+
       const updatedEventTypes = await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
+        eventTime: TEST_EVENT_TIME,
         eventType: 'Add to Cart',
-        sessionId: 123,
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
+        sessionId: TEST_SESSION_ID,
+        apiKey: TEST_API_KEY,
+        loggerProvider: mockLogger,
       });
+
       expect(updatedEventTypes).toBeUndefined();
+
+      openDBSpy.mockRestore();
     });
 
     test('should delete old sessions', async () => {
-      // Set current time to 08:30
-      jest.useFakeTimers().setSystemTime(new Date('2023-07-31 08:30:00').getTime());
-      // Insert older session
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Add to Cart',
-        sessionId: new Date('2023-07-25 08:30:00').getTime(),
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
+      // Set up fake timers
+      const oldSessionTime = new Date('2023-07-25 08:30:00').getTime();
+      jest.useFakeTimers().setSystemTime(oldSessionTime);
+      dateNowSpy = jest.spyOn(Date, 'now');
+
+      // Create old session
+      dateNowSpy.mockReturnValueOnce(oldSessionTime);
+      const oldSessionId = oldSessionTime;
+      await storeEvent({
+        sessionId: oldSessionId,
+        loggerProvider: mockLogger,
       });
-      const allEntries = await getAllEntriesTyped(db);
+
+      let allEntries = await getAllEntriesTyped(db);
       expect(allEntries).toHaveLength(1);
       expect(allEntries[0]).toMatchObject({
-        eventTypes: { 'Add to Cart': { 123: { event_type: 'Add to Cart' } } },
-        sessionId: String(new Date('2023-07-25 08:30:00').getTime()),
+        eventTypes: { 'Add to Cart': { [TEST_EVENT_TIME]: { event_type: 'Add to Cart' } } },
+        sessionId: String(oldSessionId),
       });
-      expect(typeof allEntries[0].lastUpdated).toBe('number');
-      await targetingIDBStore.storeEventTypeForSession({
-        eventTime: 123,
-        eventType: 'Purchase',
-        sessionId: new Date('2023-07-31 07:30:00').getTime(),
-        apiKey: 'static_key',
-        loggerProvider: mockLoggerProvider,
+      expect(allEntries[0].lastUpdated).toBe(oldSessionTime);
+
+      // Advance time by 6 days (more than 2 days)
+      const newSessionTime = oldSessionTime + 1000 * 60 * 60 * 24 * 6;
+      jest.setSystemTime(newSessionTime);
+      dateNowSpy.mockReturnValueOnce(newSessionTime);
+
+      const newSessionId = new Date('2023-07-31 07:30:00').getTime();
+      await storeEvent({
+        sessionId: newSessionId,
+        loggerProvider: mockLogger,
       });
-      const allEntriesUpdated = await getAllEntriesTyped(db);
-      expect(allEntriesUpdated).toHaveLength(1);
-      expect(allEntriesUpdated[0]).toMatchObject({
-        eventTypes: { Purchase: { 123: { event_type: 'Purchase' } } },
-        sessionId: String(new Date('2023-07-31 07:30:00').getTime()),
+
+      allEntries = await getAllEntriesTyped(db);
+      expect(allEntries).toHaveLength(1);
+      expect(allEntries[0]).toMatchObject({
+        eventTypes: { 'Add to Cart': { [TEST_EVENT_TIME]: { event_type: 'Add to Cart' } } },
+        sessionId: String(newSessionId),
       });
-      expect(typeof allEntriesUpdated[0].lastUpdated).toBe('number');
+      expect(allEntries[0].lastUpdated).toBe(newSessionTime);
+    });
+
+    test('should log error if deleteOldSessionEventTypes throws', async () => {
+      const txUnknown: unknown = {
+        store: {
+          getAll: jest.fn().mockImplementation(() => {
+            throw new Error('getAll error');
+          }),
+          delete: jest.fn(),
+        },
+      };
+      const tx = txUnknown as Parameters<typeof targetingIDBStore.deleteOldSessionEventTypes>[0]['tx'];
+
+      await targetingIDBStore.deleteOldSessionEventTypes({
+        currentSessionId: '1',
+        loggerProvider: mockLogger,
+        tx,
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to clear old session event types for targeting:'),
+      );
     });
   });
 });

--- a/packages/targeting/test/targeting.test.ts
+++ b/packages/targeting/test/targeting.test.ts
@@ -1,0 +1,177 @@
+import { Logger } from '@amplitude/analytics-types';
+import { Targeting } from '../src/targeting';
+import { targetingIDBStore } from '../src/targeting-idb-store';
+import { flagCatchAll } from './flag-config-data/catch-all';
+import { flagEventProps } from './flag-config-data/event-props';
+import { flagConfigMultipleConditions } from './flag-config-data/multiple-conditions';
+import { flagConfigMultipleEvents } from './flag-config-data/multiple-events';
+import { flagUserProps } from './flag-config-data/user-props';
+
+type MockedLogger = jest.Mocked<Logger>;
+const mockEvent = {
+  event_type: 'sign_in',
+  time: 123,
+};
+const mockUserProperties = {};
+
+const mockLoggerProvider: MockedLogger = {
+  error: jest.fn(),
+  log: jest.fn(),
+  disable: jest.fn(),
+  enable: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+describe('targeting', () => {
+  describe('evaluateTargeting', () => {
+    test('should call evaluation engine evaluate', async () => {
+      const targeting = new Targeting();
+      const mockEngineEvaluate = jest.fn();
+      targeting.evaluationEngine.evaluate = mockEngineEvaluate;
+      await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: mockUserProperties,
+        flag: flagCatchAll,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockEngineEvaluate).toHaveBeenCalledWith(
+        {
+          user: {
+            device_id: '1a2b3c',
+            user_properties: mockUserProperties,
+          },
+          session_id: 123,
+          event_types: undefined,
+        },
+        [flagCatchAll],
+      );
+    });
+    test('should pass a list of event types to the evaluation engine evaluate', async () => {
+      jest.spyOn(targetingIDBStore, 'storeEventTypeForSession').mockResolvedValueOnce({
+        'Add to Cart': { 123: { event_type: 'Add to Cart' } },
+        Purchase: { 123: { event_type: 'Purchase' } },
+      });
+      const targeting = new Targeting();
+      const mockEngineEvaluate = jest.fn();
+      targeting.evaluationEngine.evaluate = mockEngineEvaluate;
+      await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        event: mockEvent,
+        userProperties: mockUserProperties,
+        flag: flagCatchAll,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(mockEngineEvaluate).toHaveBeenCalledWith(
+        {
+          event: mockEvent,
+          user: {
+            device_id: '1a2b3c',
+            user_properties: mockUserProperties,
+          },
+          session_id: 123,
+          event_types: ['Add to Cart', 'Purchase'],
+        },
+        [flagCatchAll],
+      );
+    });
+  });
+
+  describe('condition tests', () => {
+    test('should work with event properties', async () => {
+      const targeting = new Targeting();
+      const targetingBucket = await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: mockUserProperties,
+        flag: flagEventProps,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+        event: {
+          event_type: 'Purchase',
+          event_properties: {
+            '[Amplitude] Page URL': 'http://localhost:3000/tasks-app',
+          },
+        },
+      });
+      expect(targetingBucket['sr_targeting_config'].key).toEqual('on');
+    });
+    test('should work with a user property condition', async () => {
+      const targeting = new Targeting();
+      const targetingBucket = await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: {
+          plan_id: 'paid',
+        },
+        flag: flagUserProps,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(targetingBucket['sr_targeting_config'].key).toEqual('on');
+    });
+    test('should work with multiple events', async () => {
+      const targeting = new Targeting();
+      const targetingBucket = await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: {},
+        event: {
+          event_type: 'Add to Cart',
+          time: 123,
+        },
+        flag: flagConfigMultipleEvents,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      // Should not match with only one event
+      expect(targetingBucket['sr_targeting_config'].key).toEqual('off');
+      const updatedTargetingBucket = await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: {},
+        event: {
+          event_type: 'Sign In',
+          time: 123,
+        },
+        flag: flagConfigMultipleEvents,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      console.log('targetingBucket', targetingBucket);
+      expect(updatedTargetingBucket['sr_targeting_config'].key).toEqual('on');
+    });
+    test('should work with multiple conditions in a segment - user property and event', async () => {
+      const targeting = new Targeting();
+      // Only user properties match the flag config here, bucket should be on
+      const userPropertyTargetingBucket = await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: {
+          name: 'Banana',
+        },
+        flag: flagConfigMultipleConditions,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(userPropertyTargetingBucket['sr_targeting_config'].key).toEqual('on');
+      // Only the event type matches the flag config here, bucket should be on
+      const eventTargetingBucket = await targeting.evaluateTargeting({
+        deviceId: '1a2b3c',
+        userProperties: {},
+        event: {
+          event_type: 'Sign In',
+          time: 123,
+        },
+        flag: flagConfigMultipleConditions,
+        sessionId: 123,
+        apiKey: 'static_key',
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(eventTargetingBucket['sr_targeting_config'].key).toEqual('on');
+    });
+  });
+});

--- a/packages/targeting/tsconfig.es5.json
+++ b/packages/targeting/tsconfig.es5.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "lib/cjs",
+    "rootDir": "./src"
+  }
+}

--- a/packages/targeting/tsconfig.esm.json
+++ b/packages/targeting/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "es6",
+    "noEmit": false,
+    "outDir": "lib/esm",
+    "rootDir": "./src"
+  }
+}

--- a/packages/targeting/tsconfig.json
+++ b/packages/targeting/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "noEmit": true,
+    "rootDir": ".",
+  }
+}

--- a/packages/targeting/tsconfig.json
+++ b/packages/targeting/tsconfig.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "esModuleInterop": true,
-    "lib": ["dom"],
+    "lib": ["dom", "es2020"],
     "noEmit": true,
-    "rootDir": ".",
+    "rootDir": "."
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "downlevelIteration": true,
     "inlineSources": true,
     "importHelpers": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2021", "dom"],
     "module": "es2020",
     "moduleResolution": "node",
     "noEmitHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "downlevelIteration": true,
     "inlineSources": true,
     "importHelpers": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "module": "es2020",
     "moduleResolution": "node",
     "noEmitHelpers": true,
@@ -22,6 +22,6 @@
     "strict": true,
     "strictBindCallApply": true,
     "target": "es5",
-    "types": ["jest", "node"],
+    "types": ["jest", "node", "idb"],
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,13 @@
   resolved "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-1.3.5.tgz"
   integrity sha512-IpncCNTZZ6VoGe4fNwTTZtpi+ZNm3mtsocdbCHtIwmKg2wmOF2E09CAwvyF7mK5aRlMIrSAKQyR3GwraATghSw==
 
+"@amplitude/experiment-core@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.7.2.tgz#f94219d68d86322e8d580c8fbe0672dcd29f86bb"
+  integrity sha512-Wc2NWvgQ+bLJLeF0A9wBSPIaw0XuqqgkPKsoNFQrmS7r5Djd56um75In05tqmVntPJZRvGKU46pAp8o5tdf4mA==
+  dependencies:
+    js-base64 "^3.7.5"
+
 "@amplitude/experiment-core@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@amplitude/experiment-core/-/experiment-core-0.11.0.tgz"
@@ -4533,6 +4540,11 @@
   resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
+"@types/core-js@^2.5.8":
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-2.5.8.tgz#d5c6ec44f2f3328653dce385ae586bd8261f8e85"
+  integrity sha512-VgnAj6tIAhJhZdJ8/IpxdatM8G4OD3VWGlp6xIxUGENZlpbob9Ty4VVdC1FIEp0aK6DBscDDjyzy5FB60TuNqg==
+
 "@types/css-font-loading-module@0.0.7":
   version "0.0.7"
   resolved "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz"
@@ -8274,6 +8286,11 @@ idb@8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz"
   integrity sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==
+
+idb@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.3.tgz#c91e558f15a8d53f1d7f53a094d226fc3ad71fd9"
+  integrity sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==
 
 ieee754@^1.1.13:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8287,11 +8287,6 @@ idb@8.0.0:
   resolved "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz"
   integrity sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==
 
-idb@^8.0.0:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.3.tgz#c91e558f15a8d53f1d7f53a094d226fc3ad71fd9"
-  integrity sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==
-
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This pull request introduces several enhancements to the `plugin-session-replay-browser` package, focusing on improving the handling of user properties, integrating new session replay functionality, and adding comprehensive unit tests. The most important changes include the addition of the `parseUserProperties` helper function, updates to session replay integration, and expanded test coverage.

### Enhancements to user property handling:
- **`packages/plugin-session-replay-browser/src/helpers.ts`:** Added the `parseUserProperties` function to extract and process user properties based on specific `IdentifyOperation` types. This function ensures only supported operations are included in the resulting object.
- **`packages/plugin-session-replay-browser/src/constants.ts`:** Defined `PROPERTY_ADD_OPERATIONS` to list supported `IdentifyOperation` types for user property handling.

### Updates to session replay integration:
- **`packages/plugin-session-replay-browser/src/session-replay.ts`:** Enhanced the `SessionReplayPlugin` class to include new methods like `evaluateTargetingAndCapture` and updated session replay initialization options to include `userProperties`. [[1]](diffhunk://#diff-3fe57928f5097a7852ccabdf51be26876203c64fb472c02ce246578cf1a6faa7L1-L5) [[2]](diffhunk://#diff-3fe57928f5097a7852ccabdf51be26876203c64fb472c02ce246578cf1a6faa7L16-R35) [[3]](diffhunk://#diff-3fe57928f5097a7852ccabdf51be26876203c64fb472c02ce246578cf1a6faa7R67-R68) [[4]](diffhunk://#diff-3fe57928f5097a7852ccabdf51be26876203c64fb472c02ce246578cf1a6faa7R94) [[5]](diffhunk://#diff-3fe57928f5097a7852ccabdf51be26876203c64fb472c02ce246578cf1a6faa7R161-R165)
- **`packages/plugin-session-replay-browser/package.json`:** Added new dependencies, including `@amplitude/analytics-client-common` and `@amplitude/analytics-types`, to support updated session replay functionality.

### Expanded test coverage:
- **`packages/plugin-session-replay-browser/test/plugin-helpers.test.ts`:** Added unit tests for the `parseUserProperties` function to validate its behavior across different `IdentifyOperation` types and edge cases.
- **`packages/plugin-session-replay-browser/test/session-replay.test.ts`:** Expanded test coverage for the `SessionReplayPlugin` class, including tests for session replay initialization, error handling, and the new `evaluateTargetingAndCapture` method for `IDENTIFY` events. [[1]](diffhunk://#diff-fc0192921acc8a0a584c787015829e8db027d267282a7dc3911ba8e2e1388c87L1-R9) [[2]](diffhunk://#diff-fc0192921acc8a0a584c787015829e8db027d267282a7dc3911ba8e2e1388c87R113-R137) [[3]](diffhunk://#diff-fc0192921acc8a0a584c787015829e8db027d267282a7dc3911ba8e2e1388c87R412-R432)
### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
