### PR TITLE
chore(session-replay): bump native iOS and Android dependency versions

### DIFF
--- a/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
+++ b/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.4.0'
+  s.dependency 'AmplitudeSessionReplay', '>=0.9.5'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/plugin-session-replay-react-native/android/build.gradle
+++ b/packages/plugin-session-replay-react-native/android/build.gradle
@@ -90,8 +90,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-    implementation("com.amplitude:session-replay-android:[0.22.0,0.23.0)")
-    implementation("com.amplitude:analytics-android:[1.22.4,1.23.0)")
+    implementation("com.amplitude:session-replay-android:[0.24.0,0.25.0)")
+    implementation("com.amplitude:analytics-android:[1.25.0,1.26.0)")
 
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin

--- a/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
+++ b/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.4.0'
-  s.dependency 'AmplitudeCore', '>=1.1.0'
+  s.dependency 'AmplitudeSessionReplay', '>=0.9.5'
+  s.dependency 'AmplitudeCore', '>=1.4.2'
 
   # This code is to support RN prior to 0.71.0. Should be removed when we drop support for RN < 0.71.0.
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.

--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -90,8 +90,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.amplitude:session-replay-android:[0.22.0,0.23.0)")
-  implementation("com.amplitude:analytics-android:[1.22.4,1.23.0)")
+  implementation("com.amplitude:session-replay-android:[0.24.0,0.25.0)")
+  implementation("com.amplitude:analytics-android:[1.25.0,1.26.0)")
 
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin


### PR DESCRIPTION
Update AmplitudeSessionReplay iOS pod from >=0.4.0 to >=0.9.5 and AmplitudeCore from >=1.1.0 to >=1.4.2. Update Android session-replay-android from [0.22.0,0.23.0) to [0.24.0,0.25.0) and analytics-android from [1.22.4,1.23.0) to [1.25.0,1.26.0). Applied to both session-replay-react-native and plugin-session-replay-react-native packages.

Jira: SR-2264

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only bump, but it changes underlying native SDK behavior and binary compatibility on both iOS and Android, which can surface runtime regressions.
> 
> **Overview**
> Upgrades native dependencies for both `session-replay-react-native` and `plugin-session-replay-react-native`.
> 
> On iOS, bumps `AmplitudeSessionReplay` to `>=0.9.5` (from `>=0.4.0`) and updates `AmplitudeCore` to `>=1.4.2` in `AmplitudeSessionReplayReactNative.podspec`. On Android, updates the Gradle ranges to `session-replay-android` `[0.24.0,0.25.0)` and `analytics-android` `[1.25.0,1.26.0)` (from `[0.22.0,0.23.0)` and `[1.22.4,1.23.0)` respectively).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 011c3be5d16030ddf392c421d5e2ffdf442cb8c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->