### PR TITLE
chore(analytics-react-native): update async-storage dependency to dev…

### DIFF
--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -60,7 +60,6 @@
   "dependencies": {
     "@amplitude/analytics-core": "^2.28.0",
     "@amplitude/ua-parser-js": "^0.7.31",
-    "@react-native-async-storage/async-storage": "^1.17.11",
     "tslib": "^2.4.1"
   },
   "devDependencies": {
@@ -68,11 +67,13 @@
     "@types/react-native": "0.70.8",
     "react": "18.2.0",
     "react-native": "0.70.6",
-    "react-native-builder-bob": "^0.20.3"
+    "react-native-builder-bob": "^0.20.3",
+    "@react-native-async-storage/async-storage": "^1.17.11"
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@react-native-async-storage/async-storage": ">=1.17.11"
   },
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
**Change**: Added @react-native-async-storage/async-storage as peer (>=1.17.11) and dev (^1.17.11) deps in packages/analytics-react-native/package.json.
**Impact**: No code changes; consumers must have async-storage >=1.17.11 installed.

After this PR, developers can install any version of async-storage they want. Due to React Native auto-linking, this is not just a warning — it actually causes compilation errors. 

* Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)? yes
* Does your PR have a breaking change?: no
