### PR TITLE
fix(analytics-core): treat 403 as invalid API key in remote config client

### DIFF
--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -27,6 +27,7 @@ export const EU_SERVER_URL = 'https://sr-client-cfg.eu.amplitude.com/config';
 export const DEFAULT_MAX_RETRIES = 3;
 const CODE_STATUS = {
   INVALID_API_KEY: 401,
+  FORBIDDEN: 403,
   RATE_LIMIT: 429,
 } as const;
 
@@ -356,9 +357,9 @@ export class RemoteConfigClient implements IRemoteConfigClient {
           const body = await res.text();
           this.logger.debug(`Remote config client fetch with retry time ${retries} failed with ${res.status}: ${body}`);
 
-          if (res.status === CODE_STATUS.INVALID_API_KEY) {
+          if (res.status === CODE_STATUS.INVALID_API_KEY || res.status === CODE_STATUS.FORBIDDEN) {
             this.logger.error(
-              `Remote config client fetch failed with ${CODE_STATUS.INVALID_API_KEY}. Invalid API key; future fetches will be skipped.`,
+              `Remote config client fetch failed with ${res.status}. Invalid API key; future fetches will be skipped.`,
             );
             this.isLastFetchInvalidApiKey = true;
             shouldRetry = false;

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -936,6 +936,51 @@ describe('RemoteConfigClient', () => {
       );
     });
 
+    test('should not retry on forbidden (403) response and treat as invalid API key', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 403,
+          text: () => Promise.resolve('Forbidden'),
+        } as Response),
+      );
+
+      const result = await client.fetch(3);
+      expect(result.remoteConfig).toBeNull();
+      expect(result.lastFetch).toBeInstanceOf(Date);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(client.isLastFetchInvalidApiKey).toBe(true);
+      expect(loggerDebug).toHaveBeenCalledTimes(1);
+      expect(loggerDebug).toHaveBeenCalledWith(expect.stringContaining('failed with 403'));
+      expect(loggerError).toHaveBeenCalledTimes(1);
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining('Remote config client fetch failed with 403. Invalid API key'),
+      );
+    });
+
+    test('should skip future fetches after a 403 response', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 403,
+          text: () => Promise.resolve('Forbidden'),
+        } as Response),
+      );
+
+      // First call triggers the 403
+      await client.getOrCreateFetchPromise();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(client.isLastFetchInvalidApiKey).toBe(true);
+
+      jest.clearAllMocks();
+
+      // Subsequent call should be skipped entirely
+      const result = await client.getOrCreateFetchPromise();
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result.remoteConfig).toBeNull();
+      expect(loggerDebug).toHaveBeenCalledWith('Remote config client skipping fetch: Invalid API key');
+    });
+
     test('should retry on rate limit and recover', async () => {
       global.fetch = jest
         .fn()


### PR DESCRIPTION
## Summary
- Adds `FORBIDDEN: 403` to `CODE_STATUS` constants in remote config client
- Treats HTTP 403 responses the same as 401 (invalid API key): sets `isLastFetchInvalidApiKey = true` and stops retrying
- Adds tests verifying 403 is handled correctly and that no future fetches are made after a 403

## Test plan
- [ ] `should not retry on forbidden (403) response and treat as invalid API key` — verifies 403 stops retries and sets the flag
- [ ] `should skip future fetches after a 403 response` — verifies `getOrCreateFetchPromise` skips the network call once the flag is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)