### PR TITLE
feat(segment-session-replay-plugin): integrate TRC targeting evaluation

### DIFF
--- a/packages/segment-session-replay-plugin/README.md
+++ b/packages/segment-session-replay-plugin/README.md
@@ -48,6 +48,39 @@ SegmentAnalytics.track("Immediate Event");
 
 The `sessionReplayOptions` parameter properties match those documented for the [Session Replay Standalone SDK](https://amplitude.com/docs/session-replay/session-replay-standalone-sdk#configuration).
 
+## Targeted Replay Capture (TRC)
+
+This plugin supports [Targeted Replay Capture](https://amplitude.com/docs/session-replay/targeted-replay-capture), which lets you selectively capture session replays based on specific criteria rather than random sampling alone.
+
+### What is TRC?
+
+TRC enables you to define targeting conditions based on:
+- Specific events (e.g., `Checkout Started`)
+- Event properties (e.g., `plan = Pro`)
+- User properties (e.g., `country = US`)
+- Combinations of the above using OR logic
+
+### Configuration
+
+Configure TRC through the Amplitude UI at Settings > Organizational Settings > Session Replay Settings. The SDK automatically fetches and evaluates these targeting conditions at runtime.
+
+### How it works with Segment
+
+The plugin converts Segment events to Amplitude's event format and evaluates targeting conditions for all `track`, `page`, and `identify` events. This ensures that:
+- Targeting conditions are evaluated before capturing session replays
+- User properties from Segment traits are included in targeting evaluation
+- Event properties are properly mapped for targeting rules
+
+### Important notes
+
+- **Browser events only**: TRC evaluation only works for events sent from the Segment browser client. Server-side events are not evaluated for targeting.
+- **Per-session evaluation**: User properties are evaluated based on traits sent with each event in the current session. The plugin does not accumulate or consider user properties from previous sessions or existing user profiles.
+- The SDK fetches targeting configuration at session start and uses it for the entire session
+- Session capture begins only after a target event occurs (no lookback period)
+- Updates to targeting rules only take effect for new sessions
+
+For more information, see the [Targeted Replay Capture documentation](https://amplitude.com/docs/session-replay/targeted-replay-capture).
+
 ## Segment Plugin Architecture
 
 This wrapper makes use of Segment's plugin architecture, which ensures that all `track` and `page` events are decorated

--- a/packages/segment-session-replay-plugin/src/helpers.ts
+++ b/packages/segment-session-replay-plugin/src/helpers.ts
@@ -45,7 +45,7 @@ export const updateSessionIdAndAddProperties = async (ctx: Context, deviceId: st
 
   // Convert Segment event to Amplitude event format for targeting evaluation
   const amplitudeEvent = {
-    event_type: ctx.event.type || ctx.event.event || 'unknown',
+    event_type: ctx.event.event || ctx.event.type || 'unknown',
     event_properties: ctx.event.properties || {},
     user_properties: ctx.event.traits || {},
     time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),

--- a/packages/segment-session-replay-plugin/src/helpers.ts
+++ b/packages/segment-session-replay-plugin/src/helpers.ts
@@ -43,6 +43,17 @@ export const updateSessionIdAndAddProperties = async (ctx: Context, deviceId: st
     await setSessionId(nextSessionId, deviceId);
   }
 
+  // Convert Segment event to Amplitude event format for targeting evaluation
+  const amplitudeEvent = {
+    event_type: ctx.event.type || ctx.event.event || 'unknown',
+    event_properties: ctx.event.properties || {},
+    user_properties: ctx.event.traits || {},
+    time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),
+  };
+
+  // Evaluate targeting and capture decision before enriching with properties
+  await sessionReplay.evaluateTargetingAndCapture({ event: amplitudeEvent });
+
   // Enrich the event with the session replay properties
   // NOTE: This is what will add the `[Amplitude] Session Replay ID` attribute to the event
   const sessionReplayProperties = sessionReplay.getSessionReplayProperties();

--- a/packages/segment-session-replay-plugin/src/helpers.ts
+++ b/packages/segment-session-replay-plugin/src/helpers.ts
@@ -58,7 +58,10 @@ export const updateSessionIdAndAddProperties = async (ctx: Context, deviceId: st
     };
 
     // Evaluate targeting and capture decision before enriching with properties
-    await sessionReplay.evaluateTargetingAndCapture({ event: amplitudeEvent });
+    await sessionReplay.evaluateTargetingAndCapture({
+      event: amplitudeEvent,
+      userProperties: ctx.event.traits || {},
+    });
   }
 
   // Enrich the event with the session replay properties

--- a/packages/segment-session-replay-plugin/src/helpers.ts
+++ b/packages/segment-session-replay-plugin/src/helpers.ts
@@ -43,16 +43,23 @@ export const updateSessionIdAndAddProperties = async (ctx: Context, deviceId: st
     await setSessionId(nextSessionId, deviceId);
   }
 
-  // Convert Segment event to Amplitude event format for targeting evaluation
-  const amplitudeEvent = {
-    event_type: ctx.event.event || ctx.event.type || 'unknown',
-    event_properties: ctx.event.properties || {},
-    user_properties: ctx.event.traits || {},
-    time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),
-  };
+  // Only evaluate targeting if the event belongs to the current session
+  // Skip evaluation for delayed/offline events from older sessions
+  const currentSessionId = getSessionId() || 0;
+  const shouldEvaluateTargeting = !nextSessionId || nextSessionId === currentSessionId;
 
-  // Evaluate targeting and capture decision before enriching with properties
-  await sessionReplay.evaluateTargetingAndCapture({ event: amplitudeEvent });
+  if (shouldEvaluateTargeting) {
+    // Convert Segment event to Amplitude event format for targeting evaluation
+    const amplitudeEvent = {
+      event_type: ctx.event.event || ctx.event.type || 'unknown',
+      event_properties: ctx.event.properties || {},
+      user_properties: ctx.event.traits || {},
+      time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),
+    };
+
+    // Evaluate targeting and capture decision before enriching with properties
+    await sessionReplay.evaluateTargetingAndCapture({ event: amplitudeEvent });
+  }
 
   // Enrich the event with the session replay properties
   // NOTE: This is what will add the `[Amplitude] Session Replay ID` attribute to the event

--- a/packages/segment-session-replay-plugin/src/index.ts
+++ b/packages/segment-session-replay-plugin/src/index.ts
@@ -3,7 +3,7 @@ import { Analytics, Context, Plugin, User } from '@segment/analytics-next';
 
 import { DEBUG_LOG_PREFIX, PLUGIN_NAME, PLUGIN_TYPE } from './constants';
 import { getSessionId, setSessionId, updateSessionIdAndAddProperties } from './helpers';
-import { PluginOptions } from './typings/wrapper';
+import { AmplitudeIntegrationData, PluginOptions } from './typings/wrapper';
 import { VERSION } from './version';
 
 export const createSegmentActionsPlugin = async ({
@@ -77,17 +77,28 @@ export const createSegmentActionsPlugin = async ({
         await setSessionId(sessionId, deviceId);
       }
 
-      // Evaluate targeting for identify events with user properties
-      const amplitudeEvent = {
-        event_type: 'identify',
-        user_properties: ctx.event.traits || {},
-        time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),
-      };
+      // Only evaluate targeting if the event belongs to the current session
+      // Skip evaluation for delayed/offline events from older sessions
+      const currentSessionId = getSessionId() || 0;
+      let nextSessionId: number | undefined;
+      if (ctx.event.integrations && (ctx.event.integrations['Actions Amplitude'] as AmplitudeIntegrationData)) {
+        nextSessionId = (ctx.event.integrations['Actions Amplitude'] as AmplitudeIntegrationData).session_id;
+      }
+      const shouldEvaluateTargeting = !nextSessionId || nextSessionId === currentSessionId;
 
-      await sessionReplay.evaluateTargetingAndCapture({
-        event: amplitudeEvent,
-        userProperties: ctx.event.traits || {},
-      });
+      if (shouldEvaluateTargeting) {
+        // Evaluate targeting for identify events with user properties
+        const amplitudeEvent = {
+          event_type: 'identify',
+          user_properties: ctx.event.traits || {},
+          time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),
+        };
+
+        await sessionReplay.evaluateTargetingAndCapture({
+          event: amplitudeEvent,
+          userProperties: ctx.event.traits || {},
+        });
+      }
 
       return ctx;
     },

--- a/packages/segment-session-replay-plugin/src/index.ts
+++ b/packages/segment-session-replay-plugin/src/index.ts
@@ -77,6 +77,18 @@ export const createSegmentActionsPlugin = async ({
         await setSessionId(sessionId, deviceId);
       }
 
+      // Evaluate targeting for identify events with user properties
+      const amplitudeEvent = {
+        event_type: 'identify',
+        user_properties: ctx.event.traits || {},
+        time: ctx.event.timestamp ? new Date(ctx.event.timestamp).getTime() : Date.now(),
+      };
+
+      await sessionReplay.evaluateTargetingAndCapture({
+        event: amplitudeEvent,
+        userProperties: ctx.event.traits || {},
+      });
+
       return ctx;
     },
   };

--- a/packages/segment-session-replay-plugin/test/helpers.test.ts
+++ b/packages/segment-session-replay-plugin/test/helpers.test.ts
@@ -286,7 +286,7 @@ describe('updateSessionIdAndAddProperties()', () => {
     expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledTimes(1);
     expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledWith({
       event: {
-        event_type: 'track',
+        event_type: 'Button Clicked',
         event_properties: {
           buttonName: 'Submit',
         },
@@ -323,7 +323,7 @@ describe('updateSessionIdAndAddProperties()', () => {
     // Assert
     expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledWith({
       event: {
-        event_type: 'track',
+        event_type: 'Button Clicked',
         event_properties: {},
         user_properties: {},
         time: mockNow,

--- a/packages/segment-session-replay-plugin/test/helpers.test.ts
+++ b/packages/segment-session-replay-plugin/test/helpers.test.ts
@@ -295,6 +295,9 @@ describe('updateSessionIdAndAddProperties()', () => {
         },
         time: new Date('2024-01-01T00:00:00Z').getTime(),
       },
+      userProperties: {
+        email: 'test@example.com',
+      },
     });
   });
 
@@ -328,6 +331,7 @@ describe('updateSessionIdAndAddProperties()', () => {
         user_properties: {},
         time: mockNow,
       },
+      userProperties: {},
     });
   });
 
@@ -353,6 +357,7 @@ describe('updateSessionIdAndAddProperties()', () => {
       event: expect.objectContaining({
         event_type: 'unknown',
       }),
+      userProperties: {},
     });
   });
 
@@ -378,6 +383,7 @@ describe('updateSessionIdAndAddProperties()', () => {
       event: expect.objectContaining({
         event_type: 'Custom Event Name',
       }),
+      userProperties: {},
     });
   });
 
@@ -406,6 +412,7 @@ describe('updateSessionIdAndAddProperties()', () => {
         user_properties: {},
         time: new Date('2024-01-01T00:00:00Z').getTime(),
       },
+      userProperties: {},
     });
   });
 
@@ -474,6 +481,7 @@ describe('updateSessionIdAndAddProperties()', () => {
         user_properties: { email: 'test@example.com' },
         time: new Date('2024-01-01T00:00:00Z').getTime(),
       },
+      userProperties: { email: 'test@example.com' },
     });
   });
 
@@ -498,5 +506,11 @@ describe('updateSessionIdAndAddProperties()', () => {
 
     // Assert - targeting should be evaluated when no session_id is provided
     expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledTimes(1);
+    expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledWith({
+      event: expect.objectContaining({
+        event_type: 'Button Clicked',
+      }),
+      userProperties: {},
+    });
   });
 });

--- a/packages/segment-session-replay-plugin/test/index.test.ts
+++ b/packages/segment-session-replay-plugin/test/index.test.ts
@@ -47,6 +47,7 @@ describe('createSegmentActionsPlugin()', () => {
     jest.clearAllMocks();
 
     (sessionReplay.init as jest.Mock).mockResolvedValue({ promise: Promise.resolve() });
+    (sessionReplay.evaluateTargetingAndCapture as jest.Mock).mockResolvedValue(undefined);
   });
 
   it('should call segmentInstance.register() with the plugin', async () => {
@@ -320,6 +321,106 @@ describe('createSegmentActionsPlugin()', () => {
 
       // Assert
       expect(setSessionId).not.toHaveBeenCalled();
+    });
+
+    it('should call evaluateTargetingAndCapture with user properties', async () => {
+      // Arrange
+      const contextWithTraits: Context = {
+        event: {
+          type: 'identify',
+          traits: {
+            email: 'test@example.com',
+            name: 'Test User',
+          },
+          timestamp: new Date('2024-01-01T00:00:00Z'),
+        },
+        updateEvent: jest.fn(),
+      } as unknown as Context;
+
+      (getSessionId as jest.Mock).mockReturnValue(123);
+
+      await createSegmentActionsPlugin({
+        segmentInstance: DEFAULT_SEGMENT_INSTANCE,
+        amplitudeApiKey: API_KEY,
+        sessionReplayOptions: {
+          ...DEFAULT_SESSION_REPLAY_OPTIONS,
+          deviceId: DEVICE_ID,
+        },
+      });
+
+      const plugin = getPlugin(DEFAULT_SEGMENT_INSTANCE);
+
+      // NOTE: load() must be called before identify()
+      await plugin.load(DEFAULT_CONTEXT, DEFAULT_ANALYTICS);
+
+      // Act
+      plugin.identify && (await plugin.identify(contextWithTraits));
+
+      // Assert
+      expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledWith({
+        event: {
+          event_type: 'identify',
+          user_properties: {
+            email: 'test@example.com',
+            name: 'Test User',
+          },
+          time: new Date('2024-01-01T00:00:00Z').getTime(),
+        },
+        userProperties: {
+          email: 'test@example.com',
+          name: 'Test User',
+        },
+      });
+    });
+
+    it('should call evaluateTargetingAndCapture with current time when timestamp is undefined', async () => {
+      // Arrange
+      const mockNow = 1640000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(mockNow);
+
+      const contextWithTraits: Context = {
+        event: {
+          type: 'identify',
+          traits: {
+            email: 'test@example.com',
+          },
+          // No timestamp provided
+        },
+        updateEvent: jest.fn(),
+      } as unknown as Context;
+
+      (getSessionId as jest.Mock).mockReturnValue(123);
+
+      await createSegmentActionsPlugin({
+        segmentInstance: DEFAULT_SEGMENT_INSTANCE,
+        amplitudeApiKey: API_KEY,
+        sessionReplayOptions: {
+          ...DEFAULT_SESSION_REPLAY_OPTIONS,
+          deviceId: DEVICE_ID,
+        },
+      });
+
+      const plugin = getPlugin(DEFAULT_SEGMENT_INSTANCE);
+
+      // NOTE: load() must be called before identify()
+      await plugin.load(DEFAULT_CONTEXT, DEFAULT_ANALYTICS);
+
+      // Act
+      plugin.identify && (await plugin.identify(contextWithTraits));
+
+      // Assert
+      expect(sessionReplay.evaluateTargetingAndCapture).toHaveBeenCalledWith({
+        event: {
+          event_type: 'identify',
+          user_properties: {
+            email: 'test@example.com',
+          },
+          time: mockNow,
+        },
+        userProperties: {
+          email: 'test@example.com',
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
### Summary

Added evaluateTargetingAndCapture calls to enable TRC (Targeted Replay Capture) capabilities in the Segment session replay plugin. This brings feature parity with the browser plugin by evaluating targeting conditions before capturing session replays.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when session replay capture may start by adding TRC evaluation to the event pipeline; incorrect session-id gating or event mapping could cause replays to be over/under-captured, but the logic is scoped and covered by new unit tests.
> 
> **Overview**
> Adds Targeted Replay Capture support to the Segment session replay plugin by calling `sessionReplay.evaluateTargetingAndCapture` for `track`/`page` (via `updateSessionIdAndAddProperties`) and `identify` events, converting Segment payloads into Amplitude event format and passing Segment traits as user properties.
> 
> Targeting evaluation is *skipped for delayed/offline events from older sessions* by comparing the event’s `integrations['Actions Amplitude'].session_id` to the current session, and tests/docs are expanded to cover TRC behavior, timestamp fallbacks, and session gating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1cec704fa8d2c390d4ad8a75f3da56c8ac3dd24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->