### PR TITLE
feat: add long task tracking

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -48,6 +48,8 @@ import {
   isWebVitalsEnabled,
   isFrustrationInteractionsEnabled,
   getFrustrationInteractionsConfig,
+  isPerformanceTrackingEnabled,
+  getPerformanceTrackingConfig,
   isPageUrlEnrichmentEnabled,
   isCustomEnrichmentEnabled,
 } from './default-tracking';
@@ -61,7 +63,7 @@ import { DEFAULT_SESSION_END_EVENT, DEFAULT_SESSION_START_EVENT, DEFAULT_SERVER_
 import { detNotify } from './det-notification';
 import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity-checker';
 import { updateBrowserConfigWithRemoteConfig } from './config/joined-config';
-import { autocapturePlugin, frustrationPlugin } from '@amplitude/plugin-autocapture-browser';
+import { autocapturePlugin, frustrationPlugin, performancePlugin } from '@amplitude/plugin-autocapture-browser';
 import { plugin as networkCapturePlugin } from '@amplitude/plugin-network-capture-browser';
 import { webVitalsPlugin } from '@amplitude/plugin-web-vitals-browser';
 import { WebAttribution } from './attribution/web-attribution';
@@ -374,6 +376,11 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
     if (isWebVitalsEnabled(this.config.autocapture)) {
       this.config.loggerProvider.debug('Adding web vitals plugin');
       await this.add(webVitalsPlugin()).promise;
+    }
+
+    if (isPerformanceTrackingEnabled(this.config.autocapture)) {
+      this.config.loggerProvider.debug('Adding performance tracking plugin');
+      await this.add(performancePlugin(getPerformanceTrackingConfig(this.config))).promise;
     }
 
     if (isPageUrlEnrichmentEnabled(this.config.autocapture)) {

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -10,6 +10,7 @@ import {
   NetworkTrackingOptions,
   FrustrationInteractionsOptions,
   CustomEnrichmentOptions,
+  PerformanceTrackingOptions,
 } from '@amplitude/analytics-core';
 
 /**
@@ -132,6 +133,28 @@ export const isFrustrationInteractionsEnabled = (autocapture: AutocaptureOptions
   }
 
   return false;
+};
+
+export const isPerformanceTrackingEnabled = (autocapture: AutocaptureOptions | boolean | undefined): boolean => {
+  if (
+    typeof autocapture === 'object' &&
+    (autocapture.performanceTracking === true || typeof autocapture.performanceTracking === 'object')
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export const getPerformanceTrackingConfig = (config: BrowserOptions): PerformanceTrackingOptions | undefined => {
+  if (
+    isPerformanceTrackingEnabled(config.autocapture) &&
+    typeof config.autocapture === 'object' &&
+    typeof config.autocapture.performanceTracking === 'object'
+  ) {
+    return config.autocapture.performanceTracking;
+  }
+  return undefined;
 };
 
 export const isCustomEnrichmentEnabled = (customEnrichment: boolean | CustomEnrichmentOptions | undefined) => {

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -147,13 +147,20 @@ export const isPerformanceTrackingEnabled = (autocapture: AutocaptureOptions | b
 };
 
 export const getPerformanceTrackingConfig = (config: BrowserOptions): PerformanceTrackingOptions | undefined => {
-  if (
-    isPerformanceTrackingEnabled(config.autocapture) &&
-    typeof config.autocapture === 'object' &&
-    typeof config.autocapture.performanceTracking === 'object'
-  ) {
-    return config.autocapture.performanceTracking;
+  if (typeof config.autocapture !== 'object') {
+    return undefined;
   }
+
+  const performanceTracking = config.autocapture.performanceTracking;
+
+  if (performanceTracking === true) {
+    return { mainThreadBlock: true };
+  }
+
+  if (typeof performanceTracking === 'object' && performanceTracking !== null) {
+    return performanceTracking;
+  }
+
   return undefined;
 };
 

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -762,6 +762,7 @@ describe('browser-client', () => {
         },
       }).promise;
       expect(performanceTrackingPlugin).toHaveBeenCalledTimes(1);
+      expect(performanceTrackingPlugin).toHaveBeenCalledWith({ mainThreadBlock: true });
     });
 
     test('should NOT add performance tracking plugin by default', async () => {
@@ -776,6 +777,18 @@ describe('browser-client', () => {
         autocapture: true,
       }).promise;
       expect(performanceTrackingPlugin).toHaveBeenCalledTimes(0);
+    });
+
+    test('should register autocapture and performance plugins when both element interactions and performance tracking are enabled', async () => {
+      await client.init(apiKey, userId, {
+        autocapture: {
+          elementInteractions: true,
+          performanceTracking: true,
+        },
+      }).promise;
+      const names = client.timeline.plugins.map((p) => p.name);
+      expect(names).toContain('@amplitude/plugin-autocapture-browser');
+      expect(names).toContain('@amplitude/plugin-performance-browser');
     });
 
     test('should add page view tracking plugin by default', async () => {

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -754,6 +754,30 @@ describe('browser-client', () => {
       expect(frustrationInteractionsPlugin).toHaveBeenCalledTimes(1);
     });
 
+    test('should add performance tracking plugin when autocapture.performanceTracking is set', async () => {
+      const performanceTrackingPlugin = jest.spyOn(autocapture, 'performancePlugin');
+      await client.init(apiKey, userId, {
+        autocapture: {
+          performanceTracking: true,
+        },
+      }).promise;
+      expect(performanceTrackingPlugin).toHaveBeenCalledTimes(1);
+    });
+
+    test('should NOT add performance tracking plugin by default', async () => {
+      const performanceTrackingPlugin = jest.spyOn(autocapture, 'performancePlugin');
+      await client.init(apiKey, userId).promise;
+      expect(performanceTrackingPlugin).toHaveBeenCalledTimes(0);
+    });
+
+    test('should NOT add performance tracking plugin when autocapture=true', async () => {
+      const performanceTrackingPlugin = jest.spyOn(autocapture, 'performancePlugin');
+      await client.init(apiKey, userId, {
+        autocapture: true,
+      }).promise;
+      expect(performanceTrackingPlugin).toHaveBeenCalledTimes(0);
+    });
+
     test('should add page view tracking plugin by default', async () => {
       const pageViewTrackingPlugin = jest.spyOn(pageViewTracking, 'pageViewTrackingPlugin');
       await client.init(apiKey, userId).promise;

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -174,8 +174,10 @@ describe('getPerformanceTrackingConfig', () => {
     expect(getPerformanceTrackingConfig({ autocapture: true })).toBeUndefined();
   });
 
-  test('should return undefined when performanceTracking=true (no options object)', () => {
-    expect(getPerformanceTrackingConfig({ autocapture: { performanceTracking: true } })).toBeUndefined();
+  test('should return mainThreadBlock true when performanceTracking=true (explicit autocapture opt-in)', () => {
+    expect(getPerformanceTrackingConfig({ autocapture: { performanceTracking: true } })).toEqual({
+      mainThreadBlock: true,
+    });
   });
 
   test('should return undefined when performanceTracking is disabled', () => {

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -5,6 +5,7 @@ import {
   getFrustrationInteractionsConfig,
   getNetworkTrackingConfig,
   getPageViewTrackingConfig,
+  getPerformanceTrackingConfig,
   isAttributionTrackingEnabled,
   isCustomEnrichmentEnabled,
   isElementInteractionsEnabled,
@@ -14,6 +15,7 @@ import {
   isNetworkTrackingEnabled,
   isPageUrlEnrichmentEnabled,
   isPageViewTrackingEnabled,
+  isPerformanceTrackingEnabled,
   isSessionTrackingEnabled,
   isWebVitalsEnabled,
 } from '../src/default-tracking';
@@ -123,6 +125,61 @@ describe('isFrustrationInteractionsEnabled', () => {
       autocapture: true,
     });
     expect(config).toBeUndefined();
+  });
+});
+
+describe('isPerformanceTrackingEnabled', () => {
+  test('should return false with undefined parameter', () => {
+    expect(isPerformanceTrackingEnabled(undefined)).toBe(false);
+  });
+
+  test('should return false when autocapture=true', () => {
+    expect(isPerformanceTrackingEnabled(true)).toBe(false);
+  });
+
+  test('should return false when autocapture=false', () => {
+    expect(isPerformanceTrackingEnabled(false)).toBe(false);
+  });
+
+  test('should return true with performanceTracking=true', () => {
+    expect(isPerformanceTrackingEnabled({ performanceTracking: true })).toBe(true);
+  });
+
+  test('should return true with performanceTracking as object', () => {
+    expect(isPerformanceTrackingEnabled({ performanceTracking: { mainThreadBlock: true } })).toBe(true);
+  });
+
+  test('should return false with performanceTracking=false', () => {
+    expect(isPerformanceTrackingEnabled({ performanceTracking: false })).toBe(false);
+  });
+
+  test('should return false when performanceTracking is undefined', () => {
+    expect(isPerformanceTrackingEnabled({ webVitals: true })).toBe(false);
+  });
+});
+
+describe('getPerformanceTrackingConfig', () => {
+  test('should return config when performanceTracking is an object', () => {
+    const config = getPerformanceTrackingConfig({
+      autocapture: {
+        performanceTracking: {
+          mainThreadBlock: { durationThreshold: 200 },
+        },
+      },
+    });
+    expect(config).toEqual({ mainThreadBlock: { durationThreshold: 200 } });
+  });
+
+  test('should return undefined when autocapture is true', () => {
+    expect(getPerformanceTrackingConfig({ autocapture: true })).toBeUndefined();
+  });
+
+  test('should return undefined when performanceTracking=true (no options object)', () => {
+    expect(getPerformanceTrackingConfig({ autocapture: { performanceTracking: true } })).toBeUndefined();
+  });
+
+  test('should return undefined when performanceTracking is disabled', () => {
+    expect(getPerformanceTrackingConfig({ autocapture: { performanceTracking: false } })).toBeUndefined();
   });
 });
 

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -107,6 +107,7 @@ export { SAFE_HEADERS, FORBIDDEN_HEADERS } from './types/constants';
 
 export { PageUrlEnrichmentOptions } from './types/page-url-enrichment';
 export { CustomEnrichmentOptions } from './types/custom-enrichment';
+export { PerformanceTrackingOptions, LongTaskOptions } from './types/performance-tracking';
 
 // Campaign
 export { Campaign, UTMParameters, ReferrerParameters, ClickIdParameters, ICampaignParser } from './types/campaign';

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -107,7 +107,7 @@ export { SAFE_HEADERS, FORBIDDEN_HEADERS } from './types/constants';
 
 export { PageUrlEnrichmentOptions } from './types/page-url-enrichment';
 export { CustomEnrichmentOptions } from './types/custom-enrichment';
-export { PerformanceTrackingOptions, LongTaskOptions } from './types/performance-tracking';
+export { PerformanceTrackingOptions, MainThreadBlockOptions } from './types/performance-tracking';
 
 // Campaign
 export { Campaign, UTMParameters, ReferrerParameters, ClickIdParameters, ICampaignParser } from './types/campaign';

--- a/packages/analytics-core/src/types/config/browser-config.ts
+++ b/packages/analytics-core/src/types/config/browser-config.ts
@@ -7,6 +7,7 @@ import { FormInteractionsOptions } from '../form-interactions';
 import { PageTrackingOptions } from '../page-view-tracking';
 import { NetworkTrackingOptions } from '../network-tracking';
 import { FrustrationInteractionsOptions } from '../frustration-interactions';
+import { PerformanceTrackingOptions } from '../performance-tracking';
 import { IDiagnosticsClient } from '../../diagnostics/diagnostics-client';
 import { IRemoteConfigClient } from '../../remote-config/remote-config';
 import { CustomEnrichmentOptions } from '../custom-enrichment';
@@ -202,6 +203,11 @@ export interface AutocaptureOptions {
    * @defaultValue `false`
    */
   webVitals?: boolean;
+  /**
+   * Enables/disables performance tracking.
+   * @defaultValue `false`
+   */
+  performanceTracking?: boolean | PerformanceTrackingOptions;
   /**
    * Enables/disables page url enrichment.
    * @defaultValue `true`

--- a/packages/analytics-core/src/types/performance-tracking.ts
+++ b/packages/analytics-core/src/types/performance-tracking.ts
@@ -1,10 +1,10 @@
 /**
- * Configuration options for long task tracking
+ * Configuration options for main thread block tracking
  */
-export interface LongTaskOptions {
+export interface MainThreadBlockOptions {
   /**
-   * Minimum duration in milliseconds to consider a long task.
-   * The browser minimum is 50ms.
+   * Minimum duration in milliseconds to consider a main thread block.
+   * The browser minimum for both Long Animation Frames and Long Tasks is 50ms.
    * @default 50
    */
   durationThreshold?: number;
@@ -30,10 +30,11 @@ export interface PerformanceTrackingOptions {
   pageUrlExcludelist?: (string | RegExp)[];
 
   /**
-   * Configuration for long task tracking.
-   * Set to `false` to disable long task tracking.
+   * Configuration for main thread block tracking.
+   * Uses the Long Animation Frames API where available, falling back to Long Tasks.
+   * Set to `false` to disable tracking.
    * Set to `true` or an options object to enable with default or custom settings.
    * Default is false.
    */
-  longTask?: boolean | LongTaskOptions;
+  mainThreadBlock?: boolean | MainThreadBlockOptions;
 }

--- a/packages/analytics-core/src/types/performance-tracking.ts
+++ b/packages/analytics-core/src/types/performance-tracking.ts
@@ -4,8 +4,7 @@
 export interface MainThreadBlockOptions {
   /**
    * Minimum duration in milliseconds to consider a main thread block.
-   * The browser minimum for both Long Animation Frames and Long Tasks is 50ms.
-   * @default 50
+   * @default 100
    */
   durationThreshold?: number;
 }

--- a/packages/analytics-core/src/types/performance-tracking.ts
+++ b/packages/analytics-core/src/types/performance-tracking.ts
@@ -1,0 +1,39 @@
+/**
+ * Configuration options for long task tracking
+ */
+export interface LongTaskOptions {
+  /**
+   * Minimum duration in milliseconds to consider a long task.
+   * The browser minimum is 50ms.
+   * @default 50
+   */
+  durationThreshold?: number;
+}
+
+/**
+ * Configuration options for performance tracking.
+ */
+export interface PerformanceTrackingOptions {
+  /**
+   * List of page URLs to allow auto tracking on.
+   * When provided, only allow tracking on these URLs.
+   * Both full URLs and regex are supported.
+   */
+  pageUrlAllowlist?: (string | RegExp)[];
+
+  /**
+   * List of page URLs to exclude from auto tracking.
+   * When provided, tracking will be blocked on these URLs.
+   * Both full URLs and regex are supported.
+   * This takes precedence over pageUrlAllowlist.
+   */
+  pageUrlExcludelist?: (string | RegExp)[];
+
+  /**
+   * Configuration for long task tracking.
+   * Set to `false` to disable long task tracking.
+   * Set to `true` or an options object to enable with default or custom settings.
+   * Default is false.
+   */
+  longTask?: boolean | LongTaskOptions;
+}

--- a/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
@@ -1,0 +1,47 @@
+import { BrowserClient, ElementInteractionsOptions, PerformanceTrackingOptions } from '@amplitude/analytics-core';
+import { AMPLITUDE_LONG_TASK_EVENT } from '../constants';
+import { isUrlAllowed } from '../helpers';
+
+const DEFAULT_LONG_TASK_DURATION_THRESHOLD = 50; // ms, browser minimum
+
+export function trackLongTask({
+  amplitude,
+  options,
+  durationThreshold = DEFAULT_LONG_TASK_DURATION_THRESHOLD,
+}: {
+  amplitude: BrowserClient;
+  options: PerformanceTrackingOptions;
+  durationThreshold?: number;
+}) {
+  /* istanbul ignore next */
+  if (typeof PerformanceObserver === 'undefined') {
+    return { unsubscribe: () => void 0 };
+  }
+
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      if (!isUrlAllowed(options as ElementInteractionsOptions)) {
+        return;
+      }
+      if (entry.duration >= durationThreshold) {
+        amplitude.track(AMPLITUDE_LONG_TASK_EVENT, {
+          '[Amplitude] Long Task Duration': entry.duration,
+          '[Amplitude] Long Task Start Time': entry.startTime,
+        });
+      }
+    }
+  });
+
+  try {
+    observer.observe({ entryTypes: ['longtask'] });
+  } catch {
+    // longtask may not be supported in all browsers
+    return { unsubscribe: () => void 0 };
+  }
+
+  return {
+    unsubscribe: () => {
+      observer.disconnect();
+    },
+  };
+}

--- a/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
@@ -2,7 +2,7 @@ import { BrowserClient, ElementInteractionsOptions, PerformanceTrackingOptions }
 import { AMPLITUDE_MAIN_THREAD_BLOCK_EVENT } from '../constants';
 import { isUrlAllowed } from '../helpers';
 
-const DEFAULT_DURATION_THRESHOLD = 50; // ms, browser minimum for both LoAF and Long Tasks
+const DEFAULT_DURATION_THRESHOLD = 100; // ms
 const MEASURE_BUFFER_WINDOW_MS = 10_000;
 
 // LoAF and Long Task types are not yet in TypeScript's built-in DOM types

--- a/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
@@ -4,6 +4,27 @@ import { isUrlAllowed } from '../helpers';
 
 const DEFAULT_LONG_TASK_DURATION_THRESHOLD = 50; // ms, browser minimum
 
+// PerformanceLongTaskTiming is not yet in TypeScript's built-in DOM types
+interface TaskAttributionTiming extends PerformanceEntry {
+  name: string;
+}
+interface PerformanceLongTaskTiming extends PerformanceEntry {
+  attribution: TaskAttributionTiming[];
+}
+// How long to keep measures in the buffer before pruning
+const MEASURE_BUFFER_WINDOW_MS = 10_000;
+
+function getOverlappingMeasures(entry: PerformanceEntry, measures: PerformanceEntry[]): string[] {
+  const taskStart = entry.startTime;
+  const taskEnd = entry.startTime + entry.duration;
+  return measures
+    .filter((measure) => {
+      const measureEnd = measure.startTime + measure.duration;
+      return measure.startTime < taskEnd && measureEnd > taskStart;
+    })
+    .map((measure) => measure.name);
+}
+
 export function trackLongTask({
   amplitude,
   options,
@@ -18,30 +39,59 @@ export function trackLongTask({
     return { unsubscribe: () => void 0 };
   }
 
-  const observer = new PerformanceObserver((list) => {
+  // Rolling buffer of recent performance.measure() entries
+  const measures: PerformanceEntry[] = [];
+
+  const measureObserver = new PerformanceObserver((list) => {
+    const now = performance.now();
+    for (const entry of list.getEntries()) {
+      measures.push(entry);
+    }
+    // Prune measures outside the buffer window to avoid unbounded memory growth
+    const cutoff = now - MEASURE_BUFFER_WINDOW_MS;
+    while (measures.length > 0 && measures[0].startTime < cutoff) {
+      measures.shift();
+    }
+  });
+
+  try {
+    measureObserver.observe({ entryTypes: ['measure'] });
+  } catch {
+    // measure may not be supported — continue without it
+  }
+
+  const longTaskObserver = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
       if (!isUrlAllowed(options as ElementInteractionsOptions)) {
         return;
       }
       if (entry.duration >= durationThreshold) {
+        const attribution = (entry as PerformanceLongTaskTiming).attribution;
+        const overlappingMeasures = getOverlappingMeasures(entry, measures);
         amplitude.track(AMPLITUDE_LONG_TASK_EVENT, {
           '[Amplitude] Long Task Duration': entry.duration,
           '[Amplitude] Long Task Start Time': entry.startTime,
+          ...(attribution && {
+            '[Amplitude] Long Task Attribution': attribution.map((a: TaskAttributionTiming) => a.name),
+          }),
+          ...(overlappingMeasures.length > 0 && { '[Amplitude] Long Task Measures': overlappingMeasures }),
         });
       }
     }
   });
 
   try {
-    observer.observe({ entryTypes: ['longtask'] });
+    longTaskObserver.observe({ entryTypes: ['longtask'] });
   } catch {
     // longtask may not be supported in all browsers
+    measureObserver.disconnect();
     return { unsubscribe: () => void 0 };
   }
 
   return {
     unsubscribe: () => {
-      observer.disconnect();
+      longTaskObserver.disconnect();
+      measureObserver.disconnect();
     },
   };
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
@@ -1,45 +1,110 @@
 import { BrowserClient, ElementInteractionsOptions, PerformanceTrackingOptions } from '@amplitude/analytics-core';
-import { AMPLITUDE_LONG_TASK_EVENT } from '../constants';
+import { AMPLITUDE_MAIN_THREAD_BLOCK_EVENT } from '../constants';
 import { isUrlAllowed } from '../helpers';
 
-const DEFAULT_LONG_TASK_DURATION_THRESHOLD = 50; // ms, browser minimum
+const DEFAULT_DURATION_THRESHOLD = 50; // ms, browser minimum for both LoAF and Long Tasks
+const MEASURE_BUFFER_WINDOW_MS = 10_000;
 
-// PerformanceLongTaskTiming is not yet in TypeScript's built-in DOM types
+// LoAF and Long Task types are not yet in TypeScript's built-in DOM types
+interface PerformanceScriptTiming extends PerformanceEntry {
+  sourceURL: string;
+  sourceFunctionName: string;
+  invokerType: string;
+  invoker: string;
+}
+
+interface PerformanceLongAnimationFrameTiming extends PerformanceEntry {
+  renderStart: number;
+  styleAndLayoutStart: number;
+  blockingDuration: number;
+  scripts: PerformanceScriptTiming[];
+}
+
 interface TaskAttributionTiming extends PerformanceEntry {
   name: string;
 }
+
 interface PerformanceLongTaskTiming extends PerformanceEntry {
   attribution: TaskAttributionTiming[];
 }
-// How long to keep measures in the buffer before pruning
-const MEASURE_BUFFER_WINDOW_MS = 10_000;
 
 function getOverlappingMeasures(entry: PerformanceEntry, measures: PerformanceEntry[]): string[] {
-  const taskStart = entry.startTime;
   const taskEnd = entry.startTime + entry.duration;
   return measures
-    .filter((measure) => {
-      const measureEnd = measure.startTime + measure.duration;
-      return measure.startTime < taskEnd && measureEnd > taskStart;
-    })
+    .filter((measure) => measure.startTime < taskEnd && measure.startTime + measure.duration > entry.startTime)
     .map((measure) => measure.name);
 }
 
-export function trackLongTask({
+function buildLoAFProperties(entry: PerformanceLongAnimationFrameTiming, measures: PerformanceEntry[]) {
+  const overlappingMeasures = getOverlappingMeasures(entry, measures);
+  const scripts = entry.scripts ?? [];
+
+  const scriptURLs = scripts.map((s) => s.sourceURL).filter(Boolean);
+  const scriptFunctions = scripts.map((s) => s.sourceFunctionName).filter(Boolean);
+  const invokerTypes = scripts.map((s) => s.invokerType).filter(Boolean);
+  const invokers = scripts.map((s) => s.invoker).filter(Boolean);
+
+  return {
+    '[Amplitude] Main Thread Block Source': 'long-animation-frame',
+    '[Amplitude] Main Thread Block Duration': entry.duration,
+    '[Amplitude] Main Thread Block Blocking Duration': entry.blockingDuration,
+    '[Amplitude] Main Thread Block Start Time': entry.startTime,
+    ...(overlappingMeasures.length > 0 && { '[Amplitude] Main Thread Block Measures': overlappingMeasures }),
+    '[Amplitude] Main Thread Block Render Start': entry.renderStart,
+    '[Amplitude] Main Thread Block Style And Layout Start': entry.styleAndLayoutStart,
+    '[Amplitude] Main Thread Block Script Count': scripts.length,
+    ...(scriptURLs.length > 0 && { '[Amplitude] Main Thread Block Script URLs': scriptURLs }),
+    ...(scriptFunctions.length > 0 && { '[Amplitude] Main Thread Block Script Functions': scriptFunctions }),
+    ...(invokerTypes.length > 0 && { '[Amplitude] Main Thread Block Invoker Types': invokerTypes }),
+    ...(invokers.length > 0 && { '[Amplitude] Main Thread Block Invokers': invokers }),
+  };
+}
+
+function buildLongTaskProperties(entry: PerformanceLongTaskTiming, measures: PerformanceEntry[]) {
+  const overlappingMeasures = getOverlappingMeasures(entry, measures);
+  const attribution = entry.attribution ?? [];
+
+  return {
+    '[Amplitude] Main Thread Block Source': 'long-task',
+    '[Amplitude] Main Thread Block Duration': entry.duration,
+    '[Amplitude] Main Thread Block Blocking Duration': entry.duration,
+    '[Amplitude] Main Thread Block Start Time': entry.startTime,
+    ...(overlappingMeasures.length > 0 && { '[Amplitude] Main Thread Block Measures': overlappingMeasures }),
+    ...(attribution.length > 0 && {
+      '[Amplitude] Main Thread Block Attribution': attribution.map((a: TaskAttributionTiming) => a.name),
+    }),
+  };
+}
+
+function getSupportedEntryType(): 'long-animation-frame' | 'longtask' | null {
+  /* istanbul ignore next */
+  if (typeof PerformanceObserver === 'undefined') return null;
+  try {
+    const supported = PerformanceObserver.supportedEntryTypes;
+    if (supported.includes('long-animation-frame')) return 'long-animation-frame';
+    if (supported.includes('longtask')) return 'longtask';
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function trackMainThreadBlock({
   amplitude,
   options,
-  durationThreshold = DEFAULT_LONG_TASK_DURATION_THRESHOLD,
+  durationThreshold = DEFAULT_DURATION_THRESHOLD,
 }: {
   amplitude: BrowserClient;
   options: PerformanceTrackingOptions;
   durationThreshold?: number;
 }) {
+  const entryType = getSupportedEntryType();
+
   /* istanbul ignore next */
-  if (typeof PerformanceObserver === 'undefined') {
+  if (!entryType) {
     return { unsubscribe: () => void 0 };
   }
 
-  // Rolling buffer of recent performance.measure() entries
   const measures: PerformanceEntry[] = [];
 
   const measureObserver = new PerformanceObserver((list) => {
@@ -47,7 +112,6 @@ export function trackLongTask({
     for (const entry of list.getEntries()) {
       measures.push(entry);
     }
-    // Prune measures outside the buffer window to avoid unbounded memory growth
     const cutoff = now - MEASURE_BUFFER_WINDOW_MS;
     while (measures.length > 0 && measures[0].startTime < cutoff) {
       measures.shift();
@@ -57,40 +121,36 @@ export function trackLongTask({
   try {
     measureObserver.observe({ entryTypes: ['measure'] });
   } catch {
-    // measure may not be supported — continue without it
+    // measure not supported — continue without it
   }
 
-  const longTaskObserver = new PerformanceObserver((list) => {
+  const blockObserver = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
       if (!isUrlAllowed(options as ElementInteractionsOptions)) {
         return;
       }
-      if (entry.duration >= durationThreshold) {
-        const attribution = (entry as PerformanceLongTaskTiming).attribution;
-        const overlappingMeasures = getOverlappingMeasures(entry, measures);
-        amplitude.track(AMPLITUDE_LONG_TASK_EVENT, {
-          '[Amplitude] Long Task Duration': entry.duration,
-          '[Amplitude] Long Task Start Time': entry.startTime,
-          ...(attribution && {
-            '[Amplitude] Long Task Attribution': attribution.map((a: TaskAttributionTiming) => a.name),
-          }),
-          ...(overlappingMeasures.length > 0 && { '[Amplitude] Long Task Measures': overlappingMeasures }),
-        });
+      if (entry.duration < durationThreshold) {
+        continue;
       }
+      const properties =
+        entryType === 'long-animation-frame'
+          ? buildLoAFProperties(entry as PerformanceLongAnimationFrameTiming, measures)
+          : buildLongTaskProperties(entry as PerformanceLongTaskTiming, measures);
+
+      amplitude.track(AMPLITUDE_MAIN_THREAD_BLOCK_EVENT, properties);
     }
   });
 
   try {
-    longTaskObserver.observe({ entryTypes: ['longtask'] });
+    blockObserver.observe({ entryTypes: [entryType] });
   } catch {
-    // longtask may not be supported in all browsers
     measureObserver.disconnect();
     return { unsubscribe: () => void 0 };
   }
 
   return {
     unsubscribe: () => {
-      longTaskObserver.disconnect();
+      blockObserver.disconnect();
       measureObserver.disconnect();
     },
   };

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -8,6 +8,7 @@ export const AMPLITUDE_ELEMENT_ERROR_CLICKED_EVENT = '[Amplitude] Error Click';
 export const AMPLITUDE_ELEMENT_CHANGED_EVENT = '[Amplitude] Element Changed';
 export const AMPLITUDE_PAGE_SCROLLED_EVENT = '[Amplitude] Page Scrolled';
 export const AMPLITUDE_THRASHED_CURSOR_EVENT = '[Amplitude] Thrashed Cursor';
+export const AMPLITUDE_LONG_TASK_EVENT = '[Amplitude] Long Task';
 
 export const AMPLITUDE_EVENT_PROP_ELEMENT_ID = '[Amplitude] Element ID';
 export const AMPLITUDE_EVENT_PROP_ELEMENT_CLASS = '[Amplitude] Element Class';

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -8,7 +8,7 @@ export const AMPLITUDE_ELEMENT_ERROR_CLICKED_EVENT = '[Amplitude] Error Click';
 export const AMPLITUDE_ELEMENT_CHANGED_EVENT = '[Amplitude] Element Changed';
 export const AMPLITUDE_PAGE_SCROLLED_EVENT = '[Amplitude] Page Scrolled';
 export const AMPLITUDE_THRASHED_CURSOR_EVENT = '[Amplitude] Thrashed Cursor';
-export const AMPLITUDE_LONG_TASK_EVENT = '[Amplitude] Long Task';
+export const AMPLITUDE_MAIN_THREAD_BLOCK_EVENT = '[Amplitude] Main Thread Block';
 
 export const AMPLITUDE_EVENT_PROP_ELEMENT_ID = '[Amplitude] Element ID';
 export const AMPLITUDE_EVENT_PROP_ELEMENT_CLASS = '[Amplitude] Element Class';

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -1,5 +1,6 @@
 export const PLUGIN_NAME = '@amplitude/plugin-autocapture-browser';
 export const FRUSTRATION_PLUGIN_NAME = '@amplitude/plugin-frustration-browser';
+export const PERFORMANCE_PLUGIN_NAME = '@amplitude/plugin-performance-browser';
 
 export const AMPLITUDE_ELEMENT_CLICKED_EVENT = '[Amplitude] Element Clicked';
 export const AMPLITUDE_ELEMENT_DEAD_CLICKED_EVENT = '[Amplitude] Dead Click';

--- a/packages/plugin-autocapture-browser/src/index.ts
+++ b/packages/plugin-autocapture-browser/src/index.ts
@@ -1,4 +1,5 @@
 export { autocapturePlugin as plugin, autocapturePlugin } from './autocapture-plugin';
 export { frustrationPlugin } from './frustration-plugin';
+export { performancePlugin } from './performance-plugin';
 export { Action, ActionData, Message, enableVisualTagging } from './libs/messenger';
 export { DataExtractor } from './data-extractor';

--- a/packages/plugin-autocapture-browser/src/performance-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/performance-plugin.ts
@@ -11,7 +11,7 @@ import { trackMainThreadBlock } from './autocapture/track-long-task';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 
-const DEFAULT_DURATION_THRESHOLD = 50; // ms, browser minimum
+const DEFAULT_DURATION_THRESHOLD = 100; // ms
 
 export const performancePlugin = (options: PerformanceTrackingOptions = {}): BrowserEnrichmentPlugin => {
   const name = constants.PLUGIN_NAME;

--- a/packages/plugin-autocapture-browser/src/performance-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/performance-plugin.ts
@@ -14,12 +14,14 @@ type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 const DEFAULT_DURATION_THRESHOLD = 100; // ms
 
 export const performancePlugin = (options: PerformanceTrackingOptions = {}): BrowserEnrichmentPlugin => {
-  const name = constants.PLUGIN_NAME;
+  const name = constants.PERFORMANCE_PLUGIN_NAME;
   const type = 'enrichment';
 
   const subscriptions: Unsubscribable[] = [];
 
-  const mainThreadBlockEnabled = options.mainThreadBlock !== false && options.mainThreadBlock !== null;
+  const mainThreadBlockEnabled =
+    options.mainThreadBlock === true ||
+    (typeof options.mainThreadBlock === 'object' && options.mainThreadBlock !== null);
 
   const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
     /* istanbul ignore if */

--- a/packages/plugin-autocapture-browser/src/performance-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/performance-plugin.ts
@@ -7,11 +7,11 @@ import {
   Unsubscribable,
 } from '@amplitude/analytics-core';
 import * as constants from './constants';
-import { trackLongTask } from './autocapture/track-long-task';
+import { trackMainThreadBlock } from './autocapture/track-long-task';
 
 type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 
-const DEFAULT_LONG_TASK_DURATION_THRESHOLD = 50; // ms, browser minimum
+const DEFAULT_DURATION_THRESHOLD = 50; // ms, browser minimum
 
 export const performancePlugin = (options: PerformanceTrackingOptions = {}): BrowserEnrichmentPlugin => {
   const name = constants.PLUGIN_NAME;
@@ -19,7 +19,7 @@ export const performancePlugin = (options: PerformanceTrackingOptions = {}): Bro
 
   const subscriptions: Unsubscribable[] = [];
 
-  const longTaskEnabled = options.longTask !== false && options.longTask !== null;
+  const mainThreadBlockEnabled = options.mainThreadBlock !== false && options.mainThreadBlock !== null;
 
   const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
     /* istanbul ignore if */
@@ -27,18 +27,18 @@ export const performancePlugin = (options: PerformanceTrackingOptions = {}): Bro
       return;
     }
 
-    if (longTaskEnabled) {
-      let durationThreshold = DEFAULT_LONG_TASK_DURATION_THRESHOLD;
-      if (typeof options.longTask === 'object' && options.longTask.durationThreshold !== undefined) {
-        durationThreshold = options.longTask.durationThreshold;
+    if (mainThreadBlockEnabled) {
+      let durationThreshold = DEFAULT_DURATION_THRESHOLD;
+      if (typeof options.mainThreadBlock === 'object' && options.mainThreadBlock.durationThreshold !== undefined) {
+        durationThreshold = options.mainThreadBlock.durationThreshold;
       }
 
-      const longTaskSubscription = trackLongTask({
+      const subscription = trackMainThreadBlock({
         amplitude,
         options,
         durationThreshold,
       });
-      subscriptions.push(longTaskSubscription);
+      subscriptions.push(subscription);
     }
 
     /* istanbul ignore next */

--- a/packages/plugin-autocapture-browser/src/performance-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/performance-plugin.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-restricted-globals */
+import {
+  BrowserClient,
+  BrowserConfig,
+  EnrichmentPlugin,
+  PerformanceTrackingOptions,
+  Unsubscribable,
+} from '@amplitude/analytics-core';
+import * as constants from './constants';
+import { trackLongTask } from './autocapture/track-long-task';
+
+type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
+
+const DEFAULT_LONG_TASK_DURATION_THRESHOLD = 50; // ms, browser minimum
+
+export const performancePlugin = (options: PerformanceTrackingOptions = {}): BrowserEnrichmentPlugin => {
+  const name = constants.PLUGIN_NAME;
+  const type = 'enrichment';
+
+  const subscriptions: Unsubscribable[] = [];
+
+  const longTaskEnabled = options.longTask !== false && options.longTask !== null;
+
+  const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
+    /* istanbul ignore if */
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    if (longTaskEnabled) {
+      let durationThreshold = DEFAULT_LONG_TASK_DURATION_THRESHOLD;
+      if (typeof options.longTask === 'object' && options.longTask.durationThreshold !== undefined) {
+        durationThreshold = options.longTask.durationThreshold;
+      }
+
+      const longTaskSubscription = trackLongTask({
+        amplitude,
+        options,
+        durationThreshold,
+      });
+      subscriptions.push(longTaskSubscription);
+    }
+
+    /* istanbul ignore next */
+    config?.loggerProvider?.log(`${name} performance tracking has been successfully added.`);
+  };
+
+  const execute: BrowserEnrichmentPlugin['execute'] = async (event) => {
+    return event;
+  };
+
+  const teardown = async () => {
+    for (const subscription of subscriptions) {
+      subscription.unsubscribe();
+    }
+  };
+
+  return {
+    name,
+    type,
+    setup,
+    execute,
+    teardown,
+  };
+};

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/performance-plugin.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/performance-plugin.test.ts
@@ -1,0 +1,107 @@
+import { BrowserConfig, EnrichmentPlugin, ILogger } from '@amplitude/analytics-core';
+import { performancePlugin } from '../../src/performance-plugin';
+import { trackMainThreadBlock } from '../../src/autocapture/track-long-task';
+import { createMockBrowserClient } from '../mock-browser-client';
+
+jest.mock('../../src/autocapture/track-long-task', () => ({
+  trackMainThreadBlock: jest.fn(),
+}));
+
+describe('performancePlugin', () => {
+  const loggerProvider: Partial<ILogger> = {
+    log: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  const config: Partial<BrowserConfig> = {
+    defaultTracking: false,
+    loggerProvider: loggerProvider as ILogger,
+  };
+
+  let mockUnsubscribe: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUnsubscribe = jest.fn();
+    (trackMainThreadBlock as jest.Mock).mockReturnValue({ unsubscribe: mockUnsubscribe });
+  });
+
+  describe('setup', () => {
+    it('should call trackMainThreadBlock with default duration threshold when mainThreadBlock is true', async () => {
+      const plugin = performancePlugin({ mainThreadBlock: true });
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+
+      expect(trackMainThreadBlock).toHaveBeenCalledWith({
+        amplitude,
+        options: { mainThreadBlock: true },
+        durationThreshold: 100,
+      });
+    });
+
+    it('should call trackMainThreadBlock with custom durationThreshold', async () => {
+      const plugin = performancePlugin({ mainThreadBlock: { durationThreshold: 200 } });
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+
+      expect(trackMainThreadBlock).toHaveBeenCalledWith({
+        amplitude,
+        options: { mainThreadBlock: { durationThreshold: 200 } },
+        durationThreshold: 200,
+      });
+    });
+
+    it('should use default duration threshold when mainThreadBlock is an object without durationThreshold', async () => {
+      const plugin = performancePlugin({ mainThreadBlock: {} });
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+
+      expect(trackMainThreadBlock).toHaveBeenCalledWith({
+        amplitude,
+        options: { mainThreadBlock: {} },
+        durationThreshold: 100,
+      });
+    });
+
+    it('should not call trackMainThreadBlock when mainThreadBlock=false', async () => {
+      const plugin = performancePlugin({ mainThreadBlock: false });
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+
+      expect(trackMainThreadBlock).not.toHaveBeenCalled();
+    });
+
+    it('should call trackMainThreadBlock when no options provided (default enables mainThreadBlock)', async () => {
+      const plugin = performancePlugin();
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+
+      expect(trackMainThreadBlock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('execute', () => {
+    it('should return the event unchanged', async () => {
+      const plugin = performancePlugin() as EnrichmentPlugin;
+      const event = { event_type: 'test' };
+      const result = await plugin.execute!(event as any);
+      expect(result).toBe(event);
+    });
+  });
+
+  describe('teardown', () => {
+    it('should call unsubscribe on all subscriptions', async () => {
+      const plugin = performancePlugin({ mainThreadBlock: true });
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+      await plugin.teardown!();
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when there are no subscriptions', async () => {
+      const plugin = performancePlugin({ mainThreadBlock: false });
+      await expect(plugin.teardown!()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/performance-plugin.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/performance-plugin.test.ts
@@ -1,5 +1,6 @@
 import { BrowserConfig, EnrichmentPlugin, ILogger } from '@amplitude/analytics-core';
 import { performancePlugin } from '../../src/performance-plugin';
+import { PERFORMANCE_PLUGIN_NAME } from '../../src/constants';
 import { trackMainThreadBlock } from '../../src/autocapture/track-long-task';
 import { createMockBrowserClient } from '../mock-browser-client';
 
@@ -24,6 +25,11 @@ describe('performancePlugin', () => {
     jest.clearAllMocks();
     mockUnsubscribe = jest.fn();
     (trackMainThreadBlock as jest.Mock).mockReturnValue({ unsubscribe: mockUnsubscribe });
+  });
+
+  it('should use a plugin name distinct from autocapturePlugin', () => {
+    const plugin = performancePlugin();
+    expect(plugin.name).toBe(PERFORMANCE_PLUGIN_NAME);
   });
 
   describe('setup', () => {
@@ -71,12 +77,20 @@ describe('performancePlugin', () => {
       expect(trackMainThreadBlock).not.toHaveBeenCalled();
     });
 
-    it('should call trackMainThreadBlock when no options provided (default enables mainThreadBlock)', async () => {
+    it('should not call trackMainThreadBlock when no options provided (mainThreadBlock defaults off)', async () => {
       const plugin = performancePlugin();
       const amplitude = createMockBrowserClient();
       await plugin.setup!(config as BrowserConfig, amplitude);
 
-      expect(trackMainThreadBlock).toHaveBeenCalledTimes(1);
+      expect(trackMainThreadBlock).not.toHaveBeenCalled();
+    });
+
+    it('should not call trackMainThreadBlock when options omit mainThreadBlock', async () => {
+      const plugin = performancePlugin({});
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
+
+      expect(trackMainThreadBlock).not.toHaveBeenCalled();
     });
   });
 
@@ -101,6 +115,13 @@ describe('performancePlugin', () => {
 
     it('should not throw when there are no subscriptions', async () => {
       const plugin = performancePlugin({ mainThreadBlock: false });
+      await expect(plugin.teardown!()).resolves.toBeUndefined();
+    });
+
+    it('should not throw on teardown when mainThreadBlock was omitted (no subscriptions)', async () => {
+      const plugin = performancePlugin();
+      const amplitude = createMockBrowserClient();
+      await plugin.setup!(config as BrowserConfig, amplitude);
       await expect(plugin.teardown!()).resolves.toBeUndefined();
     });
   });

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-long-task.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-long-task.test.ts
@@ -1,0 +1,365 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { trackMainThreadBlock } from '../../src/autocapture/track-long-task';
+import { createMockBrowserClient } from '../mock-browser-client';
+import { AMPLITUDE_MAIN_THREAD_BLOCK_EVENT } from '../../src/constants';
+
+type PerformanceObserverCallback = (list: { getEntries: () => PerformanceEntry[] }) => void;
+
+class MockPerformanceObserver {
+  static callback: PerformanceObserverCallback;
+  static instances: MockPerformanceObserver[] = [];
+  static supportedEntryTypes: string[] = ['long-animation-frame'];
+
+  callback: PerformanceObserverCallback;
+  disconnected = false;
+  observed: { entryTypes: string[] } | null = null;
+
+  constructor(callback: PerformanceObserverCallback) {
+    this.callback = callback;
+    MockPerformanceObserver.instances.push(this);
+  }
+
+  observe(options: { entryTypes: string[] }) {
+    this.observed = options;
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  fire(entries: Partial<PerformanceEntry>[]) {
+    this.callback({ getEntries: () => entries as PerformanceEntry[] });
+  }
+}
+
+function getMeasureObserver() {
+  return MockPerformanceObserver.instances.find((i) => i.observed?.entryTypes.includes('measure'))!;
+}
+
+function getBlockObserver() {
+  return MockPerformanceObserver.instances.find(
+    (i) => i.observed?.entryTypes.includes('long-animation-frame') || i.observed?.entryTypes.includes('longtask'),
+  )!;
+}
+
+describe('trackMainThreadBlock', () => {
+  let originalPerformanceObserver: typeof PerformanceObserver;
+  let amplitude: ReturnType<typeof createMockBrowserClient>;
+
+  beforeEach(() => {
+    MockPerformanceObserver.instances = [];
+    MockPerformanceObserver.supportedEntryTypes = ['long-animation-frame'];
+    originalPerformanceObserver = global.PerformanceObserver;
+    (global as any).PerformanceObserver = MockPerformanceObserver;
+    amplitude = createMockBrowserClient();
+  });
+
+  afterEach(() => {
+    global.PerformanceObserver = originalPerformanceObserver;
+  });
+
+  describe('long-animation-frame entry type', () => {
+    it('should track LoAF event with script metadata', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [
+            { sourceURL: 'app.js', sourceFunctionName: 'onClick', invokerType: 'event-listener', invoker: 'click' },
+          ],
+        } as any,
+      ]);
+
+      expect(amplitude.track).toHaveBeenCalledWith(AMPLITUDE_MAIN_THREAD_BLOCK_EVENT, {
+        '[Amplitude] Main Thread Block Source': 'long-animation-frame',
+        '[Amplitude] Main Thread Block Duration': 150,
+        '[Amplitude] Main Thread Block Blocking Duration': 120,
+        '[Amplitude] Main Thread Block Start Time': 1000,
+        '[Amplitude] Main Thread Block Render Start': 1050,
+        '[Amplitude] Main Thread Block Style And Layout Start': 1080,
+        '[Amplitude] Main Thread Block Script Count': 1,
+        '[Amplitude] Main Thread Block Script URLs': ['app.js'],
+        '[Amplitude] Main Thread Block Script Functions': ['onClick'],
+        '[Amplitude] Main Thread Block Invoker Types': ['event-listener'],
+        '[Amplitude] Main Thread Block Invokers': ['click'],
+      });
+    });
+
+    it('should omit empty script fields', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [{ sourceURL: '', sourceFunctionName: '', invokerType: '', invoker: '' }],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Script URLs']).toBeUndefined();
+      expect(call['[Amplitude] Main Thread Block Script Functions']).toBeUndefined();
+      expect(call['[Amplitude] Main Thread Block Invoker Types']).toBeUndefined();
+      expect(call['[Amplitude] Main Thread Block Invokers']).toBeUndefined();
+    });
+
+    it('should include overlapping measures', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      // Fire a measure entry first
+      getMeasureObserver().fire([{ name: 'my-measure', startTime: 900, duration: 200 } as any]);
+
+      // Fire a LoAF entry that overlaps with the measure
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Measures']).toEqual(['my-measure']);
+    });
+
+    it('should not include non-overlapping measures', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      // Measure that ends before the block starts
+      getMeasureObserver().fire([{ name: 'old-measure', startTime: 0, duration: 500 } as any]);
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Measures']).toBeUndefined();
+    });
+
+    it('should not track when duration is below threshold', () => {
+      trackMainThreadBlock({ amplitude, options: {}, durationThreshold: 200 });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [],
+        } as any,
+      ]);
+
+      expect(amplitude.track).not.toHaveBeenCalled();
+    });
+
+    it('should not track when URL is not allowed', () => {
+      trackMainThreadBlock({
+        amplitude,
+        options: { pageUrlAllowlist: ['https://allowed.com'] } as any,
+      });
+
+      // jsdom default URL is about:blank, not in allowlist
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [],
+        } as any,
+      ]);
+
+      expect(amplitude.track).not.toHaveBeenCalled();
+    });
+
+    it('should handle no scripts property (undefined scripts)', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: undefined,
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Script Count']).toBe(0);
+    });
+  });
+
+  describe('longtask entry type', () => {
+    beforeEach(() => {
+      MockPerformanceObserver.supportedEntryTypes = ['longtask'];
+    });
+
+    it('should track longtask event with attribution', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          attribution: [{ name: 'same-origin' }],
+        } as any,
+      ]);
+
+      expect(amplitude.track).toHaveBeenCalledWith(AMPLITUDE_MAIN_THREAD_BLOCK_EVENT, {
+        '[Amplitude] Main Thread Block Source': 'long-task',
+        '[Amplitude] Main Thread Block Duration': 150,
+        '[Amplitude] Main Thread Block Blocking Duration': 150,
+        '[Amplitude] Main Thread Block Start Time': 1000,
+        '[Amplitude] Main Thread Block Attribution': ['same-origin'],
+      });
+    });
+
+    it('should omit attribution when empty', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([{ duration: 150, startTime: 1000, attribution: [] } as any]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Attribution']).toBeUndefined();
+    });
+
+    it('should handle undefined attribution', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([{ duration: 150, startTime: 1000, attribution: undefined } as any]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Attribution']).toBeUndefined();
+    });
+
+    it('should include overlapping measures for longtask entries', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getMeasureObserver().fire([{ name: 'my-measure', startTime: 900, duration: 200 } as any]);
+
+      getBlockObserver().fire([{ duration: 150, startTime: 1000, attribution: [] } as any]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Measures']).toEqual(['my-measure']);
+    });
+  });
+
+  describe('measure buffer pruning', () => {
+    it('should prune stale measures older than the buffer window', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(20_000);
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      // Stale measure: startTime=0 < now(20000) - 10000 = 10000
+      getMeasureObserver().fire([{ name: 'stale', startTime: 0, duration: 100 } as any]);
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 15_000,
+          blockingDuration: 120,
+          renderStart: 15_050,
+          styleAndLayoutStart: 15_080,
+          scripts: [],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Measures']).toBeUndefined();
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('unsupported entry types', () => {
+    it('should return no-op unsubscribe when neither long-animation-frame nor longtask is supported', () => {
+      MockPerformanceObserver.supportedEntryTypes = [];
+      const { unsubscribe } = trackMainThreadBlock({ amplitude, options: {} });
+      // Should not have created any observers
+      expect(MockPerformanceObserver.instances.length).toBe(0);
+      // unsubscribe is the istanbul-ignored no-op
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+
+  describe('measureObserver.observe failure', () => {
+    it('should continue without measures when measure observation throws', () => {
+      const originalObserve = MockPerformanceObserver.prototype.observe;
+      let callCount = 0;
+      MockPerformanceObserver.prototype.observe = function (opts: { entryTypes: string[] }) {
+        callCount++;
+        if (callCount === 1 && opts.entryTypes.includes('measure')) {
+          throw new Error('measure not supported');
+        }
+        originalObserve.call(this, opts);
+      };
+
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [],
+        } as any,
+      ]);
+
+      expect(amplitude.track).toHaveBeenCalledTimes(1);
+      MockPerformanceObserver.prototype.observe = originalObserve;
+    });
+  });
+
+  describe('blockObserver.observe failure', () => {
+    it('should disconnect measureObserver and return no-op unsubscribe when block observation throws', () => {
+      const originalObserve = MockPerformanceObserver.prototype.observe;
+      let callCount = 0;
+      MockPerformanceObserver.prototype.observe = function (opts: { entryTypes: string[] }) {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error('longtask not supported');
+        }
+        originalObserve.call(this, opts);
+      };
+
+      const { unsubscribe } = trackMainThreadBlock({ amplitude, options: {} });
+      unsubscribe();
+
+      expect(amplitude.track).not.toHaveBeenCalled();
+      MockPerformanceObserver.prototype.observe = originalObserve;
+    });
+  });
+
+  describe('unsubscribe', () => {
+    it('should disconnect both observers on unsubscribe', () => {
+      const { unsubscribe } = trackMainThreadBlock({ amplitude, options: {} });
+      unsubscribe();
+
+      MockPerformanceObserver.instances.forEach((i) => {
+        expect(i.disconnected).toBe(true);
+      });
+    });
+  });
+});

--- a/test-server/autocapture/long-task.html
+++ b/test-server/autocapture/long-task.html
@@ -2,39 +2,39 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Long Task Test</title>
+    <title>Main Thread Block Test</title>
     <style>
       body { font-family: monospace; margin: 20px; }
       h2 { margin-top: 32px; }
       button { margin: 4px 0; display: block; }
-      .log { margin-top: 24px; background: #f4f4f4; padding: 12px; border-radius: 4px; min-height: 60px; white-space: pre; font-size: 13px; }
-      .tag { display: inline-block; background: #1a73e8; color: white; border-radius: 3px; padding: 1px 6px; font-size: 11px; margin-right: 4px; }
-      .tag.measure { background: #188038; }
+      #source-badge { font-weight: bold; margin-bottom: 16px; color: #1a73e8; }
+      .log { margin-top: 24px; background: #f4f4f4; padding: 12px; border-radius: 4px; min-height: 60px; white-space: pre-wrap; font-size: 13px; max-height: 400px; overflow-y: auto; }
     </style>
   </head>
   <body>
-    <h1>Long Task Test</h1>
-    <p>Open the Network tab or Amplitude debugger to see <strong>[Amplitude] Long Task</strong> events fire. Each test below is designed to trigger a specific scenario.</p>
+    <h1>Main Thread Block Test</h1>
+    <div id="source-badge">Detecting API support...</div>
+    <p>Open the Network tab or Amplitude debugger to see <strong>[Amplitude] Main Thread Block</strong> events. The on-page log below also mirrors each event.</p>
 
-    <h2>1. Basic long task (no measure)</h2>
-    <p>Blocks the main thread for 200ms. Expect: event with no <code>[Amplitude] Long Task Measures</code>.</p>
-    <button id="basic-long-task">Trigger 200ms long task</button>
+    <h2>1. Basic block (no measure)</h2>
+    <p>Blocks for 200ms. Expect: event with no <code>[Amplitude] Main Thread Block Measures</code>.</p>
+    <button id="basic">Trigger 200ms block</button>
 
-    <h2>2. Long task with measure correlation</h2>
-    <p>Wraps the busy work in a <code>performance.measure()</code>. Expect: event with <code>[Amplitude] Long Task Measures: ["heavy-calculation"]</code>.</p>
-    <button id="measured-long-task">Trigger long task with measure</button>
+    <h2>2. Block with measure correlation</h2>
+    <p>Wraps the work in a <code>performance.measure()</code>. Expect: <code>Measures: ["heavy-calculation"]</code>.</p>
+    <button id="measured">Trigger block with measure</button>
 
-    <h2>3. Long task after a click</h2>
-    <p>Simulates a click handler that triggers a long task. Useful for correlating tasks with user actions in Amplitude.</p>
-    <button id="click-long-task">Click me (triggers long task after 50ms)</button>
+    <h2>3. Block after a click</h2>
+    <p>Simulates a slow click handler. Lets you correlate the task with a user action in Amplitude.</p>
+    <button id="click-block">Click me (triggers block after 50ms)</button>
 
     <h2>4. Multiple overlapping measures</h2>
-    <p>Two measures overlap the same long task. Expect: <code>[Amplitude] Long Task Measures: ["step-one", "step-two"]</code>.</p>
-    <button id="multi-measure-long-task">Trigger long task with multiple measures</button>
+    <p>Two measures overlap the same block. Expect: <code>Measures: ["step-one", "step-two"]</code>.</p>
+    <button id="multi-measure">Trigger block with multiple measures</button>
 
     <h2>5. Short task (should NOT fire)</h2>
     <p>Blocks for only 10ms — below the 50ms threshold. Expect: no event.</p>
-    <button id="short-task">Trigger 10ms task (no event expected)</button>
+    <button id="short">Trigger 10ms block (no event expected)</button>
 
     <div class="log" id="log">Waiting for events...</div>
 
@@ -49,28 +49,26 @@
         el.textContent = new Date().toISOString().slice(11, 23) + '  ' + msg + '\n' + el.textContent;
       }
 
-      document.getElementById('basic-long-task').addEventListener('click', () => {
-        log('Triggering 200ms long task...');
+      document.getElementById('basic').addEventListener('click', () => {
+        log('Triggering 200ms block...');
         blockMainThread(200);
       });
 
-      document.getElementById('measured-long-task').addEventListener('click', () => {
-        log('Triggering long task with measure "heavy-calculation"...');
+      document.getElementById('measured').addEventListener('click', () => {
+        log('Triggering block with measure "heavy-calculation"...');
         performance.mark('heavy-calculation-start');
         blockMainThread(200);
         performance.mark('heavy-calculation-end');
         performance.measure('heavy-calculation', 'heavy-calculation-start', 'heavy-calculation-end');
       });
 
-      document.getElementById('click-long-task').addEventListener('click', () => {
-        log('Click captured — triggering long task in 50ms...');
-        setTimeout(() => {
-          blockMainThread(200);
-        }, 50);
+      document.getElementById('click-block').addEventListener('click', () => {
+        log('Click captured — triggering block in 50ms...');
+        setTimeout(() => blockMainThread(200), 50);
       });
 
-      document.getElementById('multi-measure-long-task').addEventListener('click', () => {
-        log('Triggering long task with measures "step-one" and "step-two"...');
+      document.getElementById('multi-measure').addEventListener('click', () => {
+        log('Triggering block with measures "step-one" and "step-two"...');
         performance.mark('step-one-start');
         blockMainThread(100);
         performance.mark('step-one-end');
@@ -82,8 +80,8 @@
         performance.measure('step-two', 'step-two-start', 'step-two-end');
       });
 
-      document.getElementById('short-task').addEventListener('click', () => {
-        log('Triggering 10ms task (no event expected)...');
+      document.getElementById('short').addEventListener('click', () => {
+        log('Triggering 10ms block (no event expected)...');
         blockMainThread(10);
       });
     </script>
@@ -94,35 +92,50 @@
 
       window.amplitude = amplitude;
 
+      // Show which API is being used
+      const supported = PerformanceObserver.supportedEntryTypes;
+      const source = supported.includes('long-animation-frame')
+        ? 'long-animation-frame (LoAF)'
+        : supported.includes('longtask')
+        ? 'long-task (fallback)'
+        : 'not supported in this browser';
+      document.getElementById('source-badge').textContent = `Tracking via: ${source}`;
+
+      amplitude.add({
+        name: 'main-thread-block-logger',
+        type: 'enrichment',
+        execute: async (event) => {
+          if (event.event_type === '[Amplitude] Main Thread Block') {
+            const p = event.event_properties ?? {};
+            const parts = [
+              `source: ${p['[Amplitude] Main Thread Block Source']}`,
+              `duration: ${Math.round(p['[Amplitude] Main Thread Block Duration'])}ms`,
+              `blocking: ${Math.round(p['[Amplitude] Main Thread Block Blocking Duration'])}ms`,
+            ];
+            const measures = p['[Amplitude] Main Thread Block Measures'];
+            if (measures?.length) parts.push(`measures: [${measures.join(', ')}]`);
+            const scripts = p['[Amplitude] Main Thread Block Script Count'];
+            if (scripts != null) parts.push(`scripts: ${scripts}`);
+            const invokers = p['[Amplitude] Main Thread Block Invokers'];
+            if (invokers?.length) parts.push(`invokers: [${invokers.join(', ')}]`);
+            const attribution = p['[Amplitude] Main Thread Block Attribution'];
+            if (attribution?.length) parts.push(`attribution: [${attribution.join(', ')}]`);
+            document.getElementById('log').textContent =
+              new Date().toISOString().slice(11, 23) + '  [Amplitude] Main Thread Block — ' + parts.join(' | ') + '\n' +
+              document.getElementById('log').textContent;
+          }
+          return event;
+        },
+      });
+
       const plugin = performancePlugin({
-        longTask: { durationThreshold: 50 },
+        mainThreadBlock: { durationThreshold: 50 },
       });
 
       amplitude.init(
         import.meta.env.VITE_AMPLITUDE_API_KEY,
         import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
       );
-
-      // Mirror long task events to the on-page log via an enrichment plugin
-      amplitude.add({
-        name: 'long-task-logger',
-        type: 'enrichment',
-        execute: async (event) => {
-          if (event.event_type === '[Amplitude] Long Task') {
-            const props = event.event_properties ?? {};
-            const duration = props['[Amplitude] Long Task Duration'];
-            const measures = props['[Amplitude] Long Task Measures'];
-            const attribution = props['[Amplitude] Long Task Attribution'];
-            let msg = `[Amplitude] Long Task fired — duration: ${Math.round(duration)}ms`;
-            if (measures?.length) msg += ` | measures: ${measures.join(', ')}`;
-            if (attribution?.length) msg += ` | attribution: ${attribution.join(', ')}`;
-            document.getElementById('log').textContent =
-              new Date().toISOString().slice(11, 23) + '  ' + msg + '\n' +
-              document.getElementById('log').textContent;
-          }
-          return event;
-        },
-      });
 
       amplitude.add(plugin);
     </script>

--- a/test-server/autocapture/long-task.html
+++ b/test-server/autocapture/long-task.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Long Task Test</title>
+    <style>
+      body { font-family: monospace; margin: 20px; }
+      h2 { margin-top: 32px; }
+      button { margin: 4px 0; display: block; }
+      .log { margin-top: 24px; background: #f4f4f4; padding: 12px; border-radius: 4px; min-height: 60px; white-space: pre; font-size: 13px; }
+      .tag { display: inline-block; background: #1a73e8; color: white; border-radius: 3px; padding: 1px 6px; font-size: 11px; margin-right: 4px; }
+      .tag.measure { background: #188038; }
+    </style>
+  </head>
+  <body>
+    <h1>Long Task Test</h1>
+    <p>Open the Network tab or Amplitude debugger to see <strong>[Amplitude] Long Task</strong> events fire. Each test below is designed to trigger a specific scenario.</p>
+
+    <h2>1. Basic long task (no measure)</h2>
+    <p>Blocks the main thread for 200ms. Expect: event with no <code>[Amplitude] Long Task Measures</code>.</p>
+    <button id="basic-long-task">Trigger 200ms long task</button>
+
+    <h2>2. Long task with measure correlation</h2>
+    <p>Wraps the busy work in a <code>performance.measure()</code>. Expect: event with <code>[Amplitude] Long Task Measures: ["heavy-calculation"]</code>.</p>
+    <button id="measured-long-task">Trigger long task with measure</button>
+
+    <h2>3. Long task after a click</h2>
+    <p>Simulates a click handler that triggers a long task. Useful for correlating tasks with user actions in Amplitude.</p>
+    <button id="click-long-task">Click me (triggers long task after 50ms)</button>
+
+    <h2>4. Multiple overlapping measures</h2>
+    <p>Two measures overlap the same long task. Expect: <code>[Amplitude] Long Task Measures: ["step-one", "step-two"]</code>.</p>
+    <button id="multi-measure-long-task">Trigger long task with multiple measures</button>
+
+    <h2>5. Short task (should NOT fire)</h2>
+    <p>Blocks for only 10ms — below the 50ms threshold. Expect: no event.</p>
+    <button id="short-task">Trigger 10ms task (no event expected)</button>
+
+    <div class="log" id="log">Waiting for events...</div>
+
+    <script>
+      function blockMainThread(ms) {
+        const start = performance.now();
+        while (performance.now() - start < ms) { /* busy wait */ }
+      }
+
+      function log(msg) {
+        const el = document.getElementById('log');
+        el.textContent = new Date().toISOString().slice(11, 23) + '  ' + msg + '\n' + el.textContent;
+      }
+
+      document.getElementById('basic-long-task').addEventListener('click', () => {
+        log('Triggering 200ms long task...');
+        blockMainThread(200);
+      });
+
+      document.getElementById('measured-long-task').addEventListener('click', () => {
+        log('Triggering long task with measure "heavy-calculation"...');
+        performance.mark('heavy-calculation-start');
+        blockMainThread(200);
+        performance.mark('heavy-calculation-end');
+        performance.measure('heavy-calculation', 'heavy-calculation-start', 'heavy-calculation-end');
+      });
+
+      document.getElementById('click-long-task').addEventListener('click', () => {
+        log('Click captured — triggering long task in 50ms...');
+        setTimeout(() => {
+          blockMainThread(200);
+        }, 50);
+      });
+
+      document.getElementById('multi-measure-long-task').addEventListener('click', () => {
+        log('Triggering long task with measures "step-one" and "step-two"...');
+        performance.mark('step-one-start');
+        blockMainThread(100);
+        performance.mark('step-one-end');
+        performance.measure('step-one', 'step-one-start', 'step-one-end');
+
+        performance.mark('step-two-start');
+        blockMainThread(100);
+        performance.mark('step-two-end');
+        performance.measure('step-two', 'step-two-start', 'step-two-end');
+      });
+
+      document.getElementById('short-task').addEventListener('click', () => {
+        log('Triggering 10ms task (no event expected)...');
+        blockMainThread(10);
+      });
+    </script>
+
+    <script type="module">
+      import * as amplitude from '@amplitude/analytics-browser';
+      import { performancePlugin } from '@amplitude/plugin-autocapture-browser';
+
+      window.amplitude = amplitude;
+
+      const plugin = performancePlugin({
+        longTask: { durationThreshold: 50 },
+      });
+
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY,
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
+      );
+
+      // Mirror long task events to the on-page log via an enrichment plugin
+      amplitude.add({
+        name: 'long-task-logger',
+        type: 'enrichment',
+        execute: async (event) => {
+          if (event.event_type === '[Amplitude] Long Task') {
+            const props = event.event_properties ?? {};
+            const duration = props['[Amplitude] Long Task Duration'];
+            const measures = props['[Amplitude] Long Task Measures'];
+            const attribution = props['[Amplitude] Long Task Attribution'];
+            let msg = `[Amplitude] Long Task fired — duration: ${Math.round(duration)}ms`;
+            if (measures?.length) msg += ` | measures: ${measures.join(', ')}`;
+            if (attribution?.length) msg += ` | attribution: ${attribution.join(', ')}`;
+            document.getElementById('log').textContent =
+              new Date().toISOString().slice(11, 23) + '  ' + msg + '\n' +
+              document.getElementById('log').textContent;
+          }
+          return event;
+        },
+      });
+
+      amplitude.add(plugin);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/wiki/spaces/IG/pages/3668344872/Performance+Tracking+long+task

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new browser-side `PerformanceObserver` instrumentation and event emission paths that could affect runtime overhead and event volume when enabled, though it is off by default and covered by tests.
> 
> **Overview**
> Adds opt-in **performance tracking** to the browser SDK under `autocapture.performanceTracking`, wiring a new `performancePlugin` into `AmplitudeBrowser.init()` and defining `PerformanceTrackingOptions` in `analytics-core`.
> 
> When enabled, the plugin observes `PerformanceObserver` `long-animation-frame` (or `longtask` fallback) entries and emits a new `[Amplitude] Main Thread Block` event with duration/blocking metrics plus optional script/attribution and correlated `performance.measure()` names, gated by URL allow/exclude lists. Tests and a `test-server` HTML fixture are added to validate enablement, config defaults, and emitted properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aacba511bb50195c41f4ab3d012a7c4a31596667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->