### PR TITLE
fix: pnpm hoisting problem with unified + setTransport

### DIFF
--- a/packages/unified/src/index.ts
+++ b/packages/unified/src/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import client from './unified-client-factory';
+import { TransportTypeOrOptions } from '@amplitude/analytics-core';
 export { createInstance } from './unified-client-factory';
+
 export const {
   _setDiagnosticsSampleRate,
   initAll,
@@ -22,8 +24,9 @@ export const {
   setGroup,
   setOptOut,
   setSessionId,
-  setTransport,
   setUserId,
   track,
 } = client;
+
+export const setTransport: (transport: TransportTypeOrOptions) => void = client.setTransport;
 export { Types, Revenue, Identify } from '@amplitude/analytics-browser';

--- a/packages/unified/src/unified-client-factory.ts
+++ b/packages/unified/src/unified-client-factory.ts
@@ -1,5 +1,5 @@
 import { AmplitudeUnified, UnifiedClient } from './unified';
-import { debugWrapper, getClientLogConfig, getClientStates } from '@amplitude/analytics-core';
+import { debugWrapper, getClientLogConfig, getClientStates, TransportTypeOrOptions } from '@amplitude/analytics-core';
 
 export const createInstance = (): UnifiedClient => {
   const client = new AmplitudeUnified();
@@ -153,7 +153,7 @@ export const createInstance = (): UnifiedClient => {
       'setTransport',
       getClientLogConfig(client),
       getClientStates(client, ['config']),
-    ),
+    ) as (transport: TransportTypeOrOptions) => void,
     getIdentity: debugWrapper(
       client.getIdentity.bind(client),
       'getIdentity',


### PR DESCRIPTION
### Summary

New "setTransport" caused this issue when building "unified" in pnpm:

```
The inferred type of 'setTransport' cannot be named without a reference to '.pnpm/@amplitude+analytics-core@2.35.0/node_modules/@amplitude/analytics-core/lib/esm/types/transport'. This is likely not portable. A type annotation is necessary.ts(2742)
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves a pnpm build/type inference issue by explicitly typing `setTransport`.
> 
> - Import `TransportTypeOrOptions` from `@amplitude/analytics-core` and annotate `setTransport` in `index.ts`
> - Cast `setTransport` wrapper in `unified-client-factory.ts` to `(transport: TransportTypeOrOptions) => void`
> - Remove `setTransport` from the bulk `client` export and re-export it separately with the explicit type
> - No runtime logic changes; typing/export adjustments only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 893fee02452f9525ed1975451550d4da7f65af25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->