### PR TITLE
test: add tests to prevent cookie renaming

### DIFF
--- a/packages/analytics-core/test/helpers/util.ts
+++ b/packages/analytics-core/test/helpers/util.ts
@@ -1,1 +1,30 @@
+import { CookieStorage } from '../../src/storage/cookie';
+
 export const uuidPattern = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
+/**
+ * Cookie names that are allowed to be set.
+ *
+ * IMPORTANT: do not add or modify these without good reason and
+ * without very careful consideration. Cookie names should be very
+ * stable and not changed without a good reason.
+ */
+const LEGAL_COOKIE_NAMES: Record<string, boolean> = {
+  AMP_TEST: true,
+  AMP_TLDTEST: true,
+};
+
+export function enforceStrictCookieNames() {
+  const Proto = CookieStorage.prototype as unknown as { setSync: (key: string, value: unknown) => void };
+  const originalSetSync = Proto.setSync;
+  Proto.setSync = function (this: unknown, key: string, value: unknown) {
+    if (!LEGAL_COOKIE_NAMES[key]) {
+      throw new Error(`Illegal cookie name: ${key}`);
+    }
+    return originalSetSync.call(this, key, value);
+  };
+
+  return () => {
+    Proto.setSync = originalSetSync;
+  };
+}

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -7,46 +7,20 @@ import { CookieStorage } from '../../src/storage/cookie';
 import { isDomainEqual, decodeCookieValue } from '../../src/index';
 import * as GlobalScopeModule from '../../src/global-scope';
 import { StorageSync } from '../../src/types/storage';
-
-/**
- * Cookie names that are allowed to be set.
- *
- * IMPORTANT: do not add or modify these without good reason and
- * without very careful consideration. Cookie names should be very
- * stable and not changed without a good reason.
- */
-const LEGAL_COOKIE_NAMES: Record<string, boolean> = {
-  AMP_TEST: true,
-  AMP_TLDTEST: true,
-};
-
-function enforceStrictCookieNames() {
-  const Proto = CookieStorage.prototype as unknown as { setSync: (key: string, value: unknown) => void };
-  const originalSetSync = Proto.setSync;
-  Proto.setSync = function (this: unknown, key: string, value: unknown) {
-    if (!LEGAL_COOKIE_NAMES[key]) {
-      throw new Error(`Illegal cookie name: ${key}`);
-    }
-    return originalSetSync.call(this, key, value);
-  };
-
-  return () => {
-    Proto.setSync = originalSetSync;
-  };
-}
+import { enforceStrictCookieNames } from '../helpers/util';
 
 describe('cookies', () => {
+  let undoStrictCookieNames: () => void;
+  beforeEach(() => {
+    // Enforce strict cookie names. This is important, do not remove it.
+    undoStrictCookieNames = enforceStrictCookieNames();
+  });
+
+  afterEach(() => {
+    undoStrictCookieNames();
+  });
+
   describe('isEnabled', () => {
-    let undoStrictCookieNames: () => void;
-    beforeEach(() => {
-      // Enforce strict cookie names. This is important, do not remove it.
-      undoStrictCookieNames = enforceStrictCookieNames();
-    });
-
-    afterEach(() => {
-      undoStrictCookieNames();
-    });
-
     describe('concurrent calls', () => {
       beforeEach(() => {
         jest.useFakeTimers();
@@ -164,6 +138,10 @@ describe('cookies', () => {
   });
 
   describe('get', () => {
+    beforeEach(() => {
+      undoStrictCookieNames?.();
+    });
+
     test('should return undefined for no cookie value', async () => {
       const cookies = new CookieStorage();
       expect(await cookies.get('hello')).toBe(undefined);
@@ -225,6 +203,10 @@ describe('cookies', () => {
   });
 
   describe('set', () => {
+    beforeEach(() => {
+      undoStrictCookieNames?.();
+    });
+
     test('should set cookie value', async () => {
       const cookies = new CookieStorage();
       await cookies.set('hello', 'world');
@@ -299,6 +281,10 @@ describe('cookies', () => {
   });
 
   describe('remove', () => {
+    beforeEach(() => {
+      undoStrictCookieNames?.();
+    });
+
     test('should call set', async () => {
       const cookies = new CookieStorage();
       const set = jest.spyOn(cookies, 'set');
@@ -317,6 +303,7 @@ describe('cookies', () => {
     let tldCookies: CookieStorage<Record<string, string>>;
     let subdomainCookies: CookieStorage<Record<string, string>>;
     beforeEach(() => {
+      undoStrictCookieNames?.();
       tldCookies = new CookieStorage<Record<string, string>>(
         {
           domain: 'example.com',
@@ -501,16 +488,8 @@ describe('cookies', () => {
   });
 
   describe('isDomainWritable', () => {
-    let undoStrictCookieNames: () => void;
-
     beforeEach(() => {
-      // Enforce strict cookie names. This is important, do not remove it.
-      undoStrictCookieNames = enforceStrictCookieNames();
       (CookieStorage as any).cachedTlds = {};
-    });
-
-    afterEach(() => {
-      undoStrictCookieNames();
     });
 
     test('should return true when domain is writable', async () => {
@@ -587,6 +566,10 @@ describe('cookies', () => {
   });
 
   describe('transaction', () => {
+    beforeEach(() => {
+      undoStrictCookieNames?.();
+    });
+
     test('should return the result of the callback', async () => {
       const cookies = new CookieStorage<string>();
       const result = await (cookies as any).transaction('test', (storageSync: StorageSync<string>) => {


### PR DESCRIPTION
### Summary

Add a unit test that prevents cookie names from being modified without careful consideration.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds a runtime guard in the test suite to detect unexpected cookie key changes; no production behavior is modified.
> 
> **Overview**
> Adds a test helper (`enforceStrictCookieNames`) that monkey-patches `CookieStorage.prototype.setSync` to **throw** if any cookie key other than `AMP_TEST` or `AMP_TLDTEST` is written during tests.
> 
> Updates `cookies.test.ts` to enable this strict cookie-name enforcement for the suite (with targeted opt-outs in sub-suites that intentionally use arbitrary keys), ensuring accidental renames of the library’s internal cookie names are caught by CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415566b4ec0908b555a8b6dd32f0e759983ac643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->