### PR TITLE
chore(gtm-snippet): sync version when publish

### DIFF
--- a/packages/gtm-snippet/package.json
+++ b/packages/gtm-snippet/package.json
@@ -2,12 +2,17 @@
   "name": "@amplitude/gtm-snippet",
   "version": "2.25.3",
   "description": "Amplitude JS SDK Wrapper for use with Google Tag Manager",
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
   "scripts": {
     "build": "yarn build:template && yarn build:bundle",
     "build:bundle": "rollup --config rollup.config.js",
     "build:template": "node ./scripts/build-snippet.js",
     "prepublishOnly": "yarn build",
-    "deploy": "node ./scripts/upload-to-s3.js"
+    "publish": "node ./scripts/upload-to-s3.js",
+    "version": "node ./scripts/version.js"
   },
   "repository": {
     "type": "git",

--- a/packages/gtm-snippet/scripts/version.js
+++ b/packages/gtm-snippet/scripts/version.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+console.log('[GTM Snippet Version Sync] START');
+
+try {
+  // Read current package.json
+  const currentPkgPath = path.join(__dirname, '..', 'package.json');
+  const currentPkg = JSON.parse(fs.readFileSync(currentPkgPath, 'utf8'));
+  
+  // Read analytics-browser package.json
+  const analyticsPkgPath = path.join(__dirname, '..', '..', 'analytics-browser', 'package.json');
+  const analyticsPkg = JSON.parse(fs.readFileSync(analyticsPkgPath, 'utf8'));
+  
+  console.log(`[GTM Snippet Version Sync] Current version: ${currentPkg.version}`);
+  console.log(`[GTM Snippet Version Sync] Analytics browser version: ${analyticsPkg.version}`);
+  
+  // Update version to match analytics-browser
+  currentPkg.version = analyticsPkg.version;
+  
+  // Write updated package.json
+  fs.writeFileSync(currentPkgPath, JSON.stringify(currentPkg, null, 2) + '\n');
+  
+  console.log(`[GTM Snippet Version Sync] Updated gtm-snippet version to: ${analyticsPkg.version}`);
+  console.log('[GTM Snippet Version Sync] SUCCESS');
+} catch (error) {
+  console.error('[GTM Snippet Version Sync] ERROR:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Mark gtm-snippet as public otherwise publish-v2 will throw an error
```
lerna WARN notice Package failed to publish: @amplitude/gtm-snippet
lerna ERR! E402 You must sign up for private packages
```

add two commands
- version, to sync version with analytics-browser, called when "Create release version" at publish-v2
- publish, to upload to s3, called when "Publish Release to NPM" 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
