### PR TITLE
fix(analytics-browser): support evaluation window for cross domain t…

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -120,7 +120,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
 
     // Check if ampTimestamp is present and valid
     const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
-    const isTimestampValid = ampTimestamp !== undefined && !Number.isNaN(ampTimestamp) && Date.now() < ampTimestamp;
+    const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
 
     const querySessionId =
       isTimestampValid && !Number.isNaN(Number(queryParams.ampSessionId))

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -112,14 +112,20 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
 
     // Step 3: Set session ID
     // Priority 1: `options.sessionId`
-    // Priority 2: sessionId from url if it's Number
+    // Priority 2: sessionId from url if it's Number and ampTimestamp is valid
     // Priority 3: last known sessionId from user identity storage
     // Default: `Date.now()`
     // Session ID is handled differently than device ID and user ID due to session events
     const queryParams = getQueryParams();
-    const querySessionId = Number.isNaN(Number(queryParams.ampSessionId))
-      ? undefined
-      : Number(queryParams.ampSessionId);
+
+    // Check if ampTimestamp is present and valid
+    const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
+    const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
+
+    const querySessionId =
+      isTimestampValid && !Number.isNaN(Number(queryParams.ampSessionId))
+        ? Number(queryParams.ampSessionId)
+        : undefined;
     this.setSessionId(options.sessionId ?? querySessionId ?? this.config.sessionId ?? Date.now());
 
     // Set up the analytics connector to integrate with the experiment SDK.

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -120,10 +120,10 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
 
     // Check if ampTimestamp is present and valid
     const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
-    const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
+    const isWithinTimeLimit = ampTimestamp ? Date.now() < ampTimestamp : true;
 
     const querySessionId =
-      isTimestampValid && !Number.isNaN(Number(queryParams.ampSessionId))
+      isWithinTimeLimit && !Number.isNaN(Number(queryParams.ampSessionId))
         ? Number(queryParams.ampSessionId)
         : undefined;
     this.setSessionId(options.sessionId ?? querySessionId ?? this.config.sessionId ?? Date.now());

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -120,7 +120,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
 
     // Check if ampTimestamp is present and valid
     const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
-    const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
+    const isTimestampValid = ampTimestamp !== undefined && !Number.isNaN(ampTimestamp) && Date.now() < ampTimestamp;
 
     const querySessionId =
       isTimestampValid && !Number.isNaN(Number(queryParams.ampSessionId))

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -244,7 +244,7 @@ export const useBrowserConfig = async (
 
   // Check if ampTimestamp is present and valid
   const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
-  const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
+  const isTimestampValid = ampTimestamp !== undefined && Date.now() < ampTimestamp;
 
   // Step 3: Reconcile user identity
   const deviceId =

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -244,7 +244,7 @@ export const useBrowserConfig = async (
 
   // Check if ampTimestamp is present and valid
   const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
-  const isTimestampValid = ampTimestamp !== undefined && Date.now() < ampTimestamp;
+  const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
 
   // Step 3: Reconcile user identity
   const deviceId =

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -242,11 +242,14 @@ export const useBrowserConfig = async (
   const previousCookies = await cookieStorage.get(getCookieName(apiKey));
   const queryParams = getQueryParams();
 
+  // Check if ampTimestamp is present and valid
+  const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
+  const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
+
   // Step 3: Reconcile user identity
   const deviceId =
     options.deviceId ??
-    queryParams.ampDeviceId ??
-    queryParams.deviceId ??
+    (isTimestampValid ? queryParams.ampDeviceId ?? queryParams.deviceId : undefined) ??
     previousCookies?.deviceId ??
     legacyCookies.deviceId ??
     UUID();

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -244,12 +244,12 @@ export const useBrowserConfig = async (
 
   // Check if ampTimestamp is present and valid
   const ampTimestamp = queryParams.ampTimestamp ? Number(queryParams.ampTimestamp) : undefined;
-  const isTimestampValid = ampTimestamp ? Date.now() < ampTimestamp : true;
+  const isWithinTimeLimit = ampTimestamp ? Date.now() < ampTimestamp : true;
 
   // Step 3: Reconcile user identity
   const deviceId =
     options.deviceId ??
-    (isTimestampValid ? queryParams.ampDeviceId ?? queryParams.deviceId : undefined) ??
+    (isWithinTimeLimit ? queryParams.ampDeviceId ?? queryParams.deviceId : undefined) ??
     previousCookies?.deviceId ??
     legacyCookies.deviceId ??
     UUID();

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -624,9 +624,12 @@ describe('browser-client', () => {
       const currentTime = 1640995200000; // 2022-01-01 00:00:00 UTC
       const futureTimestamp = currentTime + 300000; // 5 minutes in the future
       const pastTimestamp = currentTime - 300000; // 5 minutes in the past
+      const mockedUUID = '1234567890';
 
       beforeEach(() => {
         Date.now = jest.fn(() => currentTime);
+        // Mock UUID() to return a fixed value
+        jest.spyOn(core, 'UUID').mockReturnValue(mockedUUID);
       });
 
       afterEach(() => {
@@ -734,10 +737,7 @@ describe('browser-client', () => {
         }).promise;
 
         // Should generate new device ID instead of using expired ampDeviceId
-        expect(client.config.deviceId).not.toEqual(testDeviceId);
-        expect(client.config.deviceId).toBeDefined();
-        expect(typeof client.config.deviceId).toBe('string');
-        expect(client.config.deviceId!.length).toBeGreaterThan(0);
+        expect(client.config.deviceId).toEqual(mockedUUID);
       });
 
       test('should work as before when ampTimestamp is missing (backward compatibility)', async () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -617,6 +617,235 @@ describe('browser-client', () => {
         Date.now = originalDate;
       },
     );
+
+    describe('ampTimestamp validation', () => {
+      const originalLocation = window.location;
+      const originalDateNow = Date.now;
+      const currentTime = 1640995200000; // 2022-01-01 00:00:00 UTC
+      const futureTimestamp = currentTime + 300000; // 5 minutes in the future
+      const pastTimestamp = currentTime - 300000; // 5 minutes in the past
+
+      beforeEach(() => {
+        Date.now = jest.fn(() => currentTime);
+      });
+
+      afterEach(() => {
+        Object.defineProperty(window, 'location', {
+          value: originalLocation,
+          writable: true,
+        });
+        Date.now = originalDateNow;
+      });
+
+      test('should use ampSessionId when ampTimestamp is valid (future)', async () => {
+        const urlWithValidTimestamp = new URL(
+          `https://www.example.com?ampSessionId=${testSessionId}&ampTimestamp=${futureTimestamp}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithValidTimestamp.search,
+          } as Location,
+          writable: true,
+        });
+
+        const setSessionId = jest.spyOn(client, 'setSessionId');
+
+        await client.init(apiKey, userId, {
+          defaultTracking: {
+            attribution: false,
+            fileDownloads: false,
+            formInteractions: false,
+            pageViews: false,
+            sessions: true,
+          },
+        }).promise;
+
+        expect(client.config.sessionId).toEqual(testSessionId);
+        expect(setSessionId).toHaveBeenCalledWith(testSessionId);
+      });
+
+      test('should ignore ampSessionId when ampTimestamp is expired (past)', async () => {
+        const urlWithExpiredTimestamp = new URL(
+          `https://www.example.com?ampSessionId=${testSessionId}&ampTimestamp=${pastTimestamp}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithExpiredTimestamp.search,
+          } as Location,
+          writable: true,
+        });
+
+        const setSessionId = jest.spyOn(client, 'setSessionId');
+
+        await client.init(apiKey, userId, {
+          defaultTracking: {
+            attribution: false,
+            fileDownloads: false,
+            formInteractions: false,
+            pageViews: false,
+            sessions: true,
+          },
+        }).promise;
+
+        // Should fall back to Date.now() instead of using expired ampSessionId
+        expect(client.config.sessionId).toEqual(currentTime);
+        expect(setSessionId).toHaveBeenCalledWith(currentTime);
+      });
+
+      test('should use ampDeviceId when ampTimestamp is valid (future)', async () => {
+        const urlWithValidTimestamp = new URL(
+          `https://www.example.com?ampDeviceId=${testDeviceId}&ampTimestamp=${futureTimestamp}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithValidTimestamp.search,
+          } as Location,
+          writable: true,
+        });
+
+        await client.init(apiKey, userId, {
+          defaultTracking: false,
+        }).promise;
+
+        expect(client.config.deviceId).toEqual(testDeviceId);
+      });
+
+      test('should ignore ampDeviceId when ampTimestamp is expired (past)', async () => {
+        const urlWithExpiredTimestamp = new URL(
+          `https://www.example.com?ampDeviceId=${testDeviceId}&ampTimestamp=${pastTimestamp}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithExpiredTimestamp.search,
+          } as Location,
+          writable: true,
+        });
+
+        await client.init(apiKey, userId, {
+          defaultTracking: false,
+        }).promise;
+
+        // Should generate new device ID instead of using expired ampDeviceId
+        expect(client.config.deviceId).not.toEqual(testDeviceId);
+        expect(client.config.deviceId).toBeDefined();
+        expect(typeof client.config.deviceId).toBe('string');
+        expect(client.config.deviceId!.length).toBeGreaterThan(0);
+      });
+
+      test('should work as before when ampTimestamp is missing (backward compatibility)', async () => {
+        const urlWithoutTimestamp = new URL(
+          `https://www.example.com?ampSessionId=${testSessionId}&ampDeviceId=${testDeviceId}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithoutTimestamp.search,
+          } as Location,
+          writable: true,
+        });
+
+        const setSessionId = jest.spyOn(client, 'setSessionId');
+
+        await client.init(apiKey, userId, {
+          defaultTracking: {
+            attribution: false,
+            fileDownloads: false,
+            formInteractions: false,
+            pageViews: false,
+            sessions: true,
+          },
+        }).promise;
+
+        // Should use both parameters when timestamp is missing (backward compatibility)
+        expect(client.config.sessionId).toEqual(testSessionId);
+        expect(client.config.deviceId).toEqual(testDeviceId);
+        expect(setSessionId).toHaveBeenCalledWith(testSessionId);
+      });
+
+      test('should handle malformed ampTimestamp gracefully', async () => {
+        const urlWithMalformedTimestamp = new URL(
+          `https://www.example.com?ampSessionId=${testSessionId}&ampDeviceId=${testDeviceId}&ampTimestamp=invalid`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithMalformedTimestamp.search,
+          } as Location,
+          writable: true,
+        });
+
+        const setSessionId = jest.spyOn(client, 'setSessionId');
+
+        await client.init(apiKey, userId, {
+          defaultTracking: {
+            attribution: false,
+            fileDownloads: false,
+            formInteractions: false,
+            pageViews: false,
+            sessions: true,
+          },
+        }).promise;
+
+        // Should treat malformed timestamp as missing and use parameters (backward compatibility)
+        expect(client.config.sessionId).toEqual(testSessionId);
+        expect(client.config.deviceId).toEqual(testDeviceId);
+        expect(setSessionId).toHaveBeenCalledWith(testSessionId);
+      });
+
+      test('should use deviceId parameter when ampTimestamp is valid', async () => {
+        const urlWithValidTimestampDeviceId = new URL(
+          `https://www.example.com?deviceId=${testDeviceId}&ampTimestamp=${futureTimestamp}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithValidTimestampDeviceId.search,
+          } as Location,
+          writable: true,
+        });
+
+        await client.init(apiKey, userId, {
+          defaultTracking: false,
+        }).promise;
+
+        expect(client.config.deviceId).toEqual(testDeviceId);
+      });
+
+      test('should ignore deviceId parameter when ampTimestamp is expired', async () => {
+        const urlWithExpiredTimestampDeviceId = new URL(
+          `https://www.example.com?deviceId=${testDeviceId}&ampTimestamp=${pastTimestamp}`,
+        );
+
+        Object.defineProperty(window, 'location', {
+          value: {
+            ...originalLocation,
+            search: urlWithExpiredTimestampDeviceId.search,
+          } as Location,
+          writable: true,
+        });
+
+        await client.init(apiKey, userId, {
+          defaultTracking: false,
+        }).promise;
+
+        // Should generate new device ID instead of using expired deviceId parameter
+        expect(client.config.deviceId).not.toEqual(testDeviceId);
+        expect(client.config.deviceId).toBeDefined();
+        expect(typeof client.config.deviceId).toBe('string');
+        expect(client.config.deviceId!.length).toBeGreaterThan(0);
+      });
+    });
   });
 
   describe('getUserId', () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

AMP-134981

This is feature request to provide a evaluation window for cross-domain tracking. Other analytics platforms do enforce a time-validation between the link being generated and cross domain tracking being supported. More details of what others do on slack thread linked in the jira ticket.

- Support ampTimestamp url param, the expiration timestamp
- The SDK would not take device id, or session id in url param if ampTimestamp passes

Note that ampTimestamp is a future timestamp and should be generated and appended to the url by customers. The advantage is that time window is more flexible. GA is 2 minutes while Adobe is 5 minutes. We can just let customers choose how long they want.



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
