### PR TITLE
ci: set lerna publish loglevel to silly

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -116,6 +116,6 @@ jobs:
       # See: https://lerna.js.org/docs/features/version-and-publish#from-package
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- ${{ env.PUBLISH_FROM }} -y --pre-dist-tag beta
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} npm run deploy:publish -- ${{ env.PUBLISH_FROM }} -y --pre-dist-tag beta --loglevel silly
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Publish v2 GHA ([example](https://github.com/amplitude/Amplitude-TypeScript/actions/runs/18545502381/job/52862540079)) failed even though all tasks (publish to npm and upload to s3) are done. Set loglevel to silly, the lowest one, to get more info

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
