### PR TITLE
feat: make web-vitals autocapture GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,13 @@ For more details visit the [Test Server README.md](/test-server/README.md)
 
 ## Troubleshooting
 
-If you ever get cryptic SQL errors when running an Nx command (yarn test, yarn build, etc...) then
-run `npx nx reset` and try again
+If you ever see an error that looks like this while running an Nx command (yarn test, yarn build, etc...):
+
+```
+ Lerna (powered by Nx)   DB transaction operation error: SqliteFailure(Error { code: SystemIoFailure, extended_code: 522 }, Some("disk I/O error"))
+ ```
+
+Run `npx nx reset` and try again
 
 ## Documentation
 

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -103,10 +103,9 @@ export const isElementInteractionsEnabled = (autocapture: AutocaptureOptions | b
  * otherwise returns false
  */
 export const isWebVitalsEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
-  // TODO restore this if statement when webVitals is GA
-  // if (typeof autocapture === 'boolean') {
-  //   return autocapture;
-  // }
+  if (typeof autocapture === 'boolean') {
+    return autocapture;
+  }
 
   if (typeof autocapture === 'object' && autocapture.webVitals === true) {
     return true;

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -12,7 +12,34 @@ import {
   getNetworkTrackingConfig,
   isNetworkTrackingEnabled,
   isFrustrationInteractionsEnabled,
+  isWebVitalsEnabled,
 } from '../src/default-tracking';
+
+describe('isWebVitalsEnabled', () => {
+  describe('is true when', () => {
+    test('autocapture=true', () => {
+      expect(isWebVitalsEnabled(true)).toBe(true);
+    });
+
+    test('autocapture.webVitals=true', () => {
+      expect(isWebVitalsEnabled({ webVitals: true })).toBe(true);
+    });
+  });
+
+  describe('is false when', () => {
+    test('autocapture=false', () => {
+      expect(isWebVitalsEnabled(false)).toBe(false);
+    });
+
+    test('autocapture.webVitals=false', () => {
+      expect(isWebVitalsEnabled({ webVitals: false })).toBe(false);
+    });
+
+    test('autocapture.webVitals is undefined', () => {
+      expect(isWebVitalsEnabled({ networkTracking: true })).toBe(false);
+    });
+  });
+});
 
 describe('isFrustrationInteractionsEnabled', () => {
   test('should return true when autocapture=true', () => {

--- a/packages/analytics-core/src/types/config/browser-config.ts
+++ b/packages/analytics-core/src/types/config/browser-config.ts
@@ -184,7 +184,6 @@ export interface AutocaptureOptions {
   /**
    * Enables/disables web vitals tracking.
    * @defaultValue `false`
-   * @experimental This feature is experimental and may not be stable
    */
   webVitals?: boolean;
 }


### PR DESCRIPTION
### Summary

Remove the @experimental flag for web-vitals and make it GA. Make it enabled when "autocapture=true".

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
