### PR TITLE
feat(autocapture): add filtering for email in isNonSensitiveString

### DIFF
--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -95,6 +95,10 @@ export const isNonSensitiveString = (text: string | null) => {
     if (ssnRegex.test(text)) {
       return false;
     }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (emailRegex.test(text)) {
+      return false;
+    }
   }
   return true;
 };

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -95,7 +95,7 @@ export const isNonSensitiveString = (text: string | null) => {
     if (ssnRegex.test(text)) {
       return false;
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const emailRegex = /[^\s@]+@[^\s@]+\.[^\s@]+/;
     if (emailRegex.test(text)) {
       return false;
     }

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -95,7 +95,7 @@ export const isNonSensitiveString = (text: string | null) => {
     if (ssnRegex.test(text)) {
       return false;
     }
-    const emailRegex = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+    const emailRegex = /[^\s@]+@[^\s@.]+\.[^\s@]+/;
     if (emailRegex.test(text)) {
       return false;
     }

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -56,6 +56,12 @@ describe('autocapture-plugin helpers', () => {
       expect(result).toEqual(false);
     });
 
+    test('should return false when text is email address format with special character in local part', () => {
+      const text = 'user.@example.com';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
     test('should return true when text is not a string', () => {
       const text = 123;
       const result = isNonSensitiveString(text as unknown as string);

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -50,6 +50,12 @@ describe('autocapture-plugin helpers', () => {
       expect(result).toEqual(false);
     });
 
+    test('should return false when text is email address format', () => {
+      const text = 'user@example.com';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
     test('should return true when text is not a string', () => {
       const text = 123;
       const result = isNonSensitiveString(text as unknown as string);

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -56,8 +56,26 @@ describe('autocapture-plugin helpers', () => {
       expect(result).toEqual(false);
     });
 
-    test('should return false when text is email address format with special character in local part', () => {
-      const text = 'user.@example.com';
+    test('should return false when text contains email address within other text', () => {
+      const text = 'Contact us at support@example.com for help';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when text contains email address at the beginning', () => {
+      const text = 'user@example.com is the admin';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when text contains email address at the end', () => {
+      const text = 'Send feedback to feedback@company.org';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when text contains multiple email addresses', () => {
+      const text = 'Contact admin@example.com or support@example.com';
       const result = isNonSensitiveString(text);
       expect(result).toEqual(false);
     });

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -80,10 +80,10 @@ describe('autocapture-plugin helpers', () => {
       expect(result).toEqual(false);
     });
 
-    test('should return true when email has dots in domain name before final dot', () => {
+    test('should return false when email has dots in domain name before final dot', () => {
       const text = 'user@sub.domain.example.com';
       const result = isNonSensitiveString(text);
-      expect(result).toEqual(true);
+      expect(result).toEqual(false);
     });
 
     test('should return true when text is not a string', () => {

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -80,6 +80,12 @@ describe('autocapture-plugin helpers', () => {
       expect(result).toEqual(false);
     });
 
+    test('should return true when email has dots in domain name before final dot', () => {
+      const text = 'user@sub.domain.example.com';
+      const result = isNonSensitiveString(text);
+      expect(result).toEqual(true);
+    });
+
     test('should return true when text is not a string', () => {
       const text = 123;
       const result = isNonSensitiveString(text as unknown as string);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,16 @@
     "@amplitude/analytics-types" "^1.3.5"
     tslib "^2.4.1"
 
+"@amplitude/analytics-remote-config@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz#b62cf8aa82290f68b314197e20351b10ea44ae3e"
+  integrity sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-core" ">=1 <3"
+    "@amplitude/analytics-types" ">=1 <3"
+    tslib "^2.4.1"
+
 "@amplitude/analytics-types@>=1 <2", "@amplitude/analytics-types@^1.3.4", "@amplitude/analytics-types@^1.3.5":
   version "1.3.5"
   resolved "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-1.3.5.tgz"


### PR DESCRIPTION
### Summary

Add email address regex match filtering along with credit card and SSN.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
