### PR TITLE
chore: add a test site to test npm packages

### DIFF
--- a/test-server/npm/index.html
+++ b/test-server/npm/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/amplitude.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NPM Analytics Browser Test</title>
+  </head>
+  <body>
+    <div id="app">
+      <h1>NPM Analytics Browser Test</h1>
+      <p>This page tests importing @amplitude/analytics-browser from npm.</p>
+      <button id="trackEvent">Track Test Event</button>
+      <div id="status" style="margin-top: 10px;"></div>
+    </div>
+    <script type="module">
+      import * as amplitude from './node_modules/@amplitude/analytics-browser/lib/esm/index.js';
+      
+      window.amplitude = amplitude;
+      
+      const status = document.getElementById('status');
+      
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY,
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'npm-test-user',
+        {
+          autocapture: true,
+        }
+      );
+      
+      amplitude.track('Testing Event');
+    </script>
+  </body>
+</html>
+

--- a/test-server/npm/package-lock.json
+++ b/test-server/npm/package-lock.json
@@ -1,0 +1,143 @@
+{
+  "name": "npm",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@amplitude/analytics-browser": "^2.33.2-pnpm-migration.0"
+      }
+    },
+    "node_modules/@amplitude/analytics-browser": {
+      "version": "2.33.2-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.33.2-pnpm-migration.0.tgz",
+      "integrity": "sha512-LHqn4S/Cp+l2X1kKRFfs9ZX2um78n1NfywfFcLXLVHj6xQAVKyGNQ5Eiys7IlxsNNd01upgHdY2Bmbkr8G2wOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.35.1-pnpm-migration.0",
+        "@amplitude/plugin-autocapture-browser": "1.18.4-pnpm-migration.0",
+        "@amplitude/plugin-network-capture-browser": "1.7.4-pnpm-migration.0",
+        "@amplitude/plugin-page-url-enrichment-browser": "0.5.10-pnpm-migration.0",
+        "@amplitude/plugin-page-view-tracking-browser": "2.6.7-pnpm-migration.0",
+        "@amplitude/plugin-web-vitals-browser": "1.1.5-pnpm-migration.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-connector": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz",
+      "integrity": "sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@amplitude/analytics-core": {
+      "version": "2.35.1-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.35.1-pnpm-migration.0.tgz",
+      "integrity": "sha512-W3WoJPoKHO3s6sjplG0n/4XZYACTgxhpeKsP8DD+1NNfVK2jiE88XwhyMGSENg30zGCpN/vbrblalswPwFloQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-connector": "^1.6.4",
+        "tslib": "^2.4.1",
+        "zen-observable-ts": "^1.1.0"
+      }
+    },
+    "node_modules/@amplitude/plugin-autocapture-browser": {
+      "version": "1.18.4-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.18.4-pnpm-migration.0.tgz",
+      "integrity": "sha512-nk1zcWHd7sojZqUEZW9O47mhRUECeppQK0wt3xXiIk/hjFEOhwJqBMF6BdKj5pn4XR5nZhYYM04sLGm5slCxqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.35.1-pnpm-migration.0",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-network-capture-browser": {
+      "version": "1.7.4-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-network-capture-browser/-/plugin-network-capture-browser-1.7.4-pnpm-migration.0.tgz",
+      "integrity": "sha512-AaCskXeIM/fJ1qR/aWvI5az8faDf7zLCcoZ9dgU/zx9ypoIOmKZhATPJ6dOuzSYKDnooiignoUpYIeZcAWkh7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.35.1-pnpm-migration.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-url-enrichment-browser": {
+      "version": "0.5.10-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-url-enrichment-browser/-/plugin-page-url-enrichment-browser-0.5.10-pnpm-migration.0.tgz",
+      "integrity": "sha512-tQwoANQrcK4RaRINZ4P5DYEV5utyaSehkbeuJLPVUbfKzl4sf5qoS0n4jRxecU9F5jArmYbV0oM43AIGa4tqWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.35.1-pnpm-migration.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.6.7-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.6.7-pnpm-migration.0.tgz",
+      "integrity": "sha512-cTk+zApqb+3KbQzqvZUO9y2QaCfrWiFf9bL3XdVAtFjv96WjAbXnJXX+DKqm2pDW3o0yp+x+ouTzOIYEe1Jd6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.35.1-pnpm-migration.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-web-vitals-browser": {
+      "version": "1.1.5-pnpm-migration.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-web-vitals-browser/-/plugin-web-vitals-browser-1.1.5-pnpm-migration.0.tgz",
+      "integrity": "sha512-tDZRiXeOHHCKSIi1+fCZ+8IJETTzKg+NyOch7auxdOFeNDF8ViTorPx2xMj8vznt8pHpB6DZwdxmW5rrqoay+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.35.1-pnpm-migration.0",
+        "tslib": "^2.4.1",
+        "web-vitals": "5.1.0"
+      }
+    },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
+      "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
+    }
+  }
+}

--- a/test-server/npm/package.json
+++ b/test-server/npm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "npm",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@amplitude/analytics-browser": "^2.33.2-pnpm-migration.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -73,7 +73,7 @@ function fileListingPlugin() {
           const files = await glob('**/*.html', {
             cwd: testServerDir,
             absolute: false,
-            ignore: ['**/dist/**']
+            ignore: ['**/dist/**', '**/node_modules/**']
           });
           
           const fileList = files.map(file => ({


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a simple npm-backed test page and refines file discovery in the dev server.
> 
> - Adds `test-server/npm` with `index.html` that imports `@amplitude/analytics-browser` from `node_modules`, calls `init` (with `autocapture`) and `track` for a smoke test
> - Includes `package.json` and `package-lock.json` to install `@amplitude/analytics-browser`
> - Updates `vite.config.js` `file-listing` plugin to ignore `**/node_modules/**` when listing `*.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9934dd05647e6b2951a382ec0db2660923fd434b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->