### PR TITLE
fix(plugin-autocapture-browser): no dead click on target=_blank

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-dead-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-dead-click.ts
@@ -35,6 +35,10 @@ export function trackDeadClick({
       // Only track change on elements that should be tracked
       return shouldTrackDeadClick('click', clickEvent.closestTrackedAncestor);
     }),
+    filter((clickEvent) => {
+      const target = clickEvent.event.target as Element;
+      return target.closest('a[target="_blank"]') === null;
+    }),
   );
 
   const changeObservables: Array<

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts
@@ -187,6 +187,34 @@ describe('trackDeadClick', () => {
     }, 100);
   });
 
+  it('should not track when target is _blank', (done) => {
+    const subscription = trackDeadClick({
+      amplitude: mockAmplitude,
+      allObservables,
+      getEventProperties,
+      shouldTrackDeadClick,
+    });
+
+    const mockElement = document.createElement('a');
+    mockElement.setAttribute('target', '_blank');
+
+    clickObservable.next({
+      event: {
+        target: mockElement,
+      },
+      timestamp: Date.now(),
+      closestTrackedAncestor: mockElement,
+      targetElementProperties: { id: 'test-element' },
+    });
+
+    // Wait for the dead click timeout
+    setTimeout(() => {
+      expect(mockAmplitude.track).not.toHaveBeenCalled();
+      subscription.unsubscribe();
+      done();
+    }, 100);
+  });
+
   it('should throttle multiple dead clicks', (done) => {
     const subscription = trackDeadClick({
       amplitude: mockAmplitude,

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -236,6 +236,7 @@
         <h2>Clickable Elements</h2>
         <div class="clickable-div" data-test-id="clickable-div-1" id="dynamic-div">Active Div</div>
         <div class="clickable-div" data-test-id="clickable-div-2">Do nothing div</div>
+        <a href="https://amplitude.com" class="role-link" target="_blank">Open New Page</a>
         <a href="#" class="role-link" data-test-id="test-link">Test Link</a>
         <div id="dynamic-content" class="border padding" style="margin-top: 10px; display: none;">
           This content was dynamically added after clicking the div!


### PR DESCRIPTION
### Summary

Don't trigger a dead click if the element clicked is an (or is inside an) `a` tag where `target=_blank`


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
