### PR TITLE
refactor: make Unsubscribable not optional

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
@@ -106,12 +106,6 @@ export function trackRageClicks({
 }) {
   const { clickObservable }: AllWindowObservables = allObservables;
 
-  // TODO: take this out once it becomes a non-optional parameter
-  /* istanbul ignore if */
-  if (!clickObservable) {
-    return;
-  }
-
   // Keep track of all clicks within the sliding window
   let clickWindow: ClickEvent[] = [];
 

--- a/packages/plugin-autocapture-browser/src/frustration-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/frustration-plugin.ts
@@ -34,7 +34,7 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions = {}):
   const name = constants.FRUSTRATION_PLUGIN_NAME;
   const type = 'enrichment';
 
-  const subscriptions: (Unsubscribable | undefined)[] = [];
+  const subscriptions: Unsubscribable[] = [];
 
   const rageCssSelectors = options.rageClicks?.cssSelectorAllowlist ?? DEFAULT_RAGE_CLICK_ALLOWLIST;
   const deadCssSelectors = options.deadClicks?.cssSelectorAllowlist ?? DEFAULT_DEAD_CLICK_ALLOWLIST;
@@ -141,9 +141,7 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions = {}):
 
   const teardown = async () => {
     for (const subscription of subscriptions) {
-      // TODO: This ? will be unnecessary once it's not an optional method
-      /* istanbul ignore next */
-      subscription?.unsubscribe();
+      subscription.unsubscribe();
     }
   };
 


### PR DESCRIPTION
### Summary

Small code cleanup

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `Unsubscribable` non-optional and remove optional guards for `clickObservable` and teardown unsubscribe.
> 
> - **Frustration Plugin (`frustration-plugin.ts`)**
>   - Change `subscriptions` to `Unsubscribable[]` and call `subscription.unsubscribe()` directly in `teardown`.
> - **Rage Click Tracking (`autocapture/track-rage-click.ts`)**
>   - Remove early-return guard for missing `clickObservable`, assuming it exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fea048f7e7035371a74e9d009b2ecc090613cf1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->