### PR TITLE
refactor: add direction change observable

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-thrashed-cursor.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-thrashed-cursor.ts
@@ -1,0 +1,61 @@
+import { Observable } from '@amplitude/analytics-core';
+import { AllWindowObservables } from '../frustration-plugin';
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+enum Direction {
+  INCREASING = 'increasing',
+  DECREASING = 'decreasing',
+}
+
+enum Axis {
+  X = 'x',
+  Y = 'y',
+}
+
+export const createMouseDirectionChangeObservable = ({
+  allWindowObservables,
+}: {
+  allWindowObservables: AllWindowObservables;
+}): Observable<Axis> => {
+  const { mouseMoveObservable } = allWindowObservables;
+  return new Observable<Axis>((observer) => {
+    let lastPosition: Position | null = null;
+    let xDirection: Direction | null = null;
+    let yDirection: Direction | null = null;
+    return mouseMoveObservable.subscribe((event) => {
+      const currentPosition = { x: event.clientX, y: event.clientY };
+      if (lastPosition === null) {
+        lastPosition = currentPosition;
+        return;
+      }
+      if (currentPosition.x > lastPosition.x) {
+        if (xDirection === Direction.DECREASING) {
+          observer.next(Axis.X);
+        }
+        xDirection = Direction.INCREASING;
+      } else if (currentPosition.x < lastPosition.x) {
+        if (xDirection === Direction.INCREASING) {
+          observer.next(Axis.X);
+        }
+        xDirection = Direction.DECREASING;
+      }
+
+      if (currentPosition.y > lastPosition.y) {
+        if (yDirection === Direction.DECREASING) {
+          observer.next(Axis.Y);
+        }
+        yDirection = Direction.INCREASING;
+      } else if (currentPosition.y < lastPosition.y) {
+        if (yDirection === Direction.INCREASING) {
+          observer.next(Axis.Y);
+        }
+        yDirection = Direction.DECREASING;
+      }
+      lastPosition = currentPosition;
+    });
+  });
+};

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-thrashed-cursor.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-thrashed-cursor.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import { Observable, Unsubscribable } from '@amplitude/analytics-core';
+import { createMouseDirectionChangeObservable } from '../../src/autocapture/track-thrashed-cursor';
+import { AllWindowObservables } from '../../src/frustration-plugin';
+import { ObservablesEnum } from '../../src/autocapture-plugin';
+
+describe('createMouseDirectionChangeObservable', () => {
+  let mouseMoveObservable: any;
+  let mouseMoveObserver: any;
+  let allWindowObservables: AllWindowObservables;
+  let directionChangeObservable: Observable<string>;
+  let subscription: Unsubscribable | undefined;
+  let subscriptionPromise: Promise<string>;
+
+  beforeEach(() => {
+    mouseMoveObservable = new Observable<any>((observer) => {
+      mouseMoveObserver = observer;
+    });
+
+    allWindowObservables = {
+      [ObservablesEnum.MouseMoveObservable]: mouseMoveObservable,
+    } as AllWindowObservables;
+
+    directionChangeObservable = createMouseDirectionChangeObservable({
+      allWindowObservables,
+    });
+
+    subscriptionPromise = new Promise<string>((resolve) => {
+      subscription = directionChangeObservable.subscribe((axis) => {
+        resolve(axis);
+      });
+    });
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    jest.clearAllMocks();
+  });
+
+  it('should emit X direction change when mouse moves to the right', async () => {
+    mouseMoveObserver.next({ clientX: 1, clientY: 1 });
+    mouseMoveObserver.next({ clientX: 2, clientY: 1 });
+    mouseMoveObserver.next({ clientX: 1, clientY: 1 });
+    const axis = await subscriptionPromise;
+    expect(axis).toEqual('x');
+  });
+
+  it('should emit X direction change when mouse moves to the left', async () => {
+    mouseMoveObserver.next({ clientX: 2, clientY: 1 });
+    mouseMoveObserver.next({ clientX: 1, clientY: 1 });
+    mouseMoveObserver.next({ clientX: 2, clientY: 1 });
+    const axis = await subscriptionPromise;
+    expect(axis).toEqual('x');
+  });
+
+  it('should emit Y direction change when mouse moves up', async () => {
+    mouseMoveObserver.next({ clientX: 1, clientY: 1 });
+    mouseMoveObserver.next({ clientX: 1, clientY: 2 });
+    mouseMoveObserver.next({ clientX: 1, clientY: 1 });
+    const axis = await subscriptionPromise;
+    expect(axis).toEqual('y');
+  });
+
+  it('should emit Y direction change when mouse moves down', async () => {
+    mouseMoveObserver.next({ clientX: 1, clientY: 2 });
+    mouseMoveObserver.next({ clientX: 1, clientY: 1 });
+    mouseMoveObserver.next({ clientX: 1, clientY: 2 });
+    const axis = await subscriptionPromise;
+    expect(axis).toEqual('y');
+  });
+});

--- a/test-server/observables/mouse-direction-change-observable.html
+++ b/test-server/observables/mouse-direction-change-observable.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mouse Direction Change Observables Test</title>
+  </head>
+  <body>
+    <h1>Mouse Direction Change Observables Test</h1>
+    <p>Move your mouse around to see direction changes logged</p>
+    <div id="output"></div>
+    <script type="module">
+      import { createMouseMoveObservable } from '@amplitude/plugin-autocapture-browser/src/observables';
+      import { createMouseDirectionChangeObservable } from '@amplitude/plugin-autocapture-browser/src/autocapture/track-thrashed-cursor';
+      
+      const mouseMoveObservable = createMouseMoveObservable();
+      const allWindowObservables = {
+        mouseMoveObservable,
+      };
+      
+      const mouseDirectionChangeObservable = createMouseDirectionChangeObservable({
+        allWindowObservables,
+      });
+      const output = document.getElementById('output');
+      
+      let directionChangeCount = 0;
+      mouseDirectionChangeObservable.subscribe((axis) => {
+        const log = `#${directionChangeCount++} Direction changed on ${axis} axis`;
+        console.log(log);
+        if (output) {
+          output.textContent = log;
+        }
+      });
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
### Summary

Start the "track-thrashed-cursor" module, and add an observable that tracks mouse direction changes. Uses the [mousemove observable](https://github.com/amplitude/Amplitude-TypeScript/pull/1515) upstream, and then triggers a direction change (x or y axis) when the mouse went from increasing to decreasing (or vice versa).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new, isolated observable logic plus tests; no changes to existing capture/dispatch flows or data handling.
> 
> **Overview**
> Adds `createMouseDirectionChangeObservable` in `track-thrashed-cursor.ts`, which listens to the existing `mouseMoveObservable` and emits `'x'` or `'y'` whenever movement reverses direction on that axis.
> 
> Includes Jest tests covering X/Y reversals and a `test-server` HTML page for manual verification/logging of direction-change events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15546c48f9f4e2161b876153ca94d091e0eb5ccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->