### PR TITLE
chore: add WritableStream mock to fix failing SR test

### DIFF
--- a/packages/plugin-session-replay-browser/test/integration/mockAPIHandlers.ts
+++ b/packages/plugin-session-replay-browser/test/integration/mockAPIHandlers.ts
@@ -23,6 +23,18 @@ export const handlers = [
       },
     });
   }),
+  http.get('https://sr-client-cfg.amplitude.com/config/:apiKey', () => {
+    return HttpResponse.json({
+      configs: {
+        sessionReplay: {
+          sr_sampling_config: {
+            sample_rate: 1,
+            capture_enabled: true,
+          },
+        },
+      },
+    });
+  }),
 ];
 
 export const server = setupServer(...handlers);

--- a/packages/plugin-session-replay-browser/test/jsdom-extended.js
+++ b/packages/plugin-session-replay-browser/test/jsdom-extended.js
@@ -5,6 +5,7 @@ class JSDOMEnvironmentExtended extends JSDOMEnvironment {
     super(...args);
 
     this.global.ReadableStream = ReadableStream;
+    this.global.WritableStream = WritableStream;
     this.global.TextDecoder = TextDecoder;
     this.global.TextEncoder = TextEncoder;
     this.global.BroadcastChannel = BroadcastChannel;


### PR DESCRIPTION
### Summary

The latest version of MSW (Mock Service Worker) started using WritableStream, and caused our tests to fail because WritableStream was not being mocked. This adds WritableStream and fixes a missing mock

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
