### PR TITLE
SR-3168 [autocapture]: add opt-in URL parameter capture with PII blocklist

### DIFF
--- a/packages/analytics-core/src/types/element-interactions.ts
+++ b/packages/analytics-core/src/types/element-interactions.ts
@@ -122,6 +122,19 @@ export interface ElementInteractionsOptions {
   exposureDuration?: number;
 
   /**
+   * When true, URL query parameters are captured as a separate event property
+   * (`[Amplitude] Page URL Parameters`). Defaults to false.
+   */
+  captureUrlParameters?: boolean;
+
+  /**
+   * Keys to exclude from captured URL parameters.
+   * Intended for PII-sensitive params (e.g. 'token', 'session_id').
+   * Matching is case-insensitive. Only applies when captureUrlParameters is true.
+   */
+  urlParameterBlocklist?: string[];
+
+  /**
    * Options for viewport content updated tracking (zoning).
    */
   viewportContentUpdated?: {

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -30,6 +30,7 @@ export const AMPLITUDE_EVENT_PROP_MAX_PAGE_X = '[Amplitude] Max Page X';
 export const AMPLITUDE_EVENT_PROP_MAX_PAGE_Y = '[Amplitude] Max Page Y';
 
 export const AMPLITUDE_EVENT_PROP_PAGE_VIEW_ID = '[Amplitude] Page View ID';
+export const AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS = '[Amplitude] Page URL Parameters';
 
 // Origin constants are now shared via analytics-core; re-export for backwards compatibility
 export {

--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -19,6 +19,7 @@ import {
   isElementBasedEvent,
   parseAttributesToMask,
   getCurrentPageViewId,
+  getFilteredUrlParameters,
 } from './helpers';
 import type { BaseTimestampedEvent, ElementBasedTimestampedEvent, TimestampedEvent, JSONValue } from './helpers';
 import { getAncestors, getElementProperties } from './hierarchy';
@@ -28,10 +29,14 @@ import { cssPath } from './libs/element-path';
 
 export class DataExtractor {
   private readonly additionalMaskTextPatterns: RegExp[];
+  private readonly captureUrlParameters: boolean;
+  private readonly urlParameterBlocklist: string[];
   diagnosticsClient?: IDiagnosticsClient;
 
   constructor(options: ElementInteractionsOptions, context?: { diagnosticsClient: IDiagnosticsClient }) {
     this.diagnosticsClient = context?.diagnosticsClient;
+    this.captureUrlParameters = options.captureUrlParameters ?? false;
+    this.urlParameterBlocklist = options.urlParameterBlocklist ?? [];
 
     const rawPatterns = options.maskTextRegex ?? [];
 
@@ -166,6 +171,12 @@ export class DataExtractor {
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_PATH]: this.getElementPath(element),
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_PARENT_LABEL]: nearestLabel,
       [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: getDecodeURI(window.location.href.split('?')[0]),
+      ...(this.captureUrlParameters
+        ? (() => {
+            const params = getFilteredUrlParameters(window.location.search, this.urlParameterBlocklist);
+            return params ? { [constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]: params } : {};
+          })()
+        : {}),
       [constants.AMPLITUDE_EVENT_PROP_PAGE_TITLE]: (
         getPageTitle as (parseTitleFunction: (title: string) => string) => string
       )(this.replaceSensitiveString),
@@ -322,11 +333,17 @@ export class DataExtractor {
     /* istanbul ignore next */
     const tag = element?.tagName?.toLowerCase?.();
 
-    const properties = {
+    const properties: Record<string, unknown> = {
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TAG]: tag,
       [constants.AMPLITUDE_EVENT_PROP_ELEMENT_TEXT]: this.getText(element),
       [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: window.location.href.split('?')[0],
     };
+    if (this.captureUrlParameters) {
+      const params = getFilteredUrlParameters(window.location.search, this.urlParameterBlocklist);
+      if (params) {
+        properties[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS] = params;
+      }
+    }
     return removeEmptyProperties(properties) as Record<string, JSONValue>;
   };
 }

--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -100,6 +100,20 @@ export const createShouldTrackEvent = (
   };
 };
 
+export const getFilteredUrlParameters = (search: string, blockList: string[] = []): Record<string, string> | null => {
+  const params = new URLSearchParams(search);
+  const blockSet = new Set(blockList.map((k) => k.toLowerCase()));
+  const result: Record<string, string> = {};
+  let hasEntries = false;
+  for (const [key, value] of params) {
+    if (!blockSet.has(key.toLowerCase())) {
+      result[key] = value;
+      hasEntries = true;
+    }
+  }
+  return hasEntries ? result : null;
+};
+
 export const isTextNode = (node: Node) => {
   return !!node && node.nodeType === 3;
 };

--- a/packages/plugin-autocapture-browser/test/data-extractor.test.ts
+++ b/packages/plugin-autocapture-browser/test/data-extractor.test.ts
@@ -1195,4 +1195,97 @@ describe('data extractor', () => {
       document.body.removeChild(element);
     });
   });
+
+  describe('getEventProperties with captureUrlParameters', () => {
+    const element = document.createElement('button');
+
+    beforeEach(() => {
+      document.body.appendChild(element);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(element);
+    });
+
+    it('does not include URL parameters property by default', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google&ref=home'));
+      const extractor = new DataExtractor({});
+      const result = extractor.getEventProperties('click', element, 'data-amp-track-');
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toBeUndefined();
+    });
+
+    it('does not include URL parameters property when captureUrlParameters is false', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google'));
+      const extractor = new DataExtractor({ captureUrlParameters: false });
+      const result = extractor.getEventProperties('click', element, 'data-amp-track-');
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toBeUndefined();
+    });
+
+    it('includes URL parameters when captureUrlParameters is true', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google&ref=home'));
+      const extractor = new DataExtractor({ captureUrlParameters: true });
+      const result = extractor.getEventProperties('click', element, 'data-amp-track-');
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toEqual({
+        utm_source: 'google',
+        ref: 'home',
+      });
+    });
+
+    it('excludes blocked parameters from URL parameters', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google&token=secret'));
+      const extractor = new DataExtractor({ captureUrlParameters: true, urlParameterBlocklist: ['token'] });
+      const result = extractor.getEventProperties('click', element, 'data-amp-track-');
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toEqual({ utm_source: 'google' });
+    });
+
+    it('omits URL parameters property when all params are blocked', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?token=secret'));
+      const extractor = new DataExtractor({ captureUrlParameters: true, urlParameterBlocklist: ['token'] });
+      const result = extractor.getEventProperties('click', element, 'data-amp-track-');
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toBeUndefined();
+    });
+
+    it('omits URL parameters property when there are no query params', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page'));
+      const extractor = new DataExtractor({ captureUrlParameters: true });
+      const result = extractor.getEventProperties('click', element, 'data-amp-track-');
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toBeUndefined();
+    });
+  });
+
+  describe('getEventTagProps with captureUrlParameters', () => {
+    beforeAll(() => {
+      Object.defineProperty(window, 'location', {
+        value: { hostname: '', href: '', pathname: '', search: '' },
+        writable: true,
+      });
+    });
+
+    it('does not include URL parameters by default', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google'));
+      const element = document.createElement('div');
+      const extractor = new DataExtractor({});
+      const result = extractor.getEventTagProps(element);
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toBeUndefined();
+    });
+
+    it('includes URL parameters when captureUrlParameters is true', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google&ref=home'));
+      const element = document.createElement('div');
+      const extractor = new DataExtractor({ captureUrlParameters: true });
+      const result = extractor.getEventTagProps(element);
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toEqual({
+        utm_source: 'google',
+        ref: 'home',
+      });
+    });
+
+    it('excludes blocked keys from URL parameters in getEventTagProps', () => {
+      mockWindowLocationFromURL(new URL('https://www.example.com/page?utm_source=google&session_id=abc'));
+      const element = document.createElement('div');
+      const extractor = new DataExtractor({ captureUrlParameters: true, urlParameterBlocklist: ['session_id'] });
+      const result = extractor.getEventTagProps(element);
+      expect(result[constants.AMPLITUDE_EVENT_PROP_PAGE_URL_PARAMETERS]).toEqual({ utm_source: 'google' });
+    });
+  });
 });

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   asyncLoadScript,
   generateUniqueId,
   createShouldTrackEvent,
+  getFilteredUrlParameters,
 } from '../src/helpers';
 import { autocapturePlugin } from '../src/autocapture-plugin';
 import { mockWindowLocationFromURL } from './utils';
@@ -710,6 +711,57 @@ describe('autocapture-plugin helpers', () => {
       );
 
       expect(shouldTrackEvent('click', element)).toEqual(true);
+    });
+  });
+});
+
+describe('getFilteredUrlParameters', () => {
+  it('returns null when search string is empty', () => {
+    expect(getFilteredUrlParameters('')).toBeNull();
+  });
+
+  it('returns all parameters when no blocklist is provided', () => {
+    expect(getFilteredUrlParameters('?utm_source=google&ref=home')).toEqual({
+      utm_source: 'google',
+      ref: 'home',
+    });
+  });
+
+  it('returns all parameters when blocklist is empty', () => {
+    expect(getFilteredUrlParameters('?utm_source=google&ref=home', [])).toEqual({
+      utm_source: 'google',
+      ref: 'home',
+    });
+  });
+
+  it('filters out blocked keys', () => {
+    expect(getFilteredUrlParameters('?utm_source=google&token=abc123&ref=home', ['token'])).toEqual({
+      utm_source: 'google',
+      ref: 'home',
+    });
+  });
+
+  it('matches blocklist keys case-insensitively', () => {
+    expect(getFilteredUrlParameters('?Token=abc123&utm_source=google', ['token'])).toEqual({
+      utm_source: 'google',
+    });
+  });
+
+  it('returns null when all parameters are blocked', () => {
+    expect(getFilteredUrlParameters('?token=abc&session_id=xyz', ['token', 'session_id'])).toBeNull();
+  });
+
+  it('handles parameters without values', () => {
+    expect(getFilteredUrlParameters('?flag&utm_source=google')).toEqual({
+      flag: '',
+      utm_source: 'google',
+    });
+  });
+
+  it('handles search string without leading ?', () => {
+    expect(getFilteredUrlParameters('utm_source=google&ref=home')).toEqual({
+      utm_source: 'google',
+      ref: 'home',
     });
   });
 });


### PR DESCRIPTION
## Description

Adds opt-in URL query parameter capture to autocapture. Currently, `[Amplitude] Page URL` strips the query string entirely — this change adds a separate `[Amplitude] Page URL Parameters` property (a `Record<string, string>`) that customers can opt into.

Jira ticket: SR-3168

### New options on `ElementInteractionsOptions`

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `captureUrlParameters` | `boolean` | `false` | When `true`, captures query parameters as `[Amplitude] Page URL Parameters` |
| `urlParameterBlocklist` | `string[]` | `[]` | Keys to exclude from captured parameters. Intended for PII-sensitive params (e.g. `token`, `session_id`). Matching is case-insensitive. |

### Behavior

- **Off by default** — no behavior change for existing customers
- Parameters are captured as a `Record<string, string>` object, making them directly queryable by individual key in Amplitude charts
- The property is **omitted entirely** (not set to `{}`) when no parameters survive filtering — avoids polluting events with empty objects
- `[Amplitude] Page URL` is **unchanged** — it continues to strip query strings
- Applies to both `getEventProperties()` (element interactions) and `getEventTagProps()` (visual tagging)
- Block list matching is case-insensitive (`Token` is blocked when `token` is in the list)

### Example usage

```typescript
autocapturePlugin({
  captureUrlParameters: true,
  urlParameterBlocklist: ['token', 'session_id', 'auth'],
})
```

For a page at `https://app.example.com/home?utm_source=google&token=abc123`, this would capture:

```json
"[Amplitude] Page URL Parameters": {
  "utm_source": "google"
}
```

## Testing

- 8 new unit tests for `getFilteredUrlParameters` in `helpers.test.ts`
- 9 new tests in `data-extractor.test.ts` covering `getEventProperties` and `getEventTagProps` with both options
- All 387 tests pass with 100% coverage