### PR TITLE
fix(analytics-core): strip out basic auth from url

### DIFF
--- a/packages/analytics-core/src/network-observer.ts
+++ b/packages/analytics-core/src/network-observer.ts
@@ -125,7 +125,7 @@ export class NetworkObserver {
     });
   }
 
-  private handleNetworkRequestEvent(
+  handleNetworkRequestEvent(
     requestType: 'fetch' | 'xhr',
     requestInfo: RequestInfo | URL | RequestUrlAndMethod | undefined,
     requestWrapper: IRequestWrapper | undefined,
@@ -149,6 +149,18 @@ export class NetworkObserver {
       method = requestInfo['method'];
     } else {
       url = requestInfo?.toString?.();
+    }
+
+    // strip basic auth from the URL
+    if (url) {
+      try {
+        const parsedUrl = new URL(url);
+        // reconstruct the URL without the basic auth
+        url = `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+      } catch (err) {
+        /* istanbul ignore next */
+        this.logger?.error('an unexpected error occurred while parsing the URL', err);
+      }
     }
     method = requestWrapper?.method || method;
 

--- a/packages/analytics-core/test/network-observer.test.ts
+++ b/packages/analytics-core/test/network-observer.test.ts
@@ -1306,3 +1306,25 @@ describe('pruneHeaders', () => {
     }
   });
 });
+
+describe('basic auth', () => {
+  test('should not capture basic auth', () => {
+    const networkObserver = new NetworkObserver();
+    const events: NetworkRequestEvent[] = [];
+    jest.spyOn(networkObserver as unknown as any, 'triggerEventCallbacks').mockImplementation((event) => {
+      events.push(event as NetworkRequestEvent);
+    });
+    networkObserver.handleNetworkRequestEvent(
+      'fetch',
+      'https://username:password@api.example.com/data',
+      undefined,
+      undefined,
+      undefined,
+      0,
+      0,
+    );
+    expect(events).toHaveLength(1);
+    console.log(events[0].url);
+    expect(events[0].url).toBe('https://api.example.com/data');
+  });
+});


### PR DESCRIPTION
### Summary

Exclude basic auth from network capture

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
