### PR TITLE
chore: add first time publishing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,20 @@ For contributions to version `1.x`, open a pull request against `v1.x`. For cont
 
 As soon as your changes are approved, a team member will merge your PR to main and will get published shortly after.
 
+#### Publishing NPM package for the first time
+
+Because the workflow uses Trusted Publishing, a new package can't be published from the publish workflow on the first try. 
+
+To publish a package for the first time (administrators only):
+1. run `pnpm install` from the route
+2. navigate to the root of the new package
+3. run `pnpm build`
+4. run `pnpm publish` (requires admin credentials with 2FA)
+5. navigate to the NPM homepage of the new package
+6. open "Settings" and configure it to use Trusted Publishing
+7. copy the same configuration used in [analytics browser](https://www.npmjs.com/package/@amplitude/analytics-browser/access). **case sensitive**
+8. now that it's in NPM and Trusted Publishing is enabled, this package can now be published from workflows
+
 ## Practices
 
 ### PR Commit Title Conventions

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run `pnpm dev` to run the test server. It will open up to the home page automati
 
 For more details visit the [Test Server README.md](/test-server/README.md)
 
-## Troubleshooting
+### Troubleshooting
 
 If you ever see an error that looks like this while running an Nx command (pnpm test, pnpm build, etc...):
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime, build, or release logic changes.
> 
> **Overview**
> Adds a new **“Publishing NPM package for the first time”** section to `CONTRIBUTING.md`, documenting the manual, admin-only steps required to publish a brand-new package and then enable *Trusted Publishing* so subsequent releases can run via workflow.
> 
> Adjusts the `README.md` “Troubleshooting” header level to be a subsection under local testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da984142820840056377d6bb94ae9376aa524391. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->