### PR TITLE
chore(targeting): make it private for publish

### DIFF
--- a/packages/targeting/package.json
+++ b/packages/targeting/package.json
@@ -16,6 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/amplitude/Amplitude-TypeScript.git"
   },
+  "private": true,
   "scripts": {
     "build": "yarn bundle && yarn build:es5 && yarn build:esm",
     "bundle": "rollup --config rollup.config.js",


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR marks the targeting package as private to hide it from lerna version to unblock publish v2 GHA. Should fix targeting package in a separate PR. 

[Publish v2 GHA](https://github.com/amplitude/Amplitude-TypeScript/actions/runs/16605794516/job/46977131456) failed without explicit error message. 
<img width="1017" height="647" alt="image" src="https://github.com/user-attachments/assets/aeff0e83-6e14-45a1-9427-60d667443cd4" />

I ran `npm run deploy:version --no-private --create-release` locally and got the error
```
error Invariant Violation: expected workspace package to exist for "glob"
    at invariant (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:2318:15)
    at _loop2 (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:91560:9)
    at PackageHoister.init (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:91619:19)
    at PackageLinker.getFlatHoistedTree (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:48551:20)
    at PackageLinker.<anonymous> (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:48562:27)
    at Generator.next (<anonymous>)
    at step (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:310:30)
    at /opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:328:14
    at new Promise (<anonymous>)
    at new F (/opt/homebrew/Cellar/yarn/1.22.22/libexec/lib/cli.js:5539:28)
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
lerna ERR! lifecycle "version" errored in "@amplitude/targeting", exiting 1
```
`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
