### PR TITLE
refactor(analytics-core): migrate isPageUrlAllowed to general helper function

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -20,6 +20,7 @@ export { returnWrapper, AmplitudeReturn } from './utils/return-wrapper';
 export { debugWrapper, getClientLogConfig, getClientStates } from './utils/debug';
 export { UUID } from './utils/uuid';
 export { createIdentifyEvent } from './utils/event-builder';
+export { isUrlMatchAllowlist } from './utils/url-utils';
 
 export { MemoryStorage } from './storage/memory';
 export { CookieStorage } from './storage/cookie';

--- a/packages/analytics-core/src/utils/url-utils.ts
+++ b/packages/analytics-core/src/utils/url-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Checks if a given URL matches any pattern in an allowlist of URLs or regex patterns.
+ * @param url - The URL to check
+ * @param allowlist - Array of allowed URLs (strings) or regex patterns
+ * @returns true if the URL matches any pattern in the allowlist, false otherwise
+ */
+export const isUrlMatchAllowlist = (url: string, allowlist: (string | RegExp)[] | undefined): boolean => {
+  if (!allowlist || !allowlist.length) {
+    return true;
+  }
+  return allowlist.some((allowedUrl) => {
+    if (typeof allowedUrl === 'string') {
+      return url === allowedUrl;
+    }
+    return url.match(allowedUrl);
+  });
+};

--- a/packages/analytics-core/test/utils/url-utils.test.ts
+++ b/packages/analytics-core/test/utils/url-utils.test.ts
@@ -1,0 +1,41 @@
+import { isUrlMatchAllowlist } from '../../src/';
+
+describe('isUrlMatchAllowlist', () => {
+  const url = 'https://amplitude.com/blog';
+
+  test('should return true when allow list is not provided', () => {
+    const result = isUrlMatchAllowlist(url, undefined);
+    expect(result).toEqual(true);
+  });
+
+  test('should return true when allow list is empty', () => {
+    const result = isUrlMatchAllowlist(url, []);
+    expect(result).toEqual(true);
+  });
+
+  test('should return true only when full url string is in the allow list', () => {
+    let result = isUrlMatchAllowlist(url, ['https://amplitude.com/blog']);
+    expect(result).toEqual(true);
+
+    result = isUrlMatchAllowlist('https://amplitude.com/market', ['https://amplitude.com/blog']);
+    expect(result).toEqual(false);
+  });
+
+  test('should return true when url regex is in the allow list', () => {
+    let result = isUrlMatchAllowlist(url, [new RegExp('https://amplitude.com/')]);
+    expect(result).toEqual(true);
+
+    result = isUrlMatchAllowlist('https://amplitude.com/market', [new RegExp('https://amplitude.com/')]);
+    expect(result).toEqual(true);
+  });
+
+  test('should return false when url is not in the allow list at all', () => {
+    const result = isUrlMatchAllowlist(url, ['https://test.com', new RegExp('https://test.com/')]);
+    expect(result).toEqual(false);
+  });
+
+  test('should return true when url is matching an item in the allow list with regex wildcard', () => {
+    const result = isUrlMatchAllowlist(url, [new RegExp('http.?://amplitude.*'), new RegExp('http.?://test.*')]);
+    expect(result).toEqual(true);
+  });
+});

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-globals */
 import * as constants from './constants';
-import { ElementInteractionsOptions, ActionType } from '@amplitude/analytics-core';
+import { ElementInteractionsOptions, ActionType, isUrlMatchAllowlist } from '@amplitude/analytics-core';
 import { getHierarchy } from './hierarchy';
 
 export type JSONValue = string | number | boolean | null | { [x: string]: JSONValue } | Array<JSONValue>;
@@ -35,7 +35,7 @@ export const createShouldTrackEvent = (
       return shouldTrackEventResolver(actionType, element);
     }
 
-    if (!isPageUrlAllowed(window.location.href, pageUrlAllowlist)) {
+    if (!isUrlMatchAllowlist(window.location.href, pageUrlAllowlist)) {
       return false;
     }
 
@@ -135,18 +135,6 @@ export const getText = (element: Element): string => {
     });
   }
   return text;
-};
-
-export const isPageUrlAllowed = (url: string, pageUrlAllowlist: (string | RegExp)[] | undefined) => {
-  if (!pageUrlAllowlist || !pageUrlAllowlist.length) {
-    return true;
-  }
-  return pageUrlAllowlist.some((allowedUrl) => {
-    if (typeof allowedUrl === 'string') {
-      return url === allowedUrl;
-    }
-    return url.match(allowedUrl);
-  });
 };
 
 export const getAttributesWithPrefix = (element: Element, prefix: string): { [key: string]: string } => {

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -3,7 +3,6 @@ import {
   isTextNode,
   isNonSensitiveElement,
   getText,
-  isPageUrlAllowed,
   getAttributesWithPrefix,
   isEmpty,
   removeEmptyProperties,
@@ -160,46 +159,6 @@ describe('autocapture-plugin helpers', () => {
       button.appendChild(div);
       const result = getText(button);
       expect(result).toEqual('submit and pay');
-    });
-  });
-
-  describe('isPageUrlAllowed', () => {
-    const url = 'https://amplitude.com/blog';
-
-    test('should return true when allow list is not provided', () => {
-      const result = isPageUrlAllowed(url, undefined);
-      expect(result).toEqual(true);
-    });
-
-    test('should return true when allow list is empty', () => {
-      const result = isPageUrlAllowed(url, []);
-      expect(result).toEqual(true);
-    });
-
-    test('should return true only when full url string is in the allow list', () => {
-      let result = isPageUrlAllowed(url, ['https://amplitude.com/blog']);
-      expect(result).toEqual(true);
-
-      result = isPageUrlAllowed('https://amplitude.com/market', ['https://amplitude.com/blog']);
-      expect(result).toEqual(false);
-    });
-
-    test('should return true when url regex is in the allow list', () => {
-      let result = isPageUrlAllowed(url, [new RegExp('https://amplitude.com/')]);
-      expect(result).toEqual(true);
-
-      result = isPageUrlAllowed('https://amplitude.com/market', [new RegExp('https://amplitude.com/')]);
-      expect(result).toEqual(true);
-    });
-
-    test('should return false when url is not in the allow list at all', () => {
-      const result = isPageUrlAllowed(url, ['https://test.com', new RegExp('https://test.com/')]);
-      expect(result).toEqual(false);
-    });
-
-    test('should return true when url is matching an item in the allow list with regex wildcard', () => {
-      const result = isPageUrlAllowed(url, [new RegExp('http.?://amplitude.*'), new RegExp('http.?://test.*')]);
-      expect(result).toEqual(true);
     });
   });
 


### PR DESCRIPTION
### Summary

Move `isPageUrlAllowed` into a helper function in `analytics-core` so that it can be used by other autocapture features.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
