### PR TITLE
fix(analytics-browser): skip localhost + single word domain on TLD check

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -497,7 +497,7 @@ export const getTopLevelDomain = async (url?: string, diagnosticsClient?: IDiagn
   const parts = host.split('.');
 
   // if hostname has less than 2 parts, it's not a registrable domain
-  // and the browser won't allow setting cookies for it so return empty string
+  // and the browser won't allow setting domain-scoped cookies for it so return empty string
   if (parts.length === 1) {
     return '';
   }

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -175,106 +175,119 @@ describe('config', () => {
       expect(config.storageProvider).toEqual(expect.any(MemoryStorage));
     });
 
-    test('should create using cookies/overwrite', async () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          hostname: 'amplitude.com',
-        },
-        configurable: true,
+    describe('with location override', () => {
+      const originalLocation = window.location;
+      beforeAll(() => {
+        Object.defineProperty(window, 'location', {
+          value: { hostname: 'amplitude.com' },
+          configurable: true,
+        });
       });
-      const cookieStorage = new core.MemoryStorage<UserSession>();
-      await cookieStorage.set(getCookieName(apiKey), {
-        deviceId: 'device-device-device',
-        sessionId: -1,
-        userId: 'user-user-user',
-        lastEventId: 100,
-        lastEventTime: 1,
-        optOut: false,
+      afterAll(() => {
+        Object.defineProperty(window, 'location', { value: originalLocation, configurable: true });
       });
-      const logger = new core.Logger();
-      logger.enable(LogLevel.Warn);
-      jest.spyOn(Config, 'createCookieStorage').mockReturnValueOnce(cookieStorage);
-      const config = await Config.useBrowserConfig(
-        apiKey,
-        {
+      test('should create using cookies/overwrite', async () => {
+        Object.defineProperty(window, 'location', {
+          value: {
+            hostname: 'amplitude.com',
+          },
+          configurable: true,
+        });
+        const cookieStorage = new core.MemoryStorage<UserSession>();
+        await cookieStorage.set(getCookieName(apiKey), {
           deviceId: 'device-device-device',
           sessionId: -1,
           userId: 'user-user-user',
-          partnerId: 'partnerId',
-          plan: {
-            version: '0',
+          lastEventId: 100,
+          lastEventTime: 1,
+          optOut: false,
+        });
+        const logger = new core.Logger();
+        logger.enable(LogLevel.Warn);
+        jest.spyOn(Config, 'createCookieStorage').mockReturnValueOnce(cookieStorage);
+        const config = await Config.useBrowserConfig(
+          apiKey,
+          {
+            deviceId: 'device-device-device',
+            sessionId: -1,
+            userId: 'user-user-user',
+            partnerId: 'partnerId',
+            plan: {
+              version: '0',
+            },
+            ingestionMetadata: {
+              sourceName: 'ampli',
+              sourceVersion: '2.0.0',
+            },
+            sessionTimeout: 1,
+            cookieOptions: {
+              domain: '.amplitude.com',
+              upgrade: false,
+            },
+            defaultTracking: true,
+            offline: true,
           },
+          new AmplitudeBrowser(),
+        );
+
+        expect(config).toEqual({
+          _cookieStorage: expect.any(MemoryStorage),
+          _deviceId: 'device-device-device',
+          _lastEventId: 100,
+          _lastEventTime: 1,
+          _optOut: false,
+          _sessionId: -1,
+          _userId: 'user-user-user',
+          apiKey,
+          appVersion: undefined,
+          cookieOptions: {
+            domain: '.amplitude.com',
+            expiration: 365,
+            sameSite: 'Lax',
+            secure: false,
+            upgrade: false,
+          },
+          defaultTracking: true,
+          flushIntervalMillis: 1000,
+          flushMaxRetries: 5,
+          flushQueueSize: 30,
+          identityStorage: DEFAULT_IDENTITY_STORAGE,
           ingestionMetadata: {
             sourceName: 'ampli',
             sourceVersion: '2.0.0',
           },
-          sessionTimeout: 1,
-          cookieOptions: {
-            domain: '.amplitude.com',
-            upgrade: false,
-          },
-          defaultTracking: true,
+          logLevel: 2,
+          loggerProvider: logger,
+          minIdLength: undefined,
           offline: true,
-        },
-        new AmplitudeBrowser(),
-      );
-      expect(config).toEqual({
-        _cookieStorage: expect.any(MemoryStorage),
-        _deviceId: 'device-device-device',
-        _lastEventId: 100,
-        _lastEventTime: 1,
-        _optOut: false,
-        _sessionId: -1,
-        _userId: 'user-user-user',
-        apiKey,
-        appVersion: undefined,
-        cookieOptions: {
-          domain: '.amplitude.com',
-          expiration: 365,
-          sameSite: 'Lax',
-          secure: false,
-          upgrade: false,
-        },
-        defaultTracking: true,
-        flushIntervalMillis: 1000,
-        flushMaxRetries: 5,
-        flushQueueSize: 30,
-        identityStorage: DEFAULT_IDENTITY_STORAGE,
-        ingestionMetadata: {
-          sourceName: 'ampli',
-          sourceVersion: '2.0.0',
-        },
-        logLevel: 2,
-        loggerProvider: logger,
-        minIdLength: undefined,
-        offline: true,
-        partnerId: 'partnerId',
-        plan: {
-          version: '0',
-        },
-        serverUrl: '',
-        serverZone: DEFAULT_SERVER_ZONE,
-        sessionTimeout: 1,
-        storageProvider: someLocalStorage,
-        trackingOptions: {
-          ipAddress: true,
-          language: true,
-          platform: true,
-        },
-        transport: 'fetch',
-        transportProvider: expect.any(FetchTransport),
-        useBatch: false,
-        fetchRemoteConfig: true,
-        version: VERSION,
-        enableDiagnostics: true,
-        diagnosticsSampleRate: 0,
-        diagnosticsClient: undefined,
-        remoteConfig: {
+          partnerId: 'partnerId',
+          plan: {
+            version: '0',
+          },
+          serverUrl: '',
+          serverZone: DEFAULT_SERVER_ZONE,
+          sessionTimeout: 1,
+          storageProvider: someLocalStorage,
+          trackingOptions: {
+            ipAddress: true,
+            language: true,
+            platform: true,
+          },
+          transport: 'fetch',
+          transportProvider: expect.any(FetchTransport),
+          useBatch: false,
           fetchRemoteConfig: true,
-        },
-        topLevelDomain: 'amplitude.com',
-        enableRequestBodyCompression: false,
-        _enableRequestBodyCompressionExperimental: false,
+          version: VERSION,
+          enableDiagnostics: true,
+          diagnosticsSampleRate: 0,
+          diagnosticsClient: undefined,
+          remoteConfig: {
+            fetchRemoteConfig: true,
+          },
+          topLevelDomain: 'amplitude.com',
+          enableRequestBodyCompression: false,
+          _enableRequestBodyCompressionExperimental: false,
+        });
       });
     });
 
@@ -394,15 +407,14 @@ describe('config', () => {
 
   describe('getTopLevelDomain', () => {
     test('should return empty string for localhost', async () => {
-      // jest env hostname is localhost
       const isDomainWritableSpy = jest.spyOn(BrowserUtils.CookieStorage, 'isDomainWritable');
-      const domain = await Config.getTopLevelDomain('localhost');
+      const domain = await Config.getTopLevelDomain(undefined);
       expect(isDomainWritableSpy).not.toHaveBeenCalled();
       expect(domain).toBe('');
+      isDomainWritableSpy.mockRestore();
     });
 
     test('should return empty string for single part hostname', async () => {
-      // jest env hostname is localhost
       const isDomainWritableSpy = jest.spyOn(BrowserUtils.CookieStorage, 'isDomainWritable');
       const domain = await Config.getTopLevelDomain('mylocaldomain');
       expect(isDomainWritableSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
### Summary

If the host is "localhost" (or a single word host, like on specific in /etc/hosts) it won't have a "top level domain" that can be settable as a cookie parameter. Skip these so that 1: we can save these users a disk write; 2: less event volume diagnostics; 3: no unnecessary error messages in Firefox due to failed cookie writes

<img width="1501" height="805" alt="Screenshot 2026-03-10 at 1 20 08 PM" src="https://github.com/user-attachments/assets/9180f2a7-aca5-410e-9da6-93874687e845" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to domain-detection logic with added coverage; risk is limited to cookie-domain selection behavior on edge-case hostnames.
> 
> **Overview**
> `getTopLevelDomain` now returns `''` immediately for single-label hostnames (e.g., `localhost` or custom `/etc/hosts` entries), skipping `CookieStorage.isDomainWritable` probing that can’t succeed and can generate noisy cookie-write errors/diagnostics.
> 
> Tests were updated to assert `isDomainWritable` is not called for these cases and to make the window `location` override setup/teardown more robust.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5f27299cb64780ec99bd0e9779ecdac9da13c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->