### PR TITLE
refactor(analytics-core): change pruneHeaders to be non-mutative

### DIFF
--- a/packages/analytics-core/src/network-request-event.ts
+++ b/packages/analytics-core/src/network-request-event.ts
@@ -157,8 +157,7 @@ export class RequestWrapperFetch implements IRequestWrapper {
     }
 
     if (headersPruned) {
-      pruneHeaders(headersPruned, { allow, captureSafeHeaders });
-      return headersPruned;
+      return pruneHeaders(headersPruned, { allow, captureSafeHeaders });
     }
 
     return;
@@ -201,8 +200,7 @@ export class RequestWrapperXhr implements IRequestWrapper {
 
   headers(allow?: string[], captureSafeHeaders?: boolean): Record<string, string> | undefined {
     this.consumptionCheck.consume('headers');
-    pruneHeaders(this.requestHeaders, { allow, captureSafeHeaders });
-    return this.requestHeaders;
+    return pruneHeaders(this.requestHeaders, { allow, captureSafeHeaders });
   }
 
   get bodySize(): number | undefined {
@@ -338,8 +336,7 @@ export class ResponseWrapperFetch implements IResponseWrapper {
       headersSafe?.forEach?.((value, key) => {
         headersOut[key] = value;
       });
-      pruneHeaders(headersOut, { allow, captureSafeHeaders });
-      return headersOut;
+      return pruneHeaders(headersOut, { allow, captureSafeHeaders });
     }
 
     return;
@@ -419,8 +416,7 @@ export class ResponseWrapperXhr implements IResponseWrapper {
         headers[key] = value;
       }
     }
-    pruneHeaders(headers, { allow, captureSafeHeaders });
-    return headers;
+    return pruneHeaders(headers, { allow, captureSafeHeaders });
   }
 
   async json(allow: string[], exclude: string[]): Promise<JsonObject | null> {
@@ -465,28 +461,29 @@ export const pruneHeaders = (
     strategy?: PRUNE_STRATEGY;
     captureSafeHeaders?: boolean;
   },
-) => {
+): Record<string, string> => {
   const { exclude = [], allow = [], strategy = PRUNE_STRATEGY.REMOVE, captureSafeHeaders = false } = options;
+  const excludeWithForbiddenHeaders = [...exclude, ...FORBIDDEN_HEADERS];
+  const allowWithSafeHeaders = captureSafeHeaders ? [...allow, ...SAFE_HEADERS] : allow;
+  const headersPruned: Record<string, string> = {};
+
   for (const key of Object.keys(headers)) {
     const lowerKey = key.toLowerCase();
-    const excludeWithForbiddenHeaders = [...exclude, ...FORBIDDEN_HEADERS];
-
-    const allowWithSafeHeaders = captureSafeHeaders ? [...allow, ...SAFE_HEADERS] : allow;
 
     if (excludeWithForbiddenHeaders.find((e) => e.toLowerCase() === lowerKey)) {
-      if (strategy === PRUNE_STRATEGY.REMOVE) {
-        delete headers[key];
-      } else {
-        headers[key] = REDACTED_VALUE;
+      if (strategy === PRUNE_STRATEGY.REDACT) {
+        headersPruned[key] = REDACTED_VALUE;
       }
     } else if (!allowWithSafeHeaders.find((i) => i.toLowerCase() === lowerKey)) {
-      if (strategy === PRUNE_STRATEGY.REMOVE) {
-        delete headers[key];
-      } else {
-        headers[key] = REDACTED_VALUE;
+      if (strategy === PRUNE_STRATEGY.REDACT) {
+        headersPruned[key] = REDACTED_VALUE;
       }
+    } else {
+      headersPruned[key] = headers[key];
     }
   }
+
+  return headersPruned;
 };
 
 export class NetworkRequestEvent {

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -104,16 +104,18 @@ describe('NetworkObserver', () => {
         status: 200,
       });
       expect(events[0].duration).toBeGreaterThanOrEqual(0);
-      expect(events[0].requestWrapper?.headers()).toEqual(requestHeaders);
+      expect(events[0].requestWrapper?.headers([], true)).toEqual({
+        'Content-Type': 'application/json',
+      });
       // expect headers to throw an error if consumed
-      expect(() => events[0].requestWrapper?.headers()).toThrow(TypeError);
+      expect(() => events[0].requestWrapper?.headers([], true)).toThrow(TypeError);
       const expectedResponseHeaders = {
         'content-type': 'application/json',
         'content-length': '20',
         server: 'test-server',
       };
       expect(events[0].responseWrapper?.headers([], true)).toEqual(expectedResponseHeaders);
-      expect(() => events[0].responseWrapper?.headers()).toThrow(TypeError);
+      expect(() => events[0].responseWrapper?.headers([], true)).toThrow(TypeError);
     });
 
     it('should track successful fetch requests with headers (uses Headers object)', async () => {
@@ -1045,8 +1047,8 @@ describe('pruneHeaders', () => {
       'Content-Length': '1234',
       authorization: 'secretpassword!',
     };
-    pruneHeaders(headers, { allow: [], captureSafeHeaders: true });
-    expect(headers).toEqual({
+    const prunedHeaders = pruneHeaders(headers, { allow: [], captureSafeHeaders: true });
+    expect(prunedHeaders).toEqual({
       'Content-Type': 'application/json',
       'Content-Length': '1234',
     });
@@ -1058,8 +1060,8 @@ describe('pruneHeaders', () => {
       'Content-Length': '1234',
       'Random-Header': 'random-value',
     };
-    pruneHeaders(headers, { allow: ['Random-Header'], captureSafeHeaders: true });
-    expect(headers).toEqual({
+    const prunedHeaders = pruneHeaders(headers, { allow: ['Random-Header'], captureSafeHeaders: true });
+    expect(prunedHeaders).toEqual({
       'Content-Type': 'application/json',
       'Content-Length': '1234',
       'Random-Header': 'random-value',
@@ -1073,8 +1075,8 @@ describe('pruneHeaders', () => {
       'X-Custom-Header': 'customvalue',
       authorization: 'secretpassword!',
     };
-    pruneHeaders(headers, { allow: [], captureSafeHeaders: true });
-    expect(headers).toEqual({
+    const prunedHeaders = pruneHeaders(headers, { allow: [], captureSafeHeaders: true });
+    expect(prunedHeaders).toEqual({
       'Content-Type': 'application/json',
       'Content-Length': '1234',
     });
@@ -1087,8 +1089,11 @@ describe('pruneHeaders', () => {
       'X-Custom-Header': 'customvalue',
       authorization: 'secretpassword!',
     };
-    pruneHeaders(headers, { exclude: ['Content-Type'], allow: ['Content-Type', 'Content-Length'] });
-    expect(headers).toEqual({
+    const prunedHeaders = pruneHeaders(headers, {
+      exclude: ['Content-Type'],
+      allow: ['Content-Type', 'Content-Length'],
+    });
+    expect(prunedHeaders).toEqual({
       'Content-Length': '1234',
     });
   });
@@ -1100,8 +1105,8 @@ describe('pruneHeaders', () => {
       'X-Custom-Header': 'customvalue',
       authorization: 'secretpassword!',
     };
-    pruneHeaders(headers, { allow: ['authorization'] });
-    expect(headers).toEqual({});
+    const prunedHeaders = pruneHeaders(headers, { allow: ['authorization'] });
+    expect(prunedHeaders).toEqual({});
   });
 
   test('should delete headers if strategy is remove', () => {
@@ -1111,13 +1116,26 @@ describe('pruneHeaders', () => {
       'X-Custom-Header': 'customvalue',
       authorization: 'secretpassword!',
     };
-    pruneHeaders(headers, {
+    const prunedHeaders = pruneHeaders(headers, {
       captureSafeHeaders: true,
       allow: [],
       exclude: ['Content-Type'],
       strategy: PRUNE_STRATEGY.REMOVE,
     });
-    expect(headers).toEqual({
+    expect(prunedHeaders).toEqual({
+      'Content-Length': '1234',
+    });
+  });
+
+  test('should default allow to be empty array', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      'Content-Length': '1234',
+      authorization: 'secretpassword!',
+    };
+    const prunedHeaders = pruneHeaders(headers, { captureSafeHeaders: true });
+    expect(prunedHeaders).toEqual({
+      'Content-Type': 'application/json',
       'Content-Length': '1234',
     });
   });
@@ -1129,13 +1147,13 @@ describe('pruneHeaders', () => {
       authorization: 'secretpassword!',
       'X-Custom-Header': 'customvalue',
     };
-    pruneHeaders(headers, {
+    const prunedHeaders = pruneHeaders(headers, {
       captureSafeHeaders: true,
       allow: [],
       exclude: ['Content-Type'],
       strategy: PRUNE_STRATEGY.REDACT,
     });
-    expect(headers).toEqual({
+    expect(prunedHeaders).toEqual({
       'Content-Type': '[REDACTED]',
       'Content-Length': '1234',
       authorization: '[REDACTED]',


### PR DESCRIPTION
### Summary

Upon careful consideration, I think it's unwise to make the `pruneHeaders` function mutate the headers object. There's a risk that somebody could unwittingly pass the original headers object into `pruneHeaders` by mistake and mutate it. Not worth the performance boost.

This PR changes it so that `pruneHeaders` returns a new headers object that has the key/value pairings pruned from the original. The original object is untouched.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
