### PR TITLE
chore(session replay): additional debug logging for trc

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -322,6 +322,20 @@ export class SessionReplay implements AmplitudeSessionReplay {
         apiKey: this.config.apiKey,
         targetingParams: { userProperties: targetingParams.userProperties, event: eventForTargeting },
       });
+
+      // Log the targeting config to debug
+      this.loggerProvider.debug(
+        JSON.stringify(
+          {
+            name: 'targeted replay capture config',
+            sessionTargetingMatch: this.sessionTargetingMatch,
+            event: eventForTargeting,
+            targetingParams: targetingParams,
+          },
+          null,
+          2,
+        ),
+      );
     }
 
     if (isInit) {


### PR DESCRIPTION
### Summary

Adding additional metadata for helping debug TRC capturing conditions - 

```
Amplitude Logger [Debug]: {
  "name": "targeted replay capture config",
  "sessionTargetingMatch": false,
  "targetingParams": {
    "event": {
      "user_id": "XXX",
      "device_id": "XXX",
      "session_id": XXX,
      "time": 1754954595601,
      "platform": "Web",
      "language": "en-US",
      "ip": "$remote",
      "insert_id": "XXX",
      "event_type": "$identify",
      "user_properties": {
        "$set": {
          "propertyBeforeInit": "true"
        }
      },
      "event_id": 3604,
      "library": "amplitude-ts/2.11.9",
      "user_agent": "XXX"
    },
    "userProperties": {
      "propertyBeforeInit": "true"
    }
  }
}
```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
