### PR TITLE
revert(analytics-browser): revert "fix: support timestamp override for Experiment events"

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -241,9 +241,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
 
     // Step 7: Add the event receiver after running remaining queued functions.
     connector.eventBridge.setEventReceiver((event) => {
-      const { time, ...eventProperties } = event.eventProperties || {};
-      const eventOptions = time ? { time } : undefined;
-      void this.track(event.eventType, eventProperties, eventOptions);
+      void this.track(event.eventType, event.eventProperties);
     });
   }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR reverts the changes from the "fix: support timestamp override for Experiment events" commit.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
