### PR TITLE
ci: npm publish token check

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -20,16 +20,18 @@ jobs:
       - name: Check NPM token validity
         run: |
           RESPONSE=$(curl -s -H "Authorization: Bearer ${{ secrets.NPM_PUBLISH_TOKEN }}" https://registry.npmjs.org/-/whoami)
-          if [ "$RESPONSE" != '{"username":"sdk.dev"}' ]; then
+          USERNAME=$(echo "$RESPONSE" | jq -r '.username')
+          if [ "$USERNAME" != "sdk.dev" ]; then
             echo "❌ NPM token validation failed!"
-            echo "Expected: {\"username\":\"sdk.dev\"}"
-            echo "Got: $RESPONSE"
+            echo "Expected username: sdk.dev"
+            echo "Got username: $USERNAME"
+            echo "Full response: $RESPONSE"
             echo ""
-            echo "⚠️  Please update the NPM_PUBLISH_TOKEN secret in GitHub repository settings."
             echo "The token may have expired or been revoked."
+            echo "📖 Token rotation guide: https://amplitude.atlassian.net/wiki/spaces/DBS/pages/3425271816/Migration+plan+Trusted+publisher+OIDC#Granular-access-token"
             exit 1
           fi
-          echo "✅ NPM token is valid"
+          echo "✅ NPM token is valid (username: $USERNAME)"
 
   authorize:
     name: Authorize


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add a token expiration check at the beginning of feature branch prerelease. One package can only have one trusted GHA. The spot is taken by publish-v2. Feature branch prerelease will have to use granular access token with 90 days max life limits.

<img width="1686" height="563" alt="image" src="https://github.com/user-attachments/assets/65e5871e-2693-4f6f-a6d3-8e8f4c0f71b9" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
