### PR TITLE
chore: make @amplitude/plugin-custom-enrichment-browser not private

### DIFF
--- a/packages/plugin-custom-enrichment-browser/package.json
+++ b/packages/plugin-custom-enrichment-browser/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@amplitude/plugin-custom-enrichment-browser",
-  "private": true,
   "version": "0.0.1",
   "description": "",
   "author": "Amplitude Inc",


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only changes package metadata, but it affects release/publishing behavior by making `@amplitude/plugin-custom-enrichment-browser` publishable to npm.
> 
> **Overview**
> Removes the `"private": true` flag from `packages/plugin-custom-enrichment-browser/package.json`, allowing `@amplitude/plugin-custom-enrichment-browser` to be published publicly (per existing `publishConfig`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae45b345e2b44ca9c0ec984368b32c1fd963c1e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->