### PR TITLE
feat(analytics-core): add diagnostics client

### DIFF
--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -137,7 +137,8 @@ export interface IDiagnosticsClient {
    * });
    * ```
    */
-  recordEvent(name: string, properties: EventProperties): void;
+  // TODO(AMP-139569)
+  // recordEvent(name: string, properties: EventProperties): void;
 
   // Flush storage
   _flush(): void;
@@ -293,6 +294,17 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     //   time: record.time,
     //   event_properties: record.event_properties,
     // }));
+
+    // Early return if all data collections are empty
+    if (
+      Object.keys(tags).length === 0 &&
+      Object.keys(counters).length === 0 &&
+      Object.keys(histogram).length === 0
+      // TODO(AMP-139569)
+      // && Object.keys(events).length === 0
+    ) {
+      return;
+    }
 
     // Create flush payload
     const payload: FlushPayload = {

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -4,7 +4,7 @@ import { DiagnosticsStorage, IDiagnosticsStorage } from './diagnostics-storage';
 import { ServerZoneType } from 'src/types/server-zone';
 
 const SAVE_INTERVAL_MS = 1000; // 1 second
-const FLUSH_INTERVAL_MS = 5 * 1000; // 5 minutes
+const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const US_SERVER_URL = 'https://diagnostics.prod.us-west-2.amplitude.com/v1/capture';
 const EU_SERVER_URL = 'https://diagnostics.prod.eu-central-1.amplitude.com/v1/capture';
 

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
-import { ILogger } from 'src/logger';
+import { ILogger } from '../logger';
 import { DiagnosticsStorage, IDiagnosticsStorage } from './diagnostics-storage';
-import { ServerZoneType } from 'src/types/server-zone';
+import { ServerZoneType } from '../types/server-zone';
 
 const SAVE_INTERVAL_MS = 1000; // 1 second
 const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -1,4 +1,3 @@
-/// <reference lib="dom" />
 import { ILogger } from '../logger';
 import { DiagnosticsStorage, IDiagnosticsStorage } from './diagnostics-storage';
 import { ServerZoneType } from '../types/server-zone';

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -306,6 +306,11 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     if (!this.storage) {
       return;
     }
+
+    await this.saveAllDataToStorage();
+    this.saveTimer = null;
+    this.flushTimer = null;
+
     // Get all data from storage and clear it
     const {
       tags: tagRecords,

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -150,7 +150,7 @@ export class DiagnosticsClient implements IDiagnosticsClient {
   // Global timer for 1-second persistence
   private globalSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(apiKey: string, logger?: ILogger, serverZone: ServerZoneType = 'US') {
+  constructor(apiKey: string, logger: ILogger, serverZone: ServerZoneType = 'US') {
     this.apiKey = apiKey;
     this.logger = logger;
     this.serverUrl = serverZone === 'US' ? US_SERVER_URL : EU_SERVER_URL;

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -169,11 +169,13 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     this.apiKey = apiKey;
     this.logger = logger;
     this.serverUrl = serverZone === 'US' ? DIAGNOSTICS_US_SERVER_URL : DIAGNOSTICS_EU_SERVER_URL;
+
     if (DiagnosticsStorage.isSupported()) {
       this.storage = new DiagnosticsStorage(apiKey, logger);
     } else {
       this.logger.debug('DiagnosticsClient: IndexedDB is not supported');
     }
+
     void this.initializeFlushInterval();
   }
 

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -1,0 +1,392 @@
+/// <reference lib="dom" />
+import { DiagnosticsStorage } from './diagnostics-storage';
+
+// Maximum number of histogram items to store (queue size limit)
+const MAX_HISTOGRAM_ITEMS = 65000;
+
+// Flush interval: 1 hour in milliseconds
+const FLUSH_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+// Interfaces for data structures
+interface DiagnosticsTag {
+  [key: string]: string;
+}
+
+interface DiagnosticsCounter {
+  [key: string]: number;
+}
+
+interface HistogramEntry {
+  name: string;
+  value: number;
+  timestamp: number;
+}
+
+interface HistogramResult {
+  count: number;
+  min: number;
+  max: number;
+  avg: number;
+  median: number;
+  p95: number;
+}
+
+interface DiagnosticsHistogram {
+  [key: string]: HistogramResult;
+}
+
+interface DiagnosticsEvent {
+  event_name: string;
+  time: number;
+  event_properties: Record<string, any>;
+}
+
+interface FlushPayload {
+  apiKey?: string;
+  tags: DiagnosticsTag;
+  histogram: DiagnosticsHistogram;
+  counters: DiagnosticsCounter;
+  events: DiagnosticsEvent[];
+}
+
+/**
+ * Amplitude Diagnostics Client
+ *
+ * A client for collecting and managing diagnostics data including tags, counters,
+ * histograms, and events. Data is stored persistently using IndexedDB to survive browser restarts and offline scenarios.
+ *
+ * Key Features:
+ * - IndexedDB storage
+ * - Queue size management (max 65,000 histogram items)
+ * - Auto-flush when histogram limit is reached (prevents data loss)
+ * - Time-based flush interval (1 hour since last flush)
+ * - Histogram statistics calculation (min, max, avg, median, p95)
+ * - Thread-safe operations through async/await
+ *
+ * Usage:
+ * ```typescript
+ * // Create diagnostics client
+ * const diagnostics = new DiagnosticsClient(apiKey);
+ *
+ * // Set environment tags
+ * await diagnostics.setTag('library', 'amplitude-typescript/2.0.0');
+ * await diagnostics.setTag('user_agent', navigator.userAgent);
+ *
+ * // Track counters
+ * await diagnostics.increment('analytics.fileNotFound');
+ * await diagnostics.increment('network.retry', 3);
+ *
+ * // Record performance metrics (auto-flushes at 65,000 items)
+ * await diagnostics.recordHistogram('sr.time', 5.2);
+ * await diagnostics.recordHistogram('network.latency', 150);
+ *
+ * // Record diagnostic events
+ * await diagnostics.recordEvent('error', {
+ *   stack_trace: '...',
+ *   api_key: 'hidden'
+ * });
+ *
+ * // Manual flush (auto-flushes every 1 hour or at 65,000 histogram items)
+ * const payload = await diagnostics._flush();
+ * // Send payload to diagnostics endpoint
+ * ```
+ */
+export interface IDiagnosticsClient {
+  // Set or update a tag
+  setTag(name: string, value: string): Promise<void>;
+
+  // Increment a counter. If doesn't exist, create a counter and set value to 1
+  increment(name: string, size?: number): Promise<void>;
+
+  // Record a histogram value
+  recordHistogram(name: string, value: number): Promise<void>;
+
+  // Record an event
+  recordEvent(name: string, properties: Record<string, any>): Promise<void>;
+
+  // Hide it from consumers but be able to be hooked to SDK flush()
+  // Flush buffered data
+  _flush(): Promise<FlushPayload>;
+}
+
+export class DiagnosticsClient implements IDiagnosticsClient {
+  private storage: DiagnosticsStorage;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(apiKey: string) {
+    this.storage = new DiagnosticsStorage(apiKey);
+    void this.initializeFlushInterval();
+  }
+
+  async setTag(name: string, value: string): Promise<void> {
+    try {
+      await this.storage.setTag(name, value);
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to set tag', error);
+    }
+  }
+
+  async increment(name: string, size = 1): Promise<void> {
+    try {
+      // Get existing counter or create new one
+      const existingCounter = await this.storage.getCounter(name);
+      const currentValue = existingCounter ? existingCounter.value : 0;
+
+      await this.storage.setCounter(name, currentValue + size);
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to increment counter', error);
+    }
+  }
+
+  async recordHistogram(name: string, value: number): Promise<void> {
+    try {
+      // Check if we've hit the maximum limit and trigger auto-flush
+      const currentCount = await this.storage.getHistogramRecordCount();
+      if (currentCount >= MAX_HISTOGRAM_ITEMS) {
+        try {
+          // Trigger auto-flush to clear data and start fresh
+          // Timer reset logic is handled inside _flush()
+          await this._flush();
+        } catch (flushError) {
+          console.error('[Amplitude] DiagnosticsClient: Auto-flush failed', flushError);
+          // If flush fails, we still need to add the record but should consider cleanup
+          // For now, we'll still add the record - in production you might want to implement
+          // a cleanup strategy here
+        }
+      }
+
+      // Add the new record to IndexedDB
+      await this.storage.addHistogramRecord(name, value);
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to record histogram', error);
+    }
+  }
+
+  async recordEvent(name: string, properties: Record<string, any>): Promise<void> {
+    try {
+      await this.storage.addEventRecord(name, properties);
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to record event', error);
+    }
+  }
+
+  async _flush(): Promise<FlushPayload> {
+    try {
+      // Clear the current timer since we're flushing now
+      this.clearFlushTimer();
+
+      // Get all stored data from IndexedDB
+      const tagRecords = await this.storage.getAllTags();
+      const counterRecords = await this.storage.getAllCounters();
+      const histogramRecords = await this.storage.getAllHistogramRecords();
+      const eventRecords = await this.storage.getAllEventRecords();
+
+      // Convert records to the expected format
+      const tags: DiagnosticsTag = {};
+      tagRecords.forEach((record) => {
+        tags[record.key] = record.value;
+      });
+
+      const counters: DiagnosticsCounter = {};
+      counterRecords.forEach((record) => {
+        counters[record.key] = record.value;
+      });
+
+      // Convert histogram records to the legacy format for calculation
+      const histogramEntries: HistogramEntry[] = histogramRecords.map((record) => ({
+        name: record.key,
+        value: record.value,
+        timestamp: record.timestamp,
+      }));
+
+      // Calculate histogram results
+      const histogram = this.calculateHistogramResults(histogramEntries);
+
+      // Convert event records to the expected format
+      const events: DiagnosticsEvent[] = eventRecords.map((record) => ({
+        event_name: record.event_name,
+        time: record.time,
+        event_properties: record.event_properties,
+      }));
+
+      // Create flush payload
+      const payload: FlushPayload = {
+        tags,
+        histogram,
+        counters,
+        events,
+      };
+
+      // Clear all data after successful flush preparation
+      await this.clearAllData();
+
+      // Update the last flush timestamp
+      await this.storage.setLastFlushTimestamp(Date.now());
+
+      // Set timer for next flush interval
+      this.setFlushTimer(FLUSH_INTERVAL_MS);
+
+      return payload;
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to flush data', error);
+      // Return empty payload on error
+      return {
+        tags: {},
+        histogram: {},
+        counters: {},
+        events: [],
+      };
+    }
+  }
+
+  private calculateHistogramResults(entries: HistogramEntry[]): DiagnosticsHistogram {
+    const histogramMap: { [name: string]: number[] } = {};
+
+    // Group values by histogram name
+    entries.forEach((entry) => {
+      if (!histogramMap[entry.name]) {
+        histogramMap[entry.name] = [];
+      }
+      histogramMap[entry.name].push(entry.value);
+    });
+
+    // Calculate statistics for each histogram
+    const results: DiagnosticsHistogram = {};
+    Object.keys(histogramMap).forEach((name) => {
+      const values = histogramMap[name];
+      if (values.length > 0) {
+        results[name] = this.calculateStatistics(values);
+      }
+    });
+
+    return results;
+  }
+
+  private calculateStatistics(values: number[]): HistogramResult {
+    if (values.length === 0) {
+      return { count: 0, min: 0, max: 0, avg: 0, median: 0, p95: 0 };
+    }
+
+    // Sort values for percentile calculations
+    const sortedValues = [...values].sort((a, b) => a - b);
+    const count = values.length;
+    const min = sortedValues[0];
+    const max = sortedValues[count - 1];
+    const sum = values.reduce((acc, val) => acc + val, 0);
+    const avg = sum / count;
+
+    // Calculate median
+    const median =
+      count % 2 === 0
+        ? (sortedValues[Math.floor(count / 2) - 1] + sortedValues[Math.floor(count / 2)]) / 2
+        : sortedValues[Math.floor(count / 2)];
+
+    // Calculate 95th percentile
+    const p95Index = Math.ceil(count * 0.95) - 1;
+    const p95 = sortedValues[Math.max(0, p95Index)];
+
+    return {
+      count,
+      min,
+      max,
+      avg: Math.round(avg * 100) / 100, // Round to 2 decimal places
+      median,
+      p95,
+    };
+  }
+
+  private async clearAllData(): Promise<void> {
+    try {
+      await this.storage.clearAllData();
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to clear data', error);
+    }
+  }
+
+  /**
+   * Initialize flush interval logic.
+   * Check if 1 hour has passed since last flush, if so flush immediately.
+   * Otherwise set a timer to flush when the interval is reached.
+   */
+  private async initializeFlushInterval(): Promise<void> {
+    try {
+      const lastFlushTimestamp = await this.storage.getLastFlushTimestamp();
+      const now = Date.now();
+
+      if (!lastFlushTimestamp) {
+        // First time - flush immediately to establish initial timestamp
+        await this.flushAndUpdateTimestamp();
+        return;
+      }
+
+      const timeSinceLastFlush = now - lastFlushTimestamp;
+
+      if (timeSinceLastFlush >= FLUSH_INTERVAL_MS) {
+        // More than 1 hour has passed, flush immediately
+        await this.flushAndUpdateTimestamp();
+      } else {
+        // Set timer for remaining time
+        const remainingTime = FLUSH_INTERVAL_MS - timeSinceLastFlush;
+        this.setFlushTimer(remainingTime);
+      }
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to initialize flush interval', error);
+    }
+  }
+
+  /**
+   * Set a timer to flush after the specified delay
+   */
+  private setFlushTimer(delayMs: number): void {
+    this.clearFlushTimer();
+    this.flushTimer = setTimeout(() => {
+      void this.flushAndUpdateTimestamp();
+    }, delayMs);
+  }
+
+  /**
+   * Clear the current flush timer
+   */
+  private clearFlushTimer(): void {
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  /**
+   * Flush data and update timestamp, then set next timer
+   */
+  private async flushAndUpdateTimestamp(): Promise<void> {
+    try {
+      // Perform the flush (timer reset logic is handled inside _flush())
+      await this._flush();
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to flush and update timestamp', error);
+      // Set timer for retry on error
+      this.setFlushTimer(FLUSH_INTERVAL_MS);
+    }
+  }
+
+  // Utility method to get current data for debugging (not part of interface)
+  async _getCurrentData() {
+    return {
+      tags: await this.storage.getAllTags(),
+      counters: await this.storage.getAllCounters(),
+      histogramEntries: await this.storage.getAllHistogramRecords(),
+      events: await this.storage.getAllEventRecords(),
+    };
+  }
+
+  // Utility method to get histogram values for a specific key, sorted by value
+  // This leverages the compound index [key, value] for efficient querying
+  async _getHistogramValuesSorted(key: string): Promise<number[]> {
+    try {
+      const records = await this.storage.getHistogramRecordsSortedByValue(key);
+      return records.map((record) => record.value);
+    } catch (error) {
+      console.error('[Amplitude] DiagnosticsClient: Failed to get sorted histogram values', error);
+      return [];
+    }
+  }
+}

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -73,7 +73,8 @@ interface FlushPayload {
   readonly tags: DiagnosticsTags;
   readonly histogram: DiagnosticsHistograms;
   readonly counters: DiagnosticsCounters;
-  readonly events: readonly DiagnosticsEvent[];
+  // TODO(AMP-139569)
+  // readonly events: readonly DiagnosticsEvent[];
 }
 
 /**
@@ -257,7 +258,8 @@ export class DiagnosticsClient implements IDiagnosticsClient {
       tags: tagRecords,
       counters: counterRecords,
       histogramStats: histogramStatsRecords,
-      events: eventRecords,
+      // TODO(AMP-139569)
+      // events: eventRecords,
     } = await this.storage.getAllAndClear();
 
     // Update the last flush timestamp
@@ -284,18 +286,21 @@ export class DiagnosticsClient implements IDiagnosticsClient {
       };
     });
 
-    const events: DiagnosticsEvent[] = eventRecords.map((record) => ({
-      event_name: record.event_name,
-      time: record.time,
-      event_properties: record.event_properties,
-    }));
+    // TODO(AMP-139569)
+    // const events: DiagnosticsEvent[] = eventRecords.map((record) => ({
+    // const events: DiagnosticsEvent[] = [];
+    //   event_name: record.event_name,
+    //   time: record.time,
+    //   event_properties: record.event_properties,
+    // }));
 
     // Create flush payload
     const payload: FlushPayload = {
       tags,
       histogram,
       counters,
-      events,
+      // TODO(AMP-139569)
+      // events,
     };
 
     // Send payload to diagnostics server

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -245,7 +245,7 @@ export class DiagnosticsClient implements IDiagnosticsClient {
 
     await Promise.all([
       this.storage.setTags(tagsToSave),
-      this.storage.setCounters(countersToSave),
+      this.storage.incrementCounters(countersToSave),
       this.storage.setHistogramStats(histogramsToSave),
       this.storage.addEventRecords(eventsToSave),
     ]);

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -1,6 +1,7 @@
 import { ILogger } from '../logger';
 import { DiagnosticsStorage, IDiagnosticsStorage } from './diagnostics-storage';
 import { ServerZoneType } from '../types/server-zone';
+import { getGlobalScope } from '../global-scope';
 
 export const SAVE_INTERVAL_MS = 1000; // 1 second
 export const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -46,7 +47,7 @@ interface HistogramResult {
 /**
  * Internal histogram statistics with sum for efficient incremental updates
  */
-interface HistogramStats {
+export interface HistogramStats {
   count: number;
   min: number;
   max: number;
@@ -323,7 +324,7 @@ export class DiagnosticsClient implements IDiagnosticsClient {
    */
   async fetch(payload: FlushPayload) {
     try {
-      const response = await fetch(this.serverUrl, {
+      const response = await getGlobalScope()?.fetch(this.serverUrl, {
         method: 'POST',
         headers: {
           'X-ApiKey': this.apiKey,
@@ -332,7 +333,7 @@ export class DiagnosticsClient implements IDiagnosticsClient {
         body: JSON.stringify(payload),
       });
 
-      if (!response.ok) {
+      if (!response?.ok) {
         this.logger.debug('DiagnosticsClient: Failed to send diagnostics data.');
         return;
       }

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -185,8 +185,8 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     }
 
     if (Object.keys(this.inMemoryTags).length >= MAX_MEMORY_STORAGE_COUNT) {
-      return;
       this.logger.debug('DiagnosticsClient: Early return setTags as reaching memory limit');
+      return;
     }
 
     this.inMemoryTags[name] = value;
@@ -199,8 +199,8 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     }
 
     if (Object.keys(this.inMemoryCounters).length >= MAX_MEMORY_STORAGE_COUNT) {
-      return;
       this.logger.debug('DiagnosticsClient: Early return increment as reaching memory limit');
+      return;
     }
 
     this.inMemoryCounters[name] = (this.inMemoryCounters[name] || 0) + size;
@@ -213,8 +213,8 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     }
 
     if (Object.keys(this.inMemoryHistograms).length >= MAX_MEMORY_STORAGE_COUNT) {
-      return;
       this.logger.debug('DiagnosticsClient: Early return recordHistogram as reaching memory limit');
+      return;
     }
 
     const existing = this.inMemoryHistograms[name];
@@ -242,8 +242,8 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     }
 
     if (this.inMemoryEvents.length >= MAX_MEMORY_STORAGE_EVENTS_COUNT) {
-      return;
       this.logger.debug('DiagnosticsClient: Early return recordEvent as reaching memory limit');
+      return;
     }
 
     this.inMemoryEvents.push({
@@ -376,7 +376,11 @@ export class DiagnosticsClient implements IDiagnosticsClient {
    */
   async fetch(payload: FlushPayload) {
     try {
-      const response = await getGlobalScope()?.fetch(this.serverUrl, {
+      if (!getGlobalScope()) {
+        throw new Error('DiagnosticsClient: Fetch is not supported');
+      }
+
+      const response = await fetch(this.serverUrl, {
         method: 'POST',
         headers: {
           'X-ApiKey': this.apiKey,
@@ -385,14 +389,14 @@ export class DiagnosticsClient implements IDiagnosticsClient {
         body: JSON.stringify(payload),
       });
 
-      if (!response?.ok) {
+      if (!response.ok) {
         this.logger.debug('DiagnosticsClient: Failed to send diagnostics data.');
         return;
       }
 
       this.logger.debug('DiagnosticsClient: Successfully sent diagnostics data');
     } catch (error) {
-      this.logger.debug('DiagnosticsClient: Failed to send diagnostics data', error);
+      this.logger.debug('DiagnosticsClient: Failed to send diagnostics data. ', error);
     }
   }
 

--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -9,7 +9,7 @@ export const DIAGNOSTICS_US_SERVER_URL = 'https://diagnostics.prod.us-west-2.amp
 export const DIAGNOSTICS_EU_SERVER_URL = 'https://diagnostics.prod.eu-central-1.amplitude.com/v1/capture';
 
 // In-memory storage limits
-export const MAX_MEMORY_STORAGE_COUNT = 100; // for tags, counters, histograms separately
+export const MAX_MEMORY_STORAGE_COUNT = 10000; // for tags, counters, histograms separately
 export const MAX_MEMORY_STORAGE_EVENTS_COUNT = 10;
 
 // === Core Data Types ===

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -331,6 +331,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     }
   }
 
+  // TODO(AMP-139569) - should save at most 10 events
   async addEventRecords(
     events: Array<{ event_name: string; time: number; event_properties: Record<string, any> }>,
   ): Promise<void> {

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -363,7 +363,6 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
           request.onsuccess = handleCompletion;
 
-          /* istanbul ignore next */
           request.onerror = () => {
             this.logger.debug('DiagnosticsStorage: Failed to add event record', event.event_name);
             handleCompletion();
@@ -413,6 +412,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     } catch (error) {
       /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to get internal value', error);
+
       return undefined;
     }
   }

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -1,0 +1,541 @@
+/// <reference lib="dom" />
+/**
+ * Purpose-specific IndexedDB storage for Amplitude Diagnostics
+ *
+ * This storage is optimized for diagnostics data with separate tables for each type:
+ * - Tags: Key-value pairs for environment/context information
+ * - Counters: Numeric counters that can be incremented
+ * - Histograms: Individual measurements with efficient sorting via compound index
+ * - Events: Diagnostic events with timestamps and properties
+ */
+
+// Database configuration
+const DB_VERSION = 1;
+
+// Table names for different diagnostics types
+export const TABLE_NAMES = {
+  TAGS: 'tags',
+  COUNTERS: 'counters',
+  HISTOGRAMS: 'histograms',
+  EVENTS: 'events',
+  INTERNAL: 'internal', // New table for internal storage like flush timestamps
+} as const;
+
+// Keys for internal storage table
+export const INTERNAL_KEYS = {
+  LAST_FLUSH_TIMESTAMP: 'last_flush_timestamp',
+} as const;
+
+// Record interfaces for each table
+export interface TagRecord {
+  key: string;
+  value: string;
+}
+
+export interface CounterRecord {
+  key: string;
+  value: number;
+}
+
+export interface HistogramRecord {
+  id?: number; // Auto-increment primary key
+  key: string;
+  value: number;
+  timestamp: number;
+}
+
+export interface EventRecord {
+  id?: number; // Auto-increment primary key
+  event_name: string;
+  time: number;
+  event_properties: Record<string, any>;
+}
+
+export interface InternalRecord {
+  key: string;
+  value: string;
+}
+
+/**
+ * Purpose-specific IndexedDB storage for diagnostics data
+ * Provides optimized methods for each type of diagnostics data
+ */
+export class DiagnosticsStorage {
+  private dbPromise: Promise<IDBDatabase> | null = null;
+  private dbName: string;
+
+  constructor(apiKey: string) {
+    this.dbName = `AMP_diagnostics_${apiKey.substring(0, 10)}`;
+  }
+
+  private async getDB(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = this.openDB();
+    }
+    return this.dbPromise;
+  }
+
+  private openDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      if (typeof indexedDB === 'undefined') {
+        reject(new Error('IndexedDB is not supported'));
+        return;
+      }
+
+      const request = indexedDB.open(this.dbName, DB_VERSION);
+
+      request.onerror = () => {
+        reject(new Error('Failed to open IndexedDB'));
+      };
+
+      request.onsuccess = () => {
+        resolve(request.result);
+      };
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        this.createTables(db);
+      };
+    });
+  }
+
+  private createTables(db: IDBDatabase): void {
+    // Create tags table
+    if (!db.objectStoreNames.contains(TABLE_NAMES.TAGS)) {
+      db.createObjectStore(TABLE_NAMES.TAGS, { keyPath: 'key' });
+    }
+
+    // Create counters table
+    if (!db.objectStoreNames.contains(TABLE_NAMES.COUNTERS)) {
+      db.createObjectStore(TABLE_NAMES.COUNTERS, { keyPath: 'key' });
+    }
+
+    // Create histograms table with auto-increment primary key and compound index
+    if (!db.objectStoreNames.contains(TABLE_NAMES.HISTOGRAMS)) {
+      const histogramsStore = db.createObjectStore(TABLE_NAMES.HISTOGRAMS, {
+        keyPath: 'id',
+        autoIncrement: true,
+      });
+
+      // Create compound index on [key, value] for efficient sorting
+      histogramsStore.createIndex('key_value_idx', ['key', 'value'], { unique: false });
+
+      // Create index on key for efficient key-based queries
+      histogramsStore.createIndex('key_idx', 'key', { unique: false });
+    }
+
+    // Create events table
+    if (!db.objectStoreNames.contains(TABLE_NAMES.EVENTS)) {
+      const eventsStore = db.createObjectStore(TABLE_NAMES.EVENTS, {
+        keyPath: 'id',
+        autoIncrement: true,
+      });
+
+      // Create index on time for chronological queries
+      eventsStore.createIndex('time_idx', 'time', { unique: false });
+    }
+
+    // Create internal table for storing internal data like flush timestamps
+    if (!db.objectStoreNames.contains(TABLE_NAMES.INTERNAL)) {
+      db.createObjectStore(TABLE_NAMES.INTERNAL, { keyPath: 'key' });
+    }
+  }
+
+  /**
+   * Check if IndexedDB is available and working
+   */
+  async isEnabled(): Promise<boolean> {
+    try {
+      if (typeof indexedDB === 'undefined') {
+        return false;
+      }
+
+      // Test if we can open the database
+      const db = await this.getDB();
+      return db !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  // === TAG OPERATIONS ===
+
+  /**
+   * Set a diagnostic tag
+   */
+  async setTag(key: string, value: string): Promise<void> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.TAGS], 'readwrite');
+      const store = transaction.objectStore(TABLE_NAMES.TAGS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.put({ key, value });
+
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(new Error('Failed to set tag'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to set tag`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a diagnostic tag
+   */
+  async getTag(key: string): Promise<TagRecord | undefined> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.TAGS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.TAGS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.get(key);
+
+        request.onsuccess = () => resolve(request.result as TagRecord | undefined);
+        request.onerror = () => reject(new Error('Failed to get tag'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get tag`, error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Get all diagnostic tags
+   */
+  async getAllTags(): Promise<TagRecord[]> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.TAGS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.TAGS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.getAll();
+
+        request.onsuccess = () => resolve(request.result as TagRecord[]);
+        request.onerror = () => reject(new Error('Failed to get all tags'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all tags`, error);
+      return [];
+    }
+  }
+
+  // === COUNTER OPERATIONS ===
+
+  /**
+   * Set a counter value
+   */
+  async setCounter(key: string, value: number): Promise<void> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.COUNTERS], 'readwrite');
+      const store = transaction.objectStore(TABLE_NAMES.COUNTERS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.put({ key, value });
+
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(new Error('Failed to set counter'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to set counter`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a counter value
+   */
+  async getCounter(key: string): Promise<CounterRecord | undefined> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.COUNTERS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.COUNTERS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.get(key);
+
+        request.onsuccess = () => resolve(request.result as CounterRecord | undefined);
+        request.onerror = () => reject(new Error('Failed to get counter'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get counter`, error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Get all counters
+   */
+  async getAllCounters(): Promise<CounterRecord[]> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.COUNTERS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.COUNTERS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.getAll();
+
+        request.onsuccess = () => resolve(request.result as CounterRecord[]);
+        request.onerror = () => reject(new Error('Failed to get all counters'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all counters`, error);
+      return [];
+    }
+  }
+
+  // === HISTOGRAM OPERATIONS ===
+
+  /**
+   * Add a histogram measurement
+   */
+  async addHistogramRecord(key: string, value: number, timestamp: number = Date.now()): Promise<void> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.HISTOGRAMS], 'readwrite');
+      const store = transaction.objectStore(TABLE_NAMES.HISTOGRAMS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.add({ key, value, timestamp });
+
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(new Error('Failed to add histogram record'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to add histogram record`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get histogram records for a specific key, sorted by value (uses compound index)
+   */
+  async getHistogramRecordsSortedByValue(key: string): Promise<HistogramRecord[]> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.HISTOGRAMS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.HISTOGRAMS);
+      const index = store.index('key_value_idx');
+
+      return new Promise((resolve, reject) => {
+        const range = IDBKeyRange.bound([key, -Infinity], [key, Infinity]);
+        const request = index.getAll(range);
+
+        request.onsuccess = () => {
+          // Records are already sorted by value due to the compound index
+          resolve(request.result as HistogramRecord[]);
+        };
+        request.onerror = () => reject(new Error('Failed to get histogram records'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get histogram records`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Get all histogram records
+   */
+  async getAllHistogramRecords(): Promise<HistogramRecord[]> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.HISTOGRAMS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.HISTOGRAMS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.getAll();
+
+        request.onsuccess = () => resolve(request.result as HistogramRecord[]);
+        request.onerror = () => reject(new Error('Failed to get all histogram records'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all histogram records`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Get total count of histogram records
+   */
+  async getHistogramRecordCount(): Promise<number> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.HISTOGRAMS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.HISTOGRAMS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.count();
+
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(new Error('Failed to count histogram records'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to count histogram records`, error);
+      return 0;
+    }
+  }
+
+  // === EVENT OPERATIONS ===
+
+  /**
+   * Add a diagnostic event
+   */
+  async addEventRecord(
+    event_name: string,
+    event_properties: Record<string, any>,
+    time: number = Date.now(),
+  ): Promise<void> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.EVENTS], 'readwrite');
+      const store = transaction.objectStore(TABLE_NAMES.EVENTS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.add({ event_name, event_properties, time });
+
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(new Error('Failed to add event record'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to add event record`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get all event records
+   */
+  async getAllEventRecords(): Promise<EventRecord[]> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.EVENTS], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.EVENTS);
+
+      return new Promise((resolve, reject) => {
+        const request = store.getAll();
+
+        request.onsuccess = () => resolve(request.result as EventRecord[]);
+        request.onerror = () => reject(new Error('Failed to get all event records'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all event records`, error);
+      return [];
+    }
+  }
+
+  // === INTERNAL STORAGE OPERATIONS ===
+
+  /**
+   * Set an internal value
+   */
+  async setInternal(key: string, value: string): Promise<void> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.INTERNAL], 'readwrite');
+      const store = transaction.objectStore(TABLE_NAMES.INTERNAL);
+
+      return new Promise((resolve, reject) => {
+        const request = store.put({ key, value });
+
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(new Error('Failed to set internal value'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to set internal value`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get an internal value
+   */
+  async getInternal(key: string): Promise<InternalRecord | undefined> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction([TABLE_NAMES.INTERNAL], 'readonly');
+      const store = transaction.objectStore(TABLE_NAMES.INTERNAL);
+
+      return new Promise((resolve, reject) => {
+        const request = store.get(key);
+
+        request.onsuccess = () => resolve(request.result as InternalRecord | undefined);
+        request.onerror = () => reject(new Error('Failed to get internal value'));
+      });
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get internal value`, error);
+      return undefined;
+    }
+  }
+
+  // === FLUSH TIMESTAMP OPERATIONS ===
+
+  /**
+   * Get the last flush timestamp
+   */
+  async getLastFlushTimestamp(): Promise<number | undefined> {
+    try {
+      const record = await this.getInternal(INTERNAL_KEYS.LAST_FLUSH_TIMESTAMP);
+      return record ? parseInt(record.value, 10) : undefined;
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to get last flush timestamp`, error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Set the last flush timestamp
+   */
+  async setLastFlushTimestamp(timestamp: number): Promise<void> {
+    try {
+      await this.setInternal(INTERNAL_KEYS.LAST_FLUSH_TIMESTAMP, timestamp.toString());
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to set last flush timestamp`, error);
+      throw error;
+    }
+  }
+
+  // === CLEANUP OPERATIONS ===
+
+  /**
+   * Clear all data from all tables
+   */
+  async clearAllData(): Promise<void> {
+    try {
+      const db = await this.getDB();
+      const transaction = db.transaction(
+        [TABLE_NAMES.TAGS, TABLE_NAMES.COUNTERS, TABLE_NAMES.HISTOGRAMS, TABLE_NAMES.EVENTS, TABLE_NAMES.INTERNAL],
+        'readwrite',
+      );
+
+      const promises = [
+        this.clearTable(transaction, TABLE_NAMES.TAGS),
+        this.clearTable(transaction, TABLE_NAMES.COUNTERS),
+        this.clearTable(transaction, TABLE_NAMES.HISTOGRAMS),
+        this.clearTable(transaction, TABLE_NAMES.EVENTS),
+        this.clearTable(transaction, TABLE_NAMES.INTERNAL),
+      ];
+
+      await Promise.all(promises);
+    } catch (error) {
+      console.error(`[Amplitude] DiagnosticsStorage: Failed to clear all data`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Clear a specific table
+   */
+  private clearTable(transaction: IDBTransaction, tableName: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const store = transaction.objectStore(tableName);
+      const request = store.clear();
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(new Error(`Failed to clear table ${tableName}`));
+    });
+  }
+}

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+import { ILogger } from 'src/logger';
 
 // Database configuration
 const DB_VERSION = 1;
@@ -83,8 +84,10 @@ export interface IDiagnosticsStorage {
 export class DiagnosticsStorage implements IDiagnosticsStorage {
   private dbPromise: Promise<IDBDatabase> | null = null;
   private dbName: string;
+  private logger?: ILogger;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, logger?: ILogger) {
+    this.logger = logger;
     this.dbName = `AMP_diagnostics_${apiKey.substring(0, 10)}`;
   }
 
@@ -189,7 +192,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to get all tags'));
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all tags`, error);
+      this.logger.error('DiagnosticsStorage: Failed to get all tags', error);
       return [];
     }
   }
@@ -226,7 +229,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to set tags`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to set tags', error);
       throw error;
     }
   }
@@ -249,7 +252,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to get all counters'));
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all counters`, error);
+      this.logger.error('DiagnosticsStorage: Failed to get all counters', error);
       return [];
     }
   }
@@ -286,7 +289,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to set counters`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to set counters', error);
       throw error;
     }
   }
@@ -327,7 +330,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to set histogram stats`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to set histogram stats', error);
       throw error;
     }
   }
@@ -348,7 +351,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to get all histogram stats'));
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all histogram stats`, error);
+      this.logger.error('DiagnosticsStorage: Failed to get all histogram stats', error);
       return [];
     }
   }
@@ -371,7 +374,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to get all event records'));
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to get all event records`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to get all event records', error);
       return [];
     }
   }
@@ -413,7 +416,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to add event records`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to add event records', error);
       throw error;
     }
   }
@@ -436,7 +439,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to set internal value'));
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to set internal value`, error);
+      this.logger.error('DiagnosticsStorage: Failed to set internal value', error);
       throw error;
     }
   }
@@ -457,7 +460,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to get internal value'));
       });
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to get internal value`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to get internal value', error);
       return undefined;
     }
   }
@@ -472,7 +475,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
       const record = await this.getInternal(INTERNAL_KEYS.LAST_FLUSH_TIMESTAMP);
       return record ? parseInt(record.value, 10) : undefined;
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to get last flush timestamp`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to get last flush timestamp', error);
       return undefined;
     }
   }
@@ -484,7 +487,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     try {
       await this.setInternal(INTERNAL_KEYS.LAST_FLUSH_TIMESTAMP, timestamp.toString());
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to set last flush timestamp`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to set last flush timestamp', error);
       throw error;
     }
   }
@@ -512,7 +515,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
       await Promise.all(promises);
     } catch (error) {
-      console.error(`[Amplitude] DiagnosticsStorage: Failed to clear all data`, error);
+      this.logger?.debug('DiagnosticsStorage: Failed to clear all data', error);
       throw error;
     }
   }

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -1,4 +1,4 @@
-/// <reference lib="dom" />
+import { getGlobalScope } from '../global-scope';
 import { ILogger } from '../logger';
 
 // Database configuration
@@ -115,7 +115,8 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
   openDB(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-      if (typeof indexedDB === 'undefined') {
+      /* istanbul ignore next */
+      if (getGlobalScope()?.indexedDB === undefined) {
         reject(new Error('IndexedDB is not supported'));
         return;
       }

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -126,7 +126,6 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, DB_VERSION);
 
-      /* istanbul ignore next */
       request.onerror = () => {
         reject(new Error('Failed to open IndexedDB'));
       };

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -122,6 +122,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
       const request = indexedDB.open(this.dbName, DB_VERSION);
 
+      /* istanbul ignore next */
       request.onerror = () => {
         reject(new Error('Failed to open IndexedDB'));
       };
@@ -199,6 +200,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
           request.onsuccess = handleCompletion;
 
+          /* istanbul ignore next */
           request.onerror = () => {
             this.logger.debug('DiagnosticsStorage: Failed to set tag', key, value);
             handleCompletion();
@@ -206,6 +208,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to set tags', error);
     }
   }
@@ -244,6 +247,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
             putRequest.onsuccess = handleWriteCompletion;
 
+            /* istanbul ignore next */
             putRequest.onerror = () => {
               this.logger.debug('DiagnosticsStorage: Failed to increment counter', key);
               handleWriteCompletion();
@@ -257,6 +261,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
           getRequest.onsuccess = () => {
             const existingRecord = getRequest.result as CounterRecord | undefined;
+            /* istanbul ignore next */
             const existingValue = existingRecord ? existingRecord.value : 0;
             updatedCounters[key] = existingValue + incrementValue;
 
@@ -266,6 +271,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
             }
           };
 
+          /* istanbul ignore next */
           getRequest.onerror = () => {
             this.logger.debug('DiagnosticsStorage: Failed to read existing counter', key);
             // Use fallback value for this counter
@@ -279,6 +285,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to increment counters', error);
     }
   }
@@ -320,6 +327,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
             putRequest.onsuccess = handleWriteCompletion;
 
+            /* istanbul ignore next */
             putRequest.onerror = () => {
               this.logger.debug('DiagnosticsStorage: Failed to set histogram stats', key);
               handleWriteCompletion();
@@ -334,6 +342,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
           getRequest.onsuccess = () => {
             const existingRecord = getRequest.result as HistogramRecord | undefined;
 
+            /* istanbul ignore next */
             if (existingRecord) {
               // Accumulate with existing stats
               updatedHistograms[key] = {
@@ -360,6 +369,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
             }
           };
 
+          /* istanbul ignore next */
           getRequest.onerror = () => {
             this.logger.debug('DiagnosticsStorage: Failed to read existing histogram stats', key);
             // Use new stats as fallback
@@ -379,16 +389,11 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to set histogram stats', error);
     }
   }
 
-  // === BATCH EVENT OPERATIONS ===
-
-  /**
-   * Add multiple event records in a single transaction (batch operation)
-   * Promise never rejects - errors are logged and operation continues gracefully
-   */
   async addEventRecords(
     events: Array<{ event_name: string; time: number; event_properties: Record<string, any> }>,
   ): Promise<void> {
@@ -421,6 +426,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
           request.onsuccess = handleCompletion;
 
+          /* istanbul ignore next */
           request.onerror = () => {
             this.logger.debug('DiagnosticsStorage: Failed to add event record', event.event_name);
             handleCompletion();
@@ -428,8 +434,8 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to add event records', error);
-      return Promise.resolve();
     }
   }
 
@@ -443,9 +449,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         const request = store.put({ key, value });
 
         request.onsuccess = () => resolve();
+
+        /* istanbul ignore next */
         request.onerror = () => reject(new Error('Failed to set internal value'));
       });
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to set internal value', error);
     }
   }
@@ -460,9 +469,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         const request = store.get(key);
 
         request.onsuccess = () => resolve(request.result as InternalRecord | undefined);
+
+        /* istanbul ignore next */
         request.onerror = () => reject(new Error('Failed to get internal value'));
       });
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to get internal value', error);
       return undefined;
     }
@@ -473,7 +485,9 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
       const record = await this.getInternal(INTERNAL_KEYS.LAST_FLUSH_TIMESTAMP);
       return record ? parseInt(record.value, 10) : undefined;
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to get last flush timestamp', error);
+      /* istanbul ignore next */
       return undefined;
     }
   }
@@ -482,10 +496,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     try {
       await this.setInternal(INTERNAL_KEYS.LAST_FLUSH_TIMESTAMP, timestamp.toString());
     } catch (error) {
+      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to set last flush timestamp', error);
     }
   }
 
+  /* istanbul ignore next */
   clearTable(transaction: IDBTransaction, tableName: string): Promise<void> {
     return new Promise((resolve, reject) => {
       const store = transaction.objectStore(tableName);
@@ -496,6 +512,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     });
   }
 
+  /* istanbul ignore next */
   async getAllAndClear(): Promise<{
     tags: TagRecord[];
     counters: CounterRecord[];
@@ -535,6 +552,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
   /**
    * Helper method to get all records from a store within a transaction
    */
+  /* istanbul ignore next */
   private getAllFromStore<T>(transaction: IDBTransaction, tableName: string): Promise<T[]> {
     return new Promise((resolve, reject) => {
       const store = transaction.objectStore(tableName);

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -344,6 +344,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
           resolve();
         };
 
+        /* istanbul ignore next */
         transaction.onabort = (event) => {
           this.logger.debug('DiagnosticsStorage: Failed to add event records', event);
           resolve();
@@ -373,6 +374,9 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
       const store = transaction.objectStore(TABLE_NAMES.INTERNAL);
 
       return new Promise((resolve, reject) => {
+        /* istanbul ignore next */
+        transaction.onabort = () => reject(new Error('Failed to set internal value'));
+
         const request = store.put({ key, value });
 
         request.onsuccess = () => resolve();
@@ -393,6 +397,9 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
       const store = transaction.objectStore(TABLE_NAMES.INTERNAL);
 
       return new Promise((resolve, reject) => {
+        /* istanbul ignore next */
+        transaction.onabort = () => reject(new Error('Failed to get internal value'));
+
         const request = store.get(key);
 
         request.onsuccess = () => resolve(request.result as InternalRecord | undefined);

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -124,12 +124,6 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
   openDB(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-      /* istanbul ignore next */
-      if (getGlobalScope()?.indexedDB === undefined) {
-        reject(new Error('IndexedDB is not supported'));
-        return;
-      }
-
       const request = indexedDB.open(this.dbName, DB_VERSION);
 
       /* istanbul ignore next */

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { ILogger } from 'src/logger';
+import { ILogger } from '../logger';
 
 // Database configuration
 const DB_VERSION = 1;

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -107,6 +107,14 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
     this.dbName = `AMP_diagnostics_${apiKey.substring(0, 10)}`;
   }
 
+  /**
+   * Check if IndexedDB is supported in the current environment
+   * @returns true if IndexedDB is available, false otherwise
+   */
+  static isSupported(): boolean {
+    return getGlobalScope()?.indexedDB !== undefined;
+  }
+
   async getDB(): Promise<IDBDatabase> {
     if (!this.dbPromise) {
       this.dbPromise = this.openDB();

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -139,6 +139,11 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
           this.dbPromise = null;
           this.logger.debug('DiagnosticsStorage: DB connection closed.');
         };
+
+        db.onerror = (event) => {
+          this.logger.debug('DiagnosticsStorage: A global database error occurred.', event);
+          db.close();
+        };
         resolve(db);
       };
 

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -207,7 +207,6 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
-      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to set tags', error);
     }
   }
@@ -249,14 +248,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
             };
           };
 
-          /* istanbul ignore next */
           getRequest.onerror = (event) => {
             this.logger.debug('DiagnosticsStorage: Failed to read existing counter', key, event);
           };
         });
       });
     } catch (error) {
-      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to increment counters', error);
     }
   }
@@ -319,14 +316,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
             };
           };
 
-          /* istanbul ignore next */
           getRequest.onerror = (event) => {
             this.logger.debug('DiagnosticsStorage: Failed to read existing histogram stats', key, event);
           };
         });
       });
     } catch (error) {
-      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to set histogram stats', error);
     }
   }
@@ -371,7 +366,6 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         });
       });
     } catch (error) {
-      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to add event records', error);
     }
   }
@@ -411,9 +405,7 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         request.onerror = () => reject(new Error('Failed to get internal value'));
       });
     } catch (error) {
-      /* istanbul ignore next */
       this.logger.debug('DiagnosticsStorage: Failed to get internal value', error);
-
       return undefined;
     }
   }

--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -251,15 +251,11 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
             const existingValue = existingRecord ? existingRecord.value : 0;
             const putRequest = store.put({ key, value: existingValue + incrementValue });
 
-            // Prevent the whole transaction from being rolled back.
-            // Only the failed request will be rolled back.
             putRequest.onerror = (event) => {
               this.logger.debug('DiagnosticsStorage: Failed to update counter', key, event);
             };
           };
 
-          // Prevent the whole transaction from being rolled back.
-          // Only the failed request will be rolled back.
           /* istanbul ignore next */
           getRequest.onerror = (event) => {
             this.logger.debug('DiagnosticsStorage: Failed to read existing counter', key, event);
@@ -326,16 +322,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
             const putRequest = store.put(updatedStats);
 
             putRequest.onerror = (event) => {
-              // Prevent the whole transaction from being rolled back.
-              // Only the failed request will be rolled back.
               this.logger.debug('DiagnosticsStorage: Failed to set histogram stats', key, event);
             };
           };
 
           /* istanbul ignore next */
           getRequest.onerror = (event) => {
-            // Prevent the whole transaction from being rolled back.
-            // Only the failed request will be rolled back.
             this.logger.debug('DiagnosticsStorage: Failed to read existing histogram stats', key, event);
           };
         });
@@ -488,7 +480,6 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
 
       // Clear all data in the same transaction
       await Promise.all([
-        this.clearTable(transaction, TABLE_NAMES.TAGS),
         this.clearTable(transaction, TABLE_NAMES.COUNTERS),
         this.clearTable(transaction, TABLE_NAMES.HISTOGRAMS),
         this.clearTable(transaction, TABLE_NAMES.EVENTS),

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -28,6 +28,8 @@ export { getStorageKey } from './storage/helpers';
 
 export { BrowserStorage } from './storage/browser-storage';
 
+export { DiagnosticsClient, IDiagnosticsClient } from './diagnostics/diagnostics-client';
+
 export { BaseTransport } from './transports/base';
 export { FetchTransport } from './transports/fetch';
 

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -28,7 +28,7 @@ export { getStorageKey } from './storage/helpers';
 
 export { BrowserStorage } from './storage/browser-storage';
 
-export { DiagnosticsClient, IDiagnosticsClient } from './diagnostics/diagnostics-client';
+// export { DiagnosticsClient, IDiagnosticsClient } from './diagnostics/diagnostics-client';
 
 export { BaseTransport } from './transports/base';
 export { FetchTransport } from './transports/fetch';

--- a/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
@@ -485,6 +485,33 @@ describe('DiagnosticsClient', () => {
         // events: EXPECTED_EVENTS,
       });
     });
+
+    test('should early return if all data collections are empty', async () => {
+      // Mock storage to return empty data
+      const emptyMockStorage = {
+        getAllAndClear: jest.fn().mockResolvedValue({
+          tags: [],
+          counters: [],
+          histogramStats: [],
+          events: [],
+        }),
+        setLastFlushTimestamp: jest.fn().mockResolvedValue(undefined),
+      };
+
+      // Replace the storage with empty mock
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      client.storage = emptyMockStorage as any;
+
+      // Call _flush
+      await client._flush();
+
+      // Verify that fetch was NOT called since all collections are empty
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      // Verify that storage methods were still called
+      expect(emptyMockStorage.getAllAndClear).toHaveBeenCalled();
+      expect(emptyMockStorage.setLastFlushTimestamp).toHaveBeenCalled();
+    });
   });
 
   describe('fetch', () => {

--- a/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
@@ -361,7 +361,7 @@ describe('DiagnosticsClient', () => {
     let client: DiagnosticsClient;
     let mockStorage: {
       setTags: jest.MockedFunction<(tags: Record<string, string>) => Promise<void>>;
-      setCounters: jest.MockedFunction<(counters: Record<string, number>) => Promise<void>>;
+      incrementCounters: jest.MockedFunction<(counters: Record<string, number>) => Promise<void>>;
       setHistogramStats: jest.MockedFunction<(histograms: Record<string, any>) => Promise<void>>;
       addEventRecords: jest.MockedFunction<(events: any[]) => Promise<void>>;
     };
@@ -376,7 +376,7 @@ describe('DiagnosticsClient', () => {
       client = new DiagnosticsClient(apiKey, mockLogger);
       mockStorage = {
         setTags: jest.fn().mockResolvedValue(undefined),
-        setCounters: jest.fn().mockResolvedValue(undefined),
+        incrementCounters: jest.fn().mockResolvedValue(undefined),
         setHistogramStats: jest.fn().mockResolvedValue(undefined),
         addEventRecords: jest.fn().mockResolvedValue(undefined),
       };
@@ -399,7 +399,7 @@ describe('DiagnosticsClient', () => {
 
       // Verify storage methods were called with correct data
       expect(mockStorage.setTags).toHaveBeenCalledWith(TEST_TAGS);
-      expect(mockStorage.setCounters).toHaveBeenCalledWith(TEST_COUNTERS);
+      expect(mockStorage.incrementCounters).toHaveBeenCalledWith(TEST_COUNTERS);
       expect(mockStorage.setHistogramStats).toHaveBeenCalledWith(TEST_HISTOGRAMS);
       expect(mockStorage.addEventRecords).toHaveBeenCalledWith(TEST_EVENTS);
 

--- a/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
@@ -19,29 +19,8 @@ const mockLogger: ILogger = {
 };
 const apiKey = '1234567890abcdefg';
 
-jest.mock('../../src/diagnostics/diagnostics-storage', () => {
-  const MockDiagnosticsStorage = jest.fn().mockImplementation(() => ({
-    // Mock instance methods
-    setTags: jest.fn(),
-    incrementCounters: jest.fn(),
-    setHistogramStats: jest.fn(),
-    addEventRecords: jest.fn(),
-    setLastFlushTimestamp: jest.fn(),
-    getLastFlushTimestamp: jest.fn(),
-    getAllAndClear: jest.fn(),
-  }));
-
-  // Add static methods to the constructor function
-  Object.defineProperty(MockDiagnosticsStorage, 'isSupported', {
-    value: jest.fn(),
-    writable: true,
-    configurable: true,
-  });
-
-  return {
-    DiagnosticsStorage: MockDiagnosticsStorage,
-  };
-});
+// Mock the DiagnosticsStorage module
+jest.mock('../../src/diagnostics/diagnostics-storage');
 
 describe('DiagnosticsClient', () => {
   let initializeFlushIntervalSpy: jest.SpyInstance;
@@ -54,7 +33,20 @@ describe('DiagnosticsClient', () => {
       .spyOn(DiagnosticsClient.prototype, 'initializeFlushInterval')
       .mockImplementation(() => Promise.resolve());
 
+    // Set up DiagnosticsStorage mock
     (DiagnosticsStorage.isSupported as jest.Mock).mockReturnValue(true);
+    (DiagnosticsStorage as jest.MockedClass<typeof DiagnosticsStorage>).mockImplementation(
+      () =>
+        ({
+          setTags: jest.fn(),
+          incrementCounters: jest.fn(),
+          setHistogramStats: jest.fn(),
+          addEventRecords: jest.fn(),
+          setLastFlushTimestamp: jest.fn(),
+          getLastFlushTimestamp: jest.fn(),
+          getAllAndClear: jest.fn(),
+        } as unknown as DiagnosticsStorage),
+    );
   });
 
   afterEach(() => {

--- a/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
@@ -445,7 +445,7 @@ describe('DiagnosticsClient', () => {
     const EXPECTED_TAGS = { library: 'amplitude-typescript/2.0.0', platform: 'web' };
     const EXPECTED_COUNTERS = { 'analytics.error': 5, 'network.retry': 3 };
     const EXPECTED_HISTOGRAMS = { 'sr.time': { count: 2, min: 50, max: 100, avg: 75 } };
-    const EXPECTED_EVENTS = [{ event_name: 'error', time: 123456789, event_properties: { type: 'network' } }];
+    // const EXPECTED_EVENTS = [{ event_name: 'error', time: 123456789, event_properties: { type: 'network' } }];
 
     beforeEach(() => {
       client = new DiagnosticsClient(apiKey, mockLogger);
@@ -482,7 +482,7 @@ describe('DiagnosticsClient', () => {
         tags: EXPECTED_TAGS,
         histogram: EXPECTED_HISTOGRAMS,
         counters: EXPECTED_COUNTERS,
-        events: EXPECTED_EVENTS,
+        // events: EXPECTED_EVENTS,
       });
     });
   });

--- a/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
@@ -1,0 +1,520 @@
+import { ILogger } from '../../src/logger';
+import {
+  DiagnosticsClient,
+  DIAGNOSTICS_US_SERVER_URL,
+  DIAGNOSTICS_EU_SERVER_URL,
+  FLUSH_INTERVAL_MS,
+  SAVE_INTERVAL_MS,
+} from '../../src/diagnostics/diagnostics-client';
+
+// Mock logger
+const mockLogger: ILogger = {
+  disable: jest.fn(),
+  enable: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+const apiKey = '1234567890abcdefg';
+
+describe('DiagnosticsClient', () => {
+  let initializeFlushIntervalSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    // Mock initializeFlushInterval globally to prevent async operations
+    initializeFlushIntervalSpy = jest
+      .spyOn(DiagnosticsClient.prototype, 'initializeFlushInterval')
+      .mockImplementation(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllTimers();
+    initializeFlushIntervalSpy.mockRestore();
+  });
+
+  describe('constructor', () => {
+    test('should create DiagnosticsClient with required parameters', () => {
+      const client = new DiagnosticsClient(apiKey, mockLogger);
+
+      expect(client.apiKey).toBe(apiKey);
+      expect(client.logger).toBe(mockLogger);
+      expect(client.serverUrl).toBe(DIAGNOSTICS_US_SERVER_URL);
+      expect(client.storage).toBeDefined();
+      expect(client.inMemoryTags).toEqual({});
+      expect(client.inMemoryCounters).toEqual({});
+      expect(client.inMemoryHistograms).toEqual({});
+      expect(client.inMemoryEvents).toEqual([]);
+      expect(client.saveTimer).toBeNull();
+      expect(client.flushTimer).toBeNull();
+      expect(initializeFlushIntervalSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should create DiagnosticsClient with EU server zone', () => {
+      const client = new DiagnosticsClient(apiKey, mockLogger, 'EU');
+
+      expect(client.serverUrl).toBe(DIAGNOSTICS_EU_SERVER_URL);
+    });
+  });
+
+  describe('initializeFlushInterval', () => {
+    let mockStorage: {
+      getLastFlushTimestamp: jest.MockedFunction<() => Promise<number | undefined>>;
+    };
+    let client: DiagnosticsClient;
+    let flushSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Restore the real initializeFlushInterval method for this describe block
+      initializeFlushIntervalSpy.mockRestore();
+
+      mockStorage = {
+        getLastFlushTimestamp: jest.fn(),
+      };
+      flushSpy = jest.spyOn(DiagnosticsClient.prototype, '_flush').mockResolvedValue();
+    });
+
+    afterEach(() => {
+      // Clean up timer if it exists
+      if (client?.flushTimer) {
+        clearTimeout(client.flushTimer);
+      }
+      flushSpy.mockRestore();
+
+      // Re-establish the mock for other describe blocks
+      initializeFlushIntervalSpy = jest
+        .spyOn(DiagnosticsClient.prototype, 'initializeFlushInterval')
+        .mockImplementation(() => Promise.resolve());
+    });
+
+    const createClientWithMockStorage = (timestampValue: number | undefined) => {
+      mockStorage.getLastFlushTimestamp.mockResolvedValue(timestampValue);
+      client = new DiagnosticsClient(apiKey, mockLogger);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      client.storage = mockStorage as any;
+      return client;
+    };
+
+    test('should early return for new client', async () => {
+      createClientWithMockStorage(undefined);
+
+      await client.initializeFlushInterval();
+
+      expect(mockStorage.getLastFlushTimestamp).toHaveBeenCalled();
+      expect(flushSpy).not.toHaveBeenCalled();
+      expect(client.flushTimer).toBeNull();
+    });
+
+    test('should flush immediately if 5 minutes have passed since last flush', async () => {
+      const oldTimestamp = Date.now() - 6 * 60 * 1000; // 6 minutes ago
+      createClientWithMockStorage(oldTimestamp);
+
+      await client.initializeFlushInterval();
+
+      expect(mockStorage.getLastFlushTimestamp).toHaveBeenCalled();
+      expect(flushSpy).toHaveBeenCalled();
+      expect(client.flushTimer).toBeNull();
+    });
+
+    test('should set timer for remaining time if less than 5 minutes have passed since last flush', async () => {
+      jest.useFakeTimers();
+      const pastTime = 2 * 60 * 1000;
+      const recentTimestamp = Date.now() - pastTime; // 2 minutes ago
+      createClientWithMockStorage(recentTimestamp);
+
+      await client.initializeFlushInterval();
+
+      expect(mockStorage.getLastFlushTimestamp).toHaveBeenCalled();
+      expect(flushSpy).not.toHaveBeenCalled();
+      expect(client.flushTimer).not.toBeNull();
+      jest.advanceTimersByTime(FLUSH_INTERVAL_MS - pastTime);
+      expect(flushSpy).toHaveBeenCalled();
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe('setters', () => {
+    let client: DiagnosticsClient;
+    let startSaveTimerIfNeededSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      client = new DiagnosticsClient(apiKey, mockLogger);
+      startSaveTimerIfNeededSpy = jest.spyOn(client, 'startSaveTimerIfNeeded').mockImplementation(() => {
+        // Mock implementation
+      });
+    });
+
+    afterEach(() => {
+      // Clear any timers that might have been set
+      if (client?.saveTimer) {
+        clearTimeout(client.saveTimer);
+        client.saveTimer = null;
+      }
+      if (client?.flushTimer) {
+        clearTimeout(client.flushTimer);
+        client.flushTimer = null;
+      }
+      startSaveTimerIfNeededSpy.mockRestore();
+      jest.clearAllTimers();
+    });
+
+    test('setTag', () => {
+      const key = 'library';
+      const value = 'amplitude-typescript/2.0.0';
+
+      client.setTag(key, value);
+
+      expect(client.inMemoryTags).toEqual({ [key]: value });
+      expect(startSaveTimerIfNeededSpy).toHaveBeenCalled();
+    });
+
+    test('increment', () => {
+      const key = 'analytics.fileNotFound';
+      const size = 3;
+
+      client.increment(key, size);
+
+      expect(client.inMemoryCounters).toEqual({ [key]: size });
+      expect(startSaveTimerIfNeededSpy).toHaveBeenCalled();
+    });
+
+    test('increment with default size', () => {
+      const key = 'analytics.fileNotFound';
+
+      client.increment(key);
+
+      expect(client.inMemoryCounters).toEqual({ [key]: 1 });
+      expect(startSaveTimerIfNeededSpy).toHaveBeenCalled();
+    });
+
+    test('recordHistogram', () => {
+      client.recordHistogram('sr.time', 50);
+      client.recordHistogram('sr.time', 100);
+      client.recordHistogram('sr.time', 150);
+      client.recordHistogram('sr.time', 100);
+
+      expect(client.inMemoryHistograms).toEqual({
+        'sr.time': {
+          count: 4,
+          min: 50,
+          max: 150,
+          sum: 400,
+        },
+      });
+      expect(startSaveTimerIfNeededSpy).toHaveBeenCalled();
+    });
+
+    test('recordEvent', () => {
+      const eventName = 'error';
+      const properties = { stack_trace: 'test stack trace' };
+
+      client.recordEvent(eventName, properties);
+
+      expect(client.inMemoryEvents).toHaveLength(1);
+      expect(client.inMemoryEvents[0]).toEqual({
+        event_name: eventName,
+        time: expect.any(Number) as number,
+        event_properties: properties,
+      });
+      expect(startSaveTimerIfNeededSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('startSaveTimerIfNeeded', () => {
+    let client: DiagnosticsClient;
+    let saveAllDataToStorageSpy: jest.SpyInstance;
+    let flushSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      client = new DiagnosticsClient(apiKey, mockLogger);
+      saveAllDataToStorageSpy = jest.spyOn(client, 'saveAllDataToStorage').mockResolvedValue();
+      flushSpy = jest.spyOn(client, '_flush').mockResolvedValue();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+      saveAllDataToStorageSpy.mockRestore();
+      flushSpy.mockRestore();
+    });
+
+    test('should set saveTimer if it is not set', () => {
+      client.saveTimer = null;
+
+      client.startSaveTimerIfNeeded();
+
+      expect(client.saveTimer).not.toBeNull();
+      jest.advanceTimersByTime(SAVE_INTERVAL_MS);
+      expect(saveAllDataToStorageSpy).toHaveBeenCalled();
+    });
+
+    test('should not set saveTimer if it is already set', () => {
+      client.saveTimer = setTimeout(() => {
+        // Mock timer callback
+      }, 500);
+      const originalTimer = client.saveTimer;
+
+      client.startSaveTimerIfNeeded();
+
+      expect(client.saveTimer).toBe(originalTimer);
+    });
+
+    test('should set flushTimer if it is not set', () => {
+      client.flushTimer = null;
+
+      client.startSaveTimerIfNeeded();
+
+      expect(client.flushTimer).not.toBeNull();
+      jest.advanceTimersByTime(FLUSH_INTERVAL_MS);
+      expect(flushSpy).toHaveBeenCalled();
+    });
+
+    test('should not set flushTimer if it is already set', () => {
+      client.flushTimer = setTimeout(() => {
+        // Mock timer callback
+      }, FLUSH_INTERVAL_MS);
+      const originalTimer = client.flushTimer;
+
+      client.startSaveTimerIfNeeded();
+
+      expect(client.flushTimer).toBe(originalTimer);
+    });
+  });
+
+  describe('saveAllDataToStorage', () => {
+    let client: DiagnosticsClient;
+    let mockStorage: {
+      setTags: jest.MockedFunction<(tags: Record<string, string>) => Promise<void>>;
+      setCounters: jest.MockedFunction<(counters: Record<string, number>) => Promise<void>>;
+      setHistogramStats: jest.MockedFunction<(histograms: Record<string, any>) => Promise<void>>;
+      addEventRecords: jest.MockedFunction<(events: any[]) => Promise<void>>;
+    };
+
+    // Test data constants
+    const TEST_TAGS = { library: 'amplitude-typescript/2.0.0', platform: 'web' };
+    const TEST_COUNTERS = { 'analytics.error': 5, 'network.retry': 3 };
+    const TEST_HISTOGRAMS = { 'sr.time': { count: 2, min: 50, max: 100, sum: 150 } };
+    const TEST_EVENTS = [{ event_name: 'error', time: 123456789, event_properties: { type: 'network' } }];
+
+    beforeEach(() => {
+      client = new DiagnosticsClient(apiKey, mockLogger);
+      mockStorage = {
+        setTags: jest.fn().mockResolvedValue(undefined),
+        setCounters: jest.fn().mockResolvedValue(undefined),
+        setHistogramStats: jest.fn().mockResolvedValue(undefined),
+        addEventRecords: jest.fn().mockResolvedValue(undefined),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      client.storage = mockStorage as any;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('should save all in-memory data to storage and clear memory', async () => {
+      // Set up in-memory data
+      client.inMemoryTags = { ...TEST_TAGS };
+      client.inMemoryCounters = { ...TEST_COUNTERS };
+      client.inMemoryHistograms = { ...TEST_HISTOGRAMS };
+      client.inMemoryEvents = [...TEST_EVENTS];
+
+      await client.saveAllDataToStorage();
+
+      // Verify storage methods were called with correct data
+      expect(mockStorage.setTags).toHaveBeenCalledWith(TEST_TAGS);
+      expect(mockStorage.setCounters).toHaveBeenCalledWith(TEST_COUNTERS);
+      expect(mockStorage.setHistogramStats).toHaveBeenCalledWith(TEST_HISTOGRAMS);
+      expect(mockStorage.addEventRecords).toHaveBeenCalledWith(TEST_EVENTS);
+
+      // Verify in-memory data is cleared
+      expect(client.inMemoryTags).toEqual({});
+      expect(client.inMemoryCounters).toEqual({});
+      expect(client.inMemoryHistograms).toEqual({});
+      expect(client.inMemoryEvents).toEqual([]);
+
+      // Verify saveTimer is cleared
+      expect(client.saveTimer).toBeNull();
+    });
+  });
+
+  describe('_flush', () => {
+    let client: DiagnosticsClient;
+    let mockStorage: {
+      getAllAndClear: jest.MockedFunction<
+        () => Promise<{
+          tags: Array<{ key: string; value: string }>;
+          counters: Array<{ key: string; value: number }>;
+          histogramStats: Array<{ key: string; count: number; min: number; max: number; sum: number }>;
+          events: Array<{ event_name: string; time: number; event_properties: any }>;
+        }>
+      >;
+      setLastFlushTimestamp: jest.MockedFunction<(timestamp: number) => Promise<void>>;
+    };
+    let fetchSpy: jest.SpyInstance;
+
+    // Test data constants for storage records
+    const MOCK_TAG_RECORDS = [
+      { key: 'library', value: 'amplitude-typescript/2.0.0' },
+      { key: 'platform', value: 'web' },
+    ];
+    const MOCK_COUNTER_RECORDS = [
+      { key: 'analytics.error', value: 5 },
+      { key: 'network.retry', value: 3 },
+    ];
+    const MOCK_HISTOGRAM_RECORDS = [{ key: 'sr.time', count: 2, min: 50, max: 100, sum: 150 }];
+    const MOCK_EVENT_RECORDS = [{ event_name: 'error', time: 123456789, event_properties: { type: 'network' } }];
+
+    // Expected transformed data
+    const EXPECTED_TAGS = { library: 'amplitude-typescript/2.0.0', platform: 'web' };
+    const EXPECTED_COUNTERS = { 'analytics.error': 5, 'network.retry': 3 };
+    const EXPECTED_HISTOGRAMS = { 'sr.time': { count: 2, min: 50, max: 100, avg: 75 } };
+    const EXPECTED_EVENTS = [{ event_name: 'error', time: 123456789, event_properties: { type: 'network' } }];
+
+    beforeEach(() => {
+      client = new DiagnosticsClient(apiKey, mockLogger);
+      mockStorage = {
+        getAllAndClear: jest.fn().mockResolvedValue({
+          tags: MOCK_TAG_RECORDS,
+          counters: MOCK_COUNTER_RECORDS,
+          histogramStats: MOCK_HISTOGRAM_RECORDS,
+          events: MOCK_EVENT_RECORDS,
+        }),
+        setLastFlushTimestamp: jest.fn().mockResolvedValue(undefined),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      client.storage = mockStorage as any;
+      fetchSpy = jest.spyOn(client, 'fetch').mockResolvedValue();
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      fetchSpy.mockRestore();
+    });
+
+    test('should call necessary APIs', async () => {
+      client.flushTimer = setTimeout(() => {
+        // Mock timer callback
+      }, 1000);
+
+      await client._flush();
+
+      expect(client.flushTimer).toBeNull();
+      expect(mockStorage.getAllAndClear).toHaveBeenCalled();
+      expect(mockStorage.setLastFlushTimestamp).toHaveBeenCalled();
+      // Also test histogram calculation
+      expect(fetchSpy).toHaveBeenCalledWith({
+        tags: EXPECTED_TAGS,
+        histogram: EXPECTED_HISTOGRAMS,
+        counters: EXPECTED_COUNTERS,
+        events: EXPECTED_EVENTS,
+      });
+    });
+  });
+
+  describe('fetch', () => {
+    let client: DiagnosticsClient;
+    let mockFetch: jest.SpyInstance;
+
+    // Test payload constant
+    const TEST_PAYLOAD = {
+      tags: { library: 'amplitude-typescript/2.0.0', platform: 'web' },
+      histogram: { 'sr.time': { count: 2, min: 50, max: 100, avg: 75 } },
+      counters: { 'analytics.error': 5, 'network.retry': 3 },
+      events: [{ event_name: 'error', time: 123456789, event_properties: { type: 'network' } }],
+    };
+
+    beforeEach(() => {
+      client = new DiagnosticsClient(apiKey, mockLogger);
+      mockFetch = jest.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+      mockFetch.mockRestore();
+      jest.clearAllMocks();
+    });
+
+    test('should send POST request with correct parameters', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse as Response);
+
+      await client.fetch(TEST_PAYLOAD);
+
+      expect(mockFetch).toHaveBeenCalledWith(client.serverUrl, {
+        method: 'POST',
+        headers: {
+          'X-ApiKey': apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(TEST_PAYLOAD),
+      });
+    });
+
+    test('should log success message on successful response', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse as Response);
+
+      await client.fetch(TEST_PAYLOAD);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith('DiagnosticsClient: Successfully sent diagnostics data');
+    });
+
+    test('should log error message on HTTP error response', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      };
+      mockFetch.mockResolvedValue(mockResponse as Response);
+
+      await client.fetch(TEST_PAYLOAD);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith('DiagnosticsClient: Failed to send diagnostics data.');
+    });
+
+    test('should log error message on fetch exception', async () => {
+      const error = new Error('error');
+      mockFetch.mockRejectedValue(error);
+
+      await client.fetch(TEST_PAYLOAD);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith('DiagnosticsClient: Failed to send diagnostics data', error);
+    });
+
+    test('should use US server URL by default', async () => {
+      const usClient = new DiagnosticsClient(apiKey, mockLogger);
+      const mockResponse = { ok: true, status: 200, statusText: 'OK' };
+      mockFetch.mockResolvedValue(mockResponse as Response);
+
+      await usClient.fetch(TEST_PAYLOAD);
+
+      expect(mockFetch).toHaveBeenCalledWith(DIAGNOSTICS_US_SERVER_URL, expect.any(Object));
+    });
+
+    test('should use EU server URL when specified', async () => {
+      const euClient = new DiagnosticsClient(apiKey, mockLogger, 'EU');
+      const mockResponse = { ok: true, status: 200, statusText: 'OK' };
+      mockFetch.mockResolvedValue(mockResponse as Response);
+
+      await euClient.fetch(TEST_PAYLOAD);
+
+      expect(mockFetch).toHaveBeenCalledWith(DIAGNOSTICS_EU_SERVER_URL, expect.any(Object));
+    });
+  });
+});

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -1,0 +1,34 @@
+import 'fake-indexeddb/auto';
+import { DiagnosticsStorage } from '../../src/diagnostics/diagnostics-storage';
+import { ILogger } from '../../src/logger';
+
+// Mock logger
+const mockLogger: ILogger = {
+  disable: jest.fn(),
+  enable: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+const apiKey = '1234567890abcdefg';
+
+describe('DiagnosticsStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('constructor', () => {
+    test('should initialize with apiKey and logger', () => {
+      const storage = new DiagnosticsStorage(apiKey, mockLogger);
+
+      expect(storage.dbName).toBe('AMP_diagnostics_1234567890');
+      expect(storage.logger).toBe(mockLogger);
+    });
+  });
+});

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -56,4 +56,92 @@ describe('DiagnosticsStorage', () => {
       await expect(storage.setTags({})).resolves.toBeUndefined();
     });
   });
+
+  describe('incrementCounters', () => {
+    test('should increment counters', async () => {
+      await expect(storage.incrementCounters({ clicks: 5, errors: 1 })).resolves.toBeUndefined();
+    });
+
+    test('should early return if counters is empty', async () => {
+      await expect(storage.incrementCounters({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('setHistogramStats', () => {
+    test('should set histogram stats', async () => {
+      const histogramStats = {
+        responseTime: { count: 10, min: 50, max: 500, sum: 2500 },
+        loadTime: { count: 5, min: 100, max: 1000, sum: 3000 },
+      };
+      await expect(storage.setHistogramStats(histogramStats)).resolves.toBeUndefined();
+    });
+
+    test('should early return if histogram stats is empty', async () => {
+      await expect(storage.setHistogramStats({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('addEventRecords', () => {
+    test('should add event records', async () => {
+      const events = [
+        { event_name: 'page_view', time: Date.now(), event_properties: { page: '/home' } },
+        { event_name: 'button_click', time: Date.now() + 1000, event_properties: { button_id: 'submit' } },
+      ];
+      await expect(storage.addEventRecords(events)).resolves.toBeUndefined();
+    });
+
+    test('should early return if events is empty', async () => {
+      await expect(storage.addEventRecords([])).resolves.toBeUndefined();
+    });
+  });
+
+  describe('setInternal', () => {
+    test('should set internal value', async () => {
+      await expect(storage.setInternal('lastFlushTimestamp', '1234567890')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getInternal', () => {
+    test('should return undefined for non-existent key', async () => {
+      await expect(storage.getInternal('nonExistentKey')).resolves.toBeUndefined();
+    });
+
+    test('should get internal value after setting it', async () => {
+      const key = 'testKey';
+      const value = 'testValue';
+
+      // Set the value first
+      await storage.setInternal(key, value);
+
+      // Then get it back
+      const result = await storage.getInternal(key);
+      expect(result).toEqual({ key, value });
+    });
+  });
+
+  describe('setLastFlushTimestamp', () => {
+    test('should set last flush timestamp', async () => {
+      const spy = jest.spyOn(storage, 'setInternal');
+      const timestamp = Date.now();
+      await expect(storage.setLastFlushTimestamp(timestamp)).resolves.toBeUndefined();
+      expect(spy).toHaveBeenCalledWith('last_flush_timestamp', timestamp.toString());
+      spy.mockRestore();
+    });
+  });
+
+  describe('getLastFlushTimestamp', () => {
+    test('should get last flush timestamp after setting it', async () => {
+      const spy = jest.spyOn(storage, 'getInternal');
+      const timestamp = 1234567890000;
+
+      // Set the timestamp first
+      await storage.setLastFlushTimestamp(timestamp);
+
+      // Then get it back
+      const result = await storage.getLastFlushTimestamp();
+      expect(result).toBe(timestamp);
+      expect(spy).toHaveBeenCalledWith('last_flush_timestamp');
+      spy.mockRestore();
+    });
+  });
 });

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -15,8 +15,10 @@ const mockLogger: ILogger = {
 const apiKey = '1234567890abcdefg';
 
 describe('DiagnosticsStorage', () => {
+  let storage: DiagnosticsStorage;
   beforeEach(() => {
     jest.clearAllMocks();
+    storage = new DiagnosticsStorage(apiKey, mockLogger);
   });
 
   afterEach(() => {
@@ -25,10 +27,23 @@ describe('DiagnosticsStorage', () => {
 
   describe('constructor', () => {
     test('should initialize with apiKey and logger', () => {
-      const storage = new DiagnosticsStorage(apiKey, mockLogger);
-
       expect(storage.dbName).toBe('AMP_diagnostics_1234567890');
       expect(storage.logger).toBe(mockLogger);
+    });
+  });
+
+  describe('getDB', () => {
+    test('should return the db', async () => {
+      await expect(storage.getDB()).resolves.toBeDefined();
+    });
+
+    test('should call openDB if dbPromise is not set', async () => {
+      storage.dbPromise = null;
+      const mockDB = {} as IDBDatabase;
+      const openDBSpy = jest.spyOn(storage, 'openDB').mockResolvedValue(mockDB);
+
+      await expect(storage.getDB()).resolves.toBeDefined();
+      expect(openDBSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -51,5 +51,9 @@ describe('DiagnosticsStorage', () => {
     test('should set tags', async () => {
       await expect(storage.setTags({ test: 'test' })).resolves.toBeUndefined();
     });
+
+    test('should early return if tags is empty', async () => {
+      await expect(storage.setTags({})).resolves.toBeUndefined();
+    });
   });
 });

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -1,6 +1,9 @@
 import 'fake-indexeddb/auto';
 import { DiagnosticsStorage } from '../../src/diagnostics/diagnostics-storage';
 import { ILogger } from '../../src/logger';
+import { getGlobalScope } from '../../src/global-scope';
+
+jest.mock('../../src/global-scope');
 
 // Mock logger
 const mockLogger: ILogger = {
@@ -19,16 +22,28 @@ describe('DiagnosticsStorage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     storage = new DiagnosticsStorage(apiKey, mockLogger);
+    (getGlobalScope as jest.Mock).mockReturnValue(globalThis);
   });
 
   afterEach(() => {
     jest.resetAllMocks();
+    (getGlobalScope as jest.Mock).mockRestore();
   });
 
   describe('constructor', () => {
     test('should initialize with apiKey and logger', () => {
       expect(storage.dbName).toBe('AMP_diagnostics_1234567890');
       expect(storage.logger).toBe(mockLogger);
+    });
+  });
+
+  describe('isSupported', () => {
+    test('should return true if IndexedDB is supported', () => {
+      expect(DiagnosticsStorage.isSupported()).toBe(true);
+    });
+    test('should return false if IndexedDB is not supported', () => {
+      (getGlobalScope as jest.Mock).mockReturnValue(undefined);
+      expect(DiagnosticsStorage.isSupported()).toBe(false);
     });
   });
 

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -605,7 +605,6 @@ describe('DiagnosticsStorage', () => {
       // Create a mock add request that will automatically trigger error
       const mockAddRequest = {
         onerror: null as ((event: Event) => void) | null,
-        onsuccess: null as ((event: Event) => void) | null,
       };
 
       // Mock the store.add to return a request that will fail
@@ -616,6 +615,11 @@ describe('DiagnosticsStorage', () => {
             if (mockAddRequest.onerror) {
               const errorEvent = new Event('error');
               mockAddRequest.onerror(errorEvent);
+            }
+            // Also trigger transaction completion (even with errors, transaction can complete)
+            if (mockTransaction.oncomplete) {
+              const completeEvent = new Event('complete');
+              mockTransaction.oncomplete(completeEvent);
             }
           }, 0);
           return mockAddRequest;
@@ -652,7 +656,10 @@ describe('DiagnosticsStorage', () => {
 
       // Verify error was logged
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLogger.debug).toHaveBeenCalledWith('DiagnosticsStorage: Failed to add event record', 'page_view');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'DiagnosticsStorage: Failed to add event record',
+        expect.any(Event),
+      );
 
       // Restore spy
       getDBSpy.mockRestore();

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -46,4 +46,10 @@ describe('DiagnosticsStorage', () => {
       expect(openDBSpy).toHaveBeenCalled();
     });
   });
+
+  describe('setTags', () => {
+    test('should set tags', async () => {
+      await expect(storage.setTags({ test: 'test' })).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/analytics-core/test/index.test.ts
+++ b/packages/analytics-core/test/index.test.ts
@@ -52,6 +52,7 @@ import {
   EMPTY_VALUE,
   MKTG,
   AmplitudeContext,
+  DiagnosticsClient,
 } from '../src/index';
 
 describe('index', () => {
@@ -123,5 +124,6 @@ describe('index', () => {
     expect(typeof BASE_CAMPAIGN).toBe('object');
     expect(typeof MKTG).toBe('string');
     expect(typeof CampaignParser).toBe('function');
+    expect(typeof DiagnosticsClient).toBe('function');
   });
 });

--- a/packages/analytics-core/test/index.test.ts
+++ b/packages/analytics-core/test/index.test.ts
@@ -52,7 +52,7 @@ import {
   EMPTY_VALUE,
   MKTG,
   AmplitudeContext,
-  DiagnosticsClient,
+  // DiagnosticsClient,
 } from '../src/index';
 
 describe('index', () => {
@@ -124,6 +124,6 @@ describe('index', () => {
     expect(typeof BASE_CAMPAIGN).toBe('object');
     expect(typeof MKTG).toBe('string');
     expect(typeof CampaignParser).toBe('function');
-    expect(typeof DiagnosticsClient).toBe('function');
+    // expect(typeof DiagnosticsClient).toBe('function');
   });
 });

--- a/test-server/diagnostics-test.html
+++ b/test-server/diagnostics-test.html
@@ -239,7 +239,7 @@
                 logger = new UILogger();
                 logger.enable(LogLevel.Debug); // Enable debug level logging
                 
-                diagnosticsClient = new DiagnosticsClient('5b9a9510e261f9ead90865bbc5a7ad1d', logger);
+                diagnosticsClient = new DiagnosticsClient('YOUR_API_KEY', logger);
                 
                 // Update server URL display
                 document.getElementById('server-url').textContent = diagnosticsClient.serverUrl;

--- a/test-server/diagnostics-test.html
+++ b/test-server/diagnostics-test.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Diagnostics Client Test</title>
+    <style>
+        body {
+            font-family: monospace;
+            margin: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 900px;
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .test-section {
+            margin: 20px 0;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            background: #fafafa;
+        }
+        .test-section h3 {
+            margin-top: 0;
+            color: #333;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 10px;
+        }
+        button {
+            background: #007cba;
+            color: white;
+            border: none;
+            padding: 12px 20px;
+            margin: 8px 5px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+        button:hover {
+            background: #005a8b;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .output {
+            background: #f8f8f8;
+            border: 1px solid #ddd;
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+            font-size: 12px;
+        }
+        .network-info {
+            background: #e8f4fd;
+            border: 1px solid #bee5eb;
+            padding: 15px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .status {
+            padding: 8px 12px;
+            border-radius: 4px;
+            font-weight: bold;
+            margin: 5px 0;
+        }
+        .status.success { background: #d4edda; color: #155724; }
+        .status.error { background: #f8d7da; color: #721c24; }
+        .status.info { background: #d1ecf1; color: #0c5460; }
+        .log-output {
+            background: #1e1e1e;
+            color: #d4d4d4;
+            padding: 15px;
+            margin: 10px 0;
+            border-radius: 4px;
+            max-height: 400px;
+            overflow-y: auto;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 11px;
+        }
+        .log-entry {
+            margin: 2px 0;
+            word-wrap: break-word;
+        }
+        .log-debug { color: #569cd6; }
+        .log-warn { color: #dcdcaa; }
+        .log-error { color: #f44747; }
+        .log-log { color: #d4d4d4; }
+        .button-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            align-items: center;
+        }
+        .inline-info {
+            color: #666;
+            font-size: 12px;
+            margin-left: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🔬 Diagnostics Client Test</h1>
+        
+        <div class="network-info">
+            <strong>API Key:</strong> 5b9a9510e261f9ead90865bbc5a7ad1d<br>
+            <strong>Server URL:</strong> <span id="server-url">Not initialized</span><br>
+            <strong>💡 Tip:</strong> Open DevTools → Network tab to see diagnostics API requests
+        </div>
+
+        <div class="test-section">
+            <h3>🚀 Initialize</h3>
+            <div class="button-group">
+                <button onclick="initializeDiagnostics()">Initialize Diagnostics Client</button>
+                <span class="inline-info">Creates DiagnosticsClient with Logger</span>
+            </div>
+            <div id="init-output" class="output"></div>
+        </div>
+
+        <div class="test-section">
+            <h3>🏷️ Tags</h3>
+            <div class="button-group">
+                <button onclick="testSetTag()" disabled id="tag-btn">Set Tag</button>
+                <span class="inline-info">library: amplitude-ts/2.11.0</span>
+            </div>
+            <div id="tag-output" class="output"></div>
+        </div>
+
+        <div class="test-section">
+            <h3>📊 Counters</h3>
+            <div class="button-group">
+                <button onclick="testIncrement()" disabled id="counter-btn">Increment Counter</button>
+                <span class="inline-info">network.retry: +3</span>
+            </div>
+            <div id="counter-output" class="output"></div>
+        </div>
+
+        <div class="test-section">
+            <h3>📈 Histograms</h3>
+            <div class="button-group">
+                <button onclick="testRecordHistogram()" disabled id="histogram-btn">Record Histogram</button>
+                <span class="inline-info">network.latency: random 0-500ms</span>
+            </div>
+            <div id="histogram-output" class="output"></div>
+        </div>
+
+        <div class="test-section">
+            <h3>📝 Events</h3>
+            <div class="button-group">
+                <button onclick="testRecordEvent()" disabled id="event-btn">Record Event</button>
+                <span class="inline-info">error event with stack_trace</span>
+            </div>
+            <div id="event-output" class="output"></div>
+        </div>
+
+        <div class="test-section">
+            <h3>🚀 Manual Actions</h3>
+            <div class="button-group">
+                <button onclick="testFlush()" disabled id="flush-btn">Flush Now</button>
+                <span class="inline-info">Send all data to server immediately</span>
+                <button onclick="clearLogs()">Clear Logs</button>
+            </div>
+            <div id="flush-output" class="output"></div>
+        </div>
+
+        <div class="test-section">
+            <h3>📋 Logger Output</h3>
+            <div id="logger-output" class="log-output">
+                <div class="log-entry">Waiting for initialization...</div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        // Import from the built ESM files
+        import { DiagnosticsClient } from '../packages/analytics-core/lib/esm/diagnostics/diagnostics-client.js';
+        import { Logger } from '../packages/analytics-core/lib/esm/logger.js';
+        import { LogLevel } from '../packages/analytics-core/lib/esm/types/loglevel.js';
+
+        // Global variables
+        let diagnosticsClient = null;
+        let logger = null;
+
+        // Helper to update output divs
+        function updateOutput(elementId, message, type = 'info') {
+            const element = document.getElementById(elementId);
+            element.innerHTML = `<div class="status ${type}">${message}</div>`;
+        }
+
+        // Helper to enable/disable buttons
+        function setButtonsEnabled(enabled) {
+            const buttons = ['tag-btn', 'counter-btn', 'histogram-btn', 'event-btn', 'flush-btn'];
+            buttons.forEach(id => {
+                document.getElementById(id).disabled = !enabled;
+            });
+        }
+
+        // Custom logger that outputs to the UI
+        class UILogger extends Logger {
+            _output(level, args) {
+                const logOutput = document.getElementById('logger-output');
+                const logEntry = document.createElement('div');
+                logEntry.className = `log-entry log-${level.toLowerCase()}`;
+                const timestamp = new Date().toLocaleTimeString();
+                logEntry.innerHTML = `<span style="color: #666;">[${timestamp}]</span> <strong>[${level}]</strong> ${args.join(' ')}`;
+                logOutput.appendChild(logEntry);
+                logOutput.scrollTop = logOutput.scrollHeight;
+            }
+
+            log(...args) {
+                super.log(...args);
+                this._output('Log', args);
+            }
+
+            warn(...args) {
+                super.warn(...args);
+                this._output('Warn', args);
+            }
+
+            error(...args) {
+                super.error(...args);
+                this._output('Error', args);
+            }
+
+            debug(...args) {
+                super.debug(...args);
+                this._output('Debug', args);
+            }
+        }
+
+        // Initialize diagnostics client
+        window.initializeDiagnostics = function() {
+            try {
+                logger = new UILogger();
+                logger.enable(LogLevel.Debug); // Enable debug level logging
+                
+                diagnosticsClient = new DiagnosticsClient('5b9a9510e261f9ead90865bbc5a7ad1d', logger);
+                
+                // Update server URL display
+                document.getElementById('server-url').textContent = diagnosticsClient.serverUrl;
+                
+                updateOutput('init-output', '✓ Diagnostics client initialized successfully', 'success');
+                setButtonsEnabled(true);
+                
+                logger.log('Diagnostics client initialized successfully');
+            } catch (error) {
+                updateOutput('init-output', `✗ Failed to initialize: ${error.message}`, 'error');
+                console.error('Failed to initialize diagnostics client:', error);
+            }
+        };
+
+        // Test setting tags
+        window.testSetTag = function() {
+            if (!diagnosticsClient) {
+                updateOutput('tag-output', '✗ Please initialize first', 'error');
+                return;
+            }
+
+            try {
+                diagnosticsClient.setTag('library', 'amplitude-ts/2.11.0');
+                updateOutput('tag-output', '✓ Tag set: library = amplitude-ts/2.11.0', 'success');
+            } catch (error) {
+                updateOutput('tag-output', `✗ Failed to set tag: ${error.message}`, 'error');
+            }
+        };
+
+        // Test incrementing counters
+        window.testIncrement = function() {
+            if (!diagnosticsClient) {
+                updateOutput('counter-output', '✗ Please initialize first', 'error');
+                return;
+            }
+
+            try {
+                diagnosticsClient.increment('network.retry', 3);
+                updateOutput('counter-output', '✓ Counter incremented: network.retry +3', 'success');
+            } catch (error) {
+                updateOutput('counter-output', `✗ Failed to increment counter: ${error.message}`, 'error');
+            }
+        };
+
+        // Test recording histograms
+        window.testRecordHistogram = function() {
+            if (!diagnosticsClient) {
+                updateOutput('histogram-output', '✗ Please initialize first', 'error');
+                return;
+            }
+
+            try {
+                const latency = Math.floor(Math.random() * 500); // Random 0-500ms
+                diagnosticsClient.recordHistogram('network.latency', latency);
+                updateOutput('histogram-output', `✓ Histogram recorded: network.latency = ${latency}ms`, 'success');
+            } catch (error) {
+                updateOutput('histogram-output', `✗ Failed to record histogram: ${error.message}`, 'error');
+            }
+        };
+
+        // Test recording events
+        window.testRecordEvent = function() {
+            if (!diagnosticsClient) {
+                updateOutput('event-output', '✗ Please initialize first', 'error');
+                return;
+            }
+
+            try {
+                diagnosticsClient.recordEvent('error', {
+                    stack_trace: 'test stack trace'
+                });
+                updateOutput('event-output', '✓ Event recorded: error with stack_trace', 'success');
+            } catch (error) {
+                updateOutput('event-output', `✗ Failed to record event: ${error.message}`, 'error');
+            }
+        };
+
+        // Test manual flush
+        window.testFlush = function() {
+            if (!diagnosticsClient) {
+                updateOutput('flush-output', '✗ Please initialize first', 'error');
+                return;
+            }
+
+            try {
+                diagnosticsClient._flush();
+                updateOutput('flush-output', '✓ Flush initiated - check Network tab for API request', 'success');
+            } catch (error) {
+                updateOutput('flush-output', `✗ Failed to flush: ${error.message}`, 'error');
+            }
+        };
+
+        // Clear logs
+        window.clearLogs = function() {
+            document.getElementById('logger-output').innerHTML = '';
+        };
+
+        // Auto-initialize on page load for convenience
+        document.addEventListener('DOMContentLoaded', function() {
+            console.log('Diagnostics test page loaded. Ready to initialize.');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add a diagnostics client with APIs: 
- setTag() for tag
- increment() for counter
- recordHistogram for histogram
- recordEvent for event. This will be added later after the diagnostic server supports events in the request payload

The client has two storages
- memory storage as cache
  - auto save to persistent storage every 1 second if there is any data
- indexedDB as persistent storage
  - auto flush every 5 minutes if there is any data
 
The client also flushes on initialization when last flush time stored in indexedDB has passed 5 minutes.

The code is based on the diagnostics client design [here](https://amplitude.atlassian.net/wiki/spaces/GOV/pages/3270639769/Diagnostics+client+design).

I'm heavily using `istanbul ignore next` in diagnostics-storage for test coverage as it's mainly just indexddb APIs call. I will set up a e2e test to further test them

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
