### PR TITLE
fix(analytics-browser): suppress unnecessary url warnings

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -76,7 +76,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
   init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {
     let userId: string | undefined;
     let options: BrowserOptions | undefined;
-
+    debugger;
     if (arguments.length > 2) {
       userId = userIdOrOptions as string | undefined;
       options = maybeOptions;
@@ -89,6 +89,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
         options = userIdOrOptions;
       }
     }
+    console.log('options', options);
     return returnWrapper(this._init({ ...options, userId, apiKey }));
   }
   protected async _init(options: BrowserOptions & { apiKey: string }) {

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -162,7 +162,7 @@ export const getNetworkTrackingConfig = (config: BrowserOptions): NetworkTrackin
       ...networkTrackingConfig,
       captureRules: networkTrackingConfig?.captureRules?.map((rule) => {
         // if URLs and hosts are both set, URLs take precedence over hosts
-        if (rule.urls && rule.hosts) {
+        if (rule.urls?.length && rule.hosts?.length) {
           const hostsString = JSON.stringify(rule.hosts);
           const urlsString = JSON.stringify(rule.urls);
           /* istanbul ignore next */

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -475,6 +475,7 @@ describe('getNetworkTrackingConfig', () => {
       captureRules: [
         { urls: ['https://example.com/path', /path\/to/], hosts: ['example.com'] },
         { hosts: ['example.com', 'helloworld.com'] },
+        { urls: ['https://example.com'] },
       ],
     };
 
@@ -496,6 +497,16 @@ describe('getNetworkTrackingConfig', () => {
       const ruleWithOnlyHosts = captureRules[1];
       expect(ruleWithOnlyHosts.hosts).toEqual(['example.com', 'helloworld.com']);
       expect(ruleWithOnlyHosts.urls).toBeUndefined();
+    });
+
+    test('should ignore hosts if urls are set and hosts is undefined', () => {
+      const captureRules =
+        getNetworkTrackingConfig({
+          autocapture: { networkTracking },
+        })?.captureRules || [];
+      const ruleWithBothSet = captureRules[2];
+      expect(ruleWithBothSet.hosts).toBeUndefined();
+      expect(ruleWithBothSet.urls).toEqual(['https://example.com']);
     });
 
     test('should not do anything if captureRules is not set', () => {

--- a/test-server/autocapture/element-interactions.html
+++ b/test-server/autocapture/element-interactions.html
@@ -267,7 +267,7 @@
         import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
         {
           identify,
-          fetchRemoteConfig: false,
+          fetchRemoteConfig: true,
           autocapture: {
             elementInteractions: true,
             frustrationInteractions,


### PR DESCRIPTION
### Summary

Hide this warning if "urls" or "hosts" is empty:

<img width="1429" height="832" alt="Screenshot 2025-10-02 at 11 15 41 AM" src="https://github.com/user-attachments/assets/0e0c9332-ba91-4c5a-aaad-98bce11ba5c8" />


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
