### PR TITLE
chore: test default amplitude is BrowserClient

### DIFF
--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -34,8 +34,10 @@ describe('index', () => {
   test(`structural typing test, 'default export' should be  BrowserClient`, () => {
     for (const key of Object.keys(FakeBrowserClient.prototype)) {
       // add message for if it fails
-      if (!((amplitude as any)[key])) {
-        throw new Error(`'${key}' is a required method in BrowserClient but is not defined in analytics-browser export`);
+      if (!(amplitude as any)[key]) {
+        throw new Error(
+          `'${key}' is a required method in BrowserClient but is not defined in analytics-browser export`,
+        );
       }
     }
     // sanity test a few known methods

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -33,7 +33,10 @@ const {
 describe('index', () => {
   test(`structural typing test, 'default export' should be  BrowserClient`, () => {
     for (const key of Object.keys(FakeBrowserClient.prototype)) {
-      expect((amplitude as any)[key]).toBeDefined();
+      // add message for if it fails
+      if (!((amplitude as any)[key])) {
+        throw new Error(`'${key}' is a required method in BrowserClient but is not defined in analytics-browser export`);
+      }
     }
     // sanity test a few known methods
     expect(typeof amplitude.add).toBe('function');

--- a/packages/analytics-browser/test/index.test.ts
+++ b/packages/analytics-browser/test/index.test.ts
@@ -1,4 +1,8 @@
-import {
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import * as amplitude from '../src/index';
+import { FakeBrowserClient } from './utils/fake-browser-client';
+
+const {
   add,
   createInstance,
   extendSession,
@@ -24,9 +28,20 @@ import {
   setUserId,
   track,
   AmplitudeBrowser,
-} from '../src/index';
+} = amplitude;
 
 describe('index', () => {
+  test(`structural typing test, 'default export' should be  BrowserClient`, () => {
+    for (const key of Object.keys(FakeBrowserClient.prototype)) {
+      expect((amplitude as any)[key]).toBeDefined();
+    }
+    // sanity test a few known methods
+    expect(typeof amplitude.add).toBe('function');
+    expect(typeof amplitude.getIdentity).toBe('function');
+    expect(typeof amplitude.track).toBe('function');
+    expect(typeof (amplitude as any).foo).toBe('undefined');
+  });
+
   test('should expose apis', () => {
     expect(typeof add).toBe('function');
     expect(typeof createInstance).toBe('function');

--- a/packages/analytics-browser/test/utils/fake-browser-client.ts
+++ b/packages/analytics-browser/test/utils/fake-browser-client.ts
@@ -1,0 +1,185 @@
+import {
+  BrowserClient,
+  returnWrapper,
+  Plugin,
+  BrowserOptions,
+  AmplitudeReturn,
+  Result,
+  EventOptions,
+  IIdentify,
+  IRevenue,
+  BaseEvent,
+  TransportType,
+  AnalyticsIdentity,
+} from '@amplitude/analytics-core';
+
+export class FakeBrowserClient implements BrowserClient {
+  // BrowserClient specific methods
+  init(apiKey: string, options?: BrowserOptions): AmplitudeReturn<void>;
+  init(apiKey: string, userId?: string, options?: BrowserOptions): AmplitudeReturn<void>;
+  init(
+    apiKey: string,
+    userIdOrOptions?: string | BrowserOptions,
+    maybeOptions?: BrowserOptions,
+  ): AmplitudeReturn<void> {
+    console.log('FakeBrowserClient.init called with:', { apiKey, userIdOrOptions, maybeOptions });
+    return returnWrapper(Promise.resolve());
+  }
+
+  setTransport(transport: TransportType): void {
+    console.log('FakeBrowserClient.setTransport called with:', { transport });
+  }
+
+  add(plugin: Plugin): AmplitudeReturn<void> {
+    console.log('FakeBrowserClient.add called with:', { plugin });
+    return returnWrapper(Promise.resolve());
+  }
+
+  getIdentity(): AnalyticsIdentity {
+    console.log('FakeBrowserClient.getIdentity called');
+    return {
+      userId: undefined,
+      deviceId: undefined,
+      userProperties: undefined,
+    };
+  }
+
+  getOptOut(): boolean | undefined {
+    console.log('FakeBrowserClient.getOptOut called');
+    return false;
+  }
+
+  // CoreClient methods
+  remove(pluginName: string): AmplitudeReturn<void> {
+    console.log('FakeBrowserClient.remove called with:', { pluginName });
+    return returnWrapper(Promise.resolve());
+  }
+
+  track(
+    eventInput: BaseEvent | string,
+    eventProperties?: Record<string, any>,
+    eventOptions?: EventOptions,
+  ): AmplitudeReturn<Result> {
+    console.log('FakeBrowserClient.track called with:', { eventInput, eventProperties, eventOptions });
+    return returnWrapper(
+      Promise.resolve({
+        code: 200,
+        message: 'Event tracked successfully',
+        event: {
+          event_type: typeof eventInput === 'string' ? eventInput : eventInput.event_type,
+        },
+      }),
+    );
+  }
+
+  logEvent(
+    eventInput: BaseEvent | string,
+    eventProperties?: Record<string, any>,
+    eventOptions?: EventOptions,
+  ): AmplitudeReturn<Result> {
+    console.log('FakeBrowserClient.logEvent called with:', { eventInput, eventProperties, eventOptions });
+    return this.track(eventInput, eventProperties, eventOptions);
+  }
+
+  identify(identify: IIdentify, eventOptions?: EventOptions): AmplitudeReturn<Result> {
+    console.log('FakeBrowserClient.identify called with:', { identify, eventOptions });
+    return returnWrapper(
+      Promise.resolve({
+        code: 200,
+        message: 'Identify event tracked successfully',
+        event: {
+          event_type: '$identify',
+        },
+      }),
+    );
+  }
+
+  groupIdentify(
+    groupType: string,
+    groupName: string | string[],
+    identify: IIdentify,
+    eventOptions?: EventOptions,
+  ): AmplitudeReturn<Result> {
+    console.log('FakeBrowserClient.groupIdentify called with:', { groupType, groupName, identify, eventOptions });
+    return returnWrapper(
+      Promise.resolve({
+        code: 200,
+        message: 'Group identify event tracked successfully',
+        event: {
+          event_type: '$groupidentify',
+        },
+      }),
+    );
+  }
+
+  setGroup(groupType: string, groupName: string | string[], eventOptions?: EventOptions): AmplitudeReturn<Result> {
+    console.log('FakeBrowserClient.setGroup called with:', { groupType, groupName, eventOptions });
+    return returnWrapper(
+      Promise.resolve({
+        code: 200,
+        message: 'Set group event tracked successfully',
+        event: {
+          event_type: '$setgroup',
+        },
+      }),
+    );
+  }
+
+  revenue(revenue: IRevenue, eventOptions?: EventOptions): AmplitudeReturn<Result> {
+    console.log('FakeBrowserClient.revenue called with:', { revenue, eventOptions });
+    return returnWrapper(
+      Promise.resolve({
+        code: 200,
+        message: 'Revenue event tracked successfully',
+        event: {
+          event_type: '$revenue',
+        },
+      }),
+    );
+  }
+
+  setOptOut(optOut: boolean): void {
+    console.log('FakeBrowserClient.setOptOut called with:', { optOut });
+  }
+
+  flush(): AmplitudeReturn<void> {
+    console.log('FakeBrowserClient.flush called');
+    return returnWrapper(Promise.resolve());
+  }
+
+  // Client methods (from Client interface)
+  getUserId(): string | undefined {
+    console.log('FakeBrowserClient.getUserId called');
+    return undefined;
+  }
+
+  setUserId(userId: string | undefined): void {
+    console.log('FakeBrowserClient.setUserId called with:', { userId });
+  }
+
+  getDeviceId(): string | undefined {
+    console.log('FakeBrowserClient.getDeviceId called');
+    return undefined;
+  }
+
+  setDeviceId(deviceId: string): void {
+    console.log('FakeBrowserClient.setDeviceId called with:', { deviceId });
+  }
+
+  getSessionId(): number | undefined {
+    console.log('FakeBrowserClient.getSessionId called');
+    return undefined;
+  }
+
+  setSessionId(sessionId: number): void {
+    console.log('FakeBrowserClient.setSessionId called with:', { sessionId });
+  }
+
+  extendSession(): void {
+    console.log('FakeBrowserClient.extendSession called');
+  }
+
+  reset(): void {
+    console.log('FakeBrowserClient.reset called');
+  }
+}


### PR DESCRIPTION
### Summary

Add test that verifies that the export of "analytics-browser" index is instance of BrowserClient (structural typing test).

Methodology: Create a "FakeBrowserClient" that implements "BrowserClient" and then check that the methods in "analytics-browser" default export match methods in `BrowserClient.prototype`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
