### PR TITLE
chore: support backticks in issue titles

### DIFF
--- a/.github/workflows/jira-issue-create-template.yml
+++ b/.github/workflows/jira-issue-create-template.yml
@@ -62,13 +62,17 @@ jobs:
           ELLIPSIS="..."
           MAX_TITLE_LENGTH=$((255 - ${#PREFIX} - ${#ELLIPSIS} - 1))
           # Use provided title or fall back to issue title for backward compatibility
-          RAW_TITLE="${{ inputs.title || github.event.issue.title }}"
+          DELIM_TITLE="EOF_$(uuidgen)"
+          RAW_TITLE=$(cat <<"$DELIM_TITLE"
+          ${{ inputs.title || github.event.issue.title }}
+          $DELIM_TITLE
+          )
           # Process and truncate title if needed
-          TITLE=$(echo "$RAW_TITLE" | tr '\n' ' ' | sed 's/"/\\"/g')
+          TITLE=$(printf "%s" "$RAW_TITLE" | tr '\n' ' ' | sed 's/"/\\"/g')
           if [ ${#TITLE} -gt $MAX_TITLE_LENGTH ]; then
-            TITLE="${TITLE:0:$MAX_TITLE_LENGTH}..."
+            TITLE="${TITLE:0:$MAX_TITLE_LENGTH}$ELLIPSIS"
           fi
-          echo "truncated_title=$TITLE" >> $GITHUB_OUTPUT
+          echo "truncated_title=$TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Create issue
         id: create


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes escape issues in title script

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts shell quoting/escaping when generating Jira issue summaries; main risk is unintended title formatting differences in the created Jira tickets.
> 
> **Overview**
> Improves the `jira-issue-create-template` workflow’s title truncation step to safely handle titles containing special characters (e.g., backticks/newlines) by capturing the input title via a unique heredoc delimiter and using `printf` instead of `echo`.
> 
> Also makes truncation/output writing more consistent by reusing the `ELLIPSIS` variable and quoting `$GITHUB_OUTPUT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f8916c9a31b3e8c375cafda60d05b175c86d90f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->