### PR TITLE
fix(analytics-browser): duplicate cookie resolution bugfix

### DIFF
--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -227,6 +227,9 @@ export const decodeCookieValue = (value: string): string | undefined => {
  * are effectively equivalent for cookie scoping.
  */
 export const isDomainEqual = (domain1: string | undefined, domain2: string | undefined): boolean => {
+  if (domain1 === '' && domain2 === '') {
+    return true;
+  }
   if (!domain1 || !domain2) {
     return false;
   }

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -412,6 +412,16 @@ describe('cookies', () => {
       expect(isDomainEqual('domain.com', 'www.domain.com')).toBe(false);
       expect(isDomainEqual('www.domain.com', 'domain.com')).toBe(false);
     });
+
+    describe('empty values and empty strings', () => {
+      test('should return true when both domains are empty strings', () => {
+        expect(isDomainEqual('', '')).toBe(true);
+      });
+      test('should return false if one domain is empty string and other is falsey', () => {
+        expect(isDomainEqual('', undefined)).toBe(false);
+        expect(isDomainEqual(undefined, '')).toBe(false);
+      });
+    });
   });
 
   describe('decodeCookieValue', () => {


### PR DESCRIPTION
### Summary

Bugfix. The "isDomainEqual" function is used in our duplicate cookie resolution algorithm. If there's multiple cookies, it will look for the cookie that has the matching `cookieDomain` set to `cookieOptions.domain`. This had a defect where it checks if either of the domains are "falsey" and returns "false". It missed the case where both domains being compared could both be empty strings.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small logic tweak in `isDomainEqual` plus tests; behavior only changes for the edge case where both compared cookie domains are empty strings.
> 
> **Overview**
> Fixes duplicate-cookie domain matching by updating `isDomainEqual` to return `true` when *both* domains are empty strings (previously treated as falsey and returned `false`).
> 
> Adds focused unit tests covering the empty-string/undefined combinations to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42a931d51bcf7e36d2de498bf1d17008b330d1de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->