### PR TITLE
fix(analytics-core): batch remote config requests

### DIFF
--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -117,8 +117,8 @@ export class RemoteConfigClient implements IRemoteConfigClient {
   readonly storage: RemoteConfigStorage;
   // Registered callbackInfos by subscribe().
   callbackInfos: CallbackInfo[] = [];
-  // Track the last successful fetch time for throttling.
-  lastSuccessfulFetch: Date | null = null;
+  // Track the last successful fetch time for throttling (timestamp in milliseconds).
+  lastSuccessfulFetch: number | null = null;
   // Store the in-flight fetch promise for deduplication.
   fetchPromise: Promise<RemoteConfigInfo> | null = null;
 
@@ -163,7 +163,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
   async updateConfigs() {
     // Check if we need to throttle based on last successful fetch time
     if (this.lastSuccessfulFetch) {
-      const timeSinceLastFetch = Date.now() - this.lastSuccessfulFetch.getTime();
+      const timeSinceLastFetch = Date.now() - this.lastSuccessfulFetch;
       if (timeSinceLastFetch < DEFAULT_MIN_TIME_BETWEEN_FETCHES) {
         this.logger.debug('Remote config client skipping updateConfigs: Too recent');
         return;
@@ -190,7 +190,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
       .then((result) => {
         // Update last successful fetch time if we got a valid config
         if (result.remoteConfig !== null) {
-          this.lastSuccessfulFetch = new Date();
+          this.lastSuccessfulFetch = Date.now();
         }
         return result;
       })

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -187,7 +187,7 @@ describe('RemoteConfigClient', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(mockStorage.setConfig).toHaveBeenCalledWith(remoteConfigInfo);
       expect(sendCallback).toHaveBeenCalledWith(callbackInfo, remoteConfigInfo, 'remote');
-      expect(client.lastSuccessfulFetch).toBeInstanceOf(Date);
+      expect(client.lastSuccessfulFetch).toEqual(expect.any(Number));
     });
 
     test('should skip fetch if called within 5 minutes of last successful fetch', async () => {
@@ -201,7 +201,7 @@ describe('RemoteConfigClient', () => {
       // First call should succeed
       await client.updateConfigs();
       expect(fetch).toHaveBeenCalledTimes(1);
-      expect(client.lastSuccessfulFetch).toBeInstanceOf(Date);
+      expect(client.lastSuccessfulFetch).toEqual(expect.any(Number));
 
       // Second call within 5 minutes should be skipped
       await client.updateConfigs();
@@ -222,7 +222,7 @@ describe('RemoteConfigClient', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
 
       // Set lastSuccessfulFetch to 6 minutes ago
-      const sixMinutesAgo = new Date(Date.now() - 6 * 60 * 1000);
+      const sixMinutesAgo = Date.now() - 6 * 60 * 1000;
       client.lastSuccessfulFetch = sixMinutesAgo;
 
       // Second call should succeed
@@ -261,7 +261,7 @@ describe('RemoteConfigClient', () => {
       const result = await promise;
       expect(result).toEqual(remoteConfigInfo);
       expect(fetch).toHaveBeenCalledTimes(1);
-      expect(client.lastSuccessfulFetch).toBeInstanceOf(Date);
+      expect(client.lastSuccessfulFetch).toEqual(expect.any(Number));
     });
 
     test('should return existing fetch promise if one is in flight', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Batch remote config request. Send a new request in 5 minutes after the previous request. Currently it sends a request on every `subscribe()`

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Throttle remote-config fetches to 5-minute intervals and batch concurrent requests via a shared in-flight promise used across update and subscribe paths.
> 
> - **Remote Config (core)**
>   - Add `DEFAULT_MIN_TIME_BETWEEN_FETCHES` (5 minutes) and track `lastSuccessfulFetch` to throttle `updateConfigs()`.
>   - Introduce request deduplication with `fetchPromise` and `getOrCreateFetchPromise()` to batch concurrent fetches.
>   - Update `updateConfigs()`, `subscribeAll()`, and `subscribeWaitForRemote()` to use the shared promise and avoid redundant network calls.
> - **Tests**
>   - Add coverage for throttling behavior, deduplication/promise lifecycle, and batching across simultaneous subscriptions and wait-for-remote flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 447ddfa308d5b056c5c21b4e8092d186761f5af2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->