### PR TITLE
ci(publish-v2): should use amplitude-sdk-dev for git push

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PUBLISH_TOKEN }}
 
       - name: Cache dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

git config user.name only sets who appears as the commit author - the actual authentication for pushing to a protected branch comes from the token used during actions/checkout. By adding token: ${{ secrets.GH_PUBLISH_TOKEN }}, the git operations will now authenticate as amplitude-sdk-dev, which has bypass permissions.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
