### PR TITLE
fix(autocapture): make the default for patterns in mask-text-regex to be case insensitive

### DIFF
--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -35,7 +35,7 @@ export class DataExtractor {
         compiled.push(entry);
       } else if ('pattern' in entry && typeof entry.pattern === 'string') {
         try {
-          compiled.push(new RegExp(entry.pattern));
+          compiled.push(new RegExp(entry.pattern, 'i'));
         } catch {
           // ignore invalid pattern strings
         }


### PR DESCRIPTION
### Summary

For text mask regex patterns, change regex into case insensitive by default.
This allows for easier RegEx patterns to be made. In the future, if necessary, an option can be added in Remote Config to allow case-sensitive to be applied.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
