### PR TITLE
Amp 140894 sr experiment undefined

### DIFF
--- a/packages/unified/src/unified-client-factory.ts
+++ b/packages/unified/src/unified-client-factory.ts
@@ -4,8 +4,18 @@ import { debugWrapper, getClientLogConfig, getClientStates } from '@amplitude/an
 export const createInstance = (): UnifiedClient => {
   const client = new AmplitudeUnified();
   return {
-    experiment: client.experiment,
-    sessionReplay: client.sessionReplay,
+    experiment: debugWrapper(
+      client.experiment.bind(client),
+      'experiment',
+      getClientLogConfig(client),
+      getClientStates(client, ['config']),
+    ),
+    sessionReplay: debugWrapper(
+      client.sessionReplay.bind(client),
+      'sessionReplay',
+      getClientLogConfig(client),
+      getClientStates(client, ['config']),
+    ),
     initAll: debugWrapper(
       client.initAll.bind(client),
       'initAll',

--- a/packages/unified/src/unified.ts
+++ b/packages/unified/src/unified.ts
@@ -27,16 +27,20 @@ export type UnifiedOptions = UnifiedSharedOptions & {
 
 export interface UnifiedClient extends BrowserClient {
   initAll(apiKey: string, unifiedOptions?: UnifiedOptions): Promise<void>;
-  sessionReplay: AmplitudeSessionReplay;
-  experiment: IExperimentClient | undefined;
+  sessionReplay(): AmplitudeSessionReplay;
+  experiment(): IExperimentClient | undefined;
 }
 
 export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  sessionReplay: AmplitudeSessionReplay;
+  private _sessionReplay: AmplitudeSessionReplay;
 
-  get experiment(): IExperimentClient | undefined {
+  sessionReplay(): AmplitudeSessionReplay {
+    return this._sessionReplay;
+  }
+
+  experiment(): IExperimentClient | undefined {
     // Return when init() or initAll() is not called
     if (this.config === undefined) {
       return undefined;
@@ -78,7 +82,7 @@ export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient 
     if (srPlugin === undefined) {
       this.config.loggerProvider.debug(`${SessionReplayPlugin.pluginName} plugin is not found.`);
     } else {
-      this.sessionReplay = (srPlugin as SessionReplayPlugin).sessionReplay;
+      this._sessionReplay = (srPlugin as SessionReplayPlugin).sessionReplay;
     }
   }
 

--- a/packages/unified/test/index.test.ts
+++ b/packages/unified/test/index.test.ts
@@ -1,0 +1,34 @@
+import * as amplitude from '../src/index';
+import { initAll, sessionReplay, experiment } from '../src/index';
+
+test('should return non undefined sessionReplay and experiment after initAll() by import method 1', async () => {
+  // Method 1: import * as amplitude should work
+  expect(typeof amplitude.initAll).toBe('function');
+  expect(typeof amplitude.sessionReplay).toBe('function');
+  expect(typeof amplitude.experiment).toBe('function');
+
+  // Test that methods work before and after initAll()
+  expect(amplitude.sessionReplay()).toBeUndefined();
+  expect(amplitude.experiment()).toBeUndefined();
+
+  await amplitude.initAll('test-api-key');
+
+  expect(amplitude.sessionReplay()).toBeDefined();
+  expect(amplitude.experiment()).toBeDefined();
+});
+
+test('should return non undefined sessionReplay and experiment after initAll() by import method 2', async () => {
+  // Method 2: named imports { initAll, sessionReplay, experiment } should work
+  expect(typeof initAll).toBe('function');
+  expect(typeof sessionReplay).toBe('function');
+  expect(typeof experiment).toBe('function');
+
+  // Test that methods work before and after initAll()
+  expect(sessionReplay()).toBeUndefined();
+  expect(experiment()).toBeUndefined();
+
+  await initAll('test-api-key');
+
+  expect(sessionReplay()).toBeDefined();
+  expect(experiment()).toBeDefined();
+});

--- a/packages/unified/test/index.test.ts
+++ b/packages/unified/test/index.test.ts
@@ -1,34 +1,17 @@
 import * as amplitude from '../src/index';
-import { initAll, sessionReplay, experiment } from '../src/index';
+import { sessionReplay, experiment } from '../src/index';
 
-test('should return non undefined sessionReplay and experiment after initAll() by import method 1', async () => {
-  // Method 1: import * as amplitude should work
-  expect(typeof amplitude.initAll).toBe('function');
-  expect(typeof amplitude.sessionReplay).toBe('function');
-  expect(typeof amplitude.experiment).toBe('function');
-
+test('should return non undefined sessionReplay and experiment after initAll() by import method 1 & 2', async () => {
   // Test that methods work before and after initAll()
   expect(amplitude.sessionReplay()).toBeUndefined();
   expect(amplitude.experiment()).toBeUndefined();
 
   await amplitude.initAll('test-api-key');
 
+  // Method 1: import * as amplitude should work
   expect(amplitude.sessionReplay()).toBeDefined();
   expect(amplitude.experiment()).toBeDefined();
-});
-
-test('should return non undefined sessionReplay and experiment after initAll() by import method 2', async () => {
   // Method 2: named imports { initAll, sessionReplay, experiment } should work
-  expect(typeof initAll).toBe('function');
-  expect(typeof sessionReplay).toBe('function');
-  expect(typeof experiment).toBe('function');
-
-  // Test that methods work before and after initAll()
-  expect(sessionReplay()).toBeUndefined();
-  expect(experiment()).toBeUndefined();
-
-  await initAll('test-api-key');
-
   expect(sessionReplay()).toBeDefined();
   expect(experiment()).toBeDefined();
 });

--- a/packages/unified/test/unified-client-factory.test.ts
+++ b/packages/unified/test/unified-client-factory.test.ts
@@ -25,3 +25,17 @@ test('should create a UnifiedClient instance with expected methods', () => {
   expect(typeof instance.setOptOut).toBe('function');
   expect(typeof instance.setTransport).toBe('function');
 });
+
+test('should return non undefined sessionReplay and experiment after initAll() by import method 3', async () => {
+  // Method 3: import {createInstance} from '@amplitude/unified'
+  // Test that sessionReplay and experiment are undefined before initAll()
+  expect(instance.sessionReplay()).toBeUndefined();
+  expect(instance.experiment()).toBeUndefined();
+
+  // Initialize with a test API key
+  await instance.initAll('test-api-key');
+
+  // Test that sessionReplay and experiment are defined after initAll()
+  expect(instance.sessionReplay()).toBeDefined();
+  expect(instance.experiment()).toBeDefined();
+});

--- a/packages/unified/test/unified.test.ts
+++ b/packages/unified/test/unified.test.ts
@@ -27,13 +27,13 @@ describe('AmplitudeUnified', () => {
       undefined,
     ])('should initialize all plugins and assign sr and experiment properties', async (unifiedOptions) => {
       const client = new AmplitudeUnified();
-      expect(client.sessionReplay).toBeUndefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.sessionReplay()).toBeUndefined();
+      expect(client.experiment()).toBeUndefined();
 
       await client.initAll('test-api-key', unifiedOptions);
 
-      expect(client.sessionReplay).toBeDefined();
-      expect(client.experiment).toBeDefined();
+      expect(client.sessionReplay()).toBeDefined();
+      expect(client.experiment()).toBeDefined();
     });
 
     test('should log when sr plugin is not found', async () => {
@@ -43,8 +43,8 @@ describe('AmplitudeUnified', () => {
         if (name === SessionReplayPlugin.pluginName) return undefined;
         return originalPlugin(name);
       });
-      expect(client.sessionReplay).toBeUndefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.sessionReplay()).toBeUndefined();
+      expect(client.experiment()).toBeUndefined();
 
       await client.initAll('test-api-key', {
         analytics: {
@@ -52,9 +52,9 @@ describe('AmplitudeUnified', () => {
         },
       });
 
-      expect(client.sessionReplay).toBeUndefined();
+      expect(client.sessionReplay()).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${SessionReplayPlugin.pluginName} plugin is not found.`);
-      expect(client.experiment).toBeDefined();
+      expect(client.experiment()).toBeDefined();
     });
 
     test('should log when experiment plugin is not found', async () => {
@@ -62,8 +62,8 @@ describe('AmplitudeUnified', () => {
       jest.spyOn(client, 'plugins').mockImplementation((_) => {
         return [];
       });
-      expect(client.sessionReplay).toBeUndefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.sessionReplay()).toBeUndefined();
+      expect(client.experiment()).toBeUndefined();
 
       await client.initAll('test-api-key', {
         analytics: {
@@ -71,8 +71,8 @@ describe('AmplitudeUnified', () => {
         },
       });
 
-      expect(client.sessionReplay).toBeDefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.sessionReplay()).toBeDefined();
+      expect(client.experiment()).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${ExperimentPlugin.pluginName} plugin is not found.`);
     });
 
@@ -81,8 +81,8 @@ describe('AmplitudeUnified', () => {
       jest.spyOn(client, 'plugins').mockImplementation((_) => {
         return [];
       });
-      expect(client.sessionReplay).toBeUndefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.sessionReplay()).toBeUndefined();
+      expect(client.experiment()).toBeUndefined();
 
       await client.initAll('test-api-key', {
         analytics: {
@@ -90,8 +90,8 @@ describe('AmplitudeUnified', () => {
         },
       });
 
-      expect(client.sessionReplay).toBeDefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.sessionReplay()).toBeDefined();
+      expect(client.experiment()).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(`${ExperimentPlugin.pluginName} plugin is not found.`);
     });
 
@@ -116,7 +116,7 @@ describe('AmplitudeUnified', () => {
     });
   });
 
-  describe('get experiment', () => {
+  describe('experiment method', () => {
     test('should return undefined and log when multiple experiment instances', async () => {
       const client = new AmplitudeUnified();
       const experimentPlugin2 = experimentPlugin();
@@ -131,7 +131,7 @@ describe('AmplitudeUnified', () => {
       await client.add(experimentPlugin2).promise;
 
       expect(client.plugin('@amplitude/experiment-analytics-plugin-2')).toBeDefined();
-      expect(client.experiment).toBeUndefined();
+      expect(client.experiment()).toBeUndefined();
       expect(mockLoggerProviderDebug).toHaveBeenCalledWith(
         `Multiple instances of ${ExperimentPlugin.pluginName} are found.`,
       );


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Fix the issue that `sessionReplay` and `experiment` are undefined by changing `sessionReplay` and `experiment` from class properties to methods. As class properties values are assigned by the time they are imported. 
```
// method 1
import * as amplitude from @amplitude/unified

// method 2
import {initAll, sessionReplay, experiment} @amplitude/unified

// method 3
import {createInstance} from @amplitude/unified
const client = createInstance()
```
Test
- Add some unit tests
- Test local unified SDK build with example app

```
import * as amplitude from '@amplitude/unified';

console.log('Method 1 - Before init - amplitude.experiment', amplitude.experiment());
console.log('Method 1 - Before init - amplitude.sessionReplay', amplitude.sessionReplay());

(async () => {
  await amplitude.initAll('5b9a9510e261f9ead90865bbc5a7ad1d');
  
  console.log('Method 1 - After init - amplitude.experiment ', amplitude.experiment());
  console.log('Method 1 - After init - amplitude.sessionReplay', amplitude.sessionReplay());

})();
```

<img width="1013" height="196" alt="image" src="https://github.com/user-attachments/assets/bb757e07-27dd-48dd-bfd1-60f722b516f8" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
