### PR TITLE
fix(analytics-browser): disable frustrationInteractions and webVitals when autocapture=true

### DIFF
--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -99,9 +99,10 @@ export const isElementInteractionsEnabled = (autocapture: AutocaptureOptions | b
  * otherwise returns false
  */
 export const isWebVitalsEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
-  if (typeof autocapture === 'boolean') {
-    return autocapture;
-  }
+  // TODO restore this if statement when webVitals is GA
+  // if (typeof autocapture === 'boolean') {
+  //   return autocapture;
+  // }
 
   if (typeof autocapture === 'object' && autocapture.webVitals === true) {
     return true;
@@ -111,9 +112,10 @@ export const isWebVitalsEnabled = (autocapture: AutocaptureOptions | boolean | u
 };
 
 export const isFrustrationInteractionsEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
-  if (typeof autocapture === 'boolean') {
-    return autocapture;
-  }
+  // TODO restore this if statement when frustrationInteractions is GA
+  // if (typeof autocapture === 'boolean') {
+  //   return autocapture;
+  // }
 
   if (
     typeof autocapture === 'object' &&

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -348,6 +348,16 @@ describe('browser-client', () => {
       expect(networkConnectivityCheckerPlugin).toHaveBeenCalledTimes(0);
     });
 
+    test('should add frustration interactions plugin when autocapture is set', async () => {
+      const frustrationInteractionsPlugin = jest.spyOn(autocapture, 'frustrationPlugin');
+      await client.init(apiKey, userId, {
+        autocapture: {
+          frustrationInteractions: true,
+        },
+      }).promise;
+      expect(frustrationInteractionsPlugin).toHaveBeenCalledTimes(1);
+    });
+
     test('should add page view tracking plugin by default', async () => {
       const pageViewTrackingPlugin = jest.spyOn(pageViewTracking, 'pageViewTrackingPlugin');
       await client.init(apiKey, userId).promise;

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -15,8 +15,8 @@ import {
 } from '../src/default-tracking';
 
 describe('isFrustrationInteractionsEnabled', () => {
-  test('should return true with true parameter', () => {
-    expect(isFrustrationInteractionsEnabled(true)).toBe(true);
+  test('should return false with true parameter while frustrationInteractions is Beta', () => {
+    expect(isFrustrationInteractionsEnabled(true)).toBe(false);
   });
 
   test('should return true with undefined parameter', () => {
@@ -56,6 +56,13 @@ describe('isFrustrationInteractionsEnabled', () => {
         cssSelectorAllowlist: ['button'],
       },
     });
+  });
+
+  test('should get undefined frustration interactions config when autocapture is true', () => {
+    const config = getFrustrationInteractionsConfig({
+      autocapture: true,
+    });
+    expect(config).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
### Summary

When "autocapture=true", disable web-vitals and frustration-interactions because they're still in beta.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
