### PR TITLE
refactor(plugin-autocapture-browser): fix redundancy in URL checking

### DIFF
--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -40,7 +40,7 @@ export const createShouldTrackEvent = (
   isAlwaysCaptureCursorPointer = false,
 ): shouldTrackEvent => {
   return (actionType: ActionType, element: Element) => {
-    const { pageUrlAllowlist, pageUrlExcludelist, shouldTrackEventResolver } = autocaptureOptions;
+    const { shouldTrackEventResolver } = autocaptureOptions;
 
     /* istanbul ignore next */
     const tag = element?.tagName?.toLowerCase?.();
@@ -53,17 +53,7 @@ export const createShouldTrackEvent = (
       return shouldTrackEventResolver(actionType, element);
     }
 
-    // check if the URL is in the allow list
-    if (!isUrlMatchAllowlist(window.location.href, pageUrlAllowlist)) {
-      return false;
-    }
-
-    // check if the URL is in the excludelist
-    if (
-      pageUrlExcludelist &&
-      pageUrlExcludelist.length > 0 &&
-      isUrlMatchAllowlist(window.location.href, pageUrlExcludelist as (string | RegExp)[])
-    ) {
+    if (!isUrlAllowed(autocaptureOptions)) {
       return false;
     }
 


### PR DESCRIPTION
### Summary

Remove redundant code in plugin-autocapture-browser that checks if URL is valid

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor to centralize URL allowlist/excludelist checks; low risk aside from potential behavior changes if the helper’s order/logic differs from the removed inline checks.
> 
> **Overview**
> Refactors `createShouldTrackEvent` to stop doing inline `pageUrlAllowlist`/`pageUrlExcludelist` checks and instead gate tracking via the shared `isUrlAllowed(autocaptureOptions)` helper.
> 
> This reduces duplicate URL-validation logic (now shared with other autocapture paths like thrashed-cursor tracking) while keeping the `shouldTrackEventResolver` override behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea26c327ca9f101d49aafb879df5046d0f686436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->