### PR TITLE
Revert: "chore: exclusively use Nx for CI workflows (#1220)"

### DIFF
--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -1,39 +1,10 @@
-name: Continuous Integration (Nx)
+name: Continuous Integration (NX)
 
 on:
-  push:
-    branches:
-      - main
-      - v1.x
   pull_request:
     types: [opened, synchronize]
 
 jobs:
-  build-docs:
-    name: Build Docs
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Check out git repository
-        uses: actions/checkout@v3
-      
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-
-      - name: Install project dependencies
-        run: |
-          yarn install --frozen-lockfile
-
-      - name: Build all packages
-        run: |
-          yarn build
-
-      - name: Build docs
-        run: |
-          yarn docs:check
-
   build:
     name: Build
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - v1.x
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
This reverts commit 8f641c5c82b2751297424aab70d5c3a3a3580b3c.

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

publish v2 failed with error "no changed packages" 
<img width="961" height="539" alt="image" src="https://github.com/user-attachments/assets/8c1a2edc-a1e9-4c07-b13c-6b736e5b2909" />

However there are plenty of changes when running the command locally
<img width="846" height="577" alt="image" src="https://github.com/user-attachments/assets/c970870c-d571-40db-a323-d29d5dcb8cb5" />

Revert the CI PR to rule out the possibility. 



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
