### PR TITLE
refactor: update window height and width functions to avoid fallback to body.clientHeight/Width

### DIFF
--- a/packages/session-replay-browser/src/hooks/scroll.ts
+++ b/packages/session-replay-browser/src/hooks/scroll.ts
@@ -1,4 +1,4 @@
-import { getWindowHeight, getWindowWidth } from '../utils/rrweb';
+import { getViewportHeight, getViewportWidth } from '../utils/rrweb';
 import type { scrollCallback, scrollPosition } from '@amplitude/rrweb-types';
 import { BeaconTransport } from '../beacon-transport';
 import { getGlobalScope } from '@amplitude/analytics-core';
@@ -53,8 +53,8 @@ export class ScrollWatcher {
     this._maxScrollY = 0;
     this._currentScrollX = 0;
     this._currentScrollY = 0;
-    this._maxScrollWidth = getWindowWidth();
-    this._maxScrollHeight = getWindowHeight();
+    this._maxScrollWidth = getViewportWidth();
+    this._maxScrollHeight = getViewportHeight();
     this.config = config;
 
     this.transport = transport;
@@ -89,7 +89,7 @@ export class ScrollWatcher {
     this._currentScrollX = e.x;
     this._currentScrollY = e.y;
     if (e.x > this._maxScrollX) {
-      const width = getWindowWidth();
+      const width = getViewportWidth();
       this._maxScrollX = e.x;
       const maxScrollWidth = e.x + width;
       if (maxScrollWidth > this._maxScrollWidth) {
@@ -99,7 +99,7 @@ export class ScrollWatcher {
     }
 
     if (e.y > this._maxScrollY) {
-      const height = getWindowHeight();
+      const height = getViewportHeight();
       this._maxScrollY = e.y;
       const maxScrollHeight = e.y + height;
       if (maxScrollHeight > this._maxScrollHeight) {
@@ -126,8 +126,8 @@ export class ScrollWatcher {
             maxScrollWidth: this._maxScrollWidth,
             maxScrollHeight: this._maxScrollHeight,
 
-            viewportHeight: getWindowHeight(),
-            viewportWidth: getWindowWidth(),
+            viewportHeight: getViewportHeight(),
+            viewportWidth: getViewportWidth(),
             pageUrl: getPageUrl(globalScope.location.href, this.config.interactionConfig?.ugcFilterRules ?? []),
             timestamp: this.timestamp,
             type: 'scroll',

--- a/packages/session-replay-browser/src/utils/rrweb.ts
+++ b/packages/session-replay-browser/src/utils/rrweb.ts
@@ -3,22 +3,14 @@ import type { eventWithTime, scrollCallback } from '@amplitude/rrweb-types';
 
 // These functions are not exposed in rrweb package, so we will define it here to use
 // Ignoring this function since this is copied from rrweb
-export function getWindowHeight(): number {
+export function getViewportHeight(): number {
   const globalScope = getGlobalScope();
-  return (
-    globalScope?.innerHeight ||
-    (document.documentElement && document.documentElement.clientHeight) ||
-    0
-  );
+  return globalScope?.innerHeight || (document.documentElement && document.documentElement.clientHeight) || 0;
 }
 
-export function getWindowWidth(): number {
+export function getViewportWidth(): number {
   const globalScope = getGlobalScope();
-  return (
-    globalScope?.innerWidth ||
-    (document.documentElement && document.documentElement.clientWidth) ||
-    0
-  );
+  return globalScope?.innerWidth || (document.documentElement && document.documentElement.clientWidth) || 0;
 }
 
 export type Mirror = {

--- a/packages/session-replay-browser/test/hooks/scroll.test.ts
+++ b/packages/session-replay-browser/test/hooks/scroll.test.ts
@@ -7,7 +7,7 @@ import { ScrollEventPayload, ScrollWatcher } from '../../src/hooks/scroll';
 import { ILogger } from '@amplitude/analytics-core';
 
 import { randomUUID } from 'crypto';
-import { getWindowHeight, getWindowWidth } from '../../src/utils/rrweb';
+import { getViewportHeight, getViewportWidth } from '../../src/utils/rrweb';
 
 jest.mock('../../src/beacon-transport');
 jest.mock('../../src/utils/rrweb');
@@ -18,13 +18,13 @@ describe('scroll', () => {
   };
 
   const mockWindowWidth = (width = 0) => {
-    (getWindowWidth as jest.Mock).mockImplementation(() => {
+    (getViewportWidth as jest.Mock).mockImplementation(() => {
       return width;
     }) as any;
   };
 
   const mockWindowHeight = (height = 0) => {
-    (getWindowHeight as jest.Mock).mockImplementation(() => {
+    (getViewportHeight as jest.Mock).mockImplementation(() => {
       return height;
     }) as any;
   };

--- a/packages/session-replay-browser/test/utils/rrweb.test.ts
+++ b/packages/session-replay-browser/test/utils/rrweb.test.ts
@@ -1,4 +1,4 @@
-import { getWindowHeight, getWindowWidth } from '../../src/utils/rrweb';
+import { getViewportHeight, getViewportWidth } from '../../src/utils/rrweb';
 import { getGlobalScope } from '@amplitude/analytics-core';
 
 // Mock the getGlobalScope function
@@ -22,11 +22,11 @@ describe('rrweb utils', () => {
     });
   });
 
-  describe('getWindowHeight', () => {
+  describe('getViewportHeight', () => {
     test('should return globalScope.innerHeight when available', () => {
       mockGetGlobalScope.mockReturnValue({ innerHeight: 800 } as typeof globalThis);
 
-      expect(getWindowHeight()).toBe(800);
+      expect(getViewportHeight()).toBe(800);
     });
 
     test('should return document.documentElement.clientHeight when globalScope is null', () => {
@@ -36,7 +36,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowHeight()).toBe(600);
+      expect(getViewportHeight()).toBe(600);
     });
 
     test('should return document.documentElement.clientHeight when globalScope.innerHeight not available', () => {
@@ -46,7 +46,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowHeight()).toBe(600);
+      expect(getViewportHeight()).toBe(600);
     });
 
     test('should return 0 when documentElement.clientHeight is 0 (not fallback to body.clientHeight)', () => {
@@ -60,7 +60,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowHeight()).toBe(0);
+      expect(getViewportHeight()).toBe(0);
     });
 
     test('should return 0 when documentElement.clientHeight not available', () => {
@@ -70,7 +70,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowHeight()).toBe(0);
+      expect(getViewportHeight()).toBe(0);
     });
 
     test('should return 0 when no height sources are available', () => {
@@ -84,15 +84,15 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowHeight()).toBe(0);
+      expect(getViewportHeight()).toBe(0);
     });
   });
 
-  describe('getWindowWidth', () => {
+  describe('getViewportWidth', () => {
     test('should return globalScope.innerWidth when available', () => {
       mockGetGlobalScope.mockReturnValue({ innerWidth: 1200 } as typeof globalThis);
 
-      expect(getWindowWidth()).toBe(1200);
+      expect(getViewportWidth()).toBe(1200);
     });
 
     test('should return document.documentElement.clientWidth when globalScope is null', () => {
@@ -102,7 +102,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowWidth()).toBe(1000);
+      expect(getViewportWidth()).toBe(1000);
     });
 
     test('should return document.documentElement.clientWidth when globalScope.innerWidth not available', () => {
@@ -112,7 +112,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowWidth()).toBe(1000);
+      expect(getViewportWidth()).toBe(1000);
     });
 
     test('should return 0 when documentElement.clientWidth is 0 (not fallback to body.clientWidth)', () => {
@@ -126,7 +126,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowWidth()).toBe(0);
+      expect(getViewportWidth()).toBe(0);
     });
 
     test('should return 0 when documentElement.clientWidth not available', () => {
@@ -136,7 +136,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowWidth()).toBe(0);
+      expect(getViewportWidth()).toBe(0);
     });
 
     test('should return 0 when no width sources are available', () => {
@@ -150,7 +150,7 @@ describe('rrweb utils', () => {
         writable: true,
       });
 
-      expect(getWindowWidth()).toBe(0);
+      expect(getViewportWidth()).toBe(0);
     });
   });
 });


### PR DESCRIPTION
fix(session-replay): remove document.body.clientHeight fallback for viewport height

Removes the problematic fallback to document.body.clientHeight/Width in getWindowHeight() and getWindowWidth() functions, which was causing incorrect viewport measurements.

Problem:
- When window.innerHeight and document.documentElement.clientHeight were unavailable or 0, the code fell back to document.body.clientHeight
- document.body.clientHeight measures full page content height, not viewport height
- This caused incorrect viewport height values (e.g., 14,000px instead of actual viewport ~800px)

Solution:
- Removed document.body.clientHeight/Width from fallback chain
- Now only uses: window.innerHeight → document.documentElement.clientHeight → 0
- Updated tests to reflect this change

This ensures viewport measurements are accurate and prevents inflated height/width values in scroll tracking events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures viewport dimensions are measured correctly and not inflated by page content size.
> 
> - Introduces `getViewportHeight`/`getViewportWidth` (removing `document.body.clientHeight/Width` fallback) and replaces `getWindowHeight/Width` usages
> - Updates `ScrollWatcher` to initialize, compute max scrolls, and emit payloads using new viewport helpers
> - Revises/extends unit tests for `rrweb` utils and `scroll` hook to validate no body fallback and correct behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcad6953030dc378ced7a7455bd36fa7f61978ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->