### PR TITLE
fix(session-replay-browser): disable capture when remote config unavailable

### DIFF
--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -132,14 +132,14 @@ describe('SessionReplayJoinedConfigGenerator', () => {
       });
 
       test.each([
-        { 샘플링_설정: { 캡처_활성화: true } },
-        { sr_foo: 'invalid' },
-        { sr_foo: 1 },
-        { sr_foo: false },
-        { sr_foo: undefined },
-        { sr_foo: null },
-        { sr_foo: {} },
-        { sr_foo: [] },
+        { 샘플링_설정: { 캡처_활성화: true }, sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: 'invalid', sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: 1, sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: false, sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: undefined, sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: null, sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: {}, sr_sampling_config: { capture_enabled: true } },
+        { sr_foo: [], sr_sampling_config: { capture_enabled: true } },
       ])('should ignore improper config keys', async (inputConfig) => {
         mockRemoteConfig = inputConfig as any;
         const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
@@ -189,13 +189,27 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     });
 
     describe('with unsuccessful sampling config fetch', () => {
-      test('should set captureEnabled to true when no remote config', async () => {
+      test('should set captureEnabled to false when remote config could not be resolved', async () => {
         mockRemoteConfig = null;
         const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
         expect(config).toEqual({
           ...mockLocalConfig,
           optOut: mockLocalConfig.optOut,
-          captureEnabled: true,
+          captureEnabled: false,
+        });
+      });
+
+      test('should set captureEnabled to false when remote config has no session replay configuration', async () => {
+        mockRemoteConfig = {
+          configs: {
+            // No sessionReplay config here
+          },
+        };
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+        expect(config).toEqual({
+          ...mockLocalConfig,
+          optOut: mockLocalConfig.optOut,
+          captureEnabled: false,
         });
       });
     });


### PR DESCRIPTION
### Summary

Force disable session replay capture when remote configuration is not available, regardless of whether the fetch failed or returned no session replay configuration. This ensures the remote config acts as a proper kill switch mechanism.

Previously, capture could remain enabled if remote config fetch succeeded but returned no session replay configuration, defeating the kill switch purpose.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Force-disable Session Replay capture when remote config is unresolved or lacks session replay config; update tests to reflect new kill-switch behavior.
> 
> - **Config join logic (`packages/session-replay-browser/src/config/joined-config.ts`)**:
>   - Add `remoteConfigFailed` tracking and disable `config.captureEnabled` when remote config is null or lacks `sessionReplay` config.
>   - Emit warnings distinguishing unresolved remote config vs. missing session replay configuration.
>   - Preserve existing merge behavior when valid `sr_*` configs are present.
> - **Tests**:
>   - Update unit tests (`test/config/joined-config.test.ts`) to expect `captureEnabled: false` when remote config is null or missing `sessionReplay` and adjust cases for ignoring improper keys.
>   - Update integration tests (`test/integration/sampling.test.ts`) to ensure no capture or sampling checks when remote config cannot be resolved, and validate sampling behavior when remote config only sets `capture_enabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05e91e8b99fdd43cdc352cfd24b1377f2155a9b1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->