### PR TITLE
feat(plugin-custom-enrichment): change expected custom enrichment code to function

### DIFF
--- a/packages/plugin-custom-enrichment-browser/src/custom-enrichment.ts
+++ b/packages/plugin-custom-enrichment-browser/src/custom-enrichment.ts
@@ -28,13 +28,16 @@ export const customEnrichmentPlugin = (): EnrichmentPlugin => {
     if (body) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-implied-eval
-        return new Function('event', body) as (event: Event) => Event;
+        const fn = new Function('return ' + body)() as unknown;
+        if (typeof fn === 'function') {
+          return fn as (event: Event) => Event;
+        }
+        loggerProvider?.error('Custom enrichment body did not evaluate to a function');
       } catch (error) {
         loggerProvider?.error('Could not create custom enrichment function', error);
       }
     }
 
-    // if there was no content, return a function that returns the event unchanged
     return (event: Event) => event;
   }
 

--- a/packages/plugin-custom-enrichment-browser/test/custom-enrichment.test.ts
+++ b/packages/plugin-custom-enrichment-browser/test/custom-enrichment.test.ts
@@ -107,11 +107,11 @@ describe('Custom Enrichment Plugin', () => {
   });
   describe('execute', () => {
     it('should execute custom enrichment function successfully', async () => {
-      const customFunction = `
+      const customFunction = `function(event) {
         event.event_properties = event.event_properties || {};
         event.event_properties.custom_field = 'enriched_value';
         return event;
-      `;
+      }`;
       const plugin = customEnrichmentPlugin();
 
       // Mock remote config to provide the custom function
@@ -151,12 +151,12 @@ describe('Custom Enrichment Plugin', () => {
 
     it('should handle enrichment function that adds or modifies the event', async () => {
       const timestamp = Date.now();
-      const customFunction = `
+      const customFunction = `function(event) {
         event.user_properties = { custom_user_prop: 'user_value' };
         event.event_properties = { ...event.event_properties, timestamp: ${timestamp} };
         event.event_type = 'enriched_event';
         return event;
-      `;
+      }`;
       const plugin = customEnrichmentPlugin();
 
       // Mock remote config to provide the custom function
@@ -191,9 +191,9 @@ describe('Custom Enrichment Plugin', () => {
     });
 
     it('should return original event if enrichment function throws error', async () => {
-      const invalidFunction = `
+      const invalidFunction = `function(event) {
         throw new Error('Invalid enrichment function');
-      `;
+      }`;
       const plugin = customEnrichmentPlugin();
 
       // Mock remote config to provide the invalid function
@@ -231,7 +231,7 @@ describe('Custom Enrichment Plugin', () => {
       const mockRemoteConfigClient = {
         subscribe: jest.fn((key, _audience, callback) => {
           if (key === 'configs.analyticsSDK.browserSDK.customEnrichment') {
-            callback({ body: 'throw new Error("test error");' });
+            callback({ body: 'function(event) { throw new Error("test error"); }' });
           }
         }),
       };
@@ -337,7 +337,38 @@ describe('Custom Enrichment Plugin', () => {
       const originalEvent = { event_type: 'test_event' };
       const result = await plugin.execute?.(originalEvent);
 
-      expect(result).toEqual(null);
+      expect(result).toEqual(originalEvent);
+      expect((mockLogger.error as jest.Mock).mock.calls.length).toBe(1);
+      expect((mockLogger.error as jest.Mock).mock.calls[0][0]).toBe(
+        'Custom enrichment body did not evaluate to a function',
+      );
+    });
+
+    it('should return null when enrichment function returns undefined', async () => {
+      const plugin = customEnrichmentPlugin();
+
+      const mockRemoteConfigClient = {
+        subscribe: jest.fn((key, _audience, callback) => {
+          if (key === 'configs.analyticsSDK.browserSDK.customEnrichment') {
+            callback({ body: 'function(event) {}' });
+          }
+        }),
+      };
+
+      const configWithRemoteConfig = {
+        ...mockConfig,
+        remoteConfigClient: mockRemoteConfigClient,
+        remoteConfig: {
+          fetchRemoteConfig: true,
+        },
+      };
+
+      await plugin.setup?.(configWithRemoteConfig, mockClient);
+
+      const originalEvent = { event_type: 'test_event' };
+      const result = await plugin.execute?.(originalEvent);
+
+      expect(result).toBeNull();
     });
 
     it('should handle remote config with invalid config', async () => {
@@ -423,10 +454,10 @@ describe('Custom Enrichment Plugin', () => {
 
     it('should handle when remote config body becomes null', async () => {
       const plugin = customEnrichmentPlugin();
-      const customFunction = `
+      const customFunction = `function(event) {
         event.event_properties = { test: "value" };
         return event;
-      `;
+      }`;
 
       // Store the callback so we can invoke it multiple times to simulate config changes
       let subscribedCallback: ((config: any) => void) | undefined;
@@ -640,7 +671,7 @@ describe('Custom Enrichment Plugin', () => {
       const mockRemoteConfigClient = {
         subscribe: jest.fn((key, _audience, callback) => {
           if (key === 'configs.analyticsSDK.browserSDK.customEnrichment') {
-            callback({ body: 'throw new Error("test error");' });
+            callback({ body: 'function(event) { throw new Error("test error"); }' });
           }
         }),
       };
@@ -663,10 +694,9 @@ describe('Custom Enrichment Plugin', () => {
       expect(result).toEqual(originalEvent);
     });
 
-    it('should handle undefined loggerProvider in createEnrichEvent', async () => {
+    it('should handle undefined loggerProvider in createEnrichEvent when body throws', async () => {
       const plugin = customEnrichmentPlugin();
 
-      // Mock remote config to provide the error function
       const mockRemoteConfigClient = {
         subscribe: jest.fn((key, _audience, callback) => {
           if (key === 'configs.analyticsSDK.browserSDK.customEnrichment') {
@@ -689,7 +719,34 @@ describe('Custom Enrichment Plugin', () => {
       const originalEvent = { event_type: 'test_event' };
       const result = await plugin.execute?.(originalEvent);
 
-      // Should return original event and not throw even with undefined loggerProvider
+      expect(result).toEqual(originalEvent);
+    });
+
+    it('should handle undefined loggerProvider when body evaluates to non-function', async () => {
+      const plugin = customEnrichmentPlugin();
+
+      const mockRemoteConfigClient = {
+        subscribe: jest.fn((key, _audience, callback) => {
+          if (key === 'configs.analyticsSDK.browserSDK.customEnrichment') {
+            callback({ body: '"a string, not a function"' });
+          }
+        }),
+      };
+
+      const configWithRemoteConfig = {
+        ...mockConfig,
+        remoteConfigClient: mockRemoteConfigClient,
+        remoteConfig: {
+          fetchRemoteConfig: true,
+        },
+        loggerProvider: undefined,
+      } as unknown as BrowserConfig;
+
+      await plugin.setup?.(configWithRemoteConfig, mockClient);
+
+      const originalEvent = { event_type: 'test_event' };
+      const result = await plugin.execute?.(originalEvent);
+
       expect(result).toEqual(originalEvent);
     });
   });


### PR DESCRIPTION
### Summary

This makes some slight changes to expect a function as the custom enrichment code instead of just the body of a function.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remotely-supplied JavaScript is evaluated (now expecting a full function expression), which can break existing remote configs and affects runtime code execution behavior. Test coverage was updated/expanded, but misconfigured bodies will now behave differently (logged and treated as no-op).
> 
> **Overview**
> **Custom enrichment remote config `body` is now expected to be a full function expression.** The plugin now evaluates `body` via `new Function('return ' + body)()` and only uses it when the result is actually a function, otherwise logging `Custom enrichment body did not evaluate to a function` and falling back to a no-op enrichment.
> 
> Tests were updated to provide `function(event) { ... }` strings (instead of raw function bodies) and expanded to cover non-function evaluation, comment-only bodies, and the `execute` behavior when the enrichment returns `undefined` (now coerced to `null`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49cd96dd275a1cbeb7905e8faf18c744fed97439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->