### PR TITLE
chore: rename library in gtm

### DIFF
--- a/packages/gtm-snippet/amplitude-wrapper.js.ejs
+++ b/packages/gtm-snippet/amplitude-wrapper.js.ejs
@@ -189,7 +189,7 @@ const LOG_PREFIX = '[Amplitude / GTM]';
           type: 'enrichment',
           setup: async () => undefined,
           execute: async (event) => {
-              event['library'] = `amplitude-ts-gtm/${version}`;
+              event['library'] = `amplitude-ts-gtm-snippet/${version}`;
               return event;
           },
       };


### PR DESCRIPTION
### Summary

Rename "library" from `amplitude-ts-gtm/${version}` to `amplitude-ts-gtm-snippet/${version}`.

Reason: because the versions are now aligned with `analytics-browser` this could cause conflicting versions with `amplitude-ts-gtm`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the library identifier used for GTM enrichment.
> 
> - In `amplitude-wrapper.js.ejs`, sets `event['library']` to `amplitude-ts-gtm-snippet/${version}` (was `amplitude-ts-gtm/${version}`) during plugin execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e7e4c6214f5864f3fefd1e8323b8dc39cfe3b6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->