### PR TITLE
feat(session-replay-browser): add remote evaluation gate for capture eligibility

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -108,6 +108,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         enableUrlChangePolling: this.options.enableUrlChangePolling,
         urlChangePollingInterval: this.options.urlChangePollingInterval,
         captureAdoptedStyleSheets: this.options.captureAdoptedStyleSheets,
+        remoteTargeting: this.options.remoteTargeting,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -3,6 +3,7 @@ import {
   StoreType,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type SessionReplayOptions as StandaloneSessionReplayOptions, // used for documentation
+  type RemoteTargetingConfig,
 } from '@amplitude/session-replay-browser';
 
 export type MaskLevel =
@@ -176,4 +177,5 @@ export interface SessionReplayOptions {
    * @see {@link StandaloneSessionReplayOptions.captureAdoptedStyleSheets}
    */
   captureAdoptedStyleSheets?: boolean;
+  remoteTargeting?: RemoteTargetingConfig;
 }

--- a/packages/session-replay-browser/e2e/remote-eval-live.spec.ts
+++ b/packages/session-replay-browser/e2e/remote-eval-live.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Live e2e tests for the remote eval gate against the real Amplitude Experiment API.
+ *
+ * Flag:       sr-capture-gate (id: 902007)
+ *             Targeting: $region IS "North Carolina" → 100% "on"
+ *             Default rollout: 0% (falls through to "off" for non-matching users)
+ * Project:    Lew Shutdown Test (631773)
+ * Deployment: lew-sr-test-client (32512)
+ *
+ * These tests do NOT mock the Amplitude eval endpoint — requests go to
+ * https://api.lab.amplitude.com/sdk/v2/vardata for real.
+ *
+ * Each test fires a lightweight analytics event to api2.amplitude.com so that
+ * Amplitude can geo-enrich and build a user profile for the device in this project.
+ * This is required for property-based Experiment targeting to work. Note that
+ * profile propagation to Experiment takes ~1 hour after the first event lands.
+ */
+
+import { test, expect, Route, Page } from '@playwright/test';
+
+const SR_PROPERTY_KEY = '[Amplitude] Session Replay ID';
+
+// Real client deployment key for project 631773, flag sr-capture-gate
+const DEPLOYMENT_KEY = 'client-cp9bqxFcxFAKoaYEBeCD1n3TW8enG0Xh';
+
+// A known device ID that already has an amplitude_id mapping in project 631773.
+// Using a UUID-format device_id is required for SR ingestion to accept events.
+const LIVE_DEVICE_ID = 'a9ea9629-5dca-4908-a86c-77a5acfbd54a';
+
+const remoteConfigRecording = {
+  configs: { sessionReplay: { sr_sampling_config: { capture_enabled: true, sample_rate: 1.0 } } },
+};
+
+function mockRemoteConfig(page: Page, body: object) {
+  return page.route('https://sr-client-cfg.amplitude.com/**', (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) }),
+  );
+}
+
+function buildUrl(path: string, params: Record<string, string | number | boolean> = {}): string {
+  const qs = new URLSearchParams(Object.entries(params).map(([k, v]) => [k, String(v)]));
+  return `${path}?${qs.toString()}`;
+}
+
+async function waitForReady(page: Page): Promise<void> {
+  await page.waitForFunction(() => (window as any).srReady === true, { timeout: 10_000 });
+}
+
+async function getProperties(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(() => (window as any).sessionReplay.getSessionReplayProperties() as Record<string, unknown>);
+}
+
+function remoteEvalParams(
+  strategy: 'conservative' | 'lookback',
+  extra: Record<string, string | number | boolean> = {},
+) {
+  return {
+    // Use a real current timestamp so the SR service accepts the events.
+    sessionId: Date.now(),
+    // Use a UUID-format device_id with an existing amplitude_id mapping so SR ingestion accepts events.
+    deviceId: LIVE_DEVICE_ID,
+    remoteEvalDeploymentKey: DEPLOYMENT_KEY,
+    remoteEvalStrategy: strategy,
+    remoteEvalTimeoutMs: 5000,
+    // Fire a real analytics event on each test run so Amplitude geo-enriches the
+    // device and populates user properties (e.g. $region) needed for flag targeting.
+    sendAnalyticsEvent: true,
+    ...extra,
+  };
+}
+
+test.describe('remote eval gate — live Amplitude Experiment API', () => {
+  test('conservative: records when live flag evaluates to "on"', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // Flag is 100% on — recording should start once decision arrives
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 10_000 },
+    );
+
+    // Give rrweb time to capture an initial snapshot, then flush and wait for the
+    // response so the request fully completes before Playwright closes the page.
+    await page.waitForTimeout(500);
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForResponse('https://api-sr.amplitude.com/**', { timeout: 15_000 });
+
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeTruthy();
+  });
+
+  test('lookback: records and flushes events when live flag evaluates to "on"', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('lookback')));
+    await waitForReady(page);
+
+    // Wait for the eval request to complete before triggering flush — in lookback mode,
+    // SR_PROPERTY_KEY appears immediately (decision not required), so we must wait for the
+    // actual decision before blurring, otherwise the buffer hasn't been flushed yet.
+    await page.waitForResponse('https://api.lab.amplitude.com/**', { timeout: 10_000 });
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    // Wait for the full SR response so the request completes before Playwright closes the page.
+    await page.waitForResponse('https://api-sr.amplitude.com/**', { timeout: 15_000 });
+
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeTruthy();
+  });
+
+  test('sends the deployment key in the Authorization header', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route: Route) => route.fulfill({ status: 200 }));
+
+    let capturedAuthHeader: string | undefined;
+    await page.route('https://api.lab.amplitude.com/**', async (route: Route) => {
+      capturedAuthHeader = route.request().headers()['authorization'];
+      // Let the real request through after capturing the header
+      await route.continue();
+    });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 10_000 },
+    );
+
+    expect(capturedAuthHeader).toBe(`Api-Key ${DEPLOYMENT_KEY}`);
+  });
+
+  test('sends flag_key and device_id as query params', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route: Route) => route.fulfill({ status: 200 }));
+
+    let capturedUrl: string | undefined;
+    await page.route('https://api.lab.amplitude.com/**', async (route: Route) => {
+      capturedUrl = route.request().url();
+      await route.continue();
+    });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        ...remoteEvalParams('conservative'),
+        deviceId: 'live-e2e-device-001',
+      }),
+    );
+    await waitForReady(page);
+
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 10_000 },
+    );
+
+    expect(capturedUrl).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get('flag_keys')).toBe('sr-capture-gate');
+    expect(url.searchParams.get('device_id')).toBe('live-e2e-device-001');
+  });
+});

--- a/packages/session-replay-browser/e2e/remote-eval.spec.ts
+++ b/packages/session-replay-browser/e2e/remote-eval.spec.ts
@@ -1,0 +1,389 @@
+import { test, expect, Route, Page } from '@playwright/test';
+
+const SR_PROPERTY_KEY = '[Amplitude] Session Replay ID';
+const TEST_SESSION_ID = 1700000000000;
+const SR_API_SUCCESS = { code: 200 };
+
+// Amplitude Experiment eval URL — intercepted by Playwright
+const REMOTE_EVAL_URL = 'https://api.lab.amplitude.com/sdk/v2/vardata**';
+
+const remoteConfigRecording = {
+  configs: { sessionReplay: { sr_sampling_config: { capture_enabled: true, sample_rate: 1.0 } } },
+};
+
+function mockRemoteConfig(page: Page, body: object) {
+  return page.route('https://sr-client-cfg.amplitude.com/**', (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) }),
+  );
+}
+
+function mockTrackApi(page: Page) {
+  return page.route('https://api-sr.amplitude.com/**', (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) }),
+  );
+}
+
+function mockRemoteEval(page: Page, response: { capture: boolean; reason?: string }) {
+  const flagKey = 'sr-capture-gate';
+  const variantKey = response.capture ? 'on' : 'off';
+  const body = { [flagKey]: { key: variantKey, value: variantKey } };
+  return page.route(REMOTE_EVAL_URL, (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) }),
+  );
+}
+
+function buildUrl(path: string, params: Record<string, string | number | boolean> = {}): string {
+  const qs = new URLSearchParams(Object.entries(params).map(([k, v]) => [k, String(v)]));
+  return `${path}?${qs.toString()}`;
+}
+
+async function waitForReady(page: Page): Promise<void> {
+  await page.waitForFunction(() => (window as any).srReady === true, { timeout: 10_000 });
+}
+
+async function getProperties(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(() => (window as any).sessionReplay.getSessionReplayProperties() as Record<string, unknown>);
+}
+
+/** Base URL params for a page with remote eval configured */
+function remoteEvalParams(
+  strategy: 'conservative' | 'lookback',
+  extra: Record<string, string | number | boolean> = {},
+) {
+  return {
+    sessionId: TEST_SESSION_ID,
+    remoteEvalDeploymentKey: 'client-test-key',
+    remoteEvalStrategy: strategy,
+    remoteEvalTimeoutMs: 2000,
+    ...extra,
+  };
+}
+
+// ─── Conservative strategy ────────────────────────────────────────────────────
+
+test.describe('remote eval gate — conservative strategy', () => {
+  test('records when remote eval returns capture=true', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+    await mockRemoteEval(page, { capture: true });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // Wait for the remote decision to arrive and recording to start
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 5_000 },
+    );
+
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeTruthy();
+    expect(String(props[SR_PROPERTY_KEY])).toContain(`/${TEST_SESSION_ID}`);
+  });
+
+  test('does not record when remote eval returns capture=false', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+    await mockRemoteEval(page, { capture: false, reason: 'not in cohort' });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // Wait for remote eval request to complete
+    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await page.waitForTimeout(300);
+
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeFalsy();
+  });
+
+  test('does not record before remote decision arrives (no premature capture)', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+
+    // Hold the remote eval response until we manually release it
+    let releaseDecision!: () => void;
+    await page.route(REMOTE_EVAL_URL, (route: Route) => {
+      releaseDecision = () => {
+        void route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ 'sr-capture-gate': { key: 'on', value: 'on' } }),
+        });
+      };
+    });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // Decision hasn't arrived yet — should not be recording
+    const propsBefore = await getProperties(page);
+    expect(propsBefore[SR_PROPERTY_KEY]).toBeFalsy();
+
+    // Release the decision
+    releaseDecision();
+
+    // Now recording should start
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 5_000 },
+    );
+
+    const propsAfter = await getProperties(page);
+    expect(propsAfter[SR_PROPERTY_KEY]).toBeTruthy();
+  });
+
+  test('does not record when remote eval times out (conservative fallback)', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+
+    // Never fulfill the remote eval request — simulates a timeout
+    await page.route(REMOTE_EVAL_URL, () => {
+      // intentionally stall — the SDK's AbortController will fire after timeoutMs
+    });
+
+    await page.goto(
+      buildUrl(
+        '/session-replay-browser/sr-capture-test.html',
+        remoteEvalParams('conservative', {
+          remoteEvalTimeoutMs: 200,
+        }),
+      ),
+    );
+    await waitForReady(page);
+
+    // Wait long enough for the SDK timeout to fire
+    await page.waitForTimeout(600);
+
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeFalsy();
+  });
+
+  test('sends events to track API after conservative capture=true', async ({ page }) => {
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route: Route) => {
+      sentUrls.push(route.request().url());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+    await mockRemoteEval(page, { capture: true });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // Wait for recording to start
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 5_000 },
+    );
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(500);
+
+    expect(sentUrls.length).toBeGreaterThan(0);
+  });
+
+  test('does not send events to track API after conservative capture=false', async ({ page }) => {
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route: Route) => {
+      sentUrls.push(route.request().url());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+    await mockRemoteEval(page, { capture: false });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await page.waitForTimeout(300);
+
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(500);
+
+    expect(sentUrls.length).toBe(0);
+  });
+});
+
+// ─── Lookback strategy ────────────────────────────────────────────────────────
+
+test.describe('remote eval gate — lookback strategy', () => {
+  test('begins recording immediately (before decision) and flushes events on capture=true', async ({ page }) => {
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route: Route) => {
+      sentUrls.push(route.request().url());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+
+    let releaseDecision!: () => void;
+    await page.route(REMOTE_EVAL_URL, (route: Route) => {
+      releaseDecision = () => {
+        void route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ 'sr-capture-gate': { key: 'on', value: 'on' } }),
+        });
+      };
+    });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('lookback')));
+    await waitForReady(page);
+
+    // Give rrweb time to capture an initial snapshot while decision is pending
+    await page.waitForTimeout(500);
+
+    // Release decision — held events should be flushed
+    const trackRequestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 5_000 });
+    releaseDecision();
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await trackRequestPromise;
+
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeTruthy();
+    expect(String(props[SR_PROPERTY_KEY])).toContain(`/${TEST_SESSION_ID}`);
+  });
+
+  test('discards buffered events and stops recording on capture=false', async ({ page }) => {
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route: Route) => {
+      sentUrls.push(route.request().url());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+    await mockRemoteEval(page, { capture: false, reason: 'excluded' });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('lookback')));
+    await waitForReady(page);
+    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await page.waitForTimeout(300);
+
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(500);
+
+    // SR property should be absent — capture denied
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeFalsy();
+    // No events should have been sent to the track API
+    expect(sentUrls.length).toBe(0);
+  });
+});
+
+// ─── Session change ───────────────────────────────────────────────────────────
+
+test.describe('remote eval gate — session ID change', () => {
+  const NEW_SESSION_ID = TEST_SESSION_ID + 60_000;
+
+  test('re-runs remote eval on setSessionId and records when capture=true', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+    await mockRemoteEval(page, { capture: true });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // Wait for initial remote eval + recording
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 5_000 },
+    );
+
+    // Switch session — remote eval fires again for the new session
+    await page.evaluate(
+      (newId) => (window as any).sessionReplay.setSessionId(newId).promise as Promise<void>,
+      NEW_SESSION_ID,
+    );
+
+    // Wait for new session remote eval to complete
+    await page.waitForFunction(
+      (args) => {
+        const props = (window as any).sessionReplay.getSessionReplayProperties() as Record<string, unknown>;
+        return typeof props[args.key] === 'string' && (props[args.key] as string).includes(`/${args.id}`);
+      },
+      { key: SR_PROPERTY_KEY, id: NEW_SESSION_ID },
+      { timeout: 5_000 },
+    );
+
+    const props = await getProperties(page);
+    expect(String(props[SR_PROPERTY_KEY])).toContain(`/${NEW_SESSION_ID}`);
+  });
+
+  test('does not record new session when remote eval returns capture=false on session change', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+
+    let callCount = 0;
+    await page.route(REMOTE_EVAL_URL, (route: Route) => {
+      callCount++;
+      // First call (init): allow capture. Second call (session change): deny.
+      const variantKey = callCount === 1 ? 'on' : 'off';
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ 'sr-capture-gate': { key: variantKey, value: variantKey } }),
+      });
+    });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
+    await waitForReady(page);
+
+    // First session: should record
+    await page.waitForFunction(
+      (key) => !!(window as any).sessionReplay.getSessionReplayProperties()[key],
+      SR_PROPERTY_KEY,
+      { timeout: 5_000 },
+    );
+    expect((await getProperties(page))[SR_PROPERTY_KEY]).toBeTruthy();
+
+    // Switch session — second remote eval returns capture=false
+    await page.evaluate(
+      (newId) => (window as any).sessionReplay.setSessionId(newId).promise as Promise<void>,
+      NEW_SESSION_ID,
+    );
+    await page.waitForTimeout(500);
+
+    // New session should not be recording
+    const props = await getProperties(page);
+    expect(props[SR_PROPERTY_KEY]).toBeFalsy();
+  });
+});
+
+// ─── Remote eval request shape ────────────────────────────────────────────────
+
+test.describe('remote eval gate — request shape', () => {
+  test('sends correct flag_key and device_id as query params to Amplitude eval API', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApi(page);
+
+    let capturedUrl: string | undefined;
+    await page.route(REMOTE_EVAL_URL, (route: Route) => {
+      capturedUrl = route.request().url();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ 'my-sr-flag': { key: 'on', value: 'on' } }),
+      });
+    });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        ...remoteEvalParams('conservative'),
+        remoteEvalFlagKey: 'my-sr-flag',
+        deviceId: 'e2e-device-001',
+      }),
+    );
+    await waitForReady(page);
+    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+
+    expect(capturedUrl).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const url = new URL(capturedUrl!);
+    expect(url.searchParams.get('flag_keys')).toBe('my-sr-flag');
+    expect(url.searchParams.get('device_id')).toBe('e2e-device-001');
+  });
+});

--- a/packages/session-replay-browser/e2e/remote-eval.spec.ts
+++ b/packages/session-replay-browser/e2e/remote-eval.spec.ts
@@ -87,11 +87,11 @@ test.describe('remote eval gate — conservative strategy', () => {
     await mockTrackApi(page);
     await mockRemoteEval(page, { capture: false, reason: 'not in cohort' });
 
+    // Register before navigation to avoid race where request fires before listener is set up
+    const evalRequestPromise = page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
     await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
     await waitForReady(page);
-
-    // Wait for remote eval request to complete
-    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await evalRequestPromise;
     await page.waitForTimeout(300);
 
     const props = await getProperties(page);
@@ -197,9 +197,11 @@ test.describe('remote eval gate — conservative strategy', () => {
     });
     await mockRemoteEval(page, { capture: false });
 
+    // Register before navigation to avoid race where request fires before listener is set up
+    const evalRequestPromise = page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
     await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('conservative')));
     await waitForReady(page);
-    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await evalRequestPromise;
     await page.waitForTimeout(300);
 
     await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
@@ -257,9 +259,11 @@ test.describe('remote eval gate — lookback strategy', () => {
     });
     await mockRemoteEval(page, { capture: false, reason: 'excluded' });
 
+    // Register before navigation to avoid race where request fires before listener is set up
+    const evalRequestPromise = page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
     await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', remoteEvalParams('lookback')));
     await waitForReady(page);
-    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await evalRequestPromise;
     await page.waitForTimeout(300);
 
     await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
@@ -370,6 +374,8 @@ test.describe('remote eval gate — request shape', () => {
       });
     });
 
+    // Register before navigation to avoid race where request fires before listener is set up
+    const evalRequestPromise = page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
     await page.goto(
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         ...remoteEvalParams('conservative'),
@@ -378,7 +384,7 @@ test.describe('remote eval gate — request shape', () => {
       }),
     );
     await waitForReady(page);
-    await page.waitForRequest(REMOTE_EVAL_URL, { timeout: 5_000 });
+    await evalRequestPromise;
 
     expect(capturedUrl).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/session-replay-browser/e2e/results.json
+++ b/packages/session-replay-browser/e2e/results.json
@@ -1,0 +1,503 @@
+{
+  "config": {
+    "configFile": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc/packages/session-replay-browser/playwright.config.ts",
+    "rootDir": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc/packages/session-replay-browser",
+    "forbidOnly": false,
+    "fullyParallel": true,
+    "globalSetup": null,
+    "globalTeardown": null,
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "actualWorkers": 7
+    },
+    "preserveOutput": "always",
+    "reporter": [
+      [
+        "json",
+        {
+          "outputFile": "e2e/results.json"
+        }
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "quiet": false,
+    "projects": [
+      {
+        "outputDir": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc/packages/session-replay-browser/test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 7
+        },
+        "id": "chromium",
+        "name": "chromium",
+        "testDir": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc/packages/session-replay-browser",
+        "testIgnore": [],
+        "testMatch": [
+          "**/e2e/**/*.spec.ts"
+        ],
+        "timeout": 30000
+      },
+      {
+        "outputDir": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc/packages/session-replay-browser/test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 7
+        },
+        "id": "webkit",
+        "name": "webkit",
+        "testDir": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc/packages/session-replay-browser",
+        "testIgnore": [],
+        "testMatch": [
+          "**/e2e/**/*.spec.ts"
+        ],
+        "timeout": 30000
+      }
+    ],
+    "shard": null,
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.55.0",
+    "workers": 7,
+    "webServer": {
+      "command": "pnpm exec vite dev --port 5173 --clearScreen=false",
+      "cwd": "/Users/lew.gordon/repos/Amplitude-TypeScript-worktrees/remote-eval-trc",
+      "url": "http://localhost:5173",
+      "reuseExistingServer": true,
+      "timeout": 30000
+    }
+  },
+  "suites": [
+    {
+      "title": "e2e/remote-eval.spec.ts",
+      "file": "e2e/remote-eval.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "remote eval gate — conservative strategy",
+          "file": "e2e/remote-eval.spec.ts",
+          "line": 64,
+          "column": 6,
+          "specs": [
+            {
+              "title": "records when remote eval returns capture=true",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 721,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.181Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-dfe3cb331910dc3d8ec3",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 65,
+              "column": 7
+            },
+            {
+              "title": "does not record when remote eval returns capture=false",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 984,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.163Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-f9db92648ac65507dce1",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 85,
+              "column": 7
+            },
+            {
+              "title": "does not record before remote decision arrives (no premature capture)",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 2,
+                      "parallelIndex": 2,
+                      "status": "passed",
+                      "duration": 728,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.175Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-d3e619218847e5da95c4",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 101,
+              "column": 7
+            },
+            {
+              "title": "does not record when remote eval times out (conservative fallback)",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 3,
+                      "parallelIndex": 3,
+                      "status": "passed",
+                      "duration": 1286,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.169Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-081a0a695be6dde6faa4",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 138,
+              "column": 7
+            },
+            {
+              "title": "sends events to track API after conservative capture=true",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 4,
+                      "parallelIndex": 4,
+                      "status": "passed",
+                      "duration": 1702,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.172Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-d7a20a0017905d678241",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 164,
+              "column": 7
+            },
+            {
+              "title": "does not send events to track API after conservative capture=false",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 5,
+                      "parallelIndex": 5,
+                      "status": "passed",
+                      "duration": 1543,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.173Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-4cfde0f18e07fd17c8c2",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 191,
+              "column": 7
+            }
+          ]
+        },
+        {
+          "title": "remote eval gate — lookback strategy",
+          "file": "e2e/remote-eval.spec.ts",
+          "line": 216,
+          "column": 6,
+          "specs": [
+            {
+              "title": "begins recording immediately (before decision) and flushes events on capture=true",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 6,
+                      "parallelIndex": 6,
+                      "status": "passed",
+                      "duration": 1218,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:46.180Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-4e7504df1f2a6a1d5a3a",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 217,
+              "column": 7
+            },
+            {
+              "title": "discards buffered events and stops recording on capture=false",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 2,
+                      "parallelIndex": 2,
+                      "status": "passed",
+                      "duration": 987,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:47.049Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-4a61212538210b70abf2",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 253,
+              "column": 7
+            }
+          ]
+        },
+        {
+          "title": "remote eval gate — session ID change",
+          "file": "e2e/remote-eval.spec.ts",
+          "line": 282,
+          "column": 6,
+          "specs": [
+            {
+              "title": "re-runs remote eval on setSessionId and records when capture=true",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 191,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:47.050Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-6f958e6ba99ba33595d7",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 285,
+              "column": 7
+            },
+            {
+              "title": "does not record new session when remote eval returns capture=false on session change",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 648,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:47.246Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-caa050332e7d0317d4c5",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 320,
+              "column": 7
+            }
+          ]
+        },
+        {
+          "title": "remote eval gate — request shape",
+          "file": "e2e/remote-eval.spec.ts",
+          "line": 362,
+          "column": 6,
+          "specs": [
+            {
+              "title": "sends correct flag_key and device_id as query params to Amplitude eval API",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 162,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-03-19T13:05:47.313Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b8416e6db608869e1678-634243d462e1d0895fa6",
+              "file": "e2e/remote-eval.spec.ts",
+              "line": 363,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2026-03-19T13:05:44.405Z",
+    "duration": 3667.131,
+    "expected": 11,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  }
+}

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -77,6 +77,7 @@ export class SessionReplayJoinedConfigGenerator {
             const samplingConfig = namespaceConfig.sr_sampling_config;
             const privacyConfig = namespaceConfig.sr_privacy_config;
             const targetingConfig = namespaceConfig.sr_targeting_config;
+            const experimentConfig = namespaceConfig.sr_experiment_config;
 
             const ugcFilterRules = config.interactionConfig?.ugcFilterRules;
             // This is intentionally forced to only be set through the remote config.
@@ -88,7 +89,7 @@ export class SessionReplayJoinedConfigGenerator {
             // This is intentionally forced to only be set through the remote config.
             config.loggingConfig = namespaceConfig.sr_logging_config;
 
-            if (samplingConfig || privacyConfig || targetingConfig) {
+            if (samplingConfig || privacyConfig || targetingConfig || experimentConfig) {
               sessionReplayRemoteConfig = {};
               if (samplingConfig) {
                 sessionReplayRemoteConfig.sr_sampling_config = samplingConfig;
@@ -98,6 +99,9 @@ export class SessionReplayJoinedConfigGenerator {
               }
               if (targetingConfig) {
                 sessionReplayRemoteConfig.sr_targeting_config = targetingConfig;
+              }
+              if (experimentConfig) {
+                sessionReplayRemoteConfig.sr_experiment_config = experimentConfig;
               }
             }
 
@@ -128,6 +132,7 @@ export class SessionReplayJoinedConfigGenerator {
       sr_sampling_config: samplingConfig,
       sr_privacy_config: remotePrivacyConfig,
       sr_targeting_config: targetingConfig,
+      sr_experiment_config: experimentConfig,
     } = sessionReplayRemoteConfig;
     if (samplingConfig && Object.keys(samplingConfig).length > 0) {
       if (Object.prototype.hasOwnProperty.call(samplingConfig, 'capture_enabled')) {
@@ -218,6 +223,15 @@ export class SessionReplayJoinedConfigGenerator {
 
     if (targetingConfig && Object.keys(targetingConfig).length > 0) {
       config.targetingConfig = targetingConfig;
+    }
+
+    // Merge deploymentKey from remote experiment config, with SDK init options taking precedence.
+    // config starts as a copy of localConfig, so config.remoteTargeting is set iff localConfig.remoteTargeting is set.
+    if (experimentConfig?.deploymentKey && config.remoteTargeting && !config.remoteTargeting.deploymentKey) {
+      config.remoteTargeting = {
+        ...config.remoteTargeting,
+        deploymentKey: experimentConfig.deploymentKey,
+      };
     }
 
     this.localConfig.loggerProvider.debug(

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -10,6 +10,7 @@ import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
   InteractionConfig,
   PrivacyConfig,
+  RemoteTargetingConfig,
   SessionReplayPerformanceConfig,
   SessionReplayVersion,
 } from './types';
@@ -45,6 +46,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   urlChangePollingInterval?: number;
   captureDocumentTitle?: boolean;
   captureAdoptedStyleSheets?: boolean;
+  remoteTargeting?: RemoteTargetingConfig;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -100,5 +102,8 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
       this.omitElementTags = options.omitElementTags;
     }
     this.captureAdoptedStyleSheets = options.captureAdoptedStyleSheets ?? true;
+    if (options.remoteTargeting) {
+      this.remoteTargeting = options.remoteTargeting;
+    }
   }
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -221,6 +221,7 @@ export interface SessionReplayLocalConfig extends IConfig {
    * @defaultValue true
    */
   captureAdoptedStyleSheets?: boolean;
+  remoteTargeting?: RemoteTargetingConfig;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {
@@ -228,6 +229,7 @@ export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {
   interactionConfig?: InteractionConfig;
   loggingConfig?: LoggingConfig;
   targetingConfig?: TargetingConfig;
+  remoteTargeting?: RemoteTargetingConfig;
 }
 
 export interface SessionReplayConfigs {
@@ -306,3 +308,26 @@ export interface InteractionPerformanceConfig {
 }
 
 export type SessionReplayType = 'standalone' | 'plugin' | 'segment';
+
+export type RemoteTargetingMode = 'off' | 'session';
+
+export type RemoteTargetingDecisionStrategy = 'conservative' | 'lookback';
+
+export type RemoteDecision = {
+  capture: boolean;
+  reason?: string;
+  /** ms epoch — optional TTL */
+  expiresAt?: number;
+};
+
+export interface RemoteTargetingConfig {
+  enabled: boolean;
+  mode: RemoteTargetingMode;
+  /** Amplitude Experiment client-side deployment key */
+  deploymentKey: string;
+  /** Flag key to evaluate. Defaults to 'sr-capture-gate' */
+  flagKey?: string;
+  /** Request timeout in ms. Defaults to 200 */
+  timeoutMs?: number;
+  decisionStrategy: RemoteTargetingDecisionStrategy;
+}

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -330,4 +330,9 @@ export interface RemoteTargetingConfig {
   /** Request timeout in ms. Defaults to 200 */
   timeoutMs?: number;
   decisionStrategy: RemoteTargetingDecisionStrategy;
+  /**
+   * Maximum number of rrweb events to buffer in lookback mode while waiting for
+   * the remote decision. Events beyond this limit are dropped. Defaults to 1000.
+   */
+  lookbackBufferMaxEvents?: number;
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -34,12 +34,18 @@ export interface LoggingConfig {
 
 export type TargetingConfig = TargetingFlag;
 
+export type ExperimentConfig = {
+  flagId?: string;
+  deploymentKey?: string;
+};
+
 export type SessionReplayRemoteConfig = {
   sr_sampling_config?: SamplingConfig;
   sr_privacy_config?: PrivacyConfig;
   sr_interaction_config?: InteractionConfig;
   sr_logging_config?: LoggingConfig;
   sr_targeting_config?: TargetingConfig;
+  sr_experiment_config?: ExperimentConfig;
 };
 
 export interface SessionReplayRemoteConfigAPIResponse {

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -9,5 +9,6 @@ export const {
   evaluateTargetingAndCapture,
 } = sessionReplay;
 export { SessionReplayOptions, StoreType } from './typings/session-replay';
+export { RemoteTargetingConfig, RemoteDecision } from './config/types';
 export { SafeLoggerProvider } from './logger';
 export { AmplitudeSessionReplay } from './typings/session-replay';

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -17,12 +17,14 @@ import { eventWithTime, EventType as RRWebEventType, scrollCallback } from '@amp
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import {
   LoggingConfig,
+  RemoteDecision,
   SessionReplayJoinedConfig,
   SessionReplayJoinedConfigGenerator,
   SessionReplayLocalConfig,
   SessionReplayMetadata,
   SessionReplayRemoteConfig,
 } from './config/types';
+import { fetchRemoteDecision } from './targeting/remote-eval-client';
 import {
   BLOCK_CLASS,
   CustomRRwebEvent,
@@ -102,6 +104,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
   private currentPageUrl = '';
 
   private recordEventsPendingShouldLogMetadata: boolean | null = null;
+
+  // Remote eval state
+  private remoteDecision: RemoteDecision | null = null;
+  private remoteDecisionPending = false;
+  private lookbackHoldUploads = false;
+  private lookbackEventBuffer: Array<{ event: eventWithTime; sessionId: string | number }> = [];
 
   /** Cleanup for URL change listener used to re-evaluate targeting on SPA route changes */
   private urlChangeCleanup: (() => void) | null = null;
@@ -326,10 +334,21 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     this.teardownEventListeners(false);
 
-    await this.evaluateTargetingAndCapture(
-      { userProperties: options.userProperties, page: this.getCurrentPageForTargeting() },
-      true,
-    );
+    const rt = this.config.remoteTargeting;
+    if (rt?.enabled && rt.mode !== 'off') {
+      this.remoteDecision = null;
+      this.remoteDecisionPending = true;
+      if (rt.decisionStrategy === 'lookback') {
+        this.lookbackHoldUploads = true;
+        await this.recordEvents();
+      }
+      void this.runRemoteEval({ userProperties: options.userProperties });
+    } else {
+      await this.evaluateTargetingAndCapture(
+        { userProperties: options.userProperties, page: this.getCurrentPageForTargeting() },
+        true,
+      );
+    }
 
     const needsUrlTracking = this.config.targetingConfig || (this.config.privacyConfig?.urlMaskLevels?.length ?? 0) > 0;
     if (needsUrlTracking) {
@@ -351,6 +370,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.sessionTargetingMatch = false;
     this.lastShouldRecordDecision = undefined; // Reset targeting decision for new session
 
+    // Reset remote eval state for the new session
+    this.remoteDecision = null;
+    this.remoteDecisionPending = false;
+    this.lookbackHoldUploads = false;
+    this.lookbackEventBuffer = [];
+
     const previousSessionId = this.identifiers && this.identifiers.sessionId;
     if (previousSessionId) {
       this.sendEvents(previousSessionId);
@@ -367,6 +392,17 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (this.joinedConfigGenerator && previousSessionId) {
       const { joinedConfig } = await this.joinedConfigGenerator.generateJoinedConfig();
       this.config = joinedConfig;
+    }
+
+    const rt = this.config?.remoteTargeting;
+    if (rt?.enabled && rt.mode !== 'off') {
+      this.remoteDecisionPending = true;
+      if (rt.decisionStrategy === 'lookback') {
+        this.lookbackHoldUploads = true;
+        await this.recordEvents();
+      }
+      void this.runRemoteEval({ userProperties: options?.userProperties });
+      return;
     }
 
     if (this.config?.targetingConfig) {
@@ -541,6 +577,97 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
   };
 
+  private async runRemoteEval(targetingParams: { userProperties?: { [key: string]: any } }): Promise<void> {
+    const config = this.config;
+    if (!config?.remoteTargeting?.enabled) {
+      return;
+    }
+
+    const { deploymentKey, flagKey = 'sr-capture-gate', timeoutMs = 200, decisionStrategy } = config.remoteTargeting;
+
+    let userId: string | undefined;
+    let userProperties: Record<string, unknown> | undefined = targetingParams.userProperties as
+      | Record<string, unknown>
+      | undefined;
+
+    if (config.instanceName) {
+      const identity = getAnalyticsConnector(config.instanceName).identityStore.getIdentity();
+      userId = identity.userId;
+      if (identity.userProperties) {
+        userProperties = identity.userProperties;
+      }
+    }
+
+    const user = {
+      device_id: this.getDeviceId(),
+      user_id: userId,
+      user_properties: userProperties,
+    };
+
+    const decision = await fetchRemoteDecision(deploymentKey, user, flagKey, timeoutMs);
+    this.remoteDecision = decision;
+    this.remoteDecisionPending = false;
+
+    const page = this.getCurrentPageForTargeting();
+    const params = { userProperties: targetingParams.userProperties, page };
+
+    if (decisionStrategy === 'lookback') {
+      if (!decision.capture) {
+        if (this.recordCancelCallback) {
+          this.stopRecordingEvents();
+        }
+        this.lookbackEventBuffer = [];
+        this.lookbackHoldUploads = false;
+        this.loggerProvider.log(
+          `Session ${this.identifiers?.sessionId ?? 'unknown'} excluded by remote targeting gate: ${
+            decision.reason ?? 'denied'
+          }.`,
+        );
+        return;
+      }
+
+      // Remote granted — check TRC if configured
+      if (config.targetingConfig) {
+        await this.evaluateTargetingAndCapture(params, false, false);
+        if (!this.sessionTargetingMatch) {
+          if (this.recordCancelCallback) {
+            this.stopRecordingEvents();
+          }
+          this.lookbackEventBuffer = [];
+          this.lookbackHoldUploads = false;
+          return;
+        }
+      }
+
+      // All checks passed — flush buffered events
+      const buffer = this.lookbackEventBuffer;
+      this.lookbackEventBuffer = [];
+      this.lookbackHoldUploads = false;
+      if (this.eventCompressor) {
+        for (const { event, sessionId } of buffer) {
+          this.eventCompressor.enqueueEvent(event, sessionId);
+        }
+      }
+      this.sendEvents();
+    } else {
+      // Conservative strategy — start recording now
+      if (!decision.capture) {
+        this.loggerProvider.log(
+          `Session ${this.identifiers?.sessionId ?? 'unknown'} excluded by remote targeting gate: ${
+            decision.reason ?? 'denied'
+          }.`,
+        );
+        return;
+      }
+
+      if (config.targetingConfig) {
+        await this.evaluateTargetingAndCapture(params, false, false);
+      } else {
+        await this.recordEvents();
+      }
+    }
+  }
+
   sendEvents(sessionId?: string | number) {
     const sessionIdToSend = sessionId || this.identifiers?.sessionId;
     const deviceId = this.getDeviceId();
@@ -579,6 +706,22 @@ export class SessionReplay implements AmplitudeSessionReplay {
   getShouldRecord() {
     if (!this.identifiers || !this.config || !this.identifiers.sessionId) {
       this.loggerProvider.warn(`Session is not being recorded due to lack of config, please call sessionReplay.init.`);
+      return false;
+    }
+
+    if (this.remoteDecision?.capture === false) {
+      this.loggerProvider.log(
+        `Session ${this.identifiers.sessionId} excluded by remote targeting gate: ${
+          this.remoteDecision.reason ?? 'denied'
+        }.`,
+      );
+      return false;
+    }
+
+    if (this.remoteDecisionPending && this.config.remoteTargeting?.decisionStrategy === 'conservative') {
+      this.loggerProvider.log(
+        `Session ${this.identifiers.sessionId} not being recorded pending remote targeting decision.`,
+      );
       return false;
     }
 
@@ -819,7 +962,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
             event.data.href = getPageUrl(event.data.href, ugcFilterRules);
           }
 
-          if (this.eventCompressor) {
+          if (this.lookbackHoldUploads) {
+            this.lookbackEventBuffer.push({ event, sessionId });
+          } else if (this.eventCompressor) {
             // Schedule processing during idle time if the browser supports requestIdleCallback
             this.eventCompressor.enqueueEvent(event, sessionId);
           }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -656,6 +656,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
           this.eventCompressor.addCompressedEvent(event, sessionId);
         }
       }
+      // Also flush any events persisted in IDB from prior sessions.
+      const lookbackDeviceId = this.getDeviceId();
+      lookbackDeviceId &&
+        this.eventsManager &&
+        void this.eventsManager.sendStoredEvents({ deviceId: lookbackDeviceId });
       this.sendEvents();
     } else {
       // Conservative strategy — start recording now
@@ -669,9 +674,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
       }
 
       if (config.targetingConfig) {
-        await this.evaluateTargetingAndCapture(params, false, false);
+        // isInit=true ensures sendStoredEvents is called (same as the non-remote init path).
+        await this.evaluateTargetingAndCapture(params, true, false);
       } else {
-        await this.recordEvents();
+        await this.initialize(true);
       }
     }
   }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -108,6 +108,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
   // Remote eval state
   private remoteDecision: RemoteDecision | null = null;
   private remoteDecisionPending = false;
+  /** Monotonic counter to discard stale remote eval results when sessions change quickly */
+  private latestRemoteEvalId = 0;
   private lookbackHoldUploads = false;
   private lookbackEventBuffer: Array<{ event: eventWithTime; sessionId: string | number }> = [];
   private static readonly LOOKBACK_BUFFER_MAX_EVENTS_DEFAULT = 1000;
@@ -586,26 +588,29 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     const { deploymentKey, flagKey = 'sr-capture-gate', timeoutMs = 200, decisionStrategy } = config.remoteTargeting;
 
+    // Capture the current eval ID so we can detect if a newer session superseded us.
+    const evalId = ++this.latestRemoteEvalId;
+
     let userId: string | undefined;
-    let userProperties: Record<string, unknown> | undefined = targetingParams.userProperties as
-      | Record<string, unknown>
-      | undefined;
 
     if (config.instanceName) {
       const identity = getAnalyticsConnector(config.instanceName).identityStore.getIdentity();
       userId = identity.userId;
-      if (identity.userProperties) {
-        userProperties = identity.userProperties;
-      }
     }
 
     const user = {
       device_id: this.getDeviceId(),
       user_id: userId,
-      user_properties: userProperties,
     };
 
     const decision = await fetchRemoteDecision(deploymentKey, user, flagKey, timeoutMs);
+
+    // Discard result if a newer session has already started a fresh eval.
+    if (evalId !== this.latestRemoteEvalId) {
+      this.loggerProvider.log(`Ignoring stale remote eval result #${evalId}; latest is #${this.latestRemoteEvalId}.`);
+      return;
+    }
+
     this.remoteDecision = decision;
     this.remoteDecisionPending = false;
 
@@ -640,13 +645,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
         }
       }
 
-      // All checks passed — flush buffered events
+      // All checks passed — flush buffered events.
+      // Use addCompressedEvent directly (bypassing idle-callback deferral) so
+      // events land in the manager before sendEvents() fires.
       const buffer = this.lookbackEventBuffer;
       this.lookbackEventBuffer = [];
       this.lookbackHoldUploads = false;
       if (this.eventCompressor) {
         for (const { event, sessionId } of buffer) {
-          this.eventCompressor.enqueueEvent(event, sessionId);
+          this.eventCompressor.addCompressedEvent(event, sessionId);
         }
       }
       this.sendEvents();

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -607,7 +607,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       user_id: userId,
     };
 
-    const decision = await fetchRemoteDecision(deploymentKey, user, flagKey, timeoutMs);
+    const decision = await fetchRemoteDecision(deploymentKey, user, flagKey, timeoutMs, config.serverZone);
 
     // Discard result if a newer session has already started a fresh eval.
     if (evalId !== this.latestRemoteEvalId) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -399,6 +399,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     const rt = this.config?.remoteTargeting;
     if (rt?.enabled && rt.mode !== 'off') {
+      // Stop any recording from the previous session before starting the new eval cycle.
+      if (this.recordCancelCallback) {
+        this.stopRecordingEvents();
+      }
       this.remoteDecisionPending = true;
       if (rt.decisionStrategy === 'lookback') {
         this.lookbackHoldUploads = true;
@@ -757,7 +761,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     // If targetingConfig exists, we'll use the sessionTargetingMatch to determine whether to record
     // Otherwise, we'll evaluate the session against the overall sample rate
-    if (this.config.targetingConfig) {
+    // Exception: during a lookback hold, TRC hasn't run yet — bypass the match check so
+    // recording can start immediately. TRC is evaluated after the remote decision arrives.
+    if (this.config.targetingConfig && !this.lookbackHoldUploads) {
       if (!this.sessionTargetingMatch) {
         message = `Not capturing replays for session ${this.identifiers.sessionId} due to not matching targeting conditions.`;
         this.loggerProvider.log(message);

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -110,6 +110,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   private remoteDecisionPending = false;
   private lookbackHoldUploads = false;
   private lookbackEventBuffer: Array<{ event: eventWithTime; sessionId: string | number }> = [];
+  private static readonly LOOKBACK_BUFFER_MAX_EVENTS_DEFAULT = 1000;
 
   /** Cleanup for URL change listener used to re-evaluate targeting on SPA route changes */
   private urlChangeCleanup: (() => void) | null = null;
@@ -907,6 +908,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (!shouldRecord || !sessionId || !config) {
       return;
     }
+    const lookbackBufferMaxEvents =
+      config.remoteTargeting?.lookbackBufferMaxEvents ?? SessionReplay.LOOKBACK_BUFFER_MAX_EVENTS_DEFAULT;
     this.stopRecordingEvents();
 
     const recordFunction = await this.getRecordFunction();
@@ -963,7 +966,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
           }
 
           if (this.lookbackHoldUploads) {
-            this.lookbackEventBuffer.push({ event, sessionId });
+            if (this.lookbackEventBuffer.length < lookbackBufferMaxEvents) {
+              this.lookbackEventBuffer.push({ event, sessionId });
+            }
           } else if (this.eventCompressor) {
             // Schedule processing during idle time if the browser supports requestIdleCallback
             this.eventCompressor.enqueueEvent(event, sessionId);

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -755,15 +755,19 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return false;
     }
 
+    // During lookback hold, TRC and sample rate haven't been evaluated yet — record unconditionally.
+    // Actual eligibility is determined after the remote decision arrives in runRemoteEval.
+    if (this.lookbackHoldUploads) {
+      return true;
+    }
+
     let shouldRecord = false;
     let message = '';
     let matched = false;
 
     // If targetingConfig exists, we'll use the sessionTargetingMatch to determine whether to record
     // Otherwise, we'll evaluate the session against the overall sample rate
-    // Exception: during a lookback hold, TRC hasn't run yet — bypass the match check so
-    // recording can start immediately. TRC is evaluated after the remote decision arrives.
-    if (this.config.targetingConfig && !this.lookbackHoldUploads) {
+    if (this.config.targetingConfig) {
       if (!this.sessionTargetingMatch) {
         message = `Not capturing replays for session ${this.identifiers.sessionId} due to not matching targeting conditions.`;
         this.loggerProvider.log(message);

--- a/packages/session-replay-browser/src/targeting/remote-eval-client.ts
+++ b/packages/session-replay-browser/src/targeting/remote-eval-client.ts
@@ -1,13 +1,19 @@
 import { RemoteDecision } from '../config/types';
 
-const AMPLITUDE_EVAL_URL = 'https://api.lab.amplitude.com/sdk/v2/vardata';
+const EVAL_URLS: Record<string, string> = {
+  US: 'https://api.lab.amplitude.com/sdk/v2/vardata',
+  EU: 'https://api.lab.eu.amplitude.com/sdk/v2/vardata',
+};
+const DEFAULT_EVAL_URL = EVAL_URLS.US;
 
 export async function fetchRemoteDecision(
   deploymentKey: string,
   user: { device_id?: string; user_id?: string },
   flagKey: string,
   timeoutMs: number,
+  serverZone?: string,
 ): Promise<RemoteDecision> {
+  const baseUrl = (serverZone && EVAL_URLS[serverZone]) || DEFAULT_EVAL_URL;
   const params = new URLSearchParams({ flag_keys: flagKey });
   if (user.device_id) params.set('device_id', user.device_id);
   if (user.user_id) params.set('user_id', user.user_id);
@@ -15,7 +21,7 @@ export async function fetchRemoteDecision(
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(`${AMPLITUDE_EVAL_URL}?${params.toString()}`, {
+    const response = await fetch(`${baseUrl}?${params.toString()}`, {
       headers: { Authorization: `Api-Key ${deploymentKey}` },
       signal: controller.signal,
     });

--- a/packages/session-replay-browser/src/targeting/remote-eval-client.ts
+++ b/packages/session-replay-browser/src/targeting/remote-eval-client.ts
@@ -1,0 +1,31 @@
+import { RemoteDecision } from '../config/types';
+
+const AMPLITUDE_EVAL_URL = 'https://api.lab.amplitude.com/sdk/v2/vardata';
+
+export async function fetchRemoteDecision(
+  deploymentKey: string,
+  user: { device_id?: string; user_id?: string },
+  flagKey: string,
+  timeoutMs: number,
+): Promise<RemoteDecision> {
+  const params = new URLSearchParams({ flag_keys: flagKey });
+  if (user.device_id) params.set('device_id', user.device_id);
+  if (user.user_id) params.set('user_id', user.user_id);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${AMPLITUDE_EVAL_URL}?${params.toString()}`, {
+      headers: { Authorization: `Api-Key ${deploymentKey}` },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    const data = (await response.json()) as Record<string, { key?: string }>;
+    const variantKey = data[flagKey]?.key;
+    return { capture: variantKey === 'on' };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    return { capture: false, reason: isAbort ? 'timeout' : 'error' };
+  }
+}

--- a/packages/session-replay-browser/src/targeting/remote-eval-client.ts
+++ b/packages/session-replay-browser/src/targeting/remote-eval-client.ts
@@ -20,6 +20,9 @@ export async function fetchRemoteDecision(
       signal: controller.signal,
     });
     clearTimeout(timeoutId);
+    if (!response.ok) {
+      return { capture: false, reason: `http-${response.status}` };
+    }
     const data = (await response.json()) as Record<string, { key?: string }>;
     const variantKey = data[flagKey]?.key;
     return { capture: variantKey === 'on' };

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -657,6 +657,83 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     });
   });
 
+  describe('with sr_experiment_config', () => {
+    let joinedConfigGenerator: SessionReplayJoinedConfigGenerator;
+
+    beforeEach(async () => {
+      jest.spyOn(document, 'createDocumentFragment').mockReturnValue({
+        querySelector: () => true,
+      } as unknown as DocumentFragment);
+    });
+
+    it('populates remoteTargeting.deploymentKey from remote config when not set in SDK options', async () => {
+      const optionsWithRemoteTargeting = {
+        ...mockOptions,
+        remoteTargeting: {
+          enabled: true,
+          mode: 'session' as const,
+          decisionStrategy: 'conservative' as const,
+          deploymentKey: '',
+        },
+      };
+      joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator('static_key', optionsWithRemoteTargeting);
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_experiment_config: { flagId: 'flag-123', deploymentKey: 'remote-deploy-key' },
+      };
+      const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+      expect(config.remoteTargeting?.deploymentKey).toBe('remote-deploy-key');
+    });
+
+    it('does not overwrite deploymentKey when already set in SDK init options', async () => {
+      const optionsWithRemoteTargeting = {
+        ...mockOptions,
+        remoteTargeting: {
+          enabled: true,
+          mode: 'session' as const,
+          decisionStrategy: 'conservative' as const,
+          deploymentKey: 'sdk-deploy-key',
+        },
+      };
+      joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator('static_key', optionsWithRemoteTargeting);
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_experiment_config: { flagId: 'flag-123', deploymentKey: 'remote-deploy-key' },
+      };
+      const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+      expect(config.remoteTargeting?.deploymentKey).toBe('sdk-deploy-key');
+    });
+
+    it('does not set deploymentKey when sr_experiment_config has no deploymentKey', async () => {
+      const optionsWithRemoteTargeting = {
+        ...mockOptions,
+        remoteTargeting: {
+          enabled: true,
+          mode: 'session' as const,
+          decisionStrategy: 'conservative' as const,
+          deploymentKey: '',
+        },
+      };
+      joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator('static_key', optionsWithRemoteTargeting);
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_experiment_config: { flagId: 'flag-123' },
+      };
+      const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+      expect(config.remoteTargeting?.deploymentKey).toBe('');
+    });
+
+    it('does not set deploymentKey when remoteTargeting is not configured in SDK options', async () => {
+      joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator('static_key', mockOptions);
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_experiment_config: { flagId: 'flag-123', deploymentKey: 'remote-deploy-key' },
+      };
+      const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+      expect(config.remoteTargeting).toBeUndefined();
+    });
+  });
+
   describe('removeInvalidSelectorsFromPrivacyConfig', () => {
     test('should handle string block selector correctly', async () => {
       const privacyConfig = {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4695,6 +4695,74 @@ describe('SessionReplay', () => {
         expect((sessionReplay as any).remoteDecision).toEqual({ capture: true });
         expect(sessionReplay.getShouldRecord()).toBe(true);
       });
+
+      test('asyncSetSessionId stops previous lookback recording before starting new eval', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // Recording is active after lookback + capture=true
+        expect((sessionReplay as any).recordCancelCallback).not.toBeNull();
+
+        const stopRecordingSpy = jest.spyOn(sessionReplay, 'stopRecordingEvents');
+        fetchRemoteDecisionSpy.mockClear();
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+
+        await sessionReplay.setSessionId(456).promise;
+
+        // stopRecordingEvents must have been called to clean up the prior session's recording
+        expect(stopRecordingSpy).toHaveBeenCalled();
+      });
+
+      test('session change clears old lookback buffer before buffering new-session events', async () => {
+        let capturedEmit: ((event: eventWithTime) => void) | undefined;
+        mockRecordFunction.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {
+          capturedEmit = options.emit;
+          return jest.fn();
+        });
+
+        let resolveFirstDecision!: (d: { capture: boolean }) => void;
+        fetchRemoteDecisionSpy.mockReturnValue(
+          new Promise<{ capture: boolean }>((resolve) => (resolveFirstDecision = resolve)),
+        );
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+
+        // Emit two events during session 1 lookback hold
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(true);
+        capturedEmit?.(mockEvent as eventWithTime);
+        capturedEmit?.(mockEvent as eventWithTime);
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(2);
+
+        // Set up a new pending decision for session 2
+        let resolveSecondDecision!: (d: { capture: boolean }) => void;
+        fetchRemoteDecisionSpy.mockReturnValue(
+          new Promise<{ capture: boolean }>((resolve) => (resolveSecondDecision = resolve)),
+        );
+
+        // Transition to a new session — old buffer must be cleared
+        await sessionReplay.setSessionId(456).promise;
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
+
+        // Events emitted during session 2 must land in the new buffer with the new session id
+        capturedEmit?.(mockEvent as eventWithTime);
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(1);
+        expect((sessionReplay as any).lookbackEventBuffer[0].sessionId).toBe(456);
+
+        // Resolve decisions to avoid unhandled promise rejections
+        resolveFirstDecision({ capture: false });
+        resolveSecondDecision({ capture: false });
+      });
     });
 
     describe('remote eval + targetingConfig: both must pass', () => {
@@ -4751,6 +4819,61 @@ describe('SessionReplay', () => {
         expect(stopRecordingSpy).toHaveBeenCalled();
         expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
         expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+      });
+
+      test('lookback: flushes buffer and continues recording when TRC also passes', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        jest.spyOn(targetingManager, 'evaluateTargetingAndStore').mockResolvedValue(true);
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        if (sessionReplay.config) {
+          sessionReplay.config.targetingConfig = flagConfig;
+        }
+        (sessionReplay as any).remoteDecision = null;
+        (sessionReplay as any).remoteDecisionPending = true;
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        (sessionReplay as any).lookbackEventBuffer = [{ event: mockEvent, sessionId: 123 }];
+        (sessionReplay as any).lookbackHoldUploads = true;
+
+        // Create spy after init so we only observe calls from the re-run
+        const stopRecordingSpy = jest.spyOn(sessionReplay, 'stopRecordingEvents');
+
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+
+        // Both gates passed: buffer flushed, hold released, and recording NOT stopped
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+        expect(stopRecordingSpy).not.toHaveBeenCalled();
+      });
+
+      test('conservative: starts recording when TRC also passes', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        jest.spyOn(targetingManager, 'evaluateTargetingAndStore').mockResolvedValue(true);
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents' as any);
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        if (sessionReplay.config) {
+          sessionReplay.config.targetingConfig = flagConfig;
+        }
+        (sessionReplay as any).remoteDecision = null;
+        (sessionReplay as any).remoteDecisionPending = true;
+        recordEventsSpy.mockClear();
+
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        expect(recordEventsSpy).toHaveBeenCalled();
+        expect(mockRecordFunction).toHaveBeenCalled();
       });
     });
 
@@ -4832,6 +4955,26 @@ describe('SessionReplay', () => {
         (sessionReplay as any).identifiers = undefined;
         await (sessionReplay as any).runRemoteEval({ userProperties: {} });
         expect(mockLoggerProvider.log).toHaveBeenCalledWith(expect.stringContaining('unknown'));
+      });
+
+      test('passes config.serverZone to fetchRemoteDecision', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        // mockOptions includes serverZone: ServerZone.EU
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+        expect(fetchRemoteDecisionSpy).toHaveBeenCalledWith(
+          remoteTargetingBase.deploymentKey,
+          expect.any(Object),
+          remoteTargetingBase.flagKey,
+          remoteTargetingBase.timeoutMs,
+          ServerZone.EU,
+        );
       });
     });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4569,6 +4569,7 @@ describe('SessionReplay', () => {
           expect.objectContaining({ device_id: mockOptions.deviceId }),
           remoteTargetingBase.flagKey,
           remoteTargetingBase.timeoutMs,
+          expect.any(String),
         );
         expect(recordEventsSpy).toHaveBeenCalled();
         expect(mockRecordFunction).toHaveBeenCalled();
@@ -4803,6 +4804,7 @@ describe('SessionReplay', () => {
           expect.any(Object),
           'sr-capture-gate', // default
           200, // default
+          expect.any(String),
         );
       });
 
@@ -4893,6 +4895,7 @@ describe('SessionReplay', () => {
           expect.objectContaining({ device_id: mockOptions.deviceId }),
           expect.any(String),
           expect.any(Number),
+          expect.any(String),
         );
       });
     });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4924,6 +4924,56 @@ describe('SessionReplay', () => {
         resolveDecision({ capture: true });
       });
 
+      test('lookback flush calls sendStoredEvents when deviceId is available', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // eventsManager is set; re-trigger lookback flush via a second session
+        const sendStoredEventsSpy = jest.spyOn((sessionReplay as any).eventsManager, 'sendStoredEvents');
+        (sessionReplay as any).lookbackHoldUploads = true;
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        await (sessionReplay as any).runRemoteEval({});
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        expect(sendStoredEventsSpy).toHaveBeenCalledWith({ deviceId: mockOptions.deviceId });
+        sendStoredEventsSpy.mockRestore();
+      });
+
+      test('lookback flush skips sendStoredEvents when eventsManager is null', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // Null out eventsManager to exercise the short-circuit branch
+        const savedEventsManager = (sessionReplay as any).eventsManager;
+        (sessionReplay as any).eventsManager = null;
+        (sessionReplay as any).lookbackHoldUploads = true;
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        await (sessionReplay as any).runRemoteEval({});
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // No error thrown; eventsManager was null so sendStoredEvents was skipped
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+        (sessionReplay as any).eventsManager = savedEventsManager;
+      });
+
       test('buffered events are flushed to eventCompressor on capture=true', async () => {
         let capturedEmit: ((event: eventWithTime) => void) | undefined;
         mockRecordFunction.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4979,6 +4979,41 @@ describe('SessionReplay', () => {
         resolveDecision({ capture: false });
       });
 
+      test('stale remote eval result is discarded when session changes mid-flight', async () => {
+        // First eval is held in-flight; second eval resolves capture=true.
+        let resolveFirstDecision!: (d: { capture: boolean }) => void;
+        let firstDecisionCallCount = 0;
+        fetchRemoteDecisionSpy.mockImplementation(() => {
+          firstDecisionCallCount++;
+          if (firstDecisionCallCount === 1) {
+            return new Promise<{ capture: boolean }>((resolve) => (resolveFirstDecision = resolve));
+          }
+          return Promise.resolve({ capture: true });
+        });
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+
+        // New session starts — increments latestRemoteEvalId, fires a second eval
+        void sessionReplay.setSessionId(456).promise;
+        // Let second eval resolve
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // Now resolve the stale first eval with capture=false — should be ignored
+        resolveFirstDecision({ capture: false });
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // remoteDecision should reflect the second (non-stale) eval, not the stale one
+        expect((sessionReplay as any).remoteDecision).toEqual({ capture: true });
+      });
+
       test('lookback strategy in asyncSetSessionId re-fires recording and remote eval', async () => {
         fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
         const options: SessionReplayOptions = {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -17,6 +17,8 @@ import * as Sampling from '../src/sampling';
 import * as Helpers from '../src/helpers';
 import { SessionReplay } from '../src/session-replay';
 import * as targetingManager from '../src/targeting/targeting-manager';
+import * as remoteEvalClient from '../src/targeting/remote-eval-client';
+import { eventWithTime } from '@amplitude/rrweb-types';
 
 // Mock the worker module
 jest.mock(
@@ -4433,6 +4435,546 @@ describe('SessionReplay', () => {
           mockOptions.sessionId?.toString() || ''
         } due to matching targeting conditions.`,
       );
+    });
+
+    describe('remote targeting gate', () => {
+      test('getShouldRecord returns false when remoteDecision.capture is false', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        (sessionReplay as any).remoteDecision = { capture: false, reason: 'denied' };
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+        expect(mockLoggerProvider.log).toHaveBeenCalledWith(
+          expect.stringContaining('excluded by remote targeting gate'),
+        );
+      });
+
+      test('getShouldRecord returns false when pending + conservative', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        if (sessionReplay.config) {
+          sessionReplay.config.remoteTargeting = {
+            enabled: true,
+            mode: 'session',
+            deploymentKey: 'client-test-key',
+            decisionStrategy: 'conservative',
+          };
+        }
+        (sessionReplay as any).remoteDecisionPending = true;
+        (sessionReplay as any).remoteDecision = null;
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+        expect(mockLoggerProvider.log).toHaveBeenCalledWith(
+          expect.stringContaining('pending remote targeting decision'),
+        );
+      });
+
+      test('getShouldRecord proceeds normally when pending + lookback', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        if (sessionReplay.config) {
+          sessionReplay.config.remoteTargeting = {
+            enabled: true,
+            mode: 'session',
+            deploymentKey: 'client-test-key',
+            decisionStrategy: 'lookback',
+          };
+        }
+        (sessionReplay as any).remoteDecisionPending = true;
+        (sessionReplay as any).remoteDecision = null;
+        // Should not return false due to remote pending in lookback mode
+        // (still subject to captureEnabled / sample rate / targeting checks)
+        const result = sessionReplay.getShouldRecord();
+        expect(result).toBe(true); // sample rate = 1 in mockOptions
+      });
+    });
+  });
+
+  describe('remote eval gate', () => {
+    let fetchRemoteDecisionSpy: jest.SpyInstance;
+    const remoteTargetingBase = {
+      enabled: true,
+      mode: 'session' as const,
+      deploymentKey: 'client-test-deployment-key',
+      flagKey: 'sr-capture-gate',
+      timeoutMs: 200,
+    };
+
+    beforeEach(() => {
+      fetchRemoteDecisionSpy = jest.spyOn(remoteEvalClient, 'fetchRemoteDecision');
+    });
+
+    afterEach(() => {
+      fetchRemoteDecisionSpy.mockRestore();
+    });
+
+    describe('mode: off (or remoteTargeting not set)', () => {
+      test('uses existing evaluateTargetingAndCapture flow when remoteTargeting not configured', async () => {
+        const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        // fetchRemoteDecision should not be called
+        expect(fetchRemoteDecisionSpy).not.toHaveBeenCalled();
+        // evaluateTargetingAndCapture should have been called (existing path)
+        expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ page: { url: 'http://localhost' } }),
+          true,
+        );
+      });
+
+      test('uses existing flow when mode is off', async () => {
+        const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+        const optionsWithOff: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, mode: 'off', decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, optionsWithOff).promise;
+        expect(fetchRemoteDecisionSpy).not.toHaveBeenCalled();
+        expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith(expect.anything(), true);
+      });
+    });
+
+    describe('conservative strategy', () => {
+      const conservativeOptions: SessionReplayOptions = {
+        ...mockOptions,
+        remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+      };
+
+      test('does not start recording before remote decision arrives', async () => {
+        // Delay remote decision resolution
+        let resolveDecision!: (d: { capture: boolean }) => void;
+        fetchRemoteDecisionSpy.mockReturnValue(
+          new Promise<{ capture: boolean }>((resolve) => {
+            resolveDecision = resolve;
+          }),
+        );
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents' as any);
+
+        await sessionReplay.init(apiKey, conservativeOptions).promise;
+
+        // getShouldRecord should return false while pending
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+        // recordEvents should not have been called yet (no recording)
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+
+        resolveDecision({ capture: true });
+      });
+
+      test('starts recording after remote decision: capture=true (no targetingConfig)', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents' as any);
+
+        await sessionReplay.init(apiKey, conservativeOptions).promise;
+        // Drain microtask queue: fetchRemoteDecision → runRemoteEval → recordEvents → getRecordFunction → initNetworkObservers → record()
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        expect(fetchRemoteDecisionSpy).toHaveBeenCalledWith(
+          remoteTargetingBase.deploymentKey,
+          expect.objectContaining({ device_id: mockOptions.deviceId }),
+          remoteTargetingBase.flagKey,
+          remoteTargetingBase.timeoutMs,
+        );
+        expect(recordEventsSpy).toHaveBeenCalled();
+        expect(mockRecordFunction).toHaveBeenCalled();
+      });
+
+      test('does not start recording after remote decision: capture=false', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false, reason: 'not in cohort' });
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents' as any);
+
+        await sessionReplay.init(apiKey, conservativeOptions).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+        expect(mockRecordFunction).not.toHaveBeenCalled();
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+      });
+
+      test('does not record on timeout (conservative fallback)', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false, reason: 'timeout' });
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents' as any);
+
+        await sessionReplay.init(apiKey, conservativeOptions).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+      });
+    });
+
+    describe('lookback strategy', () => {
+      const lookbackOptions: SessionReplayOptions = {
+        ...mockOptions,
+        remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+      };
+
+      test('starts recording immediately before remote decision arrives', async () => {
+        let resolveDecision!: (d: { capture: boolean }) => void;
+        fetchRemoteDecisionSpy.mockReturnValue(
+          new Promise<{ capture: boolean }>((resolve) => (resolveDecision = resolve)),
+        );
+
+        await sessionReplay.init(apiKey, lookbackOptions).promise;
+
+        // rrweb recording should have started immediately
+        expect(mockRecordFunction).toHaveBeenCalled();
+        // But uploads are held
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(true);
+
+        resolveDecision({ capture: true });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      test('flushes buffered events and continues recording on capture=true', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+
+        await sessionReplay.init(apiKey, lookbackOptions).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
+      });
+
+      test('stops recording and discards buffer on capture=false', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false, reason: 'denied' });
+        const stopRecordingSpy = jest.spyOn(sessionReplay, 'stopRecordingEvents');
+
+        await sessionReplay.init(apiKey, lookbackOptions).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(stopRecordingSpy).toHaveBeenCalled();
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+      });
+    });
+
+    describe('session ID change re-runs remote eval', () => {
+      test('resets remote eval state and re-fires runRemoteEval on asyncSetSessionId', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        fetchRemoteDecisionSpy.mockClear();
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+
+        await sessionReplay.setSessionId(456).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Should have called fetchRemoteDecision again for the new session
+        expect(fetchRemoteDecisionSpy).toHaveBeenCalledTimes(1);
+        // Remote decision state should be reset and re-applied
+        expect((sessionReplay as any).remoteDecision).toEqual({ capture: true });
+      });
+
+      test('remote eval state is reset on session change even when previous decision was capture=false', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+
+        // New session - new chance
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        await sessionReplay.setSessionId(789).promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect((sessionReplay as any).remoteDecision).toEqual({ capture: true });
+        expect(sessionReplay.getShouldRecord()).toBe(true);
+      });
+    });
+
+    describe('remote eval + targetingConfig: both must pass', () => {
+      const flagConfig = {
+        key: 'sr_targeting_config',
+        variants: { on: { key: 'on' }, off: { key: 'off' } },
+        segments: [],
+      };
+
+      test('conservative: does not record when remote=true but TRC fails', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        jest.spyOn(targetingManager, 'evaluateTargetingAndStore').mockResolvedValue(false);
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        // Manually inject targetingConfig after init to simulate both being set
+        if (sessionReplay.config) {
+          sessionReplay.config.targetingConfig = flagConfig;
+        }
+        // Reset to re-run
+        (sessionReplay as any).remoteDecision = null;
+        (sessionReplay as any).remoteDecisionPending = true;
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+
+        expect(sessionReplay.getShouldRecord()).toBe(false);
+      });
+
+      test('lookback: stops recording and clears buffer when remote=true but TRC fails', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        jest.spyOn(targetingManager, 'evaluateTargetingAndStore').mockResolvedValue(false);
+        const stopRecordingSpy = jest.spyOn(sessionReplay, 'stopRecordingEvents');
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        // Inject targetingConfig and force a re-run
+        if (sessionReplay.config) {
+          sessionReplay.config.targetingConfig = flagConfig;
+        }
+        (sessionReplay as any).remoteDecision = null;
+        (sessionReplay as any).remoteDecisionPending = true;
+        // Simulate recording active with buffered events
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        (sessionReplay as any).lookbackEventBuffer = [{ event: mockEvent, sessionId: 123 }];
+        (sessionReplay as any).lookbackHoldUploads = true;
+
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+
+        expect(stopRecordingSpy).toHaveBeenCalled();
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+      });
+    });
+
+    describe('runRemoteEval early return', () => {
+      test('returns early when config is null', async () => {
+        // Do NOT call init — config is undefined
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+        expect(fetchRemoteDecisionSpy).not.toHaveBeenCalled();
+      });
+
+      test('returns early when remoteTargeting is not enabled on config', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        // config has no remoteTargeting — call runRemoteEval directly
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+        expect(fetchRemoteDecisionSpy).not.toHaveBeenCalled();
+      });
+
+      test('returns early when remoteTargeting.enabled is false', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        if (sessionReplay.config) {
+          sessionReplay.config.remoteTargeting = {
+            enabled: false,
+            mode: 'session',
+            deploymentKey: 'client-test-key',
+            decisionStrategy: 'conservative',
+          };
+        }
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+        expect(fetchRemoteDecisionSpy).not.toHaveBeenCalled();
+      });
+
+      test('uses default flagKey and timeoutMs when not provided in config', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        // Config without flagKey or timeoutMs — defaults should be used
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: {
+            enabled: true,
+            mode: 'session',
+            deploymentKey: remoteTargetingBase.deploymentKey,
+            decisionStrategy: 'conservative',
+            // flagKey and timeoutMs deliberately omitted
+          },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+        expect(fetchRemoteDecisionSpy).toHaveBeenCalledWith(
+          remoteTargetingBase.deploymentKey,
+          expect.any(Object),
+          'sr-capture-gate', // default
+          200, // default
+        );
+      });
+
+      test('logs "unknown" for sessionId when identifiers is null at deny time (lookback)', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        // Simulate identifiers being null before decision arrives
+        (sessionReplay as any).identifiers = undefined;
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+        expect(mockLoggerProvider.log).toHaveBeenCalledWith(expect.stringContaining('unknown'));
+      });
+
+      test('logs "unknown" for sessionId when identifiers is null at deny time (conservative)', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        // Simulate identifiers being null before decision arrives
+        (sessionReplay as any).identifiers = undefined;
+        await (sessionReplay as any).runRemoteEval({ userProperties: {} });
+        expect(mockLoggerProvider.log).toHaveBeenCalledWith(expect.stringContaining('unknown'));
+      });
+    });
+
+    describe('getShouldRecord with remoteDecisionPending but no remoteTargeting config', () => {
+      test('does not block when remoteDecisionPending=true but remoteTargeting is undefined', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        // Simulate a weird state: pending=true but config has no remoteTargeting
+        (sessionReplay as any).remoteDecisionPending = true;
+        // Without remoteTargeting config, the conservative check doesn't apply
+        const result = sessionReplay.getShouldRecord();
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('decision.reason fallback', () => {
+      test('lookback: logs "denied" when decision has no reason', async () => {
+        // capture=false with no reason field
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+        expect(mockLoggerProvider.log).toHaveBeenCalledWith(expect.stringContaining('denied'));
+      });
+
+      test('conservative: logs "denied" when decision has no reason', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: false });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+        expect(mockLoggerProvider.log).toHaveBeenCalledWith(expect.stringContaining('denied'));
+      });
+    });
+
+    describe('asyncSetSessionId with userProperties in options', () => {
+      test('fires remote eval when asyncSetSessionId called with options containing userProperties', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'conservative' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+
+        fetchRemoteDecisionSpy.mockClear();
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+
+        // Call asyncSetSessionId with options.userProperties defined (covers options?.userProperties branch)
+        await (sessionReplay as any).asyncSetSessionId(789, undefined, { userProperties: { plan: 'pro' } });
+
+        expect(fetchRemoteDecisionSpy).toHaveBeenCalledWith(
+          remoteTargetingBase.deploymentKey,
+          expect.objectContaining({ device_id: mockOptions.deviceId }),
+          expect.any(String),
+          expect.any(Number),
+        );
+      });
+    });
+
+    describe('lookback event buffering', () => {
+      test('events are pushed to lookbackEventBuffer during lookback hold', async () => {
+        let capturedEmit: ((event: eventWithTime) => void) | undefined;
+        mockRecordFunction.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {
+          capturedEmit = options.emit;
+          return jest.fn();
+        });
+
+        let resolveDecision!: (d: { capture: boolean }) => void;
+        fetchRemoteDecisionSpy.mockReturnValue(
+          new Promise<{ capture: boolean }>((resolve) => (resolveDecision = resolve)),
+        );
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+
+        // Simulate rrweb emitting an event while hold is active
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(true);
+        capturedEmit?.(mockEvent as eventWithTime);
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(1);
+
+        resolveDecision({ capture: true });
+      });
+
+      test('buffered events are flushed to eventCompressor on capture=true', async () => {
+        let capturedEmit: ((event: eventWithTime) => void) | undefined;
+        mockRecordFunction.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {
+          capturedEmit = options.emit;
+          return jest.fn();
+        });
+
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+
+        // Simulate an event before decision arrives
+        capturedEmit?.(mockEvent as eventWithTime);
+
+        // Allow runRemoteEval to complete
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // After decision: buffer should be drained
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(0);
+        expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
+      });
+
+      test('lookback strategy in asyncSetSessionId re-fires recording and remote eval', async () => {
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback' },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        fetchRemoteDecisionSpy.mockClear();
+        fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
+
+        await sessionReplay.setSessionId(456).promise;
+        for (let i = 0; i < 6; i++) {
+          await Promise.resolve();
+        }
+
+        // lookback: recording should start immediately and remote eval re-fires
+        expect(mockRecordFunction.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(fetchRemoteDecisionSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4952,6 +4952,33 @@ describe('SessionReplay', () => {
         expect((sessionReplay as any).lookbackHoldUploads).toBe(false);
       });
 
+      test('drops events beyond lookbackBufferMaxEvents', async () => {
+        let capturedEmit: ((event: eventWithTime) => void) | undefined;
+        mockRecordFunction.mockImplementation((options: { emit: (event: eventWithTime) => void }) => {
+          capturedEmit = options.emit;
+          return jest.fn();
+        });
+
+        let resolveDecision!: (d: { capture: boolean }) => void;
+        fetchRemoteDecisionSpy.mockReturnValue(
+          new Promise<{ capture: boolean }>((resolve) => (resolveDecision = resolve)),
+        );
+
+        const options: SessionReplayOptions = {
+          ...mockOptions,
+          remoteTargeting: { ...remoteTargetingBase, decisionStrategy: 'lookback', lookbackBufferMaxEvents: 3 },
+        };
+        await sessionReplay.init(apiKey, options).promise;
+
+        // Emit more events than the cap
+        for (let i = 0; i < 5; i++) {
+          capturedEmit?.(mockEvent as eventWithTime);
+        }
+
+        expect((sessionReplay as any).lookbackEventBuffer).toHaveLength(3);
+        resolveDecision({ capture: false });
+      });
+
       test('lookback strategy in asyncSetSessionId re-fires recording and remote eval', async () => {
         fetchRemoteDecisionSpy.mockResolvedValue({ capture: true });
         const options: SessionReplayOptions = {

--- a/packages/session-replay-browser/test/targeting/remote-eval-client.test.ts
+++ b/packages/session-replay-browser/test/targeting/remote-eval-client.test.ts
@@ -125,4 +125,28 @@ describe('fetchRemoteDecision', () => {
     const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
     expect(url).toContain('flag_keys=custom-flag');
   });
+
+  it('uses EU eval URL when serverZone is EU', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'on' } }),
+    });
+
+    await fetchRemoteDecision(deploymentKey, user, flagKey, 200, 'EU');
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://api.lab.eu.amplitude.com/sdk/v2/vardata');
+  });
+
+  it('falls back to US eval URL for unknown serverZone', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'on' } }),
+    });
+
+    await fetchRemoteDecision(deploymentKey, user, flagKey, 200, 'STAGING');
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://api.lab.amplitude.com/sdk/v2/vardata');
+  });
 });

--- a/packages/session-replay-browser/test/targeting/remote-eval-client.test.ts
+++ b/packages/session-replay-browser/test/targeting/remote-eval-client.test.ts
@@ -1,0 +1,103 @@
+import { fetchRemoteDecision } from '../../src/targeting/remote-eval-client';
+
+describe('fetchRemoteDecision', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  const deploymentKey = 'client-abc123';
+  const user = { device_id: 'device-1', user_id: 'user-1' };
+  const flagKey = 'sr-capture-gate';
+
+  it('returns capture: true when Amplitude eval returns variant "on"', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'on', value: 'on' } }),
+    });
+
+    const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
+    expect(result).toEqual({ capture: true });
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://api.lab.amplitude.com/sdk/v2/vardata');
+    expect(url).toContain('flag_keys=sr-capture-gate');
+    expect(url).toContain('device_id=device-1');
+    expect(url).toContain('user_id=user-1');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Api-Key ${deploymentKey}`);
+  });
+
+  it('returns capture: false when Amplitude eval returns variant "off"', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'off' } }),
+    });
+
+    const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
+    expect(result).toEqual({ capture: false });
+  });
+
+  it('returns capture: false when flag key is absent from response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+
+    const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
+    expect(result).toEqual({ capture: false });
+  });
+
+  it('returns capture: false with reason "error" on network error', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network failure'));
+
+    const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
+    expect(result).toEqual({ capture: false, reason: 'error' });
+  });
+
+  it('returns capture: false with reason "timeout" when timeout is exceeded', async () => {
+    global.fetch = jest.fn().mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('Aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+
+    const promise = fetchRemoteDecision(deploymentKey, user, flagKey, 100);
+    jest.advanceTimersByTime(100);
+    const result = await promise;
+
+    expect(result).toEqual({ capture: false, reason: 'timeout' });
+  });
+
+  it('omits device_id and user_id query params when not provided', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'on' } }),
+    });
+
+    await fetchRemoteDecision(deploymentKey, {}, flagKey, 200);
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain('device_id');
+    expect(url).not.toContain('user_id');
+  });
+
+  it('uses the correct flag key in the query params', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ 'custom-flag': { key: 'on' } }),
+    });
+
+    await fetchRemoteDecision(deploymentKey, user, 'custom-flag', 200);
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('flag_keys=custom-flag');
+  });
+});

--- a/packages/session-replay-browser/test/targeting/remote-eval-client.test.ts
+++ b/packages/session-replay-browser/test/targeting/remote-eval-client.test.ts
@@ -20,6 +20,7 @@ describe('fetchRemoteDecision', () => {
 
   it('returns capture: true when Amplitude eval returns variant "on"', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'on', value: 'on' } }),
     });
 
@@ -36,6 +37,7 @@ describe('fetchRemoteDecision', () => {
 
   it('returns capture: false when Amplitude eval returns variant "off"', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'off' } }),
     });
 
@@ -45,11 +47,32 @@ describe('fetchRemoteDecision', () => {
 
   it('returns capture: false when flag key is absent from response', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue({}),
     });
 
     const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
     expect(result).toEqual({ capture: false });
+  });
+
+  it('returns capture: false with reason "http-401" on HTTP 401', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
+    expect(result).toEqual({ capture: false, reason: 'http-401' });
+  });
+
+  it('returns capture: false with reason "http-500" on HTTP 500', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const result = await fetchRemoteDecision(deploymentKey, user, flagKey, 200);
+    expect(result).toEqual({ capture: false, reason: 'http-500' });
   });
 
   it('returns capture: false with reason "error" on network error', async () => {
@@ -80,6 +103,7 @@ describe('fetchRemoteDecision', () => {
 
   it('omits device_id and user_id query params when not provided', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue({ [flagKey]: { key: 'on' } }),
     });
 
@@ -92,6 +116,7 @@ describe('fetchRemoteDecision', () => {
 
   it('uses the correct flag key in the query params', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue({ 'custom-flag': { key: 'on' } }),
     });
 

--- a/test-server/session-replay-browser/sr-capture-test.html
+++ b/test-server/session-replay-browser/sr-capture-test.html
@@ -11,7 +11,6 @@
     <button id="test-button" aria-label="Submit form">Submit</button>
     <script type="module">
       import * as sessionReplay from '@amplitude/session-replay-browser';
-
       window.sessionReplay = sessionReplay;
 
       const params = new URLSearchParams(location.search);
@@ -22,6 +21,36 @@
       const logLevel = params.has('logLevel') ? Number(params.get('logLevel')) : 0;
       const useWebWorker = params.get('useWebWorker') === 'true';
 
+      // Remote targeting config — enabled when remoteEvalDeploymentKey param is present
+      const remoteEvalDeploymentKey = params.get('remoteEvalDeploymentKey');
+      const remoteTargeting = remoteEvalDeploymentKey
+        ? {
+            enabled: true,
+            mode: 'session',
+            deploymentKey: remoteEvalDeploymentKey,
+            flagKey: params.get('remoteEvalFlagKey') ?? 'sr-capture-gate',
+            timeoutMs: params.has('remoteEvalTimeoutMs') ? Number(params.get('remoteEvalTimeoutMs')) : 200,
+            decisionStrategy: params.get('remoteEvalStrategy') ?? 'conservative',
+          }
+        : undefined;
+
+      // Fire a lightweight analytics event so Amplitude can geo-enrich and build
+      // a user profile for this device in this project (needed for Experiment targeting).
+      if (params.get('sendAnalyticsEvent') === 'true') {
+        fetch('https://api2.amplitude.com/2/httpapi', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            api_key: 'd90c5cf09ca2546a1626272906b99a76',
+            events: [{
+              device_id: deviceId,
+              event_type: 'sr_capture_test_page_view',
+              time: Date.now(),
+            }],
+          }),
+        }).catch(() => { /* best effort */ });
+      }
+
       void (async () => {
         try {
           await sessionReplay.init('d90c5cf09ca2546a1626272906b99a76', {
@@ -31,6 +60,7 @@
             optOut,
             logLevel,
             useWebWorker,
+            remoteTargeting,
           }).promise;
         } catch (err) {
           document.getElementById('status').textContent = 'error: ' + err.message;


### PR DESCRIPTION
### Summary

Integrates Amplitude Experiment as a remote gate that runs once per session (and on session change) to decide whether a session is eligible for capture, before local TRC evaluation runs. Enables server-side targeting logic (cohorts, feature flags) as a precondition for Session Replay capture.

- New `remoteTargeting` config option with `deploymentKey`, `flagKey`, `timeoutMs`, and `decisionStrategy` ('conservative' | 'lookback')
- Conservative strategy: hold recording until remote decision arrives; no capture on timeout or error
- Lookback strategy: record immediately, hold uploads until decision, then flush or discard based on result
- Re-evaluates on `setSessionId` for new session targeting
- Direct integration with Amplitude Experiment eval API (api.lab.amplitude.com/sdk/v2/vardata) — no proxy required
- Unit tests (100% coverage), mocked e2e tests, and live e2e tests against real Amplitude Experiment API (project 631773)

**Tech Design Doc:** https://amplitude.atlassian.net/wiki/spaces/IG/pages/3710976009

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core capture-start/stop behavior by adding an async remote Experiment evaluation step (including buffering/flush logic) that can prevent recording on timeout/error or session change. Risk is mitigated by extensive unit and e2e coverage, but mistakes could reduce capture rates or increase event buffering overhead.
> 
> **Overview**
> Adds an optional **remote targeting gate** (`remoteTargeting`) that calls the Amplitude Experiment eval API once per session (and on `setSessionId`) to decide whether Session Replay is eligible to capture.
> 
> Implements two strategies in `SessionReplay`: *conservative* waits for the remote decision before recording, while *lookback* starts rrweb immediately, buffers events (bounded by `lookbackBufferMaxEvents`), then flushes or discards once the decision (and any local targeting) resolves.
> 
> Plumbs the new config through local/joined config and the plugin wrapper, exports the new `RemoteTargetingConfig`/`RemoteDecision` types, and adds `fetchRemoteDecision` plus comprehensive unit tests and Playwright e2e tests (mocked and live) for request shape and capture/flush behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 838a2b239c392d3d7710684365b94f3702ad0510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->