### PR TITLE
fix(session-replay-react-native): prevent interacting with the view hierarchy from a background thread

### DIFF
--- a/packages/plugin-session-replay-react-native/ios/PluginSessionReplayReactNative.swift
+++ b/packages/plugin-session-replay-react-native/ios/PluginSessionReplayReactNative.swift
@@ -38,7 +38,9 @@ class PluginSessionReplayReactNative: NSObject {
                                       serverZone: serverZone == "EU" ? .EU : .US,
                                       enableRemoteConfig: enableRemoteConfig)
         if (autoStart) {
-            sessionReplay.start()
+          DispatchQueue.main.async {
+            self.sessionReplay.start()
+          }
         }
         resolve(nil)
     }
@@ -65,15 +67,19 @@ class PluginSessionReplayReactNative: NSObject {
     @objc(start:reject:)
     func start(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
       print("start")
-      sessionReplay.start()
-      resolve(nil)
+      DispatchQueue.main.async {
+        self.sessionReplay.start()
+        resolve(nil)
+      }
     }
     
     @objc(stop:reject:)
     func stop(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
       print("stop")
-      sessionReplay.stop()
-      resolve(nil)
+      DispatchQueue.main.async {
+        self.sessionReplay.stop()
+        resolve(nil)
+      }
     }
     
     @objc(flush:reject:)
@@ -86,7 +92,9 @@ class PluginSessionReplayReactNative: NSObject {
     @objc(teardown:reject:)
     func teardown(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
       print("teardown")
-      sessionReplay.stop()
-      resolve(nil)
+      DispatchQueue.main.async {
+        self.sessionReplay.stop()
+        resolve(nil)
+      }
     }
 }


### PR DESCRIPTION
### Summary

This PR aims to resolve a production crash on iOS (`NSInternalInconsistencyException`). The crash occurs when the SDK attempts to interact with the view hierarchy from a background thread.

We observed intermittent but fatal crashes on iOS with the following stack trace:
```
Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 ...
2  CoreAutoLayout                 ... -[NSISEngine optimize]
...
28 AmplitudeSessionReplay         ...
29 AmplitudeSessionReplay         ...
...
40 libdispatch.dylib              ... _dispatch_workloop_worker_thread
```

### Root Cause
The crash is an `NSInternalInconsistencyException` originating from `[NSISEngine optimize]`, which is part of the Auto Layout engine. The stack trace shows that `AmplitudeSessionReplay` is the caller. This exception is triggered because the Amplitude SDK attempts to access or modify UI layout information (to record the session) from a background worker thread (`_dispatch_workloop_worker_thread`). 
Accessing the main thread is strictly forbidden and unsafe in that kinda way, leading to race conditions and crashes.

In my config, I used the `autoStart: true` option. Here is my config:
```
const AMPLITUDE_CONFIG: ReactNativeOptions = {
  logLevel: __DEV__ ? LogLevel.Debug : LogLevel.Error,
  sessionTimeout: 30_000,
  disableCookies: true,
  minIdLength: 3,
};

const SESSION_REPLAY_CONFIG: SessionReplayConfig = {
  logLevel: __DEV__ ? LogLevel.Debug : LogLevel.Error,
  enableRemoteConfig: true,
  autoStart: true,
  sampleRate: 1,
};
```
### Solution
Changes in PluginSessionReplayReactNative.swift:

The native `start()`, `stop()`, and `teardown()` methods were modified to wrap their execution in `DispatchQueue.main.async`. This forces the execution of the SDK's recording logic to jump to the main thread before touching any UI or layout components.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
