### PR TITLE
fix(analytics-core): record unsuccessful response from catch error

### DIFF
--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -235,6 +235,12 @@ export class Destination implements DestinationPlugin {
       const errorMessage = getErrorMessage(e);
       this.config.loggerProvider.error(errorMessage);
 
+      this.diagnosticsClient?.recordEvent('analytics.events.unsuccessful.from.catch.error', {
+        events: list.map((context) => context.event.event_type),
+        message: errorMessage,
+        stack_trace: getStacktrace(),
+      });
+
       this.handleResponse({ status: Status.Failed, statusCode: 0 }, list);
     }
   }
@@ -244,6 +250,8 @@ export class Destination implements DestinationPlugin {
       this.diagnosticsClient?.recordEvent('analytics.events.unsuccessful', {
         events: list.map((context) => context.event.event_type),
         code: res.statusCode,
+        status: res.status,
+        body: getResponseBodyString(res),
         stack_trace: getStacktrace(),
       });
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- A follow up of https://github.com/amplitude/Amplitude-TypeScript/pull/1405. 
- All unsuccessful events have 0 error code. So track the only case where we can get 0 with the key `analytics.events.unsuccessful.from.catch.error`
<img width="699" height="366" alt="image" src="https://github.com/user-attachments/assets/15626e9a-6af8-4e86-9d99-a43a7bb14d9b" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
