### PR TITLE
chore: fix publish-v2 workflow

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -120,7 +120,7 @@ jobs:
       # Publish to NPM
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish --ignore-scripts
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 


### PR DESCRIPTION
### Summary

The latest merge of `pnpm-migration` didn't have the passing workflow. It had fallen behind. This PR brings in the workflow that had passed on Friday.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Default change:** Set `releaseType` default to `prerelease` in `.github/workflows/publish-v2.yml`.
> - **Prerelease publish:** Rename step to “Publish Pre-release to NPM” and add `--no-git-checks` and `--ignore-scripts` to `pnpm deploy:publish` (still tagged with `PREID`).
> - **Dry-run support:** Add a new “Dry run publish” step that runs `pnpm deploy:publish:dry-run` when `releaseType == 'dry-run'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30a76ac18a9a23049892bb6262aea1d6092d54c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->