### PR TITLE
chore: fix problem with asset naming of gtm wrapper

### DIFF
--- a/packages/gtm-snippet/scripts/upload-to-s3.js
+++ b/packages/gtm-snippet/scripts/upload-to-s3.js
@@ -3,12 +3,15 @@ const path = require('path');
 const analyticsBrowserPkg = require(path.join(process.cwd(), '..', 'analytics-browser', 'package.json'));
 const { S3Client, PutObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 const bucket = process.env.S3_BUCKET_NAME;
-const gtmWrapper = `./lib/scripts/analytics-browser-gtm-wrapper.min.js.gz`;
+
+const extension = 'min.js.gz';
+const filename = 'analytics-browser-gtm-wrapper';
+const gtmWrapper = `./lib/scripts/${filename}.${extension}`;
 
 const getVersion = () => analyticsBrowserPkg.version;
 let deployed = false;
 const body = fs.readFileSync(path.join(process.cwd(), gtmWrapper));
-const key = `libs/analytics-browser-gtm-wrapper-${getVersion()}.js.br`;
+const key = `libs/${filename}-${getVersion()}.${extension}`;
 
 if (process.env.DRY_RUN) {
   console.log(`[Publish to AWS S3] Dry run. Skipping upload job.`);


### PR DESCRIPTION
### Summary

Was given ".br" extension despite the fact that it's using gz. Replace ".js.br" with ".min.js.gz"

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
