### PR TITLE
fix(autocapture): remove cloneNode in getText can cause duplicate network requests

### DIFF
--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -250,10 +250,7 @@ export class DataExtractor {
     const maskedSelector = `[${TEXT_MASK_ATTRIBUTE}], [contenteditable]`;
     // Fast path: if no masked descendants exist, rely on native text extraction.
     if (!element.querySelector(maskedSelector)) {
-      if (element instanceof HTMLElement) {
-        return element.innerText || '';
-      }
-      return element.textContent || '';
+      return (element as HTMLElement).innerText;
     }
 
     let output = '';
@@ -273,10 +270,8 @@ export class DataExtractor {
         output += MASKED_TEXT_VALUE;
         continue;
       }
-
       output += this.getTextWithMaskedDescendants(childNode);
     }
-
     return output;
   };
 


### PR DESCRIPTION
https://amplitude.atlassian.net/browse/AMP-149318

### Summary

The Cause:
- The text masking logic was temporarily creating duplicate DOM nodes in memory. When a <video> node was duplicated—even for a split second—the browser automatically initiated a new network request for its source.
- This same duplication issue affected SVGs, triggering extra network requests (most noticeably when "Disable Cache" was checked in DevTools).

Fix: 
- Updated the text masking implementation to prevent the unintended in-memory duplication of DOM nodes.

This eliminates the redundant media network requests and cleans up the memory footprint.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
