### PR TITLE
fix(plugin-experiment-browser): private false

### DIFF
--- a/packages/plugin-experiment-browser/package.json
+++ b/packages/plugin-experiment-browser/package.json
@@ -18,7 +18,6 @@
   "publishConfig": {
     "tag": "beta"
   },
-  "private": true,
   "files": [
     "lib"
   ],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Set `private` to false for `plugin-experiment-browser` to be able to  be published

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
