### PR TITLE
fix: add missing BrowserClient attributes

### DIFF
--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -6,6 +6,8 @@ export const {
   extendSession,
   flush,
   getDeviceId,
+  getIdentity,
+  getOptOut,
   getSessionId,
   getUserId,
   groupIdentify,


### PR DESCRIPTION
### Summary

* Add "getIdentity" and "getOptOut" to the "analytics-browser" index
* This fixes a type issue, these two attributes not being present in the "default" export make it not be duck-typable as a BrowserClient

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
