### PR TITLE
fix(analytics-react-native): fix Types export

### DIFF
--- a/packages/analytics-react-native/src/index.ts
+++ b/packages/analytics-react-native/src/index.ts
@@ -26,4 +26,5 @@ export { Revenue, Identify } from '@amplitude/analytics-core';
 
 // Export types to maintain backward compatibility with `analytics-types`.
 // In the next major version, only export customer-facing types to reduce the public API surface.
-export * as Types from './types';
+import * as Types from './types';
+export { Types };


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-136845]

Fix https://github.com/amplitude/Amplitude-TypeScript/issues/1240.

`export * as Types from './types';` syntax (ES2020 export namespace syntax) that requires a specific Babel plugin to transform it. The fix splits this to a more widely supported statements. 

Local test:
1. Run `yarn pack` under `Amplitude-TypeScript/packages/analytics-react-native`
2. Run `npm install /Users/xinyi.ye/code/amp/Amplitude-TypeScript/packages/analytics-react-native/amplitude-analytics-react-native-v1.5.1.tgz` under the example RN app
3. Successfully run the app on android without any error
Note: I've tried npm install [path] and npm link, however, neither of them work somehow so using pack here. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
