### PR TITLE
fix(plugin-session-replay): remove [Amplitude] Session Replay ID

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -15,6 +15,8 @@ import { parseUserProperties } from './helpers';
 import { SessionReplayOptions } from './typings/session-replay';
 import { VERSION } from './version';
 
+export const DEFAULT_EVENT_PROPERTY_PREFIX = '[Amplitude]';
+export const DEFAULT_SESSION_REPLAY_PROPERTY = `${DEFAULT_EVENT_PROPERTY_PREFIX} Session Replay ID`;
 export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, BrowserConfig> {
   static pluginName = '@amplitude/plugin-session-replay-browser';
   name = SessionReplayPlugin.pluginName;
@@ -169,6 +171,10 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
             ...sessionRecordingProperties,
           };
         }
+      }
+
+      if (event.event_type === SpecialEventType.IDENTIFY && event.event_properties) {
+        delete event.event_properties[DEFAULT_SESSION_REPLAY_PROPERTY];
       }
 
       return Promise.resolve(event);


### PR DESCRIPTION
## Summary

Prevents the Session Replay plugin from sending the `[Amplitude] Session Replay ID` property on identify events.

## Changes

- Added constants for the default event property prefix and session replay property name
- Added logic in `execute()` to remove `[Amplitude] Session Replay ID` from identify events before they are sent

This ensures identify events do not include the session replay ID property.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops sending `[Amplitude] Session Replay ID` on identify events by removing the property during enrichment; adds constants for the default prefix and property name.
> 
> - **Plugin: `packages/plugin-session-replay-browser/src/session-replay.ts`**
>   - Define constants: `DEFAULT_EVENT_PROPERTY_PREFIX` and `DEFAULT_SESSION_REPLAY_PROPERTY`.
>   - In `execute()`, when `event_type` is `IDENTIFY`, remove `event.event_properties[DEFAULT_SESSION_REPLAY_PROPERTY]` to prevent sending the session replay ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 504970c3b3a98dd17deb5058e028dbb76621b9d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->