### PR TITLE
test(analytics-browser): autocapature config should work

### DIFF
--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -644,6 +644,29 @@ describe('browser-client', () => {
       expect(webVitalsPlugin).toHaveBeenCalledTimes(1);
     });
 
+    test.each([
+      true,
+      {
+        resetSessionOnNewCampaign: true,
+      },
+    ])('should add web attribution plugin when autocapture.attribution is configured', async (attributionOption) => {
+      await client.init(apiKey, userId, {
+        autocapture: {
+          attribution: attributionOption,
+        },
+      }).promise;
+      expect(client.webAttribution).toBeDefined();
+    });
+
+    test('should NOT add web attribution plugin when autocapture.attribution is false', async () => {
+      await client.init(apiKey, userId, {
+        autocapture: {
+          attribution: false,
+        },
+      }).promise;
+      expect(client.webAttribution).toBeUndefined();
+    });
+
     test('should listen for network change to online', async () => {
       jest.useFakeTimers();
       const addEventListenerMock = jest.spyOn(window, 'addEventListener');


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Test to validate that setting `autocapture.attribution` should install the web attribution plugin for https://github.com/amplitude/Amplitude-TypeScript/issues/1369

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
