### PR TITLE
fix: resolve pluralization issue frustrationInteractions

### DIFF
--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -131,6 +131,19 @@ export function translateRemoteConfigToLocal(config?: Record<string, any>) {
     /* istanbul ignore next */
     // surprise exception, so don't translate it
   }
+
+  // translate frustrationInteractions pluralization
+  const frustrationInteractions = config.autocapture?.frustrationInteractions;
+  if (frustrationInteractions) {
+    if (frustrationInteractions.rageClick) {
+      frustrationInteractions.rageClicks = frustrationInteractions.rageClick;
+      delete frustrationInteractions.rageClick;
+    }
+    if (frustrationInteractions.deadClick) {
+      frustrationInteractions.deadClicks = frustrationInteractions.deadClick;
+      delete frustrationInteractions.deadClick;
+    }
+  }
 }
 
 function mergeUrls(urlsExact: (string | RegExp)[], urlsRegex: string[] | undefined, browserConfig: BrowserConfig) {

--- a/packages/analytics-browser/test/config/joined-config.test.ts
+++ b/packages/analytics-browser/test/config/joined-config.test.ts
@@ -628,5 +628,30 @@ describe('joined-config', () => {
         expect(config).toEqual({ hello: true });
       });
     });
+    describe('frustrationInteractions', () => {
+      test('should translate rageClick to rageClicks', () => {
+        const remoteConfig = {
+          browserSDK: {
+            autocapture: {
+              frustrationInteractions: { rageClick: true },
+            },
+          },
+        };
+        translateRemoteConfigToLocal(remoteConfig);
+        expect(remoteConfig.browserSDK.autocapture.frustrationInteractions).toEqual({ rageClicks: true });
+      });
+
+      test('should translate deadClick to deadClicks', () => {
+        const remoteConfig = {
+          browserSDK: {
+            autocapture: {
+              frustrationInteractions: { deadClick: true },
+            },
+          },
+        };
+        translateRemoteConfigToLocal(remoteConfig);
+        expect(remoteConfig.browserSDK.autocapture.frustrationInteractions).toEqual({ deadClicks: true });
+      });
+    });
   });
 });


### PR DESCRIPTION
### Summary

If remote config supplies "rageClick" or "deadClick" rename it to "rageClicks" and "deadClicks" (respectively).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No