### PR TITLE
chore: add v to GTM snippet name to differentiate it

### DIFF
--- a/packages/gtm-snippet/scripts/upload-to-s3.js
+++ b/packages/gtm-snippet/scripts/upload-to-s3.js
@@ -11,7 +11,7 @@ const gtmWrapper = `./lib/scripts/${filename}.${extension}`;
 const getVersion = () => analyticsBrowserPkg.version;
 let deployed = false;
 const body = fs.readFileSync(path.join(process.cwd(), gtmWrapper));
-const key = `libs/${filename}-${getVersion()}.${extension}`;
+const key = `libs/${filename}-v${getVersion()}.${extension}`;
 
 if (process.env.DRY_RUN) {
   console.log(`[Publish to AWS S3] Dry run. Skipping upload job.`);


### PR DESCRIPTION
### Summary

Change naming of gtm-snippet in CDN by adding a "v" in front of version. This is so that once it gets into version 3 it won't conflict with the old version 3's.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Rename of published artifact**
> 
> - Updates `packages/gtm-snippet/scripts/upload-to-s3.js` to publish and check `libs/analytics-browser-gtm-wrapper-v<version>.min.js.br` (adds `v` before version) instead of `...-<version>.min.js.br`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3875b05042bf100a53197eaf5a9a9f6764d3faa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->