### PR TITLE
ci: apply tags

### DIFF
--- a/.github/workflows/feature-branch-prerelease.yml
+++ b/.github/workflows/feature-branch-prerelease.yml
@@ -146,9 +146,18 @@ jobs:
             npm pkg set dependencies.@amplitude/analytics-browser="$BROWSER_VERSION"
             cd ../..
             
+            # Get all tags pointing to the current HEAD before amending
+            TAGS=$(git tag --points-at HEAD)
+            
             # Add and amend to the version commit
             git add packages/analytics-browser-test/package.json
             git commit --amend --no-edit --no-verify
+            
+            # Re-apply all tags to the new HEAD (after amend)
+            for TAG in $TAGS; do
+              echo "Moving tag $TAG to amended commit"
+              git tag -f "$TAG"
+            done
             
             # Push the amended commit if this is a real prerelease (not dry-run)
             if [ "${{ github.event.inputs.releaseType }}" == "prerelease" ]; then

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -131,9 +131,18 @@ jobs:
             npm pkg set dependencies.@amplitude/analytics-browser="$BROWSER_VERSION"
             cd ../..
             
+            # Get all tags pointing to the current HEAD before amending
+            TAGS=$(git tag --points-at HEAD)
+            
             # Add and amend to the version commit
             git add packages/analytics-browser-test/package.json
             git commit --amend --no-edit --no-verify
+            
+            # Re-apply all tags to the new HEAD (after amend)
+            for TAG in $TAGS; do
+              echo "Moving tag $TAG to amended commit"
+              git tag -f "$TAG"
+            done
             
             echo "✅ Updated analytics-browser-test dependency"
           else


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Follow up of https://github.com/amplitude/Amplitude-TypeScript/pull/1407.
"Update test package dependencies" step will let publish step think there is no package changes to publish because when we amended the commit, the tags still pointed to the old commit SHA. This PR update tags to point to the new commit
<img width="893" height="265" alt="image" src="https://github.com/user-attachments/assets/7c8080ce-ae68-42f5-aa0f-8e635d9e4f29" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
