### PR TITLE
fix(plugin-autocapture-plugin): no dead click on visibility hidden

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -50,6 +50,7 @@ export enum ObservablesEnum {
   // ErrorObservable = 'errorObservable',
   NavigateObservable = 'navigateObservable',
   MutationObservable = 'mutationObservable',
+  VisibilityChangeObservable = 'visibilityChangeObservable',
 }
 
 export interface AllWindowObservables {
@@ -58,6 +59,7 @@ export interface AllWindowObservables {
   // [ObservablesEnum.ErrorObservable]: Observable<TimestampedEvent<ErrorEvent>>;
   [ObservablesEnum.NavigateObservable]: Observable<TimestampedEvent<NavigateEvent>> | undefined;
   [ObservablesEnum.MutationObservable]: Observable<TimestampedEvent<MutationRecord[]>>;
+  [ObservablesEnum.VisibilityChangeObservable]?: Observable<TimestampedEvent<Event>>;
 }
 
 export const autocapturePlugin = (options: ElementInteractionsOptions = {}): BrowserEnrichmentPlugin => {

--- a/packages/plugin-autocapture-browser/src/autocapture/track-dead-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-dead-click.ts
@@ -27,7 +27,7 @@ export function trackDeadClick({
   getEventProperties: (actionType: ActionType, element: Element) => Record<string, any>;
   shouldTrackDeadClick: shouldTrackEvent;
 }) {
-  const { clickObservable, mutationObservable, navigateObservable } = allObservables;
+  const { clickObservable, mutationObservable, navigateObservable, visibilityChangeObservable } = allObservables;
 
   const filteredClickObservable = clickObservable.pipe(
     filter(filterOutNonTrackableEvents),
@@ -38,10 +38,15 @@ export function trackDeadClick({
   );
 
   const changeObservables: Array<
-    AllWindowObservables[ObservablesEnum.MutationObservable] | AllWindowObservables[ObservablesEnum.NavigateObservable]
+    | AllWindowObservables[ObservablesEnum.MutationObservable]
+    | AllWindowObservables[ObservablesEnum.NavigateObservable]
+    | AllWindowObservables[ObservablesEnum.VisibilityChangeObservable]
   > = [mutationObservable];
   if (navigateObservable) {
     changeObservables.push(navigateObservable);
+  }
+  if (visibilityChangeObservable) {
+    changeObservables.push(visibilityChangeObservable);
   }
   const mutationOrNavigate = merge(...changeObservables);
 

--- a/packages/plugin-autocapture-browser/src/frustration-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/frustration-plugin.ts
@@ -10,7 +10,7 @@ import {
 } from '@amplitude/analytics-core';
 import * as constants from './constants';
 import { fromEvent, map, Observable, Subscription, share } from 'rxjs';
-import { createShouldTrackEvent, ElementBasedTimestampedEvent, NavigateEvent } from './helpers';
+import { createShouldTrackEvent, ElementBasedTimestampedEvent, NavigateEvent, TimestampedEvent } from './helpers';
 import { trackDeadClick } from './autocapture/track-dead-click';
 import { trackRageClicks } from './autocapture/track-rage-click';
 import { AllWindowObservables, ObservablesEnum } from './autocapture-plugin';
@@ -63,6 +63,15 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions = {}):
       );
     }
 
+    const visibilityChangeObservable = fromEvent<TimestampedEvent<Event>>(document, 'visibilitychange').pipe(
+      map((visibilityChange) => {
+        console.log('visibilityChange', visibilityChange);
+        dataExtractor.addAdditionalEventProperties(visibilityChange, 'visibilitychange', [], dataAttributePrefix);
+        return visibilityChange;
+      }),
+      share(),
+    );
+
     // Track DOM Mutations
     const enrichedMutationObservable = createMutationObservable().pipe(
       map((mutation) =>
@@ -76,6 +85,7 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions = {}):
       [ObservablesEnum.ChangeObservable]: new Observable<ElementBasedTimestampedEvent<Event>>(), // Empty observable since we don't need change events
       [ObservablesEnum.NavigateObservable]: navigateObservable,
       [ObservablesEnum.MutationObservable]: enrichedMutationObservable,
+      [ObservablesEnum.VisibilityChangeObservable]: visibilityChangeObservable,
     };
   };
 

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -228,7 +228,7 @@ export type AutoCaptureOptionsWithDefaults = Required<
 export type BaseTimestampedEvent<T> = {
   event: T;
   timestamp: number;
-  type: 'rage' | 'click' | 'change' | 'error' | 'navigate' | 'mutation';
+  type: 'rage' | 'click' | 'change' | 'error' | 'navigate' | 'visibilitychange' | 'mutation';
 };
 
 // Specific types for events with targetElementProperties

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin.test.ts
@@ -239,6 +239,7 @@ describe('frustrationPlugin', () => {
       expect(observables).toHaveProperty('mutationObservable');
       expect(observables).toHaveProperty('navigateObservable');
       expect(observables).toHaveProperty('changeObservable');
+      expect(observables).toHaveProperty('visibilityChangeObservable');
 
       // Test click observable
       const clickSpy = jest.fn();
@@ -282,6 +283,13 @@ describe('frustrationPlugin', () => {
 
       // Verify mutation was captured
       expect(mutationSpy).toHaveBeenCalled();
+
+      // Test visibility change observable
+      const visibilityChangeSpy = jest.fn();
+      const visibilityChangeSubscription = observables.visibilityChangeObservable.subscribe(visibilityChangeSpy);
+      document.dispatchEvent(new Event('visibilitychange'));
+      expect(visibilityChangeSpy).toHaveBeenCalled();
+      visibilityChangeSubscription.unsubscribe();
 
       // Cleanup
       mutationSubscription.unsubscribe();

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
@@ -26,6 +26,7 @@ describe('trackRageClicks', () => {
       [ObservablesEnum.ChangeObservable]: new Subject(),
       [ObservablesEnum.NavigateObservable]: new Subject(),
       [ObservablesEnum.MutationObservable]: new Subject(),
+      [ObservablesEnum.VisibilityChangeObservable]: new Subject(),
     };
     shouldTrackRageClick = jest.fn().mockReturnValue(true);
   });

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -113,7 +113,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="https://amplitude.com" class="role-link" target="_blank">New Page</a></td>
+              <td><a href="https://amplitude.com" class="role-link" target="_blank">New Page (no dead click)</a></td>
               <td class="center">Yes</td>
               <td>Always, unless <code>tabindex="-1"</code> or <code>disabled</code></td>
             </tr>

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -113,6 +113,11 @@
           </thead>
           <tbody>
             <tr>
+              <td><a href="https://amplitude.com" class="role-link" target="_blank">New Page</a></td>
+              <td class="center">Yes</td>
+              <td>Always, unless <code>tabindex="-1"</code> or <code>disabled</code></td>
+            </tr>
+            <tr>
               <td><a href="#" class="role-link">Link</a></td>
               <td class="center">Yes</td>
               <td>Always, unless <code>tabindex="-1"</code> or <code>disabled</code></td>


### PR DESCRIPTION
### Summary

If the visibility state changes after a click, do not trigger a dead click. Visibility change heavily suggests that a new page was opened and thus not a dead click

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
