### PR TITLE
fix: Use original marketing cookies set by web experiment pre-redirect

### DIFF
--- a/packages/analytics-client-common/src/attribution/web-attribution.ts
+++ b/packages/analytics-client-common/src/attribution/web-attribution.ts
@@ -10,6 +10,7 @@ export class WebAttribution {
   options: Options;
   storage: Storage<Campaign>;
   storageKey: string;
+  webExpStorageKey: string;
   previousCampaign?: Campaign;
   currentCampaign: Campaign;
   shouldTrackNewCampaign = false;
@@ -26,6 +27,7 @@ export class WebAttribution {
     };
     this.storage = config.cookieStorage as unknown as Storage<Campaign>;
     this.storageKey = getStorageKey(config.apiKey, 'MKTG');
+    this.webExpStorageKey = getStorageKey(config.apiKey, 'MKTG_ORIGINAL');
     this.currentCampaign = BASE_CAMPAIGN;
     this.sessionTimeout = config.sessionTimeout;
     this.lastEventTime = config.lastEventTime;
@@ -44,7 +46,11 @@ export class WebAttribution {
   }
 
   async fetchCampaign() {
-    return await Promise.all([new CampaignParser().parse(), this.storage.get(this.storageKey)]);
+    const originalCampaign = await this.storage.get(this.webExpStorageKey);
+    if (originalCampaign) {
+      await this.storage.remove(this.webExpStorageKey);
+    }
+    return await Promise.all([originalCampaign || new CampaignParser().parse(), this.storage.get(this.storageKey)]);
   }
 
   /**


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Amplitude web experiment redirect uses `location.replace`, which leads the the `referrer` being lost when landing on the redirected page. This change will make use of the `MKTG_ORIGINAL` cookie set by the web experiment client ([PR](https://github.com/amplitude/experiment-js-client/pull/206)) before redirect to properly capture the landing page campaign info.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
