### PR TITLE
fix(analytics-core): network request event circular dependency

### DIFF
--- a/packages/analytics-core/src/network-request-event.ts
+++ b/packages/analytics-core/src/network-request-event.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope } from './global-scope';
 import { pruneJson } from './utils/json-query';
-import { SAFE_HEADERS, FORBIDDEN_HEADERS } from './';
+import { SAFE_HEADERS, FORBIDDEN_HEADERS } from './types/constants';
 
 /* SAFE TYPE DEFINITIONS
   These type definitions expose limited properties of the original types


### PR DESCRIPTION
### Summary

Break circular dependency in network-request-event

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only an import path to avoid a barrel (`./`) circular dependency, with no runtime logic changes.
> 
> **Overview**
> Breaks a circular dependency by updating `network-request-event.ts` to import `SAFE_HEADERS`/`FORBIDDEN_HEADERS` directly from `./types/constants` instead of the package barrel (`./`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7818690210456185e3b01786bc99dec6a8028a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->