### PR TITLE
fix: early return isEnabled false when document not present

### DIFF
--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -30,8 +30,9 @@ export class CookieStorage<T> implements Storage<T> {
   }
 
   async isEnabled(): Promise<boolean> {
+    const globalScope = getGlobalScope();
     /* istanbul ignore if */
-    if (!getGlobalScope()) {
+    if (!globalScope || !globalScope.document) {
       return false;
     }
 

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -21,6 +21,11 @@ describe('cookies', () => {
       const cookies = new CookieStorage();
       expect(await cookies.isEnabled()).toBe(true);
     });
+    test('should return false when document is not available', async () => {
+      jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValueOnce({} as typeof globalThis);
+      const cookies = new CookieStorage();
+      expect(await cookies.isEnabled()).toBe(false);
+    });
   });
 
   describe('get', () => {


### PR DESCRIPTION
### Summary

Return `false` for CookieStorage.isEnabled if `document` is not present. No `document` implies that it's not a web environment (React Native, Node, Web Worker, etc...)

This is so that non-web environments don't go through the process if reading and writing test cookies to check `isEnabled`.

(resolution for a problem identified in: https://github.com/amplitude/Amplitude-TypeScript/issues/1549)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard change to avoid cookie read/write attempts in non-browser environments; risk is limited to potentially changing enabled/disabled behavior where `document` is unexpectedly missing.
> 
> **Overview**
> `CookieStorage.isEnabled()` now early-returns `false` when `getGlobalScope()` is missing **or** when `document` is unavailable, preventing the test-cookie write/read probe in non-web environments.
> 
> Adds a unit test that mocks `getGlobalScope()` to return an object without `document` and asserts `isEnabled()` returns `false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ba4778e4c655db744703821dff68cd34e3436c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->