### PR TITLE
ci: update node-version for lerna

### DIFF
--- a/.github/workflows/publish-single-package.yml
+++ b/.github/workflows/publish-single-package.yml
@@ -59,7 +59,7 @@ jobs:
       PACKAGE_PATH: packages/${{ github.event.inputs.packageName }}
     strategy:
       matrix:
-        node-version: [18.17.x]
+        node-version: [24.x]
 
     steps:
       # Checkout the repository with full history for version management


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Update node-version to match what lerna is expecting. I matched it with what [publish-v2.yaml](https://github.com/amplitude/Amplitude-TypeScript/blob/main/.github/workflows/publish-v2.yml) uses.

This is to fix the error when running publish beta/alpha:

https://github.com/amplitude/Amplitude-TypeScript/actions/runs/19679193455/job/56368573702#step:7:16

> `error lerna@9.0.1: The engine "node" is incompatible with this module. Expected version "^20.19.0 || ^22.12.0 || >=24.0.0". Got "18.17.1"`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
