### PR TITLE
chore: bump prerelease min node version to 20

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        node-version: [18.17.x]
+        node-version: [20.x]
 
     steps:
       - name: Get branch name


### PR DESCRIPTION
### Summary

Bumping min node version in pre-release to 20.X
<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
