### PR TITLE
fix(docs): add `engagement` import to Unified SDK doc

### DIFF
--- a/packages/unified/README.md
+++ b/packages/unified/README.md
@@ -69,6 +69,7 @@ The Unified SDK provides access to all Amplitude features through a single inter
 import {
   track,
   identify,
+  engagement,
   experiment,
   sessionReplay
 } from '@amplitude/unified';


### PR DESCRIPTION
## Changes

Updates the `@amplitude/unified` README to include the "engagement" import in the example.

Related docs PR:
https://github.com/amplitude/amplitude-docs/pull/1546