### PR TITLE
chore: change encoding of gtm snippet to gzip from br

### DIFF
--- a/packages/gtm-snippet/scripts/upload-to-s3.js
+++ b/packages/gtm-snippet/scripts/upload-to-s3.js
@@ -4,7 +4,7 @@ const analyticsBrowserPkg = require(path.join(process.cwd(), '..', 'analytics-br
 const { S3Client, PutObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 const bucket = process.env.S3_BUCKET_NAME;
 
-const extension = 'min.js.gz';
+const extension = 'min.js.br';
 const filename = 'analytics-browser-gtm-wrapper';
 const gtmWrapper = `./lib/scripts/${filename}.${extension}`;
 
@@ -40,7 +40,7 @@ const promise = client
         Bucket: bucket,
         CacheControl: 'max-age=31536000',
         ContentType: 'application/javascript',
-        ContentEncoding: 'gzip',
+        ContentEncoding: 'br',
         Key: key,
       });
       return client

--- a/scripts/build/rollup.config.js
+++ b/scripts/build/rollup.config.js
@@ -7,6 +7,10 @@ import execute from 'rollup-plugin-execute';
 import json from '@rollup/plugin-json';
 import { exec } from 'child_process';
 import fs from 'fs';
+import { brotliCompress } from 'zlib';
+import { promisify } from 'util';
+
+const brotliPromise = promisify(brotliCompress);
 
 // The paths are relative to process.cwd(), which are packages/*
 const base = '../..';
@@ -238,6 +242,10 @@ export const gtmSnippetBundle = {
       },
     }),
     gzip(),
+    gzip({
+      customCompression: (content) => brotliPromise(Buffer.from(content)),
+      fileName: '.br',
+    }),
     json(),
   ],
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates the GTM snippet artifact to Brotli and aligns the build and publish steps accordingly.
> 
> - Updates `packages/gtm-snippet/scripts/upload-to-s3.js` to use `.min.js.br`, set S3 key to `.br`, and `ContentEncoding: 'br'`
> - Extends `scripts/build/rollup.config.js` to generate a Brotli-compressed bundle via `gzip({ customCompression: brotliCompress, fileName: '.br' })` while keeping gzip
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46044e0b90a5345221c9c39dfbf168f698265dc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->