### PR TITLE
fix(plugin-page-view-tracking-browser): migrate to analytics-core

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -39,7 +39,14 @@ export { RemoteConfigClient, IRemoteConfigClient, RemoteConfig, Source } from '.
 export { LogLevel } from './types/loglevel';
 export { AMPLITUDE_PREFIX, STORAGE_PREFIX } from './types/constants';
 export { Storage, IdentityStorageType } from './types/storage';
-export { Event, IdentifyOperation, SpecialEventType, IdentifyEvent, GroupIdentifyEvent } from './types/event/event';
+export {
+  Event,
+  IdentifyOperation,
+  SpecialEventType,
+  IdentifyEvent,
+  GroupIdentifyEvent,
+  IdentifyUserProperties,
+} from './types/event/event';
 export { EventOptions, BaseEvent } from './types/event/base-event';
 export { IngestionMetadata } from './types/event/ingestion-metadata';
 export { ServerZoneType, ServerZone } from './types/server-zone';

--- a/packages/plugin-page-view-tracking-browser/package.json
+++ b/packages/plugin-page-view-tracking-browser/package.json
@@ -37,9 +37,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-client-common": "^2.4.6",
     "@amplitude/analytics-core": "^2.27.1",
-    "@amplitude/analytics-types": "^2.10.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts
@@ -1,14 +1,17 @@
-import { CampaignParser, getGlobalScope, BASE_CAMPAIGN } from '@amplitude/analytics-client-common';
-import { getPageTitle, replaceSensitiveString } from '@amplitude/analytics-core';
 import {
-  BrowserClient,
+  getPageTitle,
+  replaceSensitiveString,
   BrowserConfig,
+  BrowserClient,
   EnrichmentPlugin,
   Event,
   IdentifyOperation,
   IdentifyUserProperties,
-  Logger,
-} from '@amplitude/analytics-types';
+  ILogger,
+  CampaignParser,
+  getGlobalScope,
+  BASE_CAMPAIGN,
+} from '@amplitude/analytics-core';
 import { CreatePageViewTrackingPlugin, Options } from './typings/page-view-tracking';
 import { omitUndefined } from './utils';
 
@@ -17,7 +20,7 @@ export const defaultPageViewEvent = '[Amplitude] Page Viewed';
 export const pageViewTrackingPlugin: CreatePageViewTrackingPlugin = (options: Options = {}) => {
   let amplitude: BrowserClient | undefined;
   const globalScope = getGlobalScope();
-  let loggerProvider: Logger | undefined = undefined;
+  let loggerProvider: ILogger | undefined = undefined;
   let isTracking = false;
   let localConfig: BrowserConfig;
   const { trackOn, trackHistoryChanges, eventType = defaultPageViewEvent } = options;

--- a/packages/plugin-page-view-tracking-browser/src/typings/page-view-tracking.ts
+++ b/packages/plugin-page-view-tracking-browser/src/typings/page-view-tracking.ts
@@ -1,10 +1,10 @@
-import { EnrichmentPlugin, PageTrackingOptions as Options } from '@amplitude/analytics-types';
+import { EnrichmentPlugin, PageTrackingOptions as Options } from '@amplitude/analytics-core';
 
 export {
   PageTrackingOptions as Options,
   PageTrackingTrackOn,
   PageTrackingHistoryChanges,
-} from '@amplitude/analytics-types';
+} from '@amplitude/analytics-core';
 
 export interface CreatePageViewTrackingPlugin {
   (options?: Options): EnrichmentPlugin;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Remove dependencies of `analytics-types` and `analytics-client-common` and replace them with `analytics-core`.
In Browser SDK, page view plugin is the only one requires these two deprecated packages
https://npmgraph.js.org/?q=%40amplitude%2Fanalytics-browser%402.26.0
<img width="1614" height="644" alt="image" src="https://github.com/user-attachments/assets/f15b5bef-2145-4e08-bcb5-19072dda431f" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
