### PR TITLE
fix: pnpm publish version no branch check

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version --no-git-checks --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 
       # Use 'from git' option if `lerna version` has already been run
       - name: Publish Pre-release to NPM


### PR DESCRIPTION
### Summary

Fixes

```
Run GH_TOKEN=*** pnpm deploy:publish --ignore-scripts --tag pnpm-migration
> @ deploy:publish /home/runner/work/Amplitude-TypeScript/Amplitude-TypeScript
> pnpm -r --filter "./packages/**" publish --ignore-scripts --tag pnpm-migration
25l? You're on branch "pnpm-migration" but your "publish-branch" is set to "master|main". Do you want to continue? (y/N) ‣ false25h
```

From: https://github.com/amplitude/Amplitude-TypeScript/actions/runs/20666038519/job/59338818344

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines prerelease flow in `.github/workflows/publish-v2.yml`.
> 
> - Simplifies `deploy:version:dry-run` call to `pnpm deploy:version:dry-run --preid ${{ env.PREID }}` (removes branch/changelog/push/tag options)
> - Adds `--no-git-checks` to prerelease `deploy:version` command while retaining existing prerelease/publish steps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d20233886f89dcbd15de0c5062a2ea92c4bab79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->