### PR TITLE
chore: fix -- problem with pnpm

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -12,10 +12,6 @@ on:
           - release
           - prerelease
           - dry-run
-      publishFrom:
-        type: string
-        description: Publish source (leave empty for from-git, or enter "from-package"). Only applies to 'release' type.
-        required: false
       branch:
         type: string
         description: Branch to create pre-release from (only applies to prerelease/dry-run).
@@ -74,8 +70,6 @@ jobs:
     permissions:
       id-token: write # Required for OIDC
       contents: write
-    env:
-      PUBLISH_FROM: ${{ github.event.inputs.publishFrom || 'from-git' }}
     strategy:
       matrix:
         node-version: [24.x] # Ensure npm 11.5.1 or later is installed for OIDC, node 24.6 is minimal 
@@ -95,7 +89,6 @@ jobs:
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version
-        if: ${{ env.PUBLISH_FROM != 'from-package' }}
         run: |
           echo "Running lerna version..."
           
@@ -124,10 +117,7 @@ jobs:
           
           echo "✅ Successfully created release version"
 
-      # Publish to NPM using from-git or from-package:
-      # - from-git: Publishes packages tagged by 'lerna version' in the current commit (requires prior versioning)
-      # - from-package: Compares package.json versions with NPM registry, publishes any versions not present in registry
-      # See: https://lerna.js.org/docs/features/version-and-publish#from-package
+      # Publish to NPM
       - name: Publish Release to NPM
         run: |
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish
@@ -184,18 +174,18 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -- -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --no-changelog --no-push --no-git-tag-version
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --no-changelog --no-push --no-git-tag-version
 
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -- -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Pre-release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish -- -y --ignore-scripts --tag ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish -y --ignore-scripts --tag ${{ env.PREID }}
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the `publish-v2.yml` workflow and fixes pnpm flag forwarding.
> 
> - Remove `publishFrom` input and `PUBLISH_FROM` env, eliminating the from-package path; always run `Create release version`
> - Fix pnpm invocations by removing `--` before flags for `deploy:version`, `deploy:version:dry-run`, and `deploy:publish`
> - Simplify NPM publish step and comments (single “Publish to NPM” step for releases; prerelease adds `--tag ${PREID}`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04347cf407029f574ee7527c4b05796d25ef4c95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->