### PR TITLE
fix(session-replay-browser): inline targeting types to fix TS2344 for consumers

### DIFF
--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -15,7 +15,6 @@ import {
 
 // Import only specific types to avoid pulling in the entire rrweb-types package
 import { eventWithTime, EventType as RRWebEventType, scrollCallback } from '@amplitude/rrweb-types';
-import { TargetingParameters } from '@amplitude/targeting';
 import { createSessionReplayJoinedConfigGenerator } from './config/joined-config';
 import {
   LoggingConfig,
@@ -54,6 +53,7 @@ import {
   EventType,
   SessionIdentifiers as ISessionIdentifiers,
   SessionReplayOptions,
+  SessionReplayTargetingInput,
 } from './typings/session-replay';
 import { VERSION } from './version';
 
@@ -75,7 +75,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   eventCount = 0;
   eventCompressor: EventCompressor | undefined;
   sessionTargetingMatch = false;
-  private lastTargetingParams?: Pick<TargetingParameters, 'event' | 'userProperties' | 'page'>;
+  private lastTargetingParams?: SessionReplayTargetingInput;
   private lastShouldRecordDecision?: boolean;
 
   // Visible for testing only
@@ -159,7 +159,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     };
   }
 
-  private getCurrentPageForTargeting(): Pick<TargetingParameters, 'page'>['page'] {
+  private getCurrentPageForTargeting(): SessionReplayTargetingInput['page'] {
     const currentUrl = getGlobalScope()?.location?.href;
     return currentUrl != null ? { url: currentUrl } : undefined;
   }
@@ -384,7 +384,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   };
 
   evaluateTargetingAndCapture = async (
-    targetingParams: Pick<TargetingParameters, 'event' | 'userProperties' | 'page'>,
+    targetingParams: SessionReplayTargetingInput,
     isInit = false,
     forceRestart = false,
     forceTargetingReevaluation = false,

--- a/packages/session-replay-browser/src/targeting/targeting-manager.ts
+++ b/packages/session-replay-browser/src/targeting/targeting-manager.ts
@@ -1,6 +1,7 @@
 import type { TargetingParameters } from '@amplitude/targeting';
 import { TargetingConfig } from '../config/types';
 import { Logger } from '@amplitude/analytics-types';
+import { SessionReplayTargetingInput } from '../typings/session-replay';
 import { targetingIDBStore } from './targeting-idb-store';
 
 export const evaluateTargetingAndStore = async ({
@@ -15,7 +16,7 @@ export const evaluateTargetingAndStore = async ({
   targetingConfig: TargetingConfig;
   loggerProvider: Logger;
   apiKey: string;
-  targetingParams?: Pick<TargetingParameters, 'event' | 'userProperties' | 'page'>;
+  targetingParams?: SessionReplayTargetingInput;
   urlChange?: boolean;
 }) => {
   await targetingIDBStore.clearStoreOfOldSessions({

--- a/packages/session-replay-browser/src/typings/session-replay.ts
+++ b/packages/session-replay-browser/src/typings/session-replay.ts
@@ -1,6 +1,12 @@
 import { AmplitudeReturn, ServerZone } from '@amplitude/analytics-core';
-import type { TargetingParameters } from '@amplitude/targeting';
+import type { Event } from '@amplitude/analytics-types';
 import { SessionReplayJoinedConfig, SessionReplayLocalConfig, SessionReplayVersion } from '../config/types';
+
+export interface SessionReplayTargetingInput {
+  event?: Event;
+  userProperties?: { [key: string]: any };
+  page?: { url?: string };
+}
 
 export type StorageData = {
   totalStorageSize: number;
@@ -95,7 +101,7 @@ export interface AmplitudeSessionReplay {
   getSessionId: () => string | number | undefined;
   getSessionReplayProperties: () => { [key: string]: boolean | string | null };
   evaluateTargetingAndCapture: (
-    targetingParams: Pick<TargetingParameters, 'event' | 'userProperties' | 'page'>,
+    targetingParams: SessionReplayTargetingInput,
     isInit?: boolean,
     forceRestart?: boolean,
     forceTargetingReevaluation?: boolean,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Replace Pick<TargetingParameters, ...> from @amplitude/targeting with a locally-defined SessionReplayTargetingInput interface so the published .d.ts files no longer reference the private @amplitude/targeting package. This fixes TS2344 errors for consumers using skipLibCheck: false.

Closes #1625

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change that swaps public method/field signatures to a local interface; runtime behavior is unchanged aside from type compatibility improvements for downstream TypeScript builds.
> 
> **Overview**
> Removes `Pick<TargetingParameters, 'event' | 'userProperties' | 'page'>` from the public/session-replay targeting surface and replaces it with a locally-defined `SessionReplayTargetingInput` (in `typings/session-replay.ts`).
> 
> Updates `SessionReplay.evaluateTargetingAndCapture`, related helpers/state (e.g., `lastTargetingParams`, `getCurrentPageForTargeting`), and `evaluateTargetingAndStore` to use the new type so the published `.d.ts` files no longer reference `@amplitude/targeting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea3913657f89b8c5e5e34508b5c48f760e395aef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->