### PR TITLE
feat(analytics-browser): add "identify" to config

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -144,6 +144,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
     await super._init(browserOptions);
     this.logBrowserOptions(browserOptions);
 
+    // if an identify object is provided, call it on init
+    if (this.config.identify) {
+      this.identify(this.config.identify);
+    }
+
     // Add web attribution plugin
     if (isAttributionTrackingEnabled(this.config.defaultTracking)) {
       const attributionTrackingOptions = getAttributionTrackingConfig(this.config);

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -25,6 +25,7 @@ import {
   AutocaptureOptions,
   CookieOptions,
   NetworkTrackingOptions,
+  IIdentify,
 } from '@amplitude/analytics-core';
 
 import { LocalStorage } from './storage/local-storage';
@@ -94,6 +95,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     pageCounter?: number,
     debugLogsEnabled?: boolean,
     public networkTrackingOptions?: NetworkTrackingOptions,
+    public identify?: IIdentify,
   ) {
     super({ apiKey, storageProvider, transportProvider: createTransport(transport) });
     this._cookieStorage = cookieStorage;
@@ -107,6 +109,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     this.debugLogsEnabled = debugLogsEnabled;
     this.loggerProvider.enable(debugLogsEnabled ? LogLevel.Debug : this.logLevel);
     this.networkTrackingOptions = networkTrackingOptions;
+    this.identify = identify;
   }
 
   get cookieStorage() {
@@ -310,6 +313,7 @@ export const useBrowserConfig = async (
     pageCounter,
     debugLogsEnabled,
     options.networkTrackingOptions,
+    options.identify,
   );
 
   if (!(await browserConfig.storageProvider.isEnabled())) {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -141,6 +141,16 @@ describe('browser-client', () => {
   });
 
   describe('init', () => {
+    test('should call identify when identify is provided', async () => {
+      const identifySpy = jest.spyOn(client, 'identify');
+      const identify = new Identify();
+      identify.set('test', 'test');
+      await client.init(apiKey, {
+        identify,
+      }).promise;
+      expect(identifySpy).toHaveBeenCalledWith(identify);
+    });
+
     test('should use remote config by default', async () => {
       await client.init(apiKey).promise;
       expect(MockedRemoteConfigClient).toHaveBeenCalled();

--- a/packages/analytics-core/src/types/config/core-config.ts
+++ b/packages/analytics-core/src/types/config/core-config.ts
@@ -7,6 +7,7 @@ import { ServerZoneType } from '../server-zone';
 import { Transport } from '../transport';
 import { Storage } from '../storage';
 import { Event } from '../event/event';
+import { IIdentify } from '../../identify';
 
 export interface IConfig {
   /**
@@ -86,6 +87,10 @@ export interface IConfig {
    * Metrics of the SDK.
    */
   requestMetadata?: IRequestMetadata;
+  /**
+   * Identify object to be called on init.
+   */
+  identify?: IIdentify;
 }
 
 export interface IRequestMetadata {

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -260,14 +260,18 @@
         deadClicks: true,
         rageClicks: true,
       };
+      const identify = new amplitude.Identify();
+      identify.set('testing', 'testing');
       amplitude.init(
         import.meta.env.VITE_AMPLITUDE_API_KEY,
         import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
         {
+          identify,
           fetchRemoteConfig: false,
           autocapture: {
             elementInteractions: true,
             frustrationInteractions,
+            sessions: true,
           },
         }
       );


### PR DESCRIPTION
### Summary
* Add a new config parameter called "identify" which takes IIdentify as an argument
* When set, client.identify will be called from within client.init with this parameter
* This is so that users have the ability to call "identify" prior to autocapture events (like `session_start`) allowing for proper attribution of events
  * Context: many users have had problems where they've called "identify" after "init" and then "session_start" won't be attribute to that identity

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
