### PR TITLE
chore(unified): make it public for publish CI

### DIFF
--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -21,7 +21,10 @@
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
-  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
   "files": [
     "lib"
   ],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Remove `private:true` to make it visible to publish-v2 GHA. The package-level `publishConfig.tag: "latest"` will override the workflow's `--pre-dist-tag beta` flag. Next run with fix/feat commits will bump unified to `1.0.0-beta.10` but with a latest npm tag. This is intended because it doesn't have non beta versions right now. 


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
