### PR TITLE
feat(plugin-network-capture-browser): enable networkTracking by default when autocapture=true

### DIFF
--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -60,6 +60,10 @@ export const isSessionTrackingEnabled = (autocapture: AutocaptureOptions | boole
  * otherwise returns false
  */
 export const isNetworkTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined) => {
+  if (typeof autocapture === 'boolean') {
+    return autocapture;
+  }
+
   if (
     typeof autocapture === 'object' &&
     (autocapture.networkTracking === true || typeof autocapture.networkTracking === 'object')

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -233,8 +233,8 @@ describe('isNetworkTrackingEnabled', () => {
     expect(isNetworkTrackingEnabled(undefined)).toBe(false);
   });
 
-  test('should return false when autocapture is true (explicit opt-in)', () => {
-    expect(isNetworkTrackingEnabled(true)).toBe(false);
+  test('should return true when autocapture is true', () => {
+    expect(isNetworkTrackingEnabled(true)).toBe(true);
   });
 
   test('should return true when autocapture.networkTracking is true', () => {


### PR DESCRIPTION
### Summary

When setting "autocapture=true", network tracking will be enabled (similar to other autocapture features).

ie) Setting `autocapture=true` enables network tracking the same way that setting `autocapture.networkTracking = true` also does

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables network tracking when `autocapture === true` and updates tests to reflect the new behavior.
> 
> - **Behavior**:
>   - `isNetworkTrackingEnabled` now returns `true` when `autocapture === true` in `packages/analytics-browser/src/default-tracking.ts`.
> - **Tests**:
>   - Update `packages/analytics-browser/test/default-tracking.test.ts` to expect `true` for `isNetworkTrackingEnabled(true)` and keep existing cases for object/false/undefined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3659623e994148f493a1fab9a04b2269b9a4609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->