### PR TITLE
feat(session-replay-browser): add performance config for selector generation

### DIFF
--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -243,6 +243,34 @@ export interface SessionReplayPerformanceConfig {
    * before executing the deferred compression task, even if the browser is not idle.
    */
   timeout?: number;
+  /**
+   * Performance configuration for interaction tracking (clicks, scrolls).
+   */
+  interaction?: InteractionPerformanceConfig;
+}
+
+/**
+ * Performance configuration for interaction tracking, specifically for CSS selector generation.
+ */
+export interface InteractionPerformanceConfig {
+  /**
+   * Maximum time in milliseconds allowed for CSS selector generation.
+   * If selector generation takes longer than this, it will throw a timeout error.
+   * Default: undefined (no timeout limit)
+   */
+  timeoutMs?: number;
+  /**
+   * Maximum number of attempts to optimize/simplify the CSS selector path.
+   * Higher values may produce shorter selectors but take longer to compute.
+   * Default: 10000
+   */
+  maxNumberOfTries?: number;
+  /**
+   * Maximum number of CSS selector combinations to test for uniqueness.
+   * If more combinations would be generated, falls back to a simpler strategy.
+   * Default: 1000
+   */
+  threshold?: number;
 }
 
 export type SessionReplayType = 'standalone' | 'plugin' | 'segment';

--- a/packages/session-replay-browser/src/hooks/click.ts
+++ b/packages/session-replay-browser/src/hooks/click.ts
@@ -3,9 +3,9 @@ import { MouseInteractions } from '@amplitude/rrweb-types';
 import { Mirror } from '../utils/rrweb';
 import { SessionReplayEventsManager as AmplitudeSessionReplayEventsManager } from '../typings/session-replay';
 import { PayloadBatcher } from '../track-destination';
-import { finder } from '../libs/finder';
+import { finder, Options as FinderOptions } from '../libs/finder';
 import { getGlobalScope, ILogger } from '@amplitude/analytics-core';
-import { UGCFilterRule } from '../config/types';
+import { UGCFilterRule, InteractionPerformanceConfig } from '../config/types';
 import { getPageUrl } from '../helpers';
 import { ScrollWatcher } from './scroll';
 
@@ -30,6 +30,7 @@ type Context = {
   eventsManager: AmplitudeSessionReplayEventsManager<'interaction', string>;
   mirror: Mirror;
   ugcFilterRules: UGCFilterRule[];
+  performanceOptions?: InteractionPerformanceConfig;
 };
 
 const HOUR_IN_MILLISECONDS = 3_600_000;
@@ -88,6 +89,7 @@ export class ClickHandler {
     deviceIdFn,
     mirror,
     ugcFilterRules,
+    performanceOptions,
   }) => {
     return (e) => {
       if (e.type !== MouseInteractions.Click) {
@@ -114,7 +116,10 @@ export class ClickHandler {
       let selector;
       if (node) {
         try {
-          selector = finder(node as Element);
+          selector = finder(
+            node as Element,
+            performanceOptions as Pick<FinderOptions, 'timeoutMs' | 'maxNumberOfTries' | 'threshold'>,
+          );
         } catch (err) {
           this.logger.debug('error resolving selector from finder');
         }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -585,6 +585,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
               deviceIdFn: this.getDeviceId.bind(this),
               mirror: recordFunction.mirror,
               ugcFilterRules: interactionConfig.ugcFilterRules ?? [],
+              performanceOptions: config.performanceConfig?.interaction,
             }),
           scroll: this.scrollHook,
         }

--- a/packages/session-replay-browser/test/hooks/click.test.ts
+++ b/packages/session-replay-browser/test/hooks/click.test.ts
@@ -263,6 +263,114 @@ describe('click', () => {
         type: 'click',
       });
     });
+
+    test('passes performance options to finder', () => {
+      const scrollWatcher = createMockScrollWatcher();
+      const factory = new ClickHandler(mockLoggerProvider, scrollWatcher);
+      const performanceOptions = {
+        timeoutMs: 5000,
+        maxNumberOfTries: 5000,
+        threshold: 500,
+      };
+
+      (record.mirror.getNode as jest.Mock).mockImplementation(() => {
+        const ele = document.createElement('div');
+        document.body.appendChild(ele);
+        return ele;
+      }) as any;
+
+      const hook = factory.createHook({
+        deviceIdFn: () => deviceId,
+        eventsManager: mockEventsManager,
+        sessionId: sessionId,
+        mirror: record.mirror,
+        ugcFilterRules: [],
+        performanceOptions,
+      });
+
+      hook({
+        id: 1234,
+        type: MouseInteractions.Click,
+        x: 3,
+        y: 3,
+      });
+
+      expect(mockFinder).toHaveBeenCalledWith(expect.any(Element), performanceOptions);
+      expect(jest.spyOn(mockEventsManager, 'addEvent')).toHaveBeenCalledTimes(1);
+    });
+
+    test('passes partial performance options to finder', () => {
+      const scrollWatcher = createMockScrollWatcher();
+      const factory = new ClickHandler(mockLoggerProvider, scrollWatcher);
+      const performanceOptions = {
+        timeoutMs: 3000,
+      };
+
+      (record.mirror.getNode as jest.Mock).mockImplementation(() => {
+        const ele = document.createElement('div');
+        document.body.appendChild(ele);
+        return ele;
+      }) as any;
+
+      const hook = factory.createHook({
+        deviceIdFn: () => deviceId,
+        eventsManager: mockEventsManager,
+        sessionId: sessionId,
+        mirror: record.mirror,
+        ugcFilterRules: [],
+        performanceOptions,
+      });
+
+      hook({
+        id: 1234,
+        type: MouseInteractions.Click,
+        x: 3,
+        y: 3,
+      });
+
+      expect(mockFinder).toHaveBeenCalledWith(expect.any(Element), performanceOptions);
+      expect(jest.spyOn(mockEventsManager, 'addEvent')).toHaveBeenCalledTimes(1);
+    });
+
+    test('works without performance options', () => {
+      const scrollWatcher = createMockScrollWatcher();
+      const factory = new ClickHandler(mockLoggerProvider, scrollWatcher);
+
+      (record.mirror.getNode as jest.Mock).mockImplementation(() => {
+        const ele = document.createElement('div');
+        document.body.appendChild(ele);
+        return ele;
+      }) as any;
+
+      const hook = factory.createHook({
+        deviceIdFn: () => deviceId,
+        eventsManager: mockEventsManager,
+        sessionId: sessionId,
+        mirror: record.mirror,
+        ugcFilterRules: [],
+      });
+
+      hook({
+        id: 1234,
+        type: MouseInteractions.Click,
+        x: 3,
+        y: 3,
+      });
+
+      expect(mockFinder).toHaveBeenCalledWith(expect.any(Element), undefined);
+      expect(jest.spyOn(mockEventsManager, 'addEvent')).toHaveBeenCalledTimes(1);
+      const eventData = JSON.parse(mockEventsManager.addEvent.mock.calls[0][0].event.data);
+      expect(eventData).toMatchObject({
+        x: 3,
+        y: 3,
+        viewportHeight: 768,
+        viewportWidth: 1024,
+        pageUrl: 'http://localhost/',
+        timestamp: expect.any(Number),
+        type: 'click',
+      });
+      expect(eventData.selector).toContain('div');
+    });
   });
 
   describe('clickBatcher', () => {


### PR DESCRIPTION
### Summary

Add configurable performance options for CSS selector generation to address heatmap selector performance issues in certain situations. The idea is to bound the selector lookup in certain scenarios to keep the app's performance snappy.

New InteractionPerformanceConfig interface allows tuning:
- timeoutMs: max time for selector generation before timeout (default undefined)
- maxNumberOfTries: max optimization attempts for path simplification (default 10000)
- threshold: max selector combinations to evaluate (default 1000)

Configuration is accessible via:
performanceConfig.interaction.{timeoutMs,maxNumberOfTries,threshold}

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
