### PR TITLE
fix: Allow timestamp override for experiment events

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -241,7 +241,9 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
 
     // Step 7: Add the event receiver after running remaining queued functions.
     connector.eventBridge.setEventReceiver((event) => {
-      void this.track(event.eventType, event.eventProperties);
+      const { time, ...cleanEventProperties } = event.eventProperties || {};
+      const eventOptions = (typeof time === 'number') ? { time } : undefined;
+      void this.track(event.eventType, cleanEventProperties, eventOptions);
     });
   }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This fix will allow experiment events to override the default timestamp provided by the Analytics SDK. This will allow the timestamp of experiment events to reflect the time of exposure, rather than when the event is processed by the Analytics SDK.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
