### PR TITLE
fix(analytics-core): remote config should not retry client side error except 429

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -31,6 +31,7 @@ import {
   createIdentifyEvent,
   Logger,
   safeJsonStringify,
+  LogLevel,
 } from '@amplitude/analytics-core';
 import {
   getAttributionTrackingConfig,
@@ -121,6 +122,9 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
     // Set up early dependencies needed for remote config client
     // These use options directly or fall back to defaults
     const loggerProvider = options.loggerProvider ?? new Logger();
+    if (!options.loggerProvider) {
+      loggerProvider.enable(options.logLevel ?? LogLevel.Warn);
+    }
     const serverZone = options.serverZone ?? DEFAULT_SERVER_ZONE;
 
     let remoteConfigClient: IRemoteConfigClient | undefined;

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -357,6 +357,9 @@ export class RemoteConfigClient implements IRemoteConfigClient {
           this.logger.debug(`Remote config client fetch with retry time ${retries} failed with ${res.status}: ${body}`);
 
           if (res.status === CODE_STATUS.INVALID_API_KEY) {
+            this.logger.error(
+              `Remote config client fetch failed with ${CODE_STATUS.INVALID_API_KEY}. Invalid API key; future fetches will be skipped.`,
+            );
             this.isLastFetchInvalidApiKey = true;
             shouldRetry = false;
           } else if (res.status >= 400 && res.status < 500 && res.status !== CODE_STATUS.RATE_LIMIT) {

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -43,10 +43,12 @@ const testKey = 'browser';
 describe('RemoteConfigClient', () => {
   let client: RemoteConfigClient;
   let loggerDebug: jest.SpyInstance;
+  let loggerError: jest.SpyInstance;
   let storageFetchConfig: jest.SpyInstance;
 
   beforeEach(() => {
     loggerDebug = jest.spyOn(mockLogger, 'debug');
+    loggerError = jest.spyOn(mockLogger, 'error');
     storageFetchConfig = jest.spyOn(mockStorage, 'fetchConfig');
 
     (RemoteConfigLocalStorage as jest.Mock).mockImplementation(() => mockStorage);
@@ -259,6 +261,10 @@ describe('RemoteConfigClient', () => {
       await client.updateConfigs();
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(loggerDebug).toHaveBeenCalledWith('Remote config client skipping fetch: Invalid API key');
+      expect(loggerError).toHaveBeenCalledTimes(1);
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining('Remote config client fetch failed with 401. Invalid API key'),
+      );
     });
   });
 
@@ -924,6 +930,10 @@ describe('RemoteConfigClient', () => {
       expect(client.isLastFetchInvalidApiKey).toBe(true);
       expect(loggerDebug).toHaveBeenCalledTimes(1);
       expect(loggerDebug).toHaveBeenCalledWith(expect.stringContaining('failed with 401'));
+      expect(loggerError).toHaveBeenCalledTimes(1);
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining('Remote config client fetch failed with 401. Invalid API key'),
+      );
     });
 
     test('should retry on rate limit and recover', async () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Apply the same logic of Swift remote config client: https://github.com/amplitude/AmplitudeCore-Swift/pull/66

- 401 indicates invalid api key, prevent future fetch calls and no retry
- No retery for client side errors 4xx except 429 rate limit
<img width="2559" height="607" alt="image" src="https://github.com/user-attachments/assets/709bf8a8-a11f-486d-a876-30230c7f1e0a" />


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-config fetch retry/short-circuit behavior, which can affect whether clients refresh configuration and how they behave under error responses. Risk is moderate due to altered network/backoff semantics but is covered by added unit tests for 400/401/429 and invalid-key short-circuiting.
> 
> **Overview**
> Remote config fetching now **stops retrying on client errors**: `fetch()` will not retry on `401` (marks the API key as invalid) or other `4xx` responses except `429` rate limiting, while still retrying on `5xx` and network/timeout failures.
> 
> Once a `401` is observed, `RemoteConfigClient` **short-circuits future `updateConfigs()`/`getOrCreateFetchPromise()` calls** to avoid repeated requests, returning a null config and logging the skip. Tests were expanded to validate the new retry matrix and the “invalid API key” skip behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 802a182047694b646650d9af94bcf3fcaf72b3ce. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->