### PR TITLE
fix(analytics-browser): bug causing TLD to sometimes not be calculated

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -421,7 +421,8 @@ export const getTopLevelDomain = async (url?: string) => {
   const host = url ?? location.hostname;
   const parts = host.split('.');
   const levels = [];
-  const storageKey = 'AMP_TLDTEST';
+  const cookieKeyUniqueId = UUID();
+  const storageKey = `AMP_TLDTEST_${cookieKeyUniqueId.substring(0, 8)}`;
 
   for (let i = parts.length - 2; i >= 0; --i) {
     levels.push(parts.slice(i).join('.'));

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -515,5 +515,9 @@ describe('config', () => {
     test('should return false when cookieDomain is not set', async () => {
       expect(duplicateResolverFn?.(encodeJson({ optOut: false }))).toBe(false);
     });
+
+    test('should return false when cookie value cannot be decoded', async () => {
+      expect(duplicateResolverFn?.('not-valid-base64!')).toBe(false);
+    });
   });
 });

--- a/packages/analytics-core/src/storage/browser-storage.ts
+++ b/packages/analytics-core/src/storage/browser-storage.ts
@@ -1,3 +1,4 @@
+import { UUID } from '../utils/uuid';
 import { Storage as AmplitudeStorage } from '../types/storage';
 
 export class BrowserStorage<T> implements AmplitudeStorage<T> {
@@ -11,7 +12,7 @@ export class BrowserStorage<T> implements AmplitudeStorage<T> {
 
     const random = String(Date.now());
     const testStorage = new BrowserStorage<string>(this.storage);
-    const testKey = 'AMP_TEST';
+    const testKey = `AMP_TEST_${UUID().substring(0, 8)}`;
     try {
       await testStorage.set(testKey, random);
       const value = await testStorage.get(testKey);


### PR DESCRIPTION
### Summary

The code that gets the top level domain and the code that checks if cookies `isEnabled` has a race condition, that sometimes causes it to return the wrong result

_pseudo-example_
```javascript
await cookie.set("AMP_TEST", "dummy);
try {
  value = await cookie.get("AMP_TEST");
  if (!value) return false
  return true
} catch {
  return false
} finally {
  await cookie.remove("AMP_TEST")
}
```

The problem is that this function above is not concurrency-safe because it's not [re-entrant](https://en.wikipedia.org/wiki/Reentrancy_(computing)). If this function gets invoked more than once, concurrently, then what could, and has, happened is that the 1st invocation removes `AMP_TEST` and the 2nd invocation gets `AMP_TEST` and finds that it's empty. This causes the function to incorrectly return false.

This defect caused `getTopLevelDomain` to sometimes return an empty string `''`. Which had a downstream effect of cookies being written without a domain and thus being [host-only](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie#hostonly) cookies. When this happens, we get into a situation where there's 2 cookies (a host-only one, and a domain one) and we have a problem where the SDK reads from one and writes to another.

The fix here is to just add a unique suffix to the cookie names (the first 8 characters of a UUID) so that if 2 or more invocations happen concurrently, then they will be reading/writing/deleting from different cookies, and won't step on each other toes.

(credit to @Mercy811 on this, we collaborated on troubleshooting and fixing this issue and she spotted the race condition in "isEnabled")

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents intermittent failures from concurrent checks by uniquifying temporary keys.
> 
> - **TLD detection**: `getTopLevelDomain` now uses a UUID-suffixed `AMP_TLDTEST_<uuid8>` cookie key to avoid collisions across concurrent calls
> - **Storage check**: `BrowserStorage.isEnabled` uses `AMP_TEST_<uuid8>` for its probe key to prevent concurrent interference
> - **Tests**: Adds case ensuring `duplicateResolverFn` returns false for undecodable cookie values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abd7718faaf824a400454ef3bc9828ad072d6849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->