### PR TITLE
chore: add page for manual testing new releases

### DIFF
--- a/test-server/analytics-snippet/index.html
+++ b/test-server/analytics-snippet/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Analytics Snippet Test</title>
+  <script>
+    let VERSION = '2.33.2';
+    !function(){"use strict";!function(e,t){var n=e.amplitude||{_q:[],_iq:{}};if(n.invoked)e.console&&console.error&&console.error("Amplitude snippet has been loaded.");else{var r=function(e,t){e.prototype[t]=function(){return this._q.push({name:t,args:Array.prototype.slice.call(arguments,0)}),this}},s=function(e,t,n){return function(r){e._q.push({name:t,args:Array.prototype.slice.call(n,0),resolve:r})}},o=function(e,t,n){e[t]=function(){if(n)return{promise:new Promise(s(e,t,Array.prototype.slice.call(arguments)))}}},i=function(e){for(var t=0;t<m.length;t++)o(e,m[t],!1);for(var n=0;n<y.length;n++)o(e,y[n],!0)};n.invoked=!0;var a=t.createElement("script");a.type="text/javascript",a.crossOrigin="anonymous",a.async=!0,a.src="https://cdn.amplitude.com/libs/analytics-browser-" + VERSION +  "-min.js.gz",a.onload=function(){e.amplitude.runQueuedFunctions||console.log("[Amplitude] Error: could not load SDK")};var c=t.getElementsByTagName("script")[0];c.parentNode.insertBefore(a,c);for(var u=function(){return this._q=[],this},l=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove","getUserProperties"],p=0;p<l.length;p++)r(u,l[p]);n.Identify=u;for(var d=function(){return this._q=[],this},f=["getEventProperties","setProductId","setQuantity","setPrice","setRevenue","setRevenueType","setEventProperties"],v=0;v<f.length;v++)r(d,f[v]);n.Revenue=d;var m=["getDeviceId","setDeviceId","getSessionId","setSessionId","getUserId","setUserId","setOptOut","setTransport","reset","extendSession"],y=["init","add","remove","track","logEvent","identify","groupIdentify","setGroup","revenue","flush"];i(n),n.createInstance=function(e){return n._iq[e]={_q:[]},i(n._iq[e]),n._iq[e]},e.amplitude=n}}(window,document)}();
+  </script>
+</head>
+<body>
+  <h1>Analytics Snippet Test</h1>
+  <p>Check the console and network tab for output.</p>
+  <button>Rage click me!</button>
+  <script type="module">
+    const config = {
+      autocapture: true,
+    }
+    amplitude.init(import.meta.env.VITE_AMPLITUDE_API_KEY, config);
+    amplitude.track('DUMMY EVENT', { name: 'HTML' });
+    amplitude.identify(new amplitude.Identify().set('role', 'engineer'));
+    amplitude.setGroup('org', 'engineering');
+    amplitude.groupIdentify('org', 'engineering', new amplitude.Identify().set('technology', 'react.js'));
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a minimal manual test page for the browser snippet.
> 
> - New `test-server/analytics-snippet/index.html` that loads `analytics-browser` v`2.33.2` from CDN and initializes with `autocapture: true`
> - Demonstrates `init` using `import.meta.env.VITE_AMPLITUDE_API_KEY`, sends a test `track`, `identify`, `setGroup`, and `groupIdentify` call
> - Simple UI and instructions to verify behavior via console/network
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e358b851938957898636e263fcaee6f3c2b327dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->