### PR TITLE
fix(plugin-ga-events-forwarder-browser): do not log errors on relative URLs

### DIFF
--- a/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
+++ b/packages/plugin-ga-events-forwarder-browser/src/ga-events-forwarder.ts
@@ -130,8 +130,15 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
    * 3b. Sends events to Amplitude after Amplitude SDK is initialized
    */
   const intercept = (requestUrl: string | URL, data: BodyInit | null | undefined): boolean => {
+    let url: URL;
     try {
-      const url = new URL(requestUrl);
+      url = new URL(requestUrl);
+    } catch (e) {
+      // it's a relative URL, therefore not a GA4 event
+      return false;
+    }
+
+    try {
       if (
         GA_SERVICE_ROOT_DOMAIN_VALUES.some((rootDomain) => url.hostname.endsWith(rootDomain)) &&
         url.pathname === GA_PAYLOAD_PATHNAME_VALUE &&
@@ -152,6 +159,7 @@ export const gaEventsForwarderPlugin = ({ measurementIds = [] }: Options = {}): 
     } catch (e) {
       /* istanbul ignore next */
       logger?.error(e);
+      /* istanbul ignore next */
       return false;
     }
   };

--- a/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
+++ b/packages/plugin-ga-events-forwarder-browser/test/ga-events-forwarder.test.ts
@@ -395,7 +395,7 @@ describe('gaEventsForwarderPlugin', () => {
         // 1. Setup is called when Amplitude SDK is initialized
         await plugin?.setup(config as BrowserConfig, amplitude as BrowserClient);
         // 2.Send event to Google Analytics
-        expect(() => window.navigator.sendBeacon('🤷‍♂️')).not.toThrow();
+        expect(() => window.navigator.sendBeacon('relative/url')).not.toThrow();
 
         expect(amplitude.track).toHaveBeenCalledTimes(0);
       });


### PR DESCRIPTION
### Summary

Problem: relative URL's cause `new URL` to throw an exception in the `intercept` function, which logs a console error in the catch block, which is creating a lot of noise for one of our customers.

Solution: move the `new URL` function before the try catch block into it's own try catch block. In this block, the catch doesn't log an error. No need to log an error, because if it reaches that block it means that it's a relative URL.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
