### PR TITLE
Revert "feat(analytics-client-common): refactor getPageTitle from aut…

### DIFF
--- a/packages/analytics-client-common/src/attribution/constants.ts
+++ b/packages/analytics-client-common/src/attribution/constants.ts
@@ -44,7 +44,3 @@ export const BASE_CAMPAIGN: Campaign = {
 };
 
 export const MKTG = 'MKTG';
-
-// Data masking constants moved from plugin-autocapture-browser
-export const TEXT_MASK_ATTRIBUTE = 'data-amp-mask';
-export const MASKED_TEXT_VALUE = '*****';

--- a/packages/analytics-client-common/src/attribution/helpers.ts
+++ b/packages/analytics-client-common/src/attribution/helpers.ts
@@ -1,6 +1,6 @@
 import { createIdentifyEvent, Identify } from '@amplitude/analytics-core';
 import { Campaign, Logger } from '@amplitude/analytics-types';
-import { BASE_CAMPAIGN, TEXT_MASK_ATTRIBUTE, MASKED_TEXT_VALUE } from './constants';
+import { BASE_CAMPAIGN } from './constants';
 
 export interface Options {
   excludeReferrers?: (string | RegExp)[];
@@ -93,19 +93,4 @@ export const getDefaultExcludedReferrers = (cookieDomain: string | undefined) =>
     return [new RegExp(`${domain.replace('.', '\\.')}$`)];
   }
   return [];
-};
-
-/**
- * Gets the page title, checking if the title element has data-amp-mask attribute
- * @returns The page title, masked if the title element has data-amp-mask attribute
- */
-export const getPageTitle = (parseTitleFunction?: (title: string) => string): string => {
-  if (typeof document === 'undefined' || !document.title) {
-    return '';
-  }
-  const titleElement = document.querySelector('title');
-  if (titleElement && titleElement.hasAttribute(TEXT_MASK_ATTRIBUTE)) {
-    return MASKED_TEXT_VALUE;
-  }
-  return parseTitleFunction ? parseTitleFunction(document.title) : document.title; // document.title is always synced to the first title element
 };

--- a/packages/analytics-client-common/src/index.ts
+++ b/packages/analytics-client-common/src/index.ts
@@ -6,10 +6,9 @@ export {
   isExcludedReferrer,
   createCampaignEvent,
   getDefaultExcludedReferrers,
-  getPageTitle,
 } from './attribution/helpers';
 export { WebAttribution } from './attribution/web-attribution';
-export { BASE_CAMPAIGN, TEXT_MASK_ATTRIBUTE, MASKED_TEXT_VALUE } from './attribution/constants';
+export { BASE_CAMPAIGN } from './attribution/constants';
 export { getQueryParams } from './query-params';
 export { isNewSession } from './session';
 export { getCookieName, getOldCookieName } from './cookie-name';

--- a/packages/analytics-client-common/test/attribution/helpers.test.ts
+++ b/packages/analytics-client-common/test/attribution/helpers.test.ts
@@ -1,10 +1,9 @@
-import { BASE_CAMPAIGN, MASKED_TEXT_VALUE } from '../../src/attribution/constants';
+import { BASE_CAMPAIGN } from '../../src/attribution/constants';
 import {
   isNewCampaign,
   createCampaignEvent,
   getDefaultExcludedReferrers,
   isExcludedReferrer,
-  getPageTitle,
 } from '../../src/attribution/helpers';
 
 import { getStorageKey } from '../../src/storage/helpers';
@@ -325,96 +324,5 @@ describe('getDefaultExcludedReferrers', () => {
   test('should return array with regex 2', () => {
     const excludedReferrers = getDefaultExcludedReferrers('.amplitude.com');
     expect(excludedReferrers).toEqual([new RegExp('amplitude\\.com$')]);
-  });
-});
-
-describe('getPageTitle', () => {
-  beforeEach(() => {
-    Object.defineProperty(document, 'title', {
-      value: 'Test Page Title',
-      writable: true,
-    });
-  });
-
-  afterEach(() => {
-    const titleElements = document.querySelectorAll('title');
-    titleElements.forEach((el) => el.remove());
-  });
-
-  test('should return document title when no title element has data-amp-mask', () => {
-    const result = getPageTitle();
-    expect(result).toBe('Test Page Title');
-  });
-
-  test('should return MASKED_TEXT_VALUE when title element has data-amp-mask attribute', () => {
-    const titleElement = document.createElement('title');
-    titleElement.setAttribute('data-amp-mask', 'true');
-    titleElement.textContent = 'Sensitive Title';
-    document.head.appendChild(titleElement);
-
-    const result = getPageTitle();
-    expect(result).toBe(MASKED_TEXT_VALUE);
-  });
-
-  test('should return document title when title element exists but does not have data-amp-mask', () => {
-    const titleElement = document.createElement('title');
-    titleElement.textContent = 'Regular Title';
-    document.head.appendChild(titleElement);
-
-    const result = getPageTitle();
-    expect(result).toBe('Test Page Title');
-  });
-
-  test('should still apply sensitive string masking when title element does not have data-amp-mask', () => {
-    Object.defineProperty(document, 'title', {
-      value: 'Contact us at test@example.com',
-      writable: true,
-    });
-
-    const titleElement = document.createElement('title');
-    titleElement.textContent = 'Contact us at test@example.com';
-    document.head.appendChild(titleElement);
-
-    const maskSensitiveEmail = (title: string) => title.replace(/[^\s@]+@[^\s@.]+\.[^\s@]+/g, MASKED_TEXT_VALUE);
-
-    const result = getPageTitle(maskSensitiveEmail);
-    expect(result).toBe('Contact us at *****');
-  });
-
-  test('should handle edge case when document title is null or undefined', () => {
-    Object.defineProperty(document, 'title', {
-      value: null,
-      writable: true,
-    });
-
-    const result = getPageTitle();
-    expect(result).toBe('');
-
-    Object.defineProperty(document, 'title', {
-      value: 'Test Page Title',
-      writable: true,
-    });
-  });
-
-  test('should return empty string when document is undefined (server-side scenario)', () => {
-    const globalWithDocument = global as typeof global & { document?: Document };
-    const originalDescriptor = Object.getOwnPropertyDescriptor(globalWithDocument, 'document');
-
-    Object.defineProperty(globalWithDocument, 'document', {
-      value: undefined,
-      writable: true,
-      configurable: true,
-    });
-
-    try {
-      const result = getPageTitle();
-      expect(result).toBe('');
-    } finally {
-      if (originalDescriptor) {
-        Object.defineProperty(globalWithDocument, 'document', originalDescriptor);
-      } else {
-        Reflect.deleteProperty(globalWithDocument, 'document');
-      }
-    }
   });
 });

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -41,5 +41,9 @@ export const AMPLITUDE_VISUAL_TAGGING_HIGHLIGHT_CLASS = 'amp-visual-tagging-sele
 
 // Data attribute for specifying which attributes should be redacted from autocapture
 export const DATA_AMP_MASK_ATTRIBUTES = 'data-amp-mask-attributes';
+// Data masking constants
+export const TEXT_MASK_ATTRIBUTE = 'data-amp-mask';
+
+export const MASKED_TEXT_VALUE = '*****';
 
 export const MAX_MASK_TEXT_PATTERNS = 25;

--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -15,7 +15,6 @@ import { getAncestors, getElementProperties } from './hierarchy';
 import type { JSONValue } from './helpers';
 import { getDataSource } from './pageActions/actions';
 import { Hierarchy } from './typings/autocapture';
-import { MASKED_TEXT_VALUE, TEXT_MASK_ATTRIBUTE, getPageTitle } from '@amplitude/analytics-client-common';
 
 const CC_REGEX = /\b(?:\d[ -]*?){13,16}\b/;
 const SSN_REGEX = /(\d{3}-?\d{2}-?\d{4})/g;
@@ -56,18 +55,18 @@ export class DataExtractor {
     let result = text;
 
     // Check for credit card number (with or without spaces/dashes)
-    result = result.replace(CC_REGEX, MASKED_TEXT_VALUE);
+    result = result.replace(CC_REGEX, constants.MASKED_TEXT_VALUE);
 
     // Check for social security number
-    result = result.replace(SSN_REGEX, MASKED_TEXT_VALUE);
+    result = result.replace(SSN_REGEX, constants.MASKED_TEXT_VALUE);
 
     // Check for email
-    result = result.replace(EMAIL_REGEX, MASKED_TEXT_VALUE);
+    result = result.replace(EMAIL_REGEX, constants.MASKED_TEXT_VALUE);
 
     // Check for additional mask text patterns
     for (const pattern of this.additionalMaskTextPatterns) {
       try {
-        result = result.replace(pattern, MASKED_TEXT_VALUE);
+        result = result.replace(pattern, constants.MASKED_TEXT_VALUE);
       } catch {
         // ignore invalid pattern
       }
@@ -165,9 +164,7 @@ export class DataExtractor {
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_ATTRIBUTES]: attributes,
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_PARENT_LABEL]: nearestLabel,
       [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: getDecodeURI(window.location.href.split('?')[0]),
-      [constants.AMPLITUDE_EVENT_PROP_PAGE_TITLE]: (
-        getPageTitle as (parseTitleFunction: (title: string) => string) => string
-      )(this.replaceSensitiveString),
+      [constants.AMPLITUDE_EVENT_PROP_PAGE_TITLE]: this.getPageTitle(),
       [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT]: window.innerHeight,
       [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_WIDTH]: window.innerWidth,
     };
@@ -254,22 +251,39 @@ export class DataExtractor {
 
   getText = (element: Element): string => {
     // Check if element or any parent has data-amp-mask attribute
-    const hasMaskAttribute = element.closest(`[${TEXT_MASK_ATTRIBUTE}]`) !== null;
+    const hasMaskAttribute = element.closest(`[${constants.TEXT_MASK_ATTRIBUTE}]`) !== null;
     if (hasMaskAttribute) {
-      return MASKED_TEXT_VALUE;
+      return constants.MASKED_TEXT_VALUE;
     }
     let output = '';
-    if (!element.querySelector(`[${TEXT_MASK_ATTRIBUTE}], [contenteditable]`)) {
+    if (!element.querySelector(`[${constants.TEXT_MASK_ATTRIBUTE}], [contenteditable]`)) {
       output = (element as HTMLElement).innerText || '';
     } else {
       const clonedTree = element.cloneNode(true) as HTMLElement;
       // replace all elements with TEXT_MASK_ATTRIBUTE attribute and contenteditable with the text MASKED_TEXT_VALUE
-      clonedTree.querySelectorAll(`[${TEXT_MASK_ATTRIBUTE}], [contenteditable]`).forEach((node) => {
-        (node as HTMLElement).innerText = MASKED_TEXT_VALUE;
+      clonedTree.querySelectorAll(`[${constants.TEXT_MASK_ATTRIBUTE}], [contenteditable]`).forEach((node) => {
+        (node as HTMLElement).innerText = constants.MASKED_TEXT_VALUE;
       });
       output = clonedTree.innerText || '';
     }
     return this.replaceSensitiveString(output.substring(0, 255)).replace(/\s+/g, ' ').trim();
+  };
+
+  /**
+   * Gets the page title, checking if the title element has data-amp-mask attribute
+   * @returns The page title, masked if the title element has data-amp-mask attribute
+   */
+  getPageTitle = (): string => {
+    if (typeof document === 'undefined') {
+      return '';
+    }
+
+    const titleElement = document.querySelector('title');
+    if (titleElement && titleElement.hasAttribute(constants.TEXT_MASK_ATTRIBUTE)) {
+      return constants.MASKED_TEXT_VALUE;
+    }
+
+    return this.replaceSensitiveString(document.title);
   };
 
   // Returns the element properties for the given element in Visual Labeling.

--- a/packages/plugin-autocapture-browser/src/hierarchy.ts
+++ b/packages/plugin-autocapture-browser/src/hierarchy.ts
@@ -1,7 +1,6 @@
 import { isNonSensitiveElement } from './helpers';
-import { DATA_AMP_MASK_ATTRIBUTES } from './constants';
+import { DATA_AMP_MASK_ATTRIBUTES, MASKED_TEXT_VALUE, TEXT_MASK_ATTRIBUTE } from './constants';
 import type { HierarchyNode } from './typings/autocapture';
-import { MASKED_TEXT_VALUE, TEXT_MASK_ATTRIBUTE } from '@amplitude/analytics-client-common';
 
 const BLOCKED_ATTRIBUTES = new Set([
   // Already captured elsewhere in the hierarchy object

--- a/packages/plugin-autocapture-browser/test/data-extractor.test.ts
+++ b/packages/plugin-autocapture-browser/test/data-extractor.test.ts
@@ -2,10 +2,9 @@ import { DataExtractor } from '../src/data-extractor';
 import * as constants from '../src/constants';
 import { mockWindowLocationFromURL } from './utils';
 import type { ElementBasedTimestampedEvent } from '../src/helpers';
-import { DATA_AMP_MASK_ATTRIBUTES } from '../src/constants';
+import { DATA_AMP_MASK_ATTRIBUTES, MASKED_TEXT_VALUE } from '../src/constants';
 import * as hierarchy from '../src/hierarchy';
 import type { Hierarchy } from '../src/typings/autocapture';
-import { MASKED_TEXT_VALUE } from '@amplitude/analytics-client-common';
 
 describe('data extractor', () => {
   let dataExtractor: DataExtractor;
@@ -67,14 +66,14 @@ describe('data extractor', () => {
 
       for (const text of sampleCreditCardNumbers) {
         const result = dataExtractor.replaceSensitiveString(text);
-        expect(result).toEqual(MASKED_TEXT_VALUE);
+        expect(result).toEqual(constants.MASKED_TEXT_VALUE);
       }
     });
 
     test('should return masked text when text is social security number format', () => {
       const text = '269-28-9315';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should return empty string when text is not a string', () => {
@@ -90,8 +89,8 @@ describe('data extractor', () => {
       const text2 = 'Florida';
       const result2 = dataExtractor.replaceSensitiveString(text2);
 
-      expect(result).toEqual(`Pittsburgh, ${MASKED_TEXT_VALUE}`);
-      expect(result2).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(`Pittsburgh, ${constants.MASKED_TEXT_VALUE}`);
+      expect(result2).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should return original text when text does not match maskTextRegex', () => {
@@ -114,8 +113,8 @@ describe('data extractor', () => {
       const text2 = 'Florida';
       const result2 = dataExtractor.replaceSensitiveString(text2);
 
-      expect(result).toEqual(`Pittsburgh, ${MASKED_TEXT_VALUE}`);
-      expect(result2).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(`Pittsburgh, ${constants.MASKED_TEXT_VALUE}`);
+      expect(result2).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should cap maskTextRegex over MAX_MASK_TEXT_PATTERNS', () => {
@@ -124,7 +123,9 @@ describe('data extractor', () => {
       const extractor = new DataExtractor({ maskTextRegex: patterns });
 
       // Matches within the cap should be masked
-      expect(extractor.replaceSensitiveString(`token${constants.MAX_MASK_TEXT_PATTERNS}`)).toEqual(MASKED_TEXT_VALUE);
+      expect(extractor.replaceSensitiveString(`token${constants.MAX_MASK_TEXT_PATTERNS}`)).toEqual(
+        constants.MASKED_TEXT_VALUE,
+      );
       // Matches beyond the cap should NOT be masked
       expect(extractor.replaceSensitiveString(`token${constants.MAX_MASK_TEXT_PATTERNS + 1}`)).toEqual(
         `token${constants.MAX_MASK_TEXT_PATTERNS + 1}`,
@@ -134,55 +135,55 @@ describe('data extractor', () => {
     test('should return masked text when text is email address format', () => {
       const text = 'user@example.com';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should return masked text when text contains email address within other text', () => {
       const text = 'Contact us at support@example.com for help';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`Contact us at ${MASKED_TEXT_VALUE} for help`);
+      expect(result).toEqual(`Contact us at ${constants.MASKED_TEXT_VALUE} for help`);
     });
 
     test('should return masked text when text contains email address at the beginning', () => {
       const text = 'user@example.com is the admin';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`${MASKED_TEXT_VALUE} is the admin`);
+      expect(result).toEqual(`${constants.MASKED_TEXT_VALUE} is the admin`);
     });
 
     test('should return masked text when text contains email address at the end', () => {
       const text = 'Send feedback to feedback@company.org';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`Send feedback to ${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`Send feedback to ${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should return masked text when text contains multiple email addresses', () => {
       const text = 'Contact admin@example.com or support@example.com';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`Contact ${MASKED_TEXT_VALUE} or ${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`Contact ${constants.MASKED_TEXT_VALUE} or ${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should return masked text when email has dots in domain name before final dot', () => {
       const text = 'user@sub.domain.example.com';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should handle credit card numbers with spaces', () => {
       const text = 'Card number: 4111 1111 1111 1111';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`Card number: ${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`Card number: ${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should handle credit card numbers with dashes', () => {
       const text = 'Card: 4111-1111-1111-1111';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`Card: ${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`Card: ${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should handle credit card numbers with mixed spaces and dashes', () => {
       const text = 'Payment: 4111 1111-1111 1111';
       const result = dataExtractor.replaceSensitiveString(text);
-      expect(result).toEqual(`Payment: ${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`Payment: ${constants.MASKED_TEXT_VALUE}`);
     });
   });
 
@@ -228,7 +229,7 @@ describe('data extractor', () => {
       div.innerText = '269-28-9315';
       button.appendChild(div);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(`submit${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`submit${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should return concatenated text with extra space removed', () => {
@@ -247,7 +248,7 @@ describe('data extractor', () => {
       button.setAttribute('data-amp-mask', 'true');
       button.innerText = 'sensitive button text';
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should return MASKED_TEXT_VALUE when parent element has data-amp-mask attribute', () => {
@@ -257,7 +258,7 @@ describe('data extractor', () => {
       button.innerText = 'button text';
       container.appendChild(button);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should return MASKED_TEXT_VALUE when ancestor element has data-amp-mask attribute', () => {
@@ -269,7 +270,7 @@ describe('data extractor', () => {
       grandparent.appendChild(parent);
       parent.appendChild(button);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should mask sensitive text content containing credit card numbers', () => {
@@ -282,7 +283,7 @@ describe('data extractor', () => {
       const moreText = document.createTextNode(' securely');
       button.appendChild(moreText);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(`Pay with card ${MASKED_TEXT_VALUE} securely`);
+      expect(result).toEqual(`Pay with card ${constants.MASKED_TEXT_VALUE} securely`);
     });
 
     test('should mask sensitive text content containing SSN', () => {
@@ -293,7 +294,7 @@ describe('data extractor', () => {
       sensitiveDiv.innerText = '269-28-9315'; // SSN
       button.appendChild(sensitiveDiv);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(`Submit form ${MASKED_TEXT_VALUE}`);
+      expect(result).toEqual(`Submit form ${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should mask sensitive text content containing email addresses', () => {
@@ -306,7 +307,7 @@ describe('data extractor', () => {
       const moreText = document.createTextNode(' for support');
       button.appendChild(moreText);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(`Contact ${MASKED_TEXT_VALUE} for support`);
+      expect(result).toEqual(`Contact ${constants.MASKED_TEXT_VALUE} for support`);
     });
 
     test('should mask text matching custom maskTextRegex patterns', () => {
@@ -319,7 +320,7 @@ describe('data extractor', () => {
       const moreText = document.createTextNode(' tourism');
       button.appendChild(moreText);
       const result = dataExtractor.getText(button);
-      expect(result).toEqual(`Welcome to ${MASKED_TEXT_VALUE} tourism`);
+      expect(result).toEqual(`Welcome to ${constants.MASKED_TEXT_VALUE} tourism`);
     });
 
     test('should handle mixed content with both masked attribute and sensitive text masking', () => {
@@ -340,11 +341,11 @@ describe('data extractor', () => {
 
       // Test the masked div individually
       const maskedResult = dataExtractor.getText(maskedDiv);
-      expect(maskedResult).toEqual(MASKED_TEXT_VALUE);
+      expect(maskedResult).toEqual(constants.MASKED_TEXT_VALUE);
 
       // Test container with mixed content - masked elements return MASKED_TEXT_VALUE, sensitive text is also masked
       const containerResult = dataExtractor.getText(container);
-      expect(containerResult).toEqual(`Normal text ${MASKED_TEXT_VALUE}${MASKED_TEXT_VALUE}`);
+      expect(containerResult).toEqual(`Normal text ${constants.MASKED_TEXT_VALUE}${constants.MASKED_TEXT_VALUE}`);
     });
 
     test('should return empty string when cloned tree has null innerText and textContent', () => {
@@ -400,7 +401,7 @@ describe('data extractor', () => {
       div.appendChild(input);
 
       const result = dataExtractor.getNearestLabel(input);
-      expect(result).toEqual(MASKED_TEXT_VALUE);
+      expect(result).toEqual(constants.MASKED_TEXT_VALUE);
     });
 
     test('should return nearest label of the element parent', () => {
@@ -1072,6 +1073,110 @@ describe('data extractor', () => {
       expect(() => {
         dataExtractorWithoutDiagnostics.getHierarchy(target);
       }).not.toThrow();
+    });
+  });
+
+  describe('getPageTitle', () => {
+    beforeEach(() => {
+      // Reset document title
+      Object.defineProperty(document, 'title', {
+        value: 'Test Page Title',
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      // Clean up any title elements added during tests
+      const titleElements = document.querySelectorAll('title');
+      titleElements.forEach((el) => el.remove());
+    });
+
+    test('should return document title when no title element has data-amp-mask', () => {
+      const result = dataExtractor.getPageTitle();
+      expect(result).toBe('Test Page Title');
+    });
+
+    test('should return MASKED_TEXT_VALUE when title element has data-amp-mask attribute', () => {
+      // Create and add title element with data-amp-mask
+      const titleElement = document.createElement('title');
+      titleElement.setAttribute('data-amp-mask', 'true');
+      titleElement.textContent = 'Sensitive Title';
+      document.head.appendChild(titleElement);
+
+      const result = dataExtractor.getPageTitle();
+      expect(result).toBe(MASKED_TEXT_VALUE);
+    });
+
+    test('should return document title when title element exists but does not have data-amp-mask', () => {
+      // Create and add title element without data-amp-mask
+      const titleElement = document.createElement('title');
+      titleElement.textContent = 'Regular Title';
+      document.head.appendChild(titleElement);
+
+      const result = dataExtractor.getPageTitle();
+      expect(result).toBe('Test Page Title');
+    });
+
+    test('should still apply sensitive string masking when title element does not have data-amp-mask', () => {
+      // Set a title with email that should be masked by replaceSensitiveString
+      Object.defineProperty(document, 'title', {
+        value: 'Contact us at test@example.com',
+        writable: true,
+      });
+
+      const titleElement = document.createElement('title');
+      titleElement.textContent = 'Contact us at test@example.com';
+      document.head.appendChild(titleElement);
+
+      const result = dataExtractor.getPageTitle();
+      expect(result).toBe('Contact us at *****');
+    });
+
+    test('should handle edge case when document title is null or undefined', () => {
+      // Test the code path where document.title might be null/undefined
+      Object.defineProperty(document, 'title', {
+        value: null,
+        writable: true,
+      });
+
+      const result = dataExtractor.getPageTitle();
+      expect(result).toBe(''); // replaceSensitiveString returns empty string for null
+
+      // Restore document title
+      Object.defineProperty(document, 'title', {
+        value: 'Test Page Title',
+        writable: true,
+      });
+    });
+
+    test('should return empty string when document is undefined (server-side scenario)', () => {
+      // Create a new test that mocks the global document to be undefined
+      // We'll temporarily replace the global document with undefined
+      const globalWithDocument = global as typeof global & { document?: Document };
+      const originalDescriptor = Object.getOwnPropertyDescriptor(globalWithDocument, 'document');
+
+      // Define document as undefined
+      Object.defineProperty(globalWithDocument, 'document', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      // Create a new DataExtractor instance in this environment
+      const serverSideExtractor = new DataExtractor({});
+
+      try {
+        const result = serverSideExtractor.getPageTitle();
+        expect(result).toBe('');
+      } finally {
+        // Restore the original document property
+        if (originalDescriptor) {
+          Object.defineProperty(globalWithDocument, 'document', originalDescriptor);
+        } else {
+          // Use Reflect.deleteProperty to avoid TypeScript linting issues
+          Reflect.deleteProperty(globalWithDocument, 'document');
+        }
+      }
     });
   });
 

--- a/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
+++ b/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
@@ -1,6 +1,5 @@
 import type { BrowserClient, BrowserConfig, EnrichmentPlugin, Event, Logger } from '@amplitude/analytics-types';
 import { getGlobalScope, BrowserStorage, getDecodeURI } from '@amplitude/analytics-core';
-import { getPageTitle } from '@amplitude/analytics-client-common';
 
 export const CURRENT_PAGE_STORAGE_KEY = 'AMP_CURRENT_PAGE';
 export const PREVIOUS_PAGE_STORAGE_KEY = 'AMP_PREVIOUS_PAGE';
@@ -156,7 +155,11 @@ export const pageUrlEnrichmentPlugin = (): EnrichmentPlugin => {
             '[Amplitude] Page Path',
             (typeof location !== 'undefined' && getDecodeURI(location.pathname)) || '',
           ),
-          '[Amplitude] Page Title': addIfNotExist(event, '[Amplitude] Page Title', getPageTitle()),
+          '[Amplitude] Page Title': addIfNotExist(
+            event,
+            '[Amplitude] Page Title',
+            (typeof document !== 'undefined' && document.title) || '',
+          ),
           '[Amplitude] Page URL': addIfNotExist(event, '[Amplitude] Page URL', locationHREF.split('?')[0]),
           '[Amplitude] Previous Page Location': previousPage,
           '[Amplitude] Previous Page Type': getPrevPageType(previousPage),

--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -1,5 +1,4 @@
 import { CampaignParser, getGlobalScope } from '@amplitude/analytics-client-common';
-import { getPageTitle } from '@amplitude/analytics-client-common';
 import {
   BrowserClient,
   BrowserConfig,
@@ -47,7 +46,7 @@ export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Op
         '[Amplitude] Page Location': locationHREF,
         '[Amplitude] Page Path':
           /* istanbul ignore next */ (typeof location !== 'undefined' && getDecodeURI(location.pathname)) || '',
-        '[Amplitude] Page Title': /* istanbul ignore next */ (getPageTitle as () => string)(),
+        '[Amplitude] Page Title': /* istanbul ignore next */ (typeof document !== 'undefined' && document.title) || '',
         '[Amplitude] Page URL': locationHREF.split('?')[0],
       },
     };


### PR DESCRIPTION
…ocapture to make it reusable (#1298)"

This reverts commit 3c931eeb7bb4d2482523c48cf796113187d9b078.

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

analytics-client-common is deprecated and is not dependency of plugin autocpature. It will break customer website 
<img width="1348" height="888" alt="image" src="https://github.com/user-attachments/assets/a179149d-6ada-4453-8dce-5c460aab67fa" />


CI didn't catch it because this is a monorepo and it's resolved by the top level build. I will have a follow-up PR to fix CI.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
