### PR TITLE
fix(session-replay-browser): wire amp-unmask as default unmaskSelector (SR-2945)

### DIFF
--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -177,6 +177,66 @@ test.describe('privacy — privacyConfig option', () => {
   });
 });
 
+// ─── amp-unmask CSS class (SR-2945) ──────────────────────────────────────────
+
+test.describe('privacy — amp-unmask CSS class', () => {
+  test('amp-unmask class unmasks text under conservative masking from remote config without explicit unmaskSelector', async ({
+    page,
+  }) => {
+    // Before SR-2945, .amp-unmask had no effect unless the user explicitly added
+    // '.amp-unmask' to privacyConfig.unmaskSelector. Now it's wired as a default.
+    await mockRemoteConfig(page, remoteConfigWithPrivacy({ defaultMaskLevel: 'conservative' }));
+    const getBodies = await captureTrackRequests(page);
+
+    // No local privacyConfig — masking comes entirely from remote config
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // #amp-unmask-text has the .amp-unmask class — should NOT be masked
+    const unmaskEl = findById(root!, 'amp-unmask-text');
+    expect(unmaskEl).toBeDefined();
+    expect(getTextContent(unmaskEl!)).toContain('Unmask class visible text');
+    expect(isMaskedText(getTextContent(unmaskEl!))).toBe(false);
+
+    // #plain-text has no special class — should be masked under conservative
+    const plainEl = findById(root!, 'plain-text');
+    expect(plainEl).toBeDefined();
+    expect(isMaskedText(getTextContent(plainEl!))).toBe(true);
+  });
+
+  test('amp-unmask class unmasks text under conservative masking from local privacyConfig without explicit unmaskSelector', async ({
+    page,
+  }) => {
+    const privacyConfig = JSON.stringify({ defaultMaskLevel: 'conservative' });
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const getBodies = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID, privacyConfig }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // #amp-unmask-text has the .amp-unmask class — should NOT be masked
+    const unmaskEl = findById(root!, 'amp-unmask-text');
+    expect(unmaskEl).toBeDefined();
+    expect(getTextContent(unmaskEl!)).toContain('Unmask class visible text');
+    expect(isMaskedText(getTextContent(unmaskEl!))).toBe(false);
+
+    // #plain-text has no special class — should be masked under conservative
+    const plainEl = findById(root!, 'plain-text');
+    expect(plainEl).toBeDefined();
+    expect(isMaskedText(getTextContent(plainEl!))).toBe(true);
+  });
+});
+
 // ─── Remote privacy config ────────────────────────────────────────────────────
 
 test.describe('privacy — remote sr_privacy_config', () => {

--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -186,7 +186,7 @@ test.describe('privacy — amp-unmask CSS class', () => {
     // Before SR-2945, .amp-unmask had no effect unless the user explicitly added
     // '.amp-unmask' to privacyConfig.unmaskSelector. Now it's wired as a default.
     await mockRemoteConfig(page, remoteConfigWithPrivacy({ defaultMaskLevel: 'conservative' }));
-    const getBodies = await captureTrackRequests(page);
+    const { getBodies } = await captureTrackRequests(page);
 
     // No local privacyConfig — masking comes entirely from remote config
     await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
@@ -214,7 +214,7 @@ test.describe('privacy — amp-unmask CSS class', () => {
   }) => {
     const privacyConfig = JSON.stringify({ defaultMaskLevel: 'conservative' });
     await mockRemoteConfig(page, remoteConfigRecording);
-    const getBodies = await captureTrackRequests(page);
+    const { getBodies } = await captureTrackRequests(page);
 
     await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID, privacyConfig }));
     await waitForReady(page);

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -164,7 +164,8 @@ export class SessionReplayJoinedConfigGenerator {
     // };
 
     if (remotePrivacyConfig) {
-      const localPrivacyConfig: PrivacyConfig = config.privacyConfig ?? {};
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const localPrivacyConfig: PrivacyConfig = config.privacyConfig!;
 
       const joinedPrivacyConfig: Required<PrivacyConfig> & { blockSelector: string[] } = {
         defaultMaskLevel: remotePrivacyConfig.defaultMaskLevel ?? localPrivacyConfig.defaultMaskLevel ?? 'medium',

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -164,8 +164,7 @@ export class SessionReplayJoinedConfigGenerator {
     // };
 
     if (remotePrivacyConfig) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const localPrivacyConfig: PrivacyConfig = config.privacyConfig!;
+      const localPrivacyConfig: PrivacyConfig = config.privacyConfig ?? {};
 
       const joinedPrivacyConfig: Required<PrivacyConfig> & { blockSelector: string[] } = {
         defaultMaskLevel: remotePrivacyConfig.defaultMaskLevel ?? localPrivacyConfig.defaultMaskLevel ?? 'medium',

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -80,7 +80,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     // symmetrically with amp-mask/amp-block without requiring explicit config (SR-2945).
     this.privacyConfig = {
       ...(options.privacyConfig ?? {}),
-      unmaskSelector: [`.${UNMASK_TEXT_CLASS}`, ...(options.privacyConfig?.unmaskSelector ?? [])],
+      unmaskSelector: Array.from(new Set([`.${UNMASK_TEXT_CLASS}`, ...(options.privacyConfig?.unmaskSelector ?? [])])),
     };
     if (options.interactionConfig) {
       this.interactionConfig = options.interactionConfig;

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_SAMPLE_RATE,
   DEFAULT_SERVER_ZONE,
   DEFAULT_URL_CHANGE_POLLING_INTERVAL,
+  UNMASK_TEXT_CLASS,
 } from '../constants';
 import { SessionReplayOptions, StoreType } from '../typings/session-replay';
 import {
@@ -75,9 +76,15 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     this.urlChangePollingInterval = options.urlChangePollingInterval ?? DEFAULT_URL_CHANGE_POLLING_INTERVAL;
     this.captureDocumentTitle = options.captureDocumentTitle ?? false;
 
-    if (options.privacyConfig) {
-      this.privacyConfig = options.privacyConfig;
-    }
+    // Auto-include .amp-unmask as a default unmaskSelector entry so it works
+    // symmetrically with amp-mask/amp-block without requiring explicit config (SR-2945).
+    this.privacyConfig = {
+      ...(options.privacyConfig ?? {}),
+      unmaskSelector: [
+        `.${UNMASK_TEXT_CLASS}`,
+        ...((options.privacyConfig?.unmaskSelector) ?? []),
+      ],
+    };
     if (options.interactionConfig) {
       this.interactionConfig = options.interactionConfig;
 

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -80,10 +80,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     // symmetrically with amp-mask/amp-block without requiring explicit config (SR-2945).
     this.privacyConfig = {
       ...(options.privacyConfig ?? {}),
-      unmaskSelector: [
-        `.${UNMASK_TEXT_CLASS}`,
-        ...((options.privacyConfig?.unmaskSelector) ?? []),
-      ],
+      unmaskSelector: [`.${UNMASK_TEXT_CLASS}`, ...(options.privacyConfig?.unmaskSelector ?? [])],
     };
     if (options.interactionConfig) {
       this.interactionConfig = options.interactionConfig;

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -297,12 +297,15 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           ...mockLocalConfig,
           captureEnabled: true,
           optOut: mockLocalConfig.optOut,
+          loggingConfig: undefined,
+          interactionConfig: undefined,
           privacyConfig: {
             defaultMaskLevel: 'medium',
             blockSelector: undefined,
             maskSelector: undefined,
             unmaskSelector: ['.amp-unmask', '.localClassName', '.remoteClassName'],
             maskAttributes: [],
+            urlMaskLevels: [],
           },
         });
       });

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -744,6 +744,21 @@ describe('SessionReplayJoinedConfigGenerator', () => {
     });
   });
 
+  describe('generateJoinedConfig with undefined privacyConfig on joined config', () => {
+    test('should fall back to empty object when config.privacyConfig is undefined', async () => {
+      // Directly instantiate with a local config that has privacyConfig stripped,
+      // exercising the `config.privacyConfig ?? {}` branch in joined-config.ts.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const generator = new SessionReplayJoinedConfigGenerator(mockRemoteConfigClient, {
+        ...mockLocalConfig,
+        privacyConfig: undefined,
+      } as any);
+      mockRemoteConfig = { sr_privacy_config: { blockSelector: ['.remote-block'] } };
+      const { joinedConfig } = await generator.generateJoinedConfig();
+      expect(joinedConfig.privacyConfig?.blockSelector).toEqual(['.remote-block']);
+    });
+  });
+
   describe('createSessionReplayJoinedConfigGenerator with config server url', () => {
     test('should create a SessionReplayJoinedConfigGenerator with the correct remote config client', async () => {
       const configServerUrl = 'https://config.amplitude.com';

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -249,13 +249,13 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           privacyConfig: {
             ...privacyConfig,
             maskSelector: undefined,
-            unmaskSelector: undefined,
+            unmaskSelector: ['.amp-unmask'],
             blockSelector: ['.className', '.anotherClassName'],
           },
         });
       });
 
-      test.each(['block', 'mask', 'unmask'])('should join %p selector from API', async (selectorType) => {
+      test.each(['block', 'mask'])('should join %p selector from API', async (selectorType) => {
         const config = await privacySelectorTest(
           {
             [`${selectorType}Selector`]: ['.remoteClassName'],
@@ -276,11 +276,33 @@ describe('SessionReplayJoinedConfigGenerator', () => {
               defaultMaskLevel: 'medium',
               blockSelector: undefined,
               maskSelector: undefined,
-              unmaskSelector: undefined,
+              unmaskSelector: ['.amp-unmask'],
               maskAttributes: [],
               urlMaskLevels: [],
             },
             ...{ [`${selectorType}Selector`]: ['.localClassName', '.remoteClassName'] },
+          },
+        });
+      });
+
+      test('should join "unmask" selector from API', async () => {
+        const config = await privacySelectorTest(
+          { unmaskSelector: ['.remoteClassName'] },
+          await createSessionReplayJoinedConfigGenerator('static_key', {
+            ...mockOptions,
+            privacyConfig: { unmaskSelector: ['.localClassName'] },
+          }),
+        );
+        expect(config).toEqual({
+          ...mockLocalConfig,
+          captureEnabled: true,
+          optOut: mockLocalConfig.optOut,
+          privacyConfig: {
+            defaultMaskLevel: 'medium',
+            blockSelector: undefined,
+            maskSelector: undefined,
+            unmaskSelector: ['.amp-unmask', '.localClassName', '.remoteClassName'],
+            maskAttributes: [],
           },
         });
       });
@@ -299,7 +321,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
             ...privacyConfig,
             defaultMaskLevel: 'light',
             maskSelector: undefined,
-            unmaskSelector: undefined,
+            unmaskSelector: ['.amp-unmask'],
           },
           interactionConfig: undefined,
         });
@@ -323,7 +345,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
             defaultMaskLevel: 'medium',
             blockSelector: ['.className'],
             maskSelector: undefined,
-            unmaskSelector: undefined,
+            unmaskSelector: ['.amp-unmask'],
             maskAttributes: [],
             urlMaskLevels: [],
           },
@@ -346,7 +368,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           privacyConfig: {
             ...privacyConfig,
             maskSelector: undefined,
-            unmaskSelector: undefined,
+            unmaskSelector: ['.amp-unmask'],
           },
         });
       });
@@ -460,6 +482,57 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           const { joinedConfig: config } = await configGenerator.generateJoinedConfig();
           expect(config.privacyConfig?.urlMaskLevels).toEqual([localRule]);
         });
+      });
+    });
+
+    describe('SessionReplayLocalConfig privacyConfig', () => {
+      test('should include .amp-unmask in unmaskSelector when no privacyConfig is provided', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          privacyConfig: undefined,
+        });
+        expect(config.privacyConfig?.unmaskSelector).toEqual(['.amp-unmask']);
+      });
+
+      test('should include .amp-unmask in unmaskSelector when privacyConfig has no unmaskSelector', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          privacyConfig: { blockSelector: '.block-me' },
+        });
+        expect(config.privacyConfig?.unmaskSelector).toEqual(['.amp-unmask']);
+      });
+
+      test('should prepend .amp-unmask before user-provided unmaskSelector entries', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          privacyConfig: { unmaskSelector: ['.custom-unmask', '#my-id'] },
+        });
+        expect(config.privacyConfig?.unmaskSelector).toEqual(['.amp-unmask', '.custom-unmask', '#my-id']);
+      });
+
+      test('should preserve other privacyConfig properties alongside the injected unmaskSelector', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          privacyConfig: {
+            blockSelector: '.block-me',
+            maskSelector: ['.mask-me'],
+            defaultMaskLevel: 'conservative',
+          },
+        });
+        expect(config.privacyConfig).toEqual({
+          blockSelector: '.block-me',
+          maskSelector: ['.mask-me'],
+          defaultMaskLevel: 'conservative',
+          unmaskSelector: ['.amp-unmask'],
+        });
+      });
+
+      test('should always set privacyConfig (never undefined)', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          privacyConfig: undefined,
+        });
+        expect(config.privacyConfig).toBeDefined();
       });
     });
 

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -310,6 +310,17 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         });
       });
 
+      test('should dedupe .amp-unmask when user explicitly passes it alongside the auto-injected default', async () => {
+        const config = await privacySelectorTest(
+          { unmaskSelector: ['.remoteClassName'] },
+          await createSessionReplayJoinedConfigGenerator('static_key', {
+            ...mockOptions,
+            privacyConfig: { unmaskSelector: ['.amp-unmask', '.localClassName'] },
+          }),
+        );
+        expect(config.privacyConfig?.unmaskSelector).toEqual(['.amp-unmask', '.localClassName', '.remoteClassName']);
+      });
+
       test('should use default mask level from API', async () => {
         const config = await privacySelectorTest({
           ...privacyConfig,
@@ -511,6 +522,14 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           privacyConfig: { unmaskSelector: ['.custom-unmask', '#my-id'] },
         });
         expect(config.privacyConfig?.unmaskSelector).toEqual(['.amp-unmask', '.custom-unmask', '#my-id']);
+      });
+
+      test('should dedupe .amp-unmask when user explicitly includes it in unmaskSelector', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          privacyConfig: { unmaskSelector: ['.amp-unmask', '.foo'] },
+        });
+        expect(config.privacyConfig?.unmaskSelector).toEqual(['.amp-unmask', '.foo']);
       });
 
       test('should preserve other privacyConfig properties alongside the injected unmaskSelector', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -302,7 +302,8 @@ describe('SessionReplay', () => {
       }).promise;
       expect(sessionReplay.config?.privacyConfig?.blockSelector).toStrictEqual(undefined);
       expect(sessionReplay.config?.privacyConfig?.maskSelector).toStrictEqual(undefined);
-      expect(sessionReplay.config?.privacyConfig?.unmaskSelector).toStrictEqual(undefined);
+      // .amp-unmask is always injected as a default and is a valid selector, so it survives
+      expect(sessionReplay.config?.privacyConfig?.unmaskSelector).toStrictEqual(['.amp-unmask']);
     });
 
     test('should start network observers when network logging is enabled in remote config', async () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -6,6 +6,7 @@
 import * as AnalyticsCore from '@amplitude/analytics-core';
 import { LogLevel, ILogger, ServerZone, SpecialEventType, RemoteConfig, Source } from '@amplitude/analytics-core';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
+import * as JoinedConfigModule from '../src/config/joined-config';
 import { NetworkObservers, NetworkRequestEvent } from '../src/observers';
 
 import { IDBFactory } from 'fake-indexeddb';
@@ -4388,6 +4389,33 @@ describe('SessionReplay', () => {
         },
       }).promise;
       expect(subscribeToUrlChanges).toHaveBeenCalled();
+    });
+
+    test('should not call subscribeToUrlChanges when privacyConfig is undefined and no targetingConfig', async () => {
+      (subscribeToUrlChanges as jest.Mock).mockClear();
+      const mockLocalConfig = new SessionReplayLocalConfig(apiKey, mockOptions);
+      const mockJoinedConfig: SessionReplayJoinedConfig = {
+        ...mockLocalConfig,
+        optOut: false,
+        privacyConfig: undefined,
+        captureEnabled: true,
+      };
+      const mockGenerator = {
+        generateJoinedConfig: jest.fn().mockResolvedValue({
+          joinedConfig: mockJoinedConfig,
+          localConfig: mockLocalConfig,
+          remoteConfig: undefined,
+        }),
+      };
+      const createGeneratorSpy = jest
+        .spyOn(JoinedConfigModule, 'createSessionReplayJoinedConfigGenerator')
+        .mockResolvedValue(mockGenerator as any);
+
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      expect(subscribeToUrlChanges).not.toHaveBeenCalled();
+      createGeneratorSpy.mockRestore();
     });
 
     test('should update currentPageUrl on URL change even without targetingConfig', async () => {

--- a/test-server/session-replay-browser/sr-privacy-test.html
+++ b/test-server/session-replay-browser/sr-privacy-test.html
@@ -30,6 +30,10 @@
     <!-- Element for selector-based blocking via privacyConfig.blockSelector -->
     <div id="selector-blocked">Selector blocked content</div>
 
+    <!-- Text with amp-unmask class: should be visible under conservative masking
+         without requiring an explicit unmaskSelector in privacyConfig (SR-2945) -->
+    <p id="amp-unmask-text" class="amp-unmask">Unmask class visible text</p>
+
     <div id="status">loading</div>
     <script type="module">
       import * as sessionReplay from '@amplitude/session-replay-browser';


### PR DESCRIPTION
### Summary

Fixes SR-2945. The \`UNMASK_TEXT_CLASS = 'amp-unmask'\` constant existed alongside \`MASK_TEXT_CLASS = 'amp-mask'\` and \`BLOCK_CLASS = 'amp-block'\`, implying all three work by just applying the CSS class. However, \`amp-mask\` and \`amp-block\` are passed to rrweb as \`maskTextClass\` and \`blockClass\` natively, while \`amp-unmask\` was never wired up — it only worked if the user explicitly set \`privacyConfig.unmaskSelector: ['.amp-unmask']\`.

**Fix:** In \`SessionReplayLocalConfig\`, \`.amp-unmask\` is now auto-included as the first entry in \`unmaskSelector\`, merged with any user-provided selectors. This makes all three classes work symmetrically.

### Checklist

* [x] Does your PR title have the correct title format?
* Does your PR have a breaking change?: No — this is additive. Existing \`unmaskSelector\` configs are preserved and extended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default privacy masking behavior by ensuring `.amp-unmask` always unmasks content, which could unintentionally expose text if customers already rely on conservative masking without expecting class-based overrides. Scope is contained to config composition and covered by added unit/E2E tests.
> 
> **Overview**
> Fixes SR-2945 by **auto-including `.amp-unmask`** as the first entry in `privacyConfig.unmaskSelector` within `SessionReplayLocalConfig`, with deduping and preservation of any user-provided selectors.
> 
> Updates config-join and session replay tests to expect the injected default (including selector merging/deduping and invalid-selector cleanup behavior), and adds E2E coverage plus a test fixture element in `sr-privacy-test.html` to verify `.amp-unmask` unmasks text under conservative masking from both remote and local privacy config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6784e028358f97eb1e4f59e6c1aa8bacecd15601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->