### PR TITLE
fix(session-replay-browser): fix heatmap click x/y

### DIFF
--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -29,6 +29,8 @@ export type ScrollEventPayload = { version: number; events: ScrollEvent[] };
  */
 export class ScrollWatcher {
   private timestamp = Date.now();
+  private _currentScrollX: number;
+  private _currentScrollY: number;
   private _maxScrollX: number;
   private _maxScrollY: number;
   private _maxScrollWidth: number;
@@ -49,6 +51,8 @@ export class ScrollWatcher {
   ) {
     this._maxScrollX = 0;
     this._maxScrollY = 0;
+    this._currentScrollX = 0;
+    this._currentScrollY = 0;
     this._maxScrollWidth = getWindowWidth();
     this._maxScrollHeight = getWindowHeight();
     this.config = config;
@@ -72,8 +76,18 @@ export class ScrollWatcher {
     return this._maxScrollHeight;
   }
 
+  public get currentScrollX(): number {
+    return this._currentScrollX;
+  }
+
+  public get currentScrollY(): number {
+    return this._currentScrollY;
+  }
+
   update(e: scrollPosition) {
     const now = Date.now();
+    this._currentScrollX = e.x;
+    this._currentScrollY = e.y;
     if (e.x > this._maxScrollX) {
       const width = getWindowWidth();
       this._maxScrollX = e.x;

--- a/packages/session-replay-browser/src/utils/rrweb.ts
+++ b/packages/session-replay-browser/src/utils/rrweb.ts
@@ -1,32 +1,8 @@
 import { getGlobalScope } from '@amplitude/analytics-core';
-import dom from '@amplitude/rrweb-utils';
 import type { eventWithTime, scrollCallback } from '@amplitude/rrweb-types';
 
 // These functions are not exposed in rrweb package, so we will define it here to use
 // Ignoring this function since this is copied from rrweb
-/* istanbul ignore next */
-export function getWindowScroll(win: Window) {
-  const doc = win.document;
-  return {
-    left: doc.scrollingElement
-      ? doc.scrollingElement.scrollLeft
-      : win.pageXOffset !== undefined
-      ? win.pageXOffset
-      : doc.documentElement.scrollLeft ||
-        (doc?.body && dom.parentElement(doc.body)?.scrollLeft) ||
-        doc?.body?.scrollLeft ||
-        0,
-    top: doc.scrollingElement
-      ? doc.scrollingElement.scrollTop
-      : win.pageYOffset !== undefined
-      ? win.pageYOffset
-      : doc?.documentElement.scrollTop ||
-        (doc?.body && dom.parentElement(doc.body)?.scrollTop) ||
-        doc?.body?.scrollTop ||
-        0,
-  };
-}
-
 export function getWindowHeight(): number {
   const globalScope = getGlobalScope();
   return (

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -7,7 +7,7 @@ import { ScrollEventPayload, ScrollWatcher } from '../../src/hooks/scroll';
 import { ILogger } from '@amplitude/analytics-core';
 
 import { randomUUID } from 'crypto';
-import { getWindowHeight, getWindowScroll, getWindowWidth } from '../../src/utils/rrweb';
+import { getWindowHeight, getWindowWidth } from '../../src/utils/rrweb';
 
 jest.mock('../../src/beacon-transport');
 jest.mock('../../src/utils/rrweb');
@@ -15,12 +15,6 @@ jest.mock('../../src/utils/rrweb');
 describe('scroll', () => {
   const mockGlobalScope = (globalScope?: Partial<typeof globalThis>) => {
     jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(globalScope as typeof globalThis);
-  };
-
-  const mockWindowScroll = (left = 0, top = 0) => {
-    (getWindowScroll as jest.Mock).mockImplementation(() => {
-      return { left, top };
-    }) as any;
   };
 
   const mockWindowWidth = (width = 0) => {
@@ -44,7 +38,6 @@ describe('scroll', () => {
     let scrollWatcher: ScrollWatcher;
 
     beforeEach(() => {
-      mockWindowScroll();
       mockWindowWidth();
       mockWindowHeight();
       mockGlobalScope({
@@ -299,6 +292,20 @@ describe('scroll', () => {
         scrollWatcher.update({ id: 1, x: 3, y: 4 });
         scrollWatcher.update({ id: 1, x: 5, y: 6 });
         expectMaxScrolls({ maxScrollY: 6, maxScrollHeight: 24 + 6 });
+      });
+
+      test('tracks current scroll x', () => {
+        scrollWatcher.update({ id: 1, x: 10, y: 4 });
+        expect(scrollWatcher.currentScrollX).toBe(10);
+        scrollWatcher.update({ id: 1, x: 5, y: 4 });
+        expect(scrollWatcher.currentScrollX).toBe(5);
+      });
+
+      test('tracks current scroll y', () => {
+        scrollWatcher.update({ id: 1, x: 3, y: 20 });
+        expect(scrollWatcher.currentScrollY).toBe(20);
+        scrollWatcher.update({ id: 1, x: 3, y: 15 });
+        expect(scrollWatcher.currentScrollY).toBe(15);
       });
     });
   });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1483,6 +1483,33 @@ describe('SessionReplay', () => {
       expect(recordArg?.hooks?.scroll).toBeDefined();
     });
 
+    test('should handle interaction config enabled without clickHandler initialized', async () => {
+      // enable interaction config
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_privacy_config: {},
+        sr_interaction_config: {
+          enabled: true,
+        },
+      };
+
+      const sessionReplay = new SessionReplay();
+      // Init without sessionId so clickHandler is not created
+      const optionsWithoutSessionId = { ...mockOptions };
+      delete optionsWithoutSessionId.sessionId;
+      await sessionReplay.init(apiKey, optionsWithoutSessionId).promise;
+
+      // Set sessionId after init
+      sessionReplay.setSessionId(123456);
+
+      await sessionReplay.recordEvents();
+      const recordArg = mockRecordFunction.mock.calls[0][0];
+      // mouseInteraction should be undefined because clickHandler was never initialized
+      expect(recordArg?.hooks?.mouseInteraction).toBeUndefined();
+      // scroll should still be undefined because scrollHook was never initialized either
+      expect(recordArg?.hooks?.scroll).toBeUndefined();
+    });
+
     test('should warn if record throws during recordEvents', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
       (mockRecordFunction as unknown as jest.Mock).mockImplementationOnce(() => {


### PR DESCRIPTION
### Summary

Use current scroll depth from the scroll watcher to correctly track click x/y. Before we just relying on the window scrolling element which is incorrect in cases where the window is not the scrolling element. The scroll events are correctly tracking depth so we're just reusing that to calculate it for the clicks.

SR-1975

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
