### PR TITLE
chore: replace setTimeout with fake timers in frustration unit tests

### DIFF
--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable jest/no-done-callback */
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import { Subject } from 'rxjs';
@@ -47,7 +46,7 @@ describe('trackDeadClick', () => {
     jest.clearAllMocks();
   });
 
-  it('should track dead click when no mutation or navigation occurs', (done) => {
+  it('should track dead click when no mutation or navigation occurs', () => {
     const subscription = trackDeadClick({
       amplitude: mockAmplitude,
       allObservables,
@@ -82,10 +81,9 @@ describe('trackDeadClick', () => {
       expect.any(Object),
     );
     subscription.unsubscribe();
-    done();
   });
 
-  it('should not track when mutation occurs after click', (done) => {
+  it('should not track when mutation occurs after click', () => {
     const subscription = trackDeadClick({
       amplitude: mockAmplitude,
       allObservables,
@@ -115,7 +113,6 @@ describe('trackDeadClick', () => {
     // Wait for the dead click timeout
     expect(mockAmplitude.track).not.toHaveBeenCalled();
     subscription.unsubscribe();
-    done();
   });
 
   it('should not track when navigation occurs after click', () => {

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable jest/no-done-callback */
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import { Subject } from 'rxjs';
@@ -16,6 +15,7 @@ describe('trackRageClicks', () => {
   let shouldTrackRageClick: jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     mockAmplitude = {
       track: jest.fn(),
     } as any;
@@ -32,9 +32,10 @@ describe('trackRageClicks', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
-  it('should track rage clicks when threshold is met', (done) => {
+  it('should track rage clicks when threshold is met', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -73,28 +74,27 @@ describe('trackRageClicks', () => {
       });
     }
 
-    // Wait for the event to be processed
-    setTimeout(() => {
-      expect(mockAmplitude.track).toHaveBeenCalledWith(
-        AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
-        expect.objectContaining({
-          '[Amplitude] Click Count': DEFAULT_RAGE_CLICK_THRESHOLD,
-          '[Amplitude] Clicks': expect.arrayContaining([
-            expect.objectContaining({
-              X: 100,
-              Y: 100,
-            }),
-          ]),
-          id: 'test-element',
-        }),
-        expect.any(Object),
-      );
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100); // Short wait since we're triggering immediate detection
+    // Advance timers to trigger the event processing
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100); // Short wait since we're triggering immediate detection
+
+    expect(mockAmplitude.track).toHaveBeenCalledWith(
+      AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
+      expect.objectContaining({
+        '[Amplitude] Click Count': DEFAULT_RAGE_CLICK_THRESHOLD,
+        '[Amplitude] Clicks': expect.arrayContaining([
+          expect.objectContaining({
+            X: 100,
+            Y: 100,
+          }),
+        ]),
+        id: 'test-element',
+      }),
+      expect.any(Object),
+    );
+    subscription.unsubscribe();
   });
 
-  it('should track rage clicks via timer when threshold is met within time window', (done) => {
+  it('should track rage clicks via timer when threshold is met within time window', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -119,28 +119,27 @@ describe('trackRageClicks', () => {
       });
     }
 
-    // Wait for the timer to complete and call amplitude.track directly
-    setTimeout(() => {
-      expect(mockAmplitude.track).toHaveBeenCalledWith(
-        AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
-        expect.objectContaining({
-          '[Amplitude] Click Count': DEFAULT_RAGE_CLICK_THRESHOLD,
-          '[Amplitude] Clicks': expect.arrayContaining([
-            expect.objectContaining({
-              X: 100,
-              Y: 100,
-            }),
-          ]),
-          id: 'test-element',
-        }),
-        expect.any(Object),
-      );
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100); // Wait for the timer to complete
+    // Advance timers to complete the timer and call amplitude.track directly
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100); // Wait for the timer to complete
+
+    expect(mockAmplitude.track).toHaveBeenCalledWith(
+      AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
+      expect.objectContaining({
+        '[Amplitude] Click Count': DEFAULT_RAGE_CLICK_THRESHOLD,
+        '[Amplitude] Clicks': expect.arrayContaining([
+          expect.objectContaining({
+            X: 100,
+            Y: 100,
+          }),
+        ]),
+        id: 'test-element',
+      }),
+      expect.any(Object),
+    );
+    subscription.unsubscribe();
   });
 
-  it('should track if clicks exceed threshold but first click is outside the rage click window', (done) => {
+  it('should track if clicks exceed threshold but first click is outside the rage click window', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -177,14 +176,13 @@ describe('trackRageClicks', () => {
       });
     }
 
-    setTimeout(() => {
-      expect(mockAmplitude.track).toHaveBeenCalledTimes(1);
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+
+    expect(mockAmplitude.track).toHaveBeenCalledTimes(1);
+    subscription.unsubscribe();
   });
 
-  it('should not track when clicks are below threshold', (done) => {
+  it('should not track when clicks are below threshold', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -209,14 +207,13 @@ describe('trackRageClicks', () => {
       });
     }
 
-    setTimeout(() => {
-      expect(mockAmplitude.track).not.toHaveBeenCalled();
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+
+    expect(mockAmplitude.track).not.toHaveBeenCalled();
+    subscription.unsubscribe();
   });
 
-  it('should not track when clicks are on different elements', (done) => {
+  it('should not track when clicks are on different elements', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -242,14 +239,13 @@ describe('trackRageClicks', () => {
       });
     }
 
-    setTimeout(() => {
-      expect(mockAmplitude.track).not.toHaveBeenCalled();
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+
+    expect(mockAmplitude.track).not.toHaveBeenCalled();
+    subscription.unsubscribe();
   });
 
-  it('should not track untracked elements', (done) => {
+  it('should not track untracked elements', () => {
     shouldTrackRageClick.mockReturnValue(false);
 
     const subscription = trackRageClicks({
@@ -276,14 +272,13 @@ describe('trackRageClicks', () => {
       });
     }
 
-    setTimeout(() => {
-      expect(mockAmplitude.track).not.toHaveBeenCalled();
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100);
+
+    expect(mockAmplitude.track).not.toHaveBeenCalled();
+    subscription.unsubscribe();
   });
 
-  it('should handle clicks that exceed the time window correctly', (done) => {
+  it('should handle clicks that exceed the time window correctly', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -322,15 +317,14 @@ describe('trackRageClicks', () => {
       targetElementProperties: { id: 'test-element' },
     });
 
-    setTimeout(() => {
-      // Should track the first rage click event
-      expect(mockAmplitude.track).toHaveBeenCalledTimes(1);
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 200);
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 200);
+
+    // Should track the first rage click event
+    expect(mockAmplitude.track).toHaveBeenCalledTimes(1);
+    subscription.unsubscribe();
   });
 
-  it('should trigger rage click when switching to different element with enough previous clicks', (done) => {
+  it('should trigger rage click when switching to different element with enough previous clicks', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -369,28 +363,27 @@ describe('trackRageClicks', () => {
       targetElementProperties: { id: 'test-element-2' },
     });
 
-    setTimeout(() => {
-      // Should track the rage click event for the first element
-      expect(mockAmplitude.track).toHaveBeenCalledWith(
-        AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
-        expect.objectContaining({
-          '[Amplitude] Click Count': DEFAULT_RAGE_CLICK_THRESHOLD,
-          '[Amplitude] Clicks': expect.arrayContaining([
-            expect.objectContaining({
-              X: 100,
-              Y: 100,
-            }),
-          ]),
-          id: 'test-element-1',
-        }),
-        expect.any(Object),
-      );
-      subscription.unsubscribe();
-      done();
-    }, 100);
+    jest.advanceTimersByTime(100);
+
+    // Should track the rage click event for the first element
+    expect(mockAmplitude.track).toHaveBeenCalledWith(
+      AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
+      expect.objectContaining({
+        '[Amplitude] Click Count': DEFAULT_RAGE_CLICK_THRESHOLD,
+        '[Amplitude] Clicks': expect.arrayContaining([
+          expect.objectContaining({
+            X: 100,
+            Y: 100,
+          }),
+        ]),
+        id: 'test-element-1',
+      }),
+      expect.any(Object),
+    );
+    subscription.unsubscribe();
   });
 
-  it('should not trigger rage click when switching to different element without enough previous clicks', (done) => {
+  it('should not trigger rage click when switching to different element without enough previous clicks', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -429,15 +422,14 @@ describe('trackRageClicks', () => {
       targetElementProperties: { id: 'test-element-2' },
     });
 
-    setTimeout(() => {
-      // Should NOT track any rage click event
-      expect(mockAmplitude.track).not.toHaveBeenCalled();
-      subscription.unsubscribe();
-      done();
-    }, 100);
+    jest.advanceTimersByTime(100);
+
+    // Should NOT track any rage click event
+    expect(mockAmplitude.track).not.toHaveBeenCalled();
+    subscription.unsubscribe();
   });
 
-  it('should not track rage clicks when threshold is met but clicks are out of bounds', (done) => {
+  it('should not track rage clicks when threshold is met but clicks are out of bounds', () => {
     const subscription = trackRageClicks({
       amplitude: mockAmplitude,
       allObservables,
@@ -476,11 +468,10 @@ describe('trackRageClicks', () => {
       });
     }
 
-    // Wait for the event to be processed
-    setTimeout(() => {
-      expect(mockAmplitude.track).not.toHaveBeenCalled();
-      subscription.unsubscribe();
-      done();
-    }, DEFAULT_RAGE_CLICK_WINDOW_MS + 100); // Short wait since we're triggering immediate detection
+    // Advance timers for the event to be processed
+    jest.advanceTimersByTime(DEFAULT_RAGE_CLICK_WINDOW_MS + 100); // Short wait since we're triggering immediate detection
+
+    expect(mockAmplitude.track).not.toHaveBeenCalled();
+    subscription.unsubscribe();
   });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

(see title)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces setTimeout-based timing in dead/rage click tests with Jest fake timers and updates assertions and imports accordingly.
> 
> - **Tests (autocapture)**:
>   - `packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts`:
>     - Use `jest.useFakeTimers()`; replace `setTimeout` with `jest.advanceTimersByTime`/`jest.runAllTimers`.
>     - Import and use `DEFAULT_DEAD_CLICK_WINDOW_MS` for timer advancement.
>     - Simulate mutation/navigation without timeouts; remove `done` where not needed; unsubscribe explicitly.
>   - `packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts`:
>     - Use `jest.useFakeTimers()` in `beforeEach` and `jest.useRealTimers()` in `afterEach`.
>     - Replace all `setTimeout` waits with `jest.advanceTimersByTime`; remove `done` usage.
>     - Keep assertions intact; rely on `DEFAULT_RAGE_CLICK_THRESHOLD`/`DEFAULT_RAGE_CLICK_WINDOW_MS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e09d2c81c59bf05ed84026989e40253a1bcb8148. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->