### PR TITLE
feat(autocapture): add redactTextRegex option to autocapture

### DIFF
--- a/packages/analytics-core/src/types/element-interactions.ts
+++ b/packages/analytics-core/src/types/element-interactions.ts
@@ -92,6 +92,11 @@ export interface ElementInteractionsOptions {
     triggers: Trigger[];
     labeledEvents: Record<string, LabeledEvent>;
   };
+
+  /**
+   * RegExp pattern list to allow custom patterns for text redaction
+   */
+  redactTextRegex?: (RegExp | { pattern: string; description: string })[];
 }
 
 type MatchingCondition = {

--- a/packages/analytics-core/src/types/frustration-interactions.ts
+++ b/packages/analytics-core/src/types/frustration-interactions.ts
@@ -59,6 +59,11 @@ export interface FrustrationInteractionsOptions {
    * Configuration for rage clicks tracking
    */
   rageClicks?: RageClickOptions;
+
+  /**
+   * Configuration for text redaction
+   */
+  redactTextRegex?: (string | RegExp)[];
 }
 
 const CLICKABLE_ELEMENT_SELECTORS = [

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -12,9 +12,7 @@ import { createRemoteConfigFetch } from '@amplitude/analytics-remote-config';
 import * as constants from './constants';
 import { fromEvent, map, type Observable, type Subscription, share } from 'rxjs';
 import {
-  addAdditionalEventProperties,
   createShouldTrackEvent,
-  getEventProperties,
   type ElementBasedTimestampedEvent,
   type TimestampedEvent,
   type NavigateEvent,
@@ -88,7 +86,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
     // Create Observables from direct user events
     const clickObservable = createClickObservable().pipe(
       map((click) =>
-        addAdditionalEventProperties(
+        dataExtractor.addAdditionalEventProperties(
           click,
           'click',
           (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
@@ -99,7 +97,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
     );
     const changeObservable = fromEvent<Event>(document, 'change', { capture: true }).pipe(
       map((change) =>
-        addAdditionalEventProperties(
+        dataExtractor.addAdditionalEventProperties(
           change,
           'change',
           (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
@@ -120,7 +118,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
     if (window.navigation) {
       navigateObservable = fromEvent<NavigateEvent>(window.navigation, 'navigate').pipe(
         map((navigate) =>
-          addAdditionalEventProperties(
+          dataExtractor.addAdditionalEventProperties(
             navigate,
             'navigate',
             (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
@@ -134,7 +132,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
     // Track DOM Mutations using shared observable
     const mutationObservable = createMutationObservable().pipe(
       map((mutation) =>
-        addAdditionalEventProperties(
+        dataExtractor.addAdditionalEventProperties(
           mutation,
           'mutation',
           (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
@@ -233,7 +231,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
 
     const changeSubscription = trackChange({
       allObservables,
-      getEventProperties: (...args) => getEventProperties(...args, dataAttributePrefix),
+      getEventProperties: (...args) => dataExtractor.getEventProperties(...args, dataAttributePrefix),
       amplitude,
       shouldTrackEvent: shouldTrackEvent,
       evaluateTriggers: evaluateTriggers.evaluate.bind(evaluateTriggers),
@@ -243,7 +241,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
     const actionClickSubscription = trackActionClick({
       allObservables,
       options: options as AutoCaptureOptionsWithDefaults,
-      getEventProperties: (...args) => getEventProperties(...args, dataAttributePrefix),
+      getEventProperties: (...args) => dataExtractor.getEventProperties(...args, dataAttributePrefix),
       amplitude,
       shouldTrackEvent,
       shouldTrackActionClick: shouldTrackActionClick,

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -31,6 +31,7 @@ import {
   createTriggerEvaluator,
   groupLabeledEventIdsByEventType,
 } from './pageActions/triggers';
+import { DataExtractor } from './data-extractor';
 
 declare global {
   interface Window {
@@ -78,6 +79,9 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
   const type = 'enrichment';
 
   const subscriptions: Subscription[] = [];
+
+  // Create data extractor based on options
+  const dataExtractor = new DataExtractor(options);
 
   // Create observables on events on the window
   const createObservables = (): AllWindowObservables => {
@@ -256,6 +260,7 @@ export const autocapturePlugin = (options: ElementInteractionsOptions = {}): Bro
 
       /* istanbul ignore next */
       visualTaggingOptions.messenger?.setup({
+        dataExtractor: dataExtractor,
         logger: config?.loggerProvider,
         ...(config?.serverZone && { endpoint: constants.AMPLITUDE_ORIGINS_MAP[config.serverZone] }),
         isElementSelectable: createShouldTrackEvent(options, [...allowlist, ...actionClickAllowlist]),

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -38,3 +38,5 @@ export const AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL =
 // This is the class name used by the visual tagging selector to highlight the selected element.
 // Should not use this class in the selector.
 export const AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS = 'amp-visual-tagging-selector-highlight';
+
+export const MAX_REDACT_TEXT_PATTERNS = 25;

--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -23,9 +23,9 @@ export class DataExtractor {
     for (const entry of rawPatterns) {
       if (entry instanceof RegExp) {
         compiled.push(entry);
-      } else if (entry && typeof (entry as { pattern: string }).pattern === 'string') {
+      } else if ('pattern' in entry && typeof (entry.pattern === 'string')) {
         try {
-          compiled.push(new RegExp((entry as { pattern: string }).pattern));
+          compiled.push(new RegExp(entry.pattern));
         } catch {
           // ignore invalid pattern strings
         }

--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -19,6 +19,7 @@ export class DataExtractor {
 
   constructor(options: ElementInteractionsOptions) {
     const rawPatterns = options.redactTextRegex ?? [];
+
     const compiled: RegExp[] = [];
     for (const entry of rawPatterns) {
       if (compiled.length >= constants.MAX_REDACT_TEXT_PATTERNS) {
@@ -34,6 +35,7 @@ export class DataExtractor {
         }
       }
     }
+    console.log(compiled);
     this.additionalRedactTextPatterns = compiled;
   }
 

--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -1,0 +1,81 @@
+/* eslint-disable no-restricted-globals */
+import type { ElementInteractionsOptions } from '@amplitude/analytics-core';
+import * as constants from './constants';
+import { isNonSensitiveElement, isTextNode, removeEmptyProperties } from './helpers';
+import type { JSONValue } from './helpers';
+
+export class DataExtractor {
+  private readonly additionalRedactTextPatterns: RegExp[];
+
+  constructor(private readonly options: ElementInteractionsOptions & { redactTextRegex?: RegExp[] } = {}) {
+    // TODO parse into a regex object
+    this.additionalRedactTextPatterns = this.options.redactTextRegex ?? []; // TODO parse into a regex object
+  }
+
+  isNonSensitiveString = (text: string | null): boolean => {
+    if (text == null) {
+      return false;
+    }
+    if (typeof text === 'string') {
+      const normalized = (text || '').replace(/[- ]/g, '');
+      const ccRegex =
+        /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/;
+      if (ccRegex.test(normalized)) {
+        return false;
+      }
+      const ssnRegex = /(^\d{3}-?\d{2}-?\d{4}$)/;
+      if (ssnRegex.test(text)) {
+        return false;
+      }
+      for (const pattern of this.additionalRedactTextPatterns) {
+        try {
+          if (pattern.test(text)) {
+            return false;
+          }
+        } catch {
+          // ignore invalid pattern
+        }
+      }
+    }
+    return true;
+  };
+
+  getText = (element: Element): string => {
+    let text = '';
+    if (isNonSensitiveElement(element) && element.childNodes && element.childNodes.length) {
+      for (const child of Array.from(element.childNodes)) {
+        let childText = '';
+        if (isTextNode(child)) {
+          if (child.textContent) {
+            childText = child.textContent;
+          }
+        } else {
+          childText = this.getText(child as Element);
+        }
+        text += childText
+          .split(/(\s+)/)
+          .filter((t) => this.isNonSensitiveString(t))
+          .join('')
+          .replace(/[\r\n]/g, ' ')
+          .replace(/[ ]+/g, ' ')
+          .substring(0, 255);
+      }
+    }
+    return text;
+  };
+
+  // Returns the element properties for the given element in Visual Labeling.
+  getEventTagProps = (element: Element): Record<string, JSONValue> => {
+    if (!element) {
+      return {} as Record<string, JSONValue>;
+    }
+    const tag = element?.tagName?.toLowerCase?.();
+    const properties: Record<string, JSONValue> = {
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
+      [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: this.getText(element),
+      [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]:
+        typeof window !== 'undefined' ? window.location.href.split('?')[0] : '',
+    };
+    return removeEmptyProperties(properties) as Record<string, JSONValue>;
+  };
+}

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -81,60 +81,8 @@ export const createShouldTrackEvent = (
   };
 };
 
-export const isNonSensitiveString = (text: string | null) => {
-  if (text == null) {
-    return false;
-  }
-  if (typeof text === 'string') {
-    const ccRegex =
-      /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/;
-    if (ccRegex.test((text || '').replace(/[- ]/g, ''))) {
-      return false;
-    }
-    const ssnRegex = /(^\d{3}-?\d{2}-?\d{4}$)/;
-    if (ssnRegex.test(text)) {
-      return false;
-    }
-  }
-  return true;
-};
-
 export const isTextNode = (node: Node) => {
   return !!node && node.nodeType === 3;
-};
-
-export const isNonSensitiveElement = (element: Element) => {
-  /* istanbul ignore next */
-  const tag = element?.tagName?.toLowerCase?.();
-  const isContentEditable =
-    element instanceof HTMLElement ? element.getAttribute('contenteditable')?.toLowerCase() === 'true' : false;
-
-  return !SENSITIVE_TAGS.includes(tag) && !isContentEditable;
-};
-
-// Maybe this can be simplified with element.innerText, keep and manual concatenating for now, more research needed.
-export const getText = (element: Element): string => {
-  let text = '';
-  if (isNonSensitiveElement(element) && element.childNodes && element.childNodes.length) {
-    element.childNodes.forEach((child) => {
-      let childText = '';
-      if (isTextNode(child)) {
-        if (child.textContent) {
-          childText = child.textContent;
-        }
-      } else {
-        childText = getText(child as Element);
-      }
-      text += childText
-        .split(/(\s+)/)
-        .filter(isNonSensitiveString)
-        .join('')
-        .replace(/[\r\n]/g, ' ')
-        .replace(/[ ]+/g, ' ')
-        .substring(0, 255);
-    });
-  }
-  return text;
 };
 
 export const getAttributesWithPrefix = (element: Element, prefix: string): { [key: string]: string } => {
@@ -216,22 +164,6 @@ export const getClosestElement = (element: Element | null, selectors: string[]):
   }
   /* istanbul ignore next */
   return getClosestElement(element?.parentElement, selectors);
-};
-
-// Returns the element properties for the given element in Visual Labeling.
-export const getEventTagProps = (element: Element) => {
-  if (!element) {
-    return {};
-  }
-  /* istanbul ignore next */
-  const tag = element?.tagName?.toLowerCase?.();
-
-  const properties: Record<string, JSONValue> = {
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: getText(element),
-    [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: window.location.href.split('?')[0],
-  };
-  return removeEmptyProperties(properties);
 };
 
 export const asyncLoadScript = (url: string) => {

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-restricted-globals */
-import * as constants from './constants';
 import { ElementInteractionsOptions, ActionType, isUrlMatchAllowlist } from '@amplitude/analytics-core';
-import { getHierarchy } from './hierarchy';
 
 export type JSONValue = string | number | boolean | null | { [x: string]: JSONValue } | Array<JSONValue>;
 
@@ -85,6 +83,15 @@ export const isTextNode = (node: Node) => {
   return !!node && node.nodeType === 3;
 };
 
+export const isNonSensitiveElement = (element: Element) => {
+  /* istanbul ignore next */
+  const tag = element?.tagName?.toLowerCase?.();
+  const isContentEditable =
+    element instanceof HTMLElement ? element.getAttribute('contenteditable')?.toLowerCase() === 'true' : false;
+
+  return !SENSITIVE_TAGS.includes(tag) && !isContentEditable;
+};
+
 export const getAttributesWithPrefix = (element: Element, prefix: string): { [key: string]: string } => {
   return element.getAttributeNames().reduce((attributes: { [key: string]: string }, attributeName) => {
     if (attributeName.startsWith(prefix)) {
@@ -115,26 +122,6 @@ export const removeEmptyProperties = (properties: { [key: string]: unknown }) =>
     }
     return filteredProperties;
   }, {});
-};
-
-export const getNearestLabel = (element: Element): string => {
-  const parent = element.parentElement;
-  if (!parent) {
-    return '';
-  }
-  let labelElement;
-  try {
-    labelElement = parent.querySelector(':scope>span,h1,h2,h3,h4,h5,h6');
-  } catch (error) {
-    /* istanbul ignore next */
-    labelElement = null;
-  }
-  if (labelElement) {
-    /* istanbul ignore next */
-    const labelText = labelElement.textContent || '';
-    return isNonSensitiveString(labelText) ? labelText : '';
-  }
-  return getNearestLabel(parent);
 };
 
 export const querySelectUniqueElements = (root: Element | Document, selectors: string[]): Element[] => {
@@ -209,89 +196,10 @@ export const filterOutNonTrackableEvents = (event: ElementBasedTimestampedEvent<
   return true;
 };
 
-// Returns the Amplitude event properties for the given element.
-export const getEventProperties = (actionType: ActionType, element: Element, dataAttributePrefix: string) => {
-  /* istanbul ignore next */
-  const tag = element?.tagName?.toLowerCase?.();
-  /* istanbul ignore next */
-  const rect =
-    typeof element.getBoundingClientRect === 'function' ? element.getBoundingClientRect() : { left: null, top: null };
-  const ariaLabel = element.getAttribute('aria-label');
-  const attributes = getAttributesWithPrefix(element, dataAttributePrefix);
-  const nearestLabel = getNearestLabel(element);
-  /* istanbul ignore next */
-  const properties: Record<string, any> = {
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ID]: element.getAttribute('id') || '',
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_CLASS]: element.getAttribute('class'),
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_HIERARCHY]: getHierarchy(element),
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: getText(element),
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_LEFT]: rect.left == null ? null : Math.round(rect.left),
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_POSITION_TOP]: rect.top == null ? null : Math.round(rect.top),
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ARIA_LABEL]: ariaLabel,
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ATTRIBUTES]: attributes,
-    [constants.AMPLITUDE_EVENT_PROP_ELEMENT_PARENT_LABEL]: nearestLabel,
-    [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: window.location.href.split('?')[0],
-    [constants.AMPLITUDE_EVENT_PROP_PAGE_TITLE]: (typeof document !== 'undefined' && document.title) || '',
-    [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT]: window.innerHeight,
-    [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH]: window.innerWidth,
-  };
-  if (tag === 'a' && actionType === 'click' && element instanceof HTMLAnchorElement) {
-    properties[constants.AMPLITUDE_EVENT_PROP_ELEMENT_HREF] = element.href;
-  }
-  return removeEmptyProperties(properties);
-};
-
 export type AutoCaptureOptionsWithDefaults = Required<
   Pick<ElementInteractionsOptions, 'debounceTime' | 'cssSelectorAllowlist' | 'actionClickAllowlist'>
 > &
   ElementInteractionsOptions;
-
-export const addAdditionalEventProperties = <T>(
-  event: T,
-  type: TimestampedEvent<T>['type'],
-  selectorAllowlist: string[],
-  dataAttributePrefix: string,
-
-  // capture the event if the cursor is a "pointer" when this element is clicked on
-  // reason: a "pointer" cursor indicates that an element should be interactable
-  //         regardless of the element's tag name
-  isCapturingCursorPointer = false,
-): TimestampedEvent<T> | ElementBasedTimestampedEvent<T> => {
-  const baseEvent: BaseTimestampedEvent<T> | ElementBasedTimestampedEvent<T> = {
-    event,
-    timestamp: Date.now(),
-    type,
-  };
-
-  if (isElementBasedEvent(baseEvent) && baseEvent.event.target !== null) {
-    if (isCapturingCursorPointer) {
-      const isCursorPointer = isElementPointerCursor(baseEvent.event.target as Element, baseEvent.type);
-      if (isCursorPointer) {
-        baseEvent.closestTrackedAncestor = baseEvent.event.target as HTMLElement;
-        baseEvent.targetElementProperties = getEventProperties(
-          baseEvent.type,
-          baseEvent.closestTrackedAncestor,
-          dataAttributePrefix,
-        );
-        return baseEvent;
-      }
-    }
-    // Retrieve additional event properties from the target element
-    const closestTrackedAncestor = getClosestElement(baseEvent.event.target as HTMLElement, selectorAllowlist);
-    if (closestTrackedAncestor) {
-      baseEvent.closestTrackedAncestor = closestTrackedAncestor;
-      baseEvent.targetElementProperties = getEventProperties(
-        baseEvent.type,
-        closestTrackedAncestor,
-        dataAttributePrefix,
-      );
-    }
-    return baseEvent;
-  }
-
-  return baseEvent;
-};
 
 // Base TimestampedEvent type
 export type BaseTimestampedEvent<T> = {

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -114,7 +114,7 @@ export const isEmpty = (value: unknown) => {
   );
 };
 
-export const removeEmptyProperties = (properties: { [key: string]: unknown }) => {
+export const removeEmptyProperties = (properties: { [key: string]: unknown }): { [key: string]: unknown } => {
   return Object.keys(properties).reduce((filteredProperties: { [key: string]: unknown }, key) => {
     const value = properties[key];
     if (!isEmpty(value)) {

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -6,9 +6,10 @@ import {
   AMPLITUDE_VISUAL_TAGGING_SELECTOR_SCRIPT_URL,
   AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS,
 } from '../constants';
-import { asyncLoadScript, generateUniqueId, getEventTagProps } from '../helpers';
+import { asyncLoadScript, generateUniqueId } from '../helpers';
 import { ILogger, Messenger, ActionType } from '@amplitude/analytics-core';
 import { VERSION } from '../version';
+import type { DataExtractor } from '../data-extractor';
 
 export type Action =
   | 'ping'
@@ -138,12 +139,14 @@ export class WindowMessenger implements Messenger {
     isElementSelectable,
     cssSelectorAllowlist,
     actionClickAllowlist,
+    dataExtractor,
   }: {
     logger?: ILogger;
     endpoint?: string;
     isElementSelectable?: (action: InitializeVisualTaggingSelectorData['actionType'], element: Element) => boolean;
     cssSelectorAllowlist?: string[];
     actionClickAllowlist?: string[];
+    dataExtractor: DataExtractor;
   } = {}) {
     this.logger = logger;
     // If endpoint is customized, don't override it.
@@ -184,7 +187,7 @@ export class WindowMessenger implements Messenger {
             .then(() => {
               // eslint-disable-next-line
               amplitudeVisualTaggingSelectorInstance = (window as any)?.amplitudeVisualTaggingSelector?.({
-                getEventTagProps,
+                getEventTagProps: dataExtractor.getEventTagProps,
                 isElementSelectable: (element: Element) => {
                   if (isElementSelectable) {
                     return isElementSelectable(actionData?.actionType || 'click', element);

--- a/packages/plugin-autocapture-browser/src/libs/messenger.ts
+++ b/packages/plugin-autocapture-browser/src/libs/messenger.ts
@@ -9,7 +9,7 @@ import {
 import { asyncLoadScript, generateUniqueId } from '../helpers';
 import { ILogger, Messenger, ActionType } from '@amplitude/analytics-core';
 import { VERSION } from '../version';
-import type { DataExtractor } from '../data-extractor';
+import { DataExtractor } from '../data-extractor';
 
 export type Action =
   | 'ping'
@@ -133,21 +133,23 @@ export class WindowMessenger implements Messenger {
     delete this.requestCallbacks[response.id];
   }
 
-  setup({
-    logger,
-    endpoint,
-    isElementSelectable,
-    cssSelectorAllowlist,
-    actionClickAllowlist,
-    dataExtractor,
-  }: {
-    logger?: ILogger;
-    endpoint?: string;
-    isElementSelectable?: (action: InitializeVisualTaggingSelectorData['actionType'], element: Element) => boolean;
-    cssSelectorAllowlist?: string[];
-    actionClickAllowlist?: string[];
-    dataExtractor: DataExtractor;
-  } = {}) {
+  setup(
+    {
+      logger,
+      endpoint,
+      isElementSelectable,
+      cssSelectorAllowlist,
+      actionClickAllowlist,
+      dataExtractor,
+    }: {
+      logger?: ILogger;
+      endpoint?: string;
+      isElementSelectable?: (action: InitializeVisualTaggingSelectorData['actionType'], element: Element) => boolean;
+      cssSelectorAllowlist?: string[];
+      actionClickAllowlist?: string[];
+      dataExtractor: DataExtractor;
+    } = { dataExtractor: new DataExtractor({}) },
+  ) {
     this.logger = logger;
     // If endpoint is customized, don't override it.
     if (endpoint && this.endpoint === AMPLITUDE_ORIGIN) {

--- a/packages/plugin-autocapture-browser/test/data-extractor.test.ts
+++ b/packages/plugin-autocapture-browser/test/data-extractor.test.ts
@@ -6,7 +6,7 @@ describe('data extractor', () => {
   let dataExtractor: DataExtractor;
 
   beforeEach(() => {
-    dataExtractor = new DataExtractor({});
+    dataExtractor = new DataExtractor({ redactTextRegex: [/Florida|California/, /Pennsylvania/] });
   });
 
   describe('isNonSensitiveString', () => {
@@ -38,6 +38,41 @@ describe('data extractor', () => {
       const text = 123;
       const result = dataExtractor.isNonSensitiveString(text as unknown as string);
       expect(result).toEqual(true);
+    });
+
+    test('should return false when text is sensitive and matches redactTextRegex', () => {
+      const text = 'Pittsburgh, Pennsylvania';
+      const result = dataExtractor.isNonSensitiveString(text);
+
+      const text2 = 'Florida';
+      const result2 = dataExtractor.isNonSensitiveString(text2);
+
+      expect(result).toEqual(false);
+      expect(result2).toEqual(false);
+    });
+
+    test('should return true when text does not match redactTextRegex', () => {
+      const text = 'Test string';
+      const result = dataExtractor.isNonSensitiveString(text);
+      expect(result).toEqual(true);
+    });
+
+    test('should parse rebactTextRegex objects into regex objects', () => {
+      const dataExtractor = new DataExtractor({
+        redactTextRegex: [
+          { pattern: 'Florida|California', description: 'Florida or California' },
+          { pattern: 'Pennsylvania', description: 'Pennsylvania' },
+        ],
+      });
+
+      const text = 'Pittsburgh, Pennsylvania';
+      const result = dataExtractor.isNonSensitiveString(text);
+
+      const text2 = 'Florida';
+      const result2 = dataExtractor.isNonSensitiveString(text2);
+
+      expect(result).toEqual(false);
+      expect(result2).toEqual(false);
     });
   });
 

--- a/packages/plugin-autocapture-browser/test/data-extractor.test.ts
+++ b/packages/plugin-autocapture-browser/test/data-extractor.test.ts
@@ -1,0 +1,246 @@
+import { DataExtractor } from '../src/data-extractor';
+import { mockWindowLocationFromURL } from './utils';
+import type { ElementBasedTimestampedEvent } from '../src/helpers';
+
+describe('data extractor', () => {
+  let dataExtractor: DataExtractor;
+
+  beforeEach(() => {
+    dataExtractor = new DataExtractor({});
+  });
+
+  describe('isNonSensitiveString', () => {
+    test('should return false when text is missing', () => {
+      const text = null;
+      const result = dataExtractor.isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return true when text is not sensitive', () => {
+      const text = 'test-string';
+      const result = dataExtractor.isNonSensitiveString(text);
+      expect(result).toEqual(true);
+    });
+
+    test('should return false when text is credit card format', () => {
+      const text = '4916024123820164';
+      const result = dataExtractor.isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return false when text is social security number format', () => {
+      const text = '269-28-9315';
+      const result = dataExtractor.isNonSensitiveString(text);
+      expect(result).toEqual(false);
+    });
+
+    test('should return true when text is not a string', () => {
+      const text = 123;
+      const result = dataExtractor.isNonSensitiveString(text as unknown as string);
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('getText', () => {
+    test('should return empty string when element is sensitive', () => {
+      const inputEl: HTMLInputElement = document.createElement('input');
+      inputEl.value = 'test';
+      const result = dataExtractor.getText(inputEl);
+      expect(result).toEqual('');
+    });
+
+    test('should return text when element has text attribute', () => {
+      const element = document.createElement('a');
+      (element as unknown as { text: string }).text = 'test';
+      const result = dataExtractor.getText(element);
+      expect(result).toEqual('test');
+    });
+
+    test('should return text when element has text node', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const result = dataExtractor.getText(button);
+      expect(result).toEqual('submit');
+    });
+
+    test('should return concatenated text when element has child text nodes', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const div = document.createElement('div');
+      div.textContent = ' and pay';
+      button.appendChild(div);
+      const result = dataExtractor.getText(button);
+      expect(result).toEqual('submit and pay');
+    });
+
+    test('should return concatenated text with sensitive text filtered', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const div = document.createElement('div');
+      div.textContent = '269-28-9315';
+      button.appendChild(div);
+      const result = dataExtractor.getText(button);
+      expect(result).toEqual('submit');
+    });
+
+    test('should return concatenated text with extra space removed', () => {
+      const button = document.createElement('button');
+      const buttonText = document.createTextNode('submit');
+      button.appendChild(buttonText);
+      const div = document.createElement('div');
+      div.textContent = ' and   \n pay';
+      button.appendChild(div);
+      const result = dataExtractor.getText(button);
+      expect(result).toEqual('submit and pay');
+    });
+  });
+
+  describe('getNearestLabel', () => {
+    test('should return nearest label of the element', () => {
+      const div = document.createElement('div');
+      const span = document.createElement('span');
+      span.textContent = 'nearest label';
+      const input = document.createElement('input');
+      div.appendChild(span);
+      div.appendChild(input);
+
+      const result = dataExtractor.getNearestLabel(input);
+      expect(result).toEqual('nearest label');
+    });
+
+    test('should return redacted nearest label when content is sensitive', () => {
+      const div = document.createElement('div');
+      const span = document.createElement('span');
+      span.textContent = '4916024123820164';
+      const input = document.createElement('input');
+      div.appendChild(span);
+      div.appendChild(input);
+
+      const result = dataExtractor.getNearestLabel(input);
+      expect(result).toEqual('');
+    });
+
+    test('should return nearest label of the element parent', () => {
+      const div = document.createElement('div');
+      const innerDiv = document.createElement('div');
+      div.appendChild(innerDiv);
+      const span = document.createElement('span');
+      span.textContent = 'parent label';
+      div.appendChild(span);
+      const input = document.createElement('input');
+      innerDiv.appendChild(input);
+
+      const result = dataExtractor.getNearestLabel(input);
+      expect(result).toEqual('parent label');
+    });
+
+    test('should return empty string when there is no parent', () => {
+      const input = document.createElement('input');
+
+      const result = dataExtractor.getNearestLabel(input);
+      expect(result).toEqual('');
+    });
+  });
+
+  describe('getEventTagProps', () => {
+    beforeAll(() => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          hostname: '',
+          href: '',
+          pathname: '',
+          search: '',
+        },
+        writable: true,
+      });
+    });
+
+    beforeEach(() => {
+      mockWindowLocationFromURL(new URL('https://www.amplitude.com/unit-test?query=getEventTagProps'));
+    });
+
+    test('should return the tag properties', () => {
+      document.getElementsByTagName('body')[0].innerHTML = `
+        <div id="container">
+          <div id="inner">
+            xxx
+          </div>
+        </div>
+      `;
+
+      const inner = document.getElementById('inner');
+      expect(dataExtractor.getEventTagProps(inner as HTMLElement)).toEqual({
+        '[Amplitude] Element Tag': 'div',
+        '[Amplitude] Element Text': ' xxx ',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+      });
+    });
+
+    test('should return empty object when element is not present', () => {
+      expect(dataExtractor.getEventTagProps(null as unknown as HTMLElement)).toEqual({});
+    });
+
+    test('should not use the visual highlight class when retrieving selector', () => {
+      document.getElementsByTagName('body')[0].innerHTML = `
+        <div id="container">
+          <div class="amp-visual-tagging-selector-highlight">
+            xxx
+          </div>
+        </div>
+      `;
+
+      const inner = document.getElementsByClassName('amp-visual-tagging-selector-highlight')[0];
+      expect(dataExtractor.getEventTagProps(inner as HTMLElement)).toEqual({
+        '[Amplitude] Element Tag': 'div',
+        '[Amplitude] Element Text': ' xxx ',
+        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
+      });
+    });
+  });
+
+  describe('addAdditionalEventProperties', () => {
+    beforeEach(() => {
+      // Mock window.location
+      mockWindowLocationFromURL(new URL('https://test.com'));
+      // Mock document.title
+      Object.defineProperty(document, 'title', {
+        value: 'Test Page',
+        writable: true,
+      });
+      // Mock window.innerHeight and innerWidth
+      Object.defineProperty(window, 'innerHeight', { value: 800 });
+      Object.defineProperty(window, 'innerWidth', { value: 1200 });
+    });
+
+    test('should add properties when isCapturingCursorPointer is true and element has pointer cursor', () => {
+      // Create a button element with pointer cursor
+      const span = document.createElement('span');
+      span.style.cursor = 'pointer';
+      span.textContent = 'Click me';
+      document.body.appendChild(span);
+
+      // Create a click event
+      const clickEvent = {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        target: span,
+      };
+
+      // Call the function with isCapturingCursorPointer set to true
+      const result = dataExtractor.addAdditionalEventProperties(
+        clickEvent,
+        'click',
+        ['.button'], // selector allowlist
+        'data-amp-', // data attribute prefix
+        true, // isCapturingCursorPointer
+      ) as ElementBasedTimestampedEvent<MouseEvent>;
+
+      // Verify the result
+      expect(result.closestTrackedAncestor).toBeDefined();
+    });
+  });
+});

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -1,22 +1,17 @@
 import {
-  isNonSensitiveString,
   isTextNode,
   isNonSensitiveElement,
-  getText,
   getAttributesWithPrefix,
   isEmpty,
   removeEmptyProperties,
-  getNearestLabel,
   querySelectUniqueElements,
   getClosestElement,
-  getEventTagProps,
   asyncLoadScript,
   generateUniqueId,
   createShouldTrackEvent,
-  addAdditionalEventProperties,
-  ElementBasedTimestampedEvent,
+  // ElementBasedTimestampedEvent,
 } from '../src/helpers';
-import { mockWindowLocationFromURL } from './utils';
+// import { mockWindowLocationFromURL } from './utils';
 
 describe('autocapture-plugin helpers', () => {
   afterEach(() => {
@@ -24,37 +19,7 @@ describe('autocapture-plugin helpers', () => {
     jest.clearAllMocks();
   });
 
-  describe('isNonSensitiveString', () => {
-    test('should return false when text is missing', () => {
-      const text = null;
-      const result = isNonSensitiveString(text);
-      expect(result).toEqual(false);
-    });
-
-    test('should return true when text is not sensitive', () => {
-      const text = 'test-string';
-      const result = isNonSensitiveString(text);
-      expect(result).toEqual(true);
-    });
-
-    test('should return false when text is credit card format', () => {
-      const text = '4916024123820164';
-      const result = isNonSensitiveString(text);
-      expect(result).toEqual(false);
-    });
-
-    test('should return false when text is social security number format', () => {
-      const text = '269-28-9315';
-      const result = isNonSensitiveString(text);
-      expect(result).toEqual(false);
-    });
-
-    test('should return true when text is not a string', () => {
-      const text = 123;
-      const result = isNonSensitiveString(text as unknown as string);
-      expect(result).toEqual(true);
-    });
-  });
+  // moved to data-extractor.test.ts: isNonSensitiveString
 
   describe('isTextNode', () => {
     test('should return false when node is not a text node', () => {
@@ -105,62 +70,7 @@ describe('autocapture-plugin helpers', () => {
     });
   });
 
-  describe('getText', () => {
-    test('should return empty string when element is sensitive', () => {
-      const element = document.createElement('input');
-      element.value = 'test';
-      const result = getText(element);
-      expect(result).toEqual('');
-    });
-
-    test('should return text when element has text attribute', () => {
-      const element = document.createElement('a');
-      element.text = 'test';
-      const result = getText(element);
-      expect(result).toEqual('test');
-    });
-
-    test('should return text when element has text node', () => {
-      const button = document.createElement('button');
-      const buttonText = document.createTextNode('submit');
-      button.appendChild(buttonText);
-      const result = getText(button);
-      expect(result).toEqual('submit');
-    });
-
-    test('should return concatenated text when element has child text nodes', () => {
-      const button = document.createElement('button');
-      const buttonText = document.createTextNode('submit');
-      button.appendChild(buttonText);
-      const div = document.createElement('div');
-      div.textContent = ' and pay';
-      button.appendChild(div);
-      const result = getText(button);
-      expect(result).toEqual('submit and pay');
-    });
-
-    test('should return concatenated text with sensitive text filtered', () => {
-      const button = document.createElement('button');
-      const buttonText = document.createTextNode('submit');
-      button.appendChild(buttonText);
-      const div = document.createElement('div');
-      div.textContent = '269-28-9315';
-      button.appendChild(div);
-      const result = getText(button);
-      expect(result).toEqual('submit');
-    });
-
-    test('should return concatenated text with extra space removed', () => {
-      const button = document.createElement('button');
-      const buttonText = document.createTextNode('submit');
-      button.appendChild(buttonText);
-      const div = document.createElement('div');
-      div.textContent = ' and   \n pay';
-      button.appendChild(div);
-      const result = getText(button);
-      expect(result).toEqual('submit and pay');
-    });
-  });
+  // moved to data-extractor.test.ts: getText
 
   describe('getAttributesWithPrefix', () => {
     test('should return attributes when matching the prefix', () => {
@@ -258,52 +168,7 @@ describe('autocapture-plugin helpers', () => {
     });
   });
 
-  describe('getNearestLabel', () => {
-    test('should return nearest label of the element', () => {
-      const div = document.createElement('div');
-      const span = document.createElement('span');
-      span.textContent = 'nearest label';
-      const input = document.createElement('input');
-      div.appendChild(span);
-      div.appendChild(input);
-
-      const result = getNearestLabel(input);
-      expect(result).toEqual('nearest label');
-    });
-
-    test('should return redacted nearest label when content is sensitive', () => {
-      const div = document.createElement('div');
-      const span = document.createElement('span');
-      span.textContent = '4916024123820164';
-      const input = document.createElement('input');
-      div.appendChild(span);
-      div.appendChild(input);
-
-      const result = getNearestLabel(input);
-      expect(result).toEqual('');
-    });
-
-    test('should return nearest label of the element parent', () => {
-      const div = document.createElement('div');
-      const innerDiv = document.createElement('div');
-      div.appendChild(innerDiv);
-      const span = document.createElement('span');
-      span.textContent = 'parent label';
-      div.appendChild(span);
-      const input = document.createElement('input');
-      innerDiv.appendChild(input);
-
-      const result = getNearestLabel(input);
-      expect(result).toEqual('parent label');
-    });
-
-    test('should return empty string when there is no parent', () => {
-      const input = document.createElement('input');
-
-      const result = getNearestLabel(input);
-      expect(result).toEqual('');
-    });
-  });
+  // moved to data-extractor.test.ts: getNearestLabel
 
   describe('querySelectUniqueElements', () => {
     test('should return unique elements with selector under root', () => {
@@ -380,61 +245,7 @@ describe('autocapture-plugin helpers', () => {
     });
   });
 
-  describe('getEventTagProps', () => {
-    beforeAll(() => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          hostname: '',
-          href: '',
-          pathname: '',
-          search: '',
-        },
-        writable: true,
-      });
-    });
-
-    beforeEach(() => {
-      mockWindowLocationFromURL(new URL('https://www.amplitude.com/unit-test?query=getEventTagProps'));
-    });
-
-    test('should return the tag properties', () => {
-      document.getElementsByTagName('body')[0].innerHTML = `
-        <div id="container">
-          <div id="inner">
-            xxx
-          </div>
-        </div>
-      `;
-
-      const inner = document.getElementById('inner');
-      expect(getEventTagProps(inner as HTMLElement)).toEqual({
-        '[Amplitude] Element Tag': 'div',
-        '[Amplitude] Element Text': ' xxx ',
-        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-      });
-    });
-
-    test('should return empty object when element is not present', () => {
-      expect(getEventTagProps(null as unknown as HTMLElement)).toEqual({});
-    });
-
-    test('should not use the visual highlight class when retrieving selector', () => {
-      document.getElementsByTagName('body')[0].innerHTML = `
-        <div id="container">
-          <div class="amp-visual-tagging-selector-highlight">
-            xxx
-          </div>
-        </div>
-      `;
-
-      const inner = document.getElementsByClassName('amp-visual-tagging-selector-highlight')[0];
-      expect(getEventTagProps(inner as HTMLElement)).toEqual({
-        '[Amplitude] Element Tag': 'div',
-        '[Amplitude] Element Text': ' xxx ',
-        '[Amplitude] Page URL': 'https://www.amplitude.com/unit-test',
-      });
-    });
-  });
+  // moved to data-extractor.test.ts: getEventTagProps
 
   describe('asyncLoadScript', () => {
     test('should append the script to document and resolve with status true', () => {
@@ -508,46 +319,5 @@ describe('autocapture-plugin helpers', () => {
     });
   });
 
-  describe('addAdditionalEventProperties', () => {
-    beforeEach(() => {
-      // Mock window.location
-      mockWindowLocationFromURL(new URL('https://test.com'));
-      // Mock document.title
-      Object.defineProperty(document, 'title', {
-        value: 'Test Page',
-        writable: true,
-      });
-      // Mock window.innerHeight and innerWidth
-      Object.defineProperty(window, 'innerHeight', { value: 800 });
-      Object.defineProperty(window, 'innerWidth', { value: 1200 });
-    });
-
-    test('should add properties when isCapturingCursorPointer is true and element has pointer cursor', () => {
-      // Create a button element with pointer cursor
-      const span = document.createElement('span');
-      span.style.cursor = 'pointer';
-      span.textContent = 'Click me';
-      document.body.appendChild(span);
-
-      // Create a click event
-      const clickEvent = {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        target: span,
-      };
-
-      // Call the function with isCapturingCursorPointer set to true
-      const result = addAdditionalEventProperties(
-        clickEvent,
-        'click',
-        ['.button'], // selector allowlist
-        'data-amp-', // data attribute prefix
-        true, // isCapturingCursorPointer
-      ) as ElementBasedTimestampedEvent<MouseEvent>;
-
-      // Verify the result
-      expect(result.closestTrackedAncestor).toBeDefined();
-    });
-  });
+  // moved to data-extractor.test.ts: addAdditionalEventProperties
 });

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -9,9 +9,7 @@ import {
   asyncLoadScript,
   generateUniqueId,
   createShouldTrackEvent,
-  // ElementBasedTimestampedEvent,
 } from '../src/helpers';
-// import { mockWindowLocationFromURL } from './utils';
 
 describe('autocapture-plugin helpers', () => {
   afterEach(() => {
@@ -69,8 +67,6 @@ describe('autocapture-plugin helpers', () => {
       expect(isNonSensitiveElement(element)).toEqual(false);
     });
   });
-
-  // moved to data-extractor.test.ts: getText
 
   describe('getAttributesWithPrefix', () => {
     test('should return attributes when matching the prefix', () => {
@@ -168,8 +164,6 @@ describe('autocapture-plugin helpers', () => {
     });
   });
 
-  // moved to data-extractor.test.ts: getNearestLabel
-
   describe('querySelectUniqueElements', () => {
     test('should return unique elements with selector under root', () => {
       const container = document.createElement('div');
@@ -245,8 +239,6 @@ describe('autocapture-plugin helpers', () => {
     });
   });
 
-  // moved to data-extractor.test.ts: getEventTagProps
-
   describe('asyncLoadScript', () => {
     test('should append the script to document and resolve with status true', () => {
       void asyncLoadScript('https://test-url.amplitude/').then((result) => {
@@ -318,6 +310,4 @@ describe('autocapture-plugin helpers', () => {
       document.head.removeChild(style);
     });
   });
-
-  // moved to data-extractor.test.ts: addAdditionalEventProperties
 });


### PR DESCRIPTION

### Summary
- add option `redactTextRegex`
  - This option is a RegExp[], or it can be a list objects passed in primarily from remote config JSON.
- Refactor data extraction from elements into DataExtractor class
  - This class helps to keep text filtering functions portable without having to pass around the options

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
