### PR TITLE
fix(session-replay-browser): prevent worker script load failure from blob URLs

### DIFF
--- a/packages/session-replay-browser/rollup.config.js
+++ b/packages/session-replay-browser/rollup.config.js
@@ -162,7 +162,7 @@ async function buildWebWorker() {
     format: 'iife',
     name: 'WebWorker',
     inlineDynamicImports: true,
-    sourcemap: true,
+    sourcemap: false,
   });
   const webWorkerCode = output[0].code;
 


### PR DESCRIPTION
### Summary

Disabled sourcemaps in worker bundle to prevent importScripts failures when loading worker from blob URLs. Added error handling to gracefully fall back to non-worker compression if worker creation or execution fails.

The worker build was generating sourcemap references that couldn't be resolved in blob URL contexts, causing NetworkError when the worker tried to load them.

Not sure of the best way to repro this, but hopefully we can follow the initial sentry issue.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build config and defensive error-handling changes with a clear fallback path; primary risk is reduced worker debugging due to disabled sourcemaps.
> 
> **Overview**
> Prevents session replay compression web workers from failing when loaded from blob URLs by **disabling sourcemaps** for the inlined worker bundle generation.
> 
> Hardens `EventCompressor` web worker usage by wrapping worker creation in `try/catch` and, on worker runtime error, terminating the worker and falling back to in-thread compression; adds a unit test covering `Worker` constructor failure fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac98235eda76bc77e208642576d5615a151da0a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->