### PR TITLE
chore: fix dependency problem introduced by pull/1628

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,7 +174,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       fake-indexeddb:
         specifier: 4.0.2
         version: 4.0.2
@@ -373,7 +373,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       css.escape:
         specifier: ^1.5.1
         version: 1.5.1
@@ -410,7 +410,38 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
+      rollup:
+        specifier: ^2.79.1
+        version: 2.79.2
+      rollup-plugin-execute:
+        specifier: ^1.1.1
+        version: 1.1.1
+      rollup-plugin-gzip:
+        specifier: ^3.1.0
+        version: 3.1.2(rollup@2.79.2)
+      rollup-plugin-terser:
+        specifier: ^7.0.2
+        version: 7.0.2(rollup@2.79.2)
+
+  packages/plugin-event-property-attribution-browser:
+    dependencies:
+      '@amplitude/analytics-core':
+        specifier: workspace:*
+        version: link:../analytics-core
+      tslib:
+        specifier: ^2.4.1
+        version: 2.8.1
+    devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^23.0.4
+        version: 23.0.7(rollup@2.79.2)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.0.1
+        version: 15.3.1(rollup@2.79.2)
+      '@rollup/plugin-typescript':
+        specifier: ^10.0.1
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       rollup:
         specifier: ^2.79.1
         version: 2.79.2
@@ -454,7 +485,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       rollup:
         specifier: ^2.79.1
         version: 2.79.2
@@ -488,7 +519,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       css.escape:
         specifier: ^1.5.1
         version: 1.5.1
@@ -525,7 +556,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       rollup:
         specifier: ^2.79.1
         version: 2.79.2
@@ -540,37 +571,6 @@ importers:
         version: 7.0.2(rollup@2.79.2)
 
   packages/plugin-page-view-tracking-browser:
-    dependencies:
-      '@amplitude/analytics-core':
-        specifier: workspace:*
-        version: link:../analytics-core
-      tslib:
-        specifier: ^2.4.1
-        version: 2.8.1
-    devDependencies:
-      '@rollup/plugin-commonjs':
-        specifier: ^23.0.4
-        version: 23.0.7(rollup@2.79.2)
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.0.1
-        version: 15.3.1(rollup@2.79.2)
-      '@rollup/plugin-typescript':
-        specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
-      rollup:
-        specifier: ^2.79.1
-        version: 2.79.2
-      rollup-plugin-execute:
-        specifier: ^1.1.1
-        version: 1.1.1
-      rollup-plugin-gzip:
-        specifier: ^3.1.0
-        version: 3.1.2(rollup@2.79.2)
-      rollup-plugin-terser:
-        specifier: ^7.0.2
-        version: 7.0.2(rollup@2.79.2)
-
-  packages/plugin-event-property-attribution-browser:
     dependencies:
       '@amplitude/analytics-core':
         specifier: workspace:*
@@ -639,13 +639,13 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       fake-indexeddb:
         specifier: 4.0.2
         version: 4.0.2
       msw:
         specifier: ^2.3.1
-        version: 2.12.2(@types/node@24.10.1)(typescript@4.9.5)
+        version: 2.12.2(@types/node@24.10.1)(typescript@5.9.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -707,7 +707,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       css.escape:
         specifier: ^1.5.1
         version: 1.5.1
@@ -750,7 +750,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       rollup:
         specifier: ^2.79.1
         version: 2.79.2
@@ -784,7 +784,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       css.escape:
         specifier: ^1.5.1
         version: 1.5.1
@@ -827,7 +827,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
@@ -915,7 +915,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       '@ungap/structured-clone':
         specifier: ^1.2.0
         version: 1.3.0
@@ -992,7 +992,7 @@ importers:
         version: 15.3.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^10.0.1
-        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)
+        version: 10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
       '@types/core-js':
         specifier: ^2.5.8
         version: 2.5.8
@@ -7794,10 +7794,6 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -12614,11 +12610,11 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.2
 
-  '@rollup/plugin-typescript@10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@4.9.5)':
+  '@rollup/plugin-typescript@10.0.1(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@2.79.2)
       resolve: 1.22.11
-      typescript: 4.9.5
+      typescript: 5.9.3
     optionalDependencies:
       rollup: 2.79.2
       tslib: 2.8.1
@@ -12639,7 +12635,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 2.79.2
 
@@ -18102,7 +18098,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.2(@types/node@24.10.1)(typescript@4.9.5):
+  msw@2.12.2(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@24.10.1)
       '@mswjs/interceptors': 0.40.0
@@ -18123,7 +18119,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -18784,8 +18780,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.2: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 


### PR DESCRIPTION
### Summary

https://github.com/amplitude/Amplitude-TypeScript/pull/1628/changes <-- this seems to have introduced a dependency mismatch between package.json and pnpm-lock.yaml. This PR fixes it.


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only changes update the resolved TypeScript peer/dependency graph (and a small `picomatch` patch bump), which is low risk but could affect build/test behavior if the new TypeScript version differs from what CI expects.
> 
> **Overview**
> Fixes a `pnpm-lock.yaml` mismatch by updating the lockfile to resolve `@rollup/plugin-typescript` (and `msw`) against `typescript@5.9.3` instead of `4.9.5`.
> 
> Also refreshes a few transitive resolutions (notably `picomatch` `4.0.3` → `4.0.4`) and reorders some workspace package lockfile sections to match current dependency placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfda5e0ca048b2dc98928f610570a5193239cbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->