### PR TITLE
docs: add session replay SDK team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS file for Amplitude TypeScript repository
+# This file defines code ownership for different parts of the repository.
+# When a pull request is opened that modifies files matching these patterns,
+# the specified teams/individuals will automatically be requested for review.
+#
+# More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Session Replay Packages (Browser)
+# Owned by the Session Replay SDK team
+/packages/session-replay-browser/ @amplitude/session-replay-sdk
+/packages/plugin-session-replay-browser/ @amplitude/session-replay-sdk
+/packages/segment-session-replay-plugin/ @amplitude/session-replay-sdk
+/packages/targeting/ @amplitude/session-replay-sdk


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata-only change affecting review routing; no runtime or build behavior changes.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file to automatically request reviews from `@amplitude/session-replay-sdk` when PRs modify the Session Replay-related packages (`session-replay-browser`, `plugin-session-replay-browser`, `segment-session-replay-plugin`, and `targeting`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee684a2674f76fd9f15d50f9a4eda1c8fe146b79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->