### PR TITLE
fix(analytics-browser): cookie re-entrancy problem in isEnabled

### DIFF
--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -23,7 +23,6 @@ type GlobalScopeWithCookieStore = {
 export class CookieStorage<T> implements Storage<T> {
   options: CookieStorageOptions;
   config: CookieStorageConfig;
-  private static testValue: undefined | string;
 
   constructor(options?: CookieStorageOptions, config: CookieStorageConfig = {}) {
     this.options = { ...options };
@@ -36,7 +35,7 @@ export class CookieStorage<T> implements Storage<T> {
       return false;
     }
 
-    CookieStorage.testValue = String(Date.now());
+    const testValue = String(Date.now());
     const testCookieOptions = {
       ...this.options,
       expirationDays: 0.003, // expire in ~5 minutes
@@ -44,9 +43,9 @@ export class CookieStorage<T> implements Storage<T> {
     const testStorage = new CookieStorage<string>(testCookieOptions);
     const testKey = `AMP_TEST_${UUID().substring(0, 8)}`;
     try {
-      await testStorage.set(testKey, CookieStorage.testValue);
+      await testStorage.set(testKey, testValue);
       const value = await testStorage.get(testKey);
-      return value === CookieStorage.testValue;
+      return value === testValue;
     } catch {
       /* istanbul ignore next */
       return false;

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -9,6 +9,14 @@ import * as GlobalScopeModule from '../../src/global-scope';
 
 describe('cookies', () => {
   describe('isEnabled', () => {
+    test('regression test re-entrancy issue', async () => {
+      const c1 = new CookieStorage();
+      const c2 = new CookieStorage();
+      // calling isEnabled one after the other should not cause a re-entrancy issue
+      const promises = [c1.isEnabled(), c2.isEnabled()];
+      const res = await Promise.all(promises);
+      expect(res).toEqual([true, true]);
+    });
     test('should return true', async () => {
       const cookies = new CookieStorage();
       expect(await cookies.isEnabled()).toBe(true);

--- a/test-server/cookies/is-enabled.html
+++ b/test-server/cookies/is-enabled.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>cookie isEnabled</title>
+</head>
+<body>
+  <pre id="out"></pre>
+  <script type="module">
+    import { CookieStorage } from '@amplitude/analytics-core';
+
+    const out = document.getElementById('out');
+
+    function log(msg) {
+      out.textContent += msg + '\n';
+    }
+
+    async function run() {
+      const c1 = new CookieStorage();
+      const c2 = new CookieStorage();
+
+      const promises = [
+        c1.isEnabled(),
+        c2.isEnabled(),
+        c1.isEnabled(),
+        c2.isEnabled(),
+      ];
+      const res = await Promise.all(promises);
+
+      const allTrue = res.every((r) => r === true);
+      log('Parallel calls: ' + JSON.stringify(res));
+      log('All true: ' + allTrue);
+
+      const a = await c1.isEnabled();
+      const b = await c1.isEnabled();
+      const c = await c2.isEnabled();
+      log('Sequential c1.isEnabled(): ' + a + ', ' + b);
+      log('Sequential c2.isEnabled(): ' + c);
+      log('All true: ' + (a && b && c));
+    }
+
+    run().catch((e) => {
+      log('Error: ' + e.message);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Summary

Change "CookieStorage" isEnabled function to set "testValue" as a local variable instead of a static variable, which can cause re-entrancy issues.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to cookie availability probing plus added tests; low risk aside from subtle behavior differences under concurrent calls.
> 
> **Overview**
> Fixes a re-entrancy/race issue in `CookieStorage.isEnabled()` by removing the shared static `testValue` and using a per-call local value when writing/reading the temporary probe cookie.
> 
> Adds a Jest regression test that runs `isEnabled()` concurrently across instances, and includes a simple `test-server` HTML page to manually verify parallel and sequential `isEnabled()` calls stay consistently `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a661c4a64c363ce5939e3f6b17e78a5b98a1ab8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->