### PR TITLE
fix(analytics-browser): remove analytics-remote-config dependency

### DIFF
--- a/packages/analytics-browser/package.json
+++ b/packages/analytics-browser/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "@amplitude/analytics-core": "^2.26.2",
-    "@amplitude/analytics-remote-config": "^0.4.0",
     "@amplitude/plugin-autocapture-browser": "^1.14.4",
     "@amplitude/plugin-network-capture-browser": "^1.6.5",
     "@amplitude/plugin-page-view-tracking-browser": "^2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,16 +15,6 @@
     "@amplitude/analytics-types" "^1.4.0"
     tslib "^2.4.1"
 
-"@amplitude/analytics-remote-config@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz#b62cf8aa82290f68b314197e20351b10ea44ae3e"
-  integrity sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==
-  dependencies:
-    "@amplitude/analytics-client-common" ">=1 <3"
-    "@amplitude/analytics-core" ">=1 <3"
-    "@amplitude/analytics-types" ">=1 <3"
-    tslib "^2.4.1"
-
 "@amplitude/analytics-types@>=1 <2", "@amplitude/analytics-types@^1.0.0", "@amplitude/analytics-types@^1.3.4", "@amplitude/analytics-types@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-1.4.0.tgz#63f84e5ea5e26beeb06745732063e3787194f0d2"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Remove analytics-remote-config dependency in analytics-browser

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
