### PR TITLE
fix: import globalScope from named versus root

### DIFF
--- a/packages/analytics-core/src/observers/network.ts
+++ b/packages/analytics-core/src/observers/network.ts
@@ -1,4 +1,4 @@
-import { getGlobalScope } from '..';
+import { getGlobalScope } from '../global-scope';
 import { UUID } from '../utils/uuid';
 import { ILogger } from '../logger';
 import {


### PR DESCRIPTION
### Summary

Fixes compilation issue found in https://github.com/amplitude/Amplitude-TypeScript/issues/1549

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-path change to resolve a build error; no logic or data handling behavior changes.
> 
> **Overview**
> Fixes a compilation/runtime import issue in `packages/analytics-core/src/observers/network.ts` by changing the `getGlobalScope` import from the package root (`'..'`) to the dedicated module (`'../global-scope'`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9d2d2b401958dd0937f562405f083e1731e8e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->