### PR TITLE
ci: output error message

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -88,8 +88,23 @@ jobs:
         if: ${{ env.PUBLISH_FROM != 'from-package' }}
         run: |
           echo "Running lerna version..."
+          
+          # Temporarily disable exit on error to capture output even when command fails
+          set +e
           OUTPUT=$(GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:version -- -y --no-private --create-release github 2>&1)
+          EXIT_CODE=$?
+          set -e
+          
+          # Always display the output first
+          echo "=== Lerna Version Output ==="
           echo "$OUTPUT"
+          echo "=== End Output ==="
+          
+          # Now handle the exit code
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "❌ Command failed with exit code: $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
           
           # Check if the output indicates no changed packages
           if echo "$OUTPUT" | grep -q "No changed packages to version"; then


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR prevent GHA step from stopping immediately before it can execute output with detailed error messages.
An example of current publish v2 not printing output: https://github.com/amplitude/Amplitude-TypeScript/pull/1224

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
