### PR TITLE
feat(unified): add engagement SDK plugin getter

### DIFF
--- a/packages/unified/src/index.ts
+++ b/packages/unified/src/index.ts
@@ -6,6 +6,7 @@ export const {
   _enableRequestBodyCompressionExperimental,
   initAll,
   experiment,
+  engagement,
   sessionReplay,
   add,
   extendSession,

--- a/packages/unified/src/unified-client-factory.ts
+++ b/packages/unified/src/unified-client-factory.ts
@@ -22,6 +22,12 @@ export const createInstance = (): UnifiedClient => {
       getClientLogConfig(client),
       getClientStates(client, ['config']),
     ),
+    engagement: debugWrapper(
+      client.engagement.bind(client),
+      'engagement',
+      getClientLogConfig(client),
+      getClientStates(client, ['config']),
+    ),
     sessionReplay: debugWrapper(
       client.sessionReplay.bind(client),
       'sessionReplay',

--- a/packages/unified/src/unified.ts
+++ b/packages/unified/src/unified.ts
@@ -27,10 +27,19 @@ export type UnifiedOptions = UnifiedSharedOptions & {
   engagement?: Omit<InitOptions, keyof UnifiedSharedOptions>;
 };
 
+type EngagementSDK = {
+  boot?: (...args: unknown[]) => unknown;
+  shutdown?: (...args: unknown[]) => unknown;
+  [key: string]: unknown;
+};
+
+export type EngagementSDKPlugin = Omit<EngagementSDK, 'boot' | 'shutdown'>;
+
 export interface UnifiedClient extends BrowserClient {
   initAll(apiKey: string, unifiedOptions?: UnifiedOptions): Promise<void>;
   sessionReplay(): AmplitudeSessionReplay;
   experiment(): IExperimentClient | undefined;
+  engagement(): EngagementSDKPlugin | undefined;
 }
 
 export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient {
@@ -59,6 +68,11 @@ export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient 
       this.config.loggerProvider.debug(`Multiple instances of ${ExperimentPlugin.pluginName} are found.`);
       return undefined;
     }
+  }
+
+  engagement(): EngagementSDKPlugin | undefined {
+    // eslint-disable-next-line no-restricted-globals
+    return (window as Window & { engagement?: EngagementSDKPlugin }).engagement as EngagementSDKPlugin;
   }
 
   /**

--- a/packages/unified/test/index.test.ts
+++ b/packages/unified/test/index.test.ts
@@ -1,10 +1,11 @@
 import * as amplitude from '../src/index';
-import { sessionReplay, experiment } from '../src/index';
+import { sessionReplay, experiment, engagement } from '../src/index';
 
 test('should return non undefined sessionReplay and experiment after initAll() by import method 1 & 2', async () => {
   // Test that methods work before and after initAll()
   expect(amplitude.sessionReplay()).toBeUndefined();
   expect(amplitude.experiment()).toBeUndefined();
+  expect(amplitude.engagement()).toBeUndefined();
 
   await amplitude.initAll('test-api-key');
 
@@ -14,4 +15,5 @@ test('should return non undefined sessionReplay and experiment after initAll() b
   // Method 2: named imports { initAll, sessionReplay, experiment } should work
   expect(sessionReplay()).toBeDefined();
   expect(experiment()).toBeDefined();
+  expect(engagement()).toBeUndefined();
 });

--- a/packages/unified/test/unified-client-factory.test.ts
+++ b/packages/unified/test/unified-client-factory.test.ts
@@ -2,6 +2,7 @@ import instance from '../src/unified-client-factory';
 
 test('should create a UnifiedClient instance with expected methods', () => {
   expect(instance).toHaveProperty('experiment');
+  expect(instance).toHaveProperty('engagement');
   expect(instance).toHaveProperty('sessionReplay');
   expect(typeof instance.initAll).toBe('function');
   expect(typeof instance.init).toBe('function');
@@ -31,6 +32,7 @@ test('should return non undefined sessionReplay and experiment after initAll() b
   // Test that sessionReplay and experiment are undefined before initAll()
   expect(instance.sessionReplay()).toBeUndefined();
   expect(instance.experiment()).toBeUndefined();
+  expect(instance.engagement()).toBeUndefined();
 
   // Initialize with a test API key
   await instance.initAll('test-api-key');

--- a/packages/unified/test/unified.test.ts
+++ b/packages/unified/test/unified.test.ts
@@ -184,4 +184,18 @@ describe('AmplitudeUnified', () => {
       );
     });
   });
+
+  describe('engagement method', () => {
+    test('should return window engagement sdk instance', () => {
+      const client = new AmplitudeUnified();
+      const mockedEngagement = {
+        track: jest.fn(),
+      } as unknown as ReturnType<AmplitudeUnified['engagement']>;
+
+      (window as Window & { engagement?: unknown }).engagement = mockedEngagement;
+
+      expect(client.engagement()).toBe(mockedEngagement);
+      delete (window as Window & { engagement?: unknown }).engagement;
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

- add `EngagementSDKPlugin` in `packages/unified/src/unified.ts` as `Omit<EngagementSDK, 'boot' | 'shutdown'>`
- extend `UnifiedClient` and `AmplitudeUnified` with an `engagement()` getter that returns `window.engagement` cast to `EngagementSDKPlugin`
- expose `engagement` through `unified-client-factory` and top-level `src/index.ts` exports
- add/update unified package tests for the new `engagement` API surface

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

### Validation

- `pnpm build`
- `pnpm --filter @amplitude/unified test`
- `pnpm --filter @amplitude/unified lint:prettier`
- `pnpm --filter @amplitude/unified lint:eslint` (passes with one pre-existing warning in test code)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf401ffb-c1b6-44ab-8e5e-27431f4b7f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf401ffb-c1b6-44ab-8e5e-27431f4b7f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

