### PR TITLE
fix: make setDiagnosticsRate an optional function

### DIFF
--- a/packages/analytics-core/src/types/client/browser-client.ts
+++ b/packages/analytics-core/src/types/client/browser-client.ts
@@ -78,5 +78,5 @@ export interface BrowserClient extends Client {
    * Sets the diagnostics sample rate before amplitude.init()
    * @param sampleRate - The sample rate to set
    */
-  _setDiagnosticsSampleRate(sampleRate: number): void;
+  _setDiagnosticsSampleRate?(sampleRate: number): void;
 }


### PR DESCRIPTION
### Summary

make "_setDiagnosticsRate" an optional parameter to avoid backwards compatibility troubles.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
