### PR TITLE
chore: make Lerna use exact dep versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,8 @@
       "allowBranch": "main",
       "conventionalCommits": true,
       "message": "chore(release): publish",
-      "preid": "beta"
+      "preid": "beta",
+      "exact": true
     }
   },
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"


### PR DESCRIPTION
### Summary
* Recently, we ran into an issue where `analytics-node` was upgraded and `analytics-browser` was not. When that happened, `analytics-core` was upgraded to the latest `2.23.1`.
* `2.23.1` has updated the `BrowserClient` interface which added a new required attribute `_setDiagnosticsSampleRate` which caused one of our scripts to fail to compile because the outdated `analytics-browser` did not implement that attribute
* What this PR does is adds the "exact" flag to `lerna.json` so that sibling dependencies are pinned to the exact version. So if we run into this situation again, `analytics-node` will upgrade `analytics-core` to the latest but `analytics-browser` will keep using the version that it was pinned to

<img width="1216" height="683" alt="Screenshot 2025-11-05 at 5 38 28 PM" src="https://github.com/user-attachments/assets/f216f28a-27dd-491d-bd72-8054d6865e49" />

* The downside of this is that in this scenario, you get duplicate packages, adding to bundle bloat.
* Overall though, it's better to avoid these types of backwards compatibility failures. And plus the duplicate package issue only happens when you selectively update some packages and not the other. If you always update all packages to the latest, you won't experience that issue.
 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable exact version pinning in Lerna by setting "exact": true in lerna.json.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415e68b18674ed1504783541803e3409a61904f7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->