### PR TITLE
chore: upgrade playwright

### DIFF
--- a/.github/workflows/e2e-session-replay.yml
+++ b/.github/workflows/e2e-session-replay.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       pull-requests: write
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0
+      image: mcr.microsoft.com/playwright:v1.59.1
 
     steps:
       - name: Check out repository

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0
+      image: mcr.microsoft.com/playwright:v1.59.1
 
     steps:
       - name: Check out git repository

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [authorize]
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0
+      image: mcr.microsoft.com/playwright:v1.59.1
 
     steps:
       - name: Check out git repository


### PR DESCRIPTION
### Summary

Tests are failing to get [Playwright container](<https://github.com/amplitude/Amplitude-TypeScript/actions/runs/24216891018/job/70699471039?pr=1656>).

Try upgrading to the latest container, perhaps the old one is unpublished.

### Checklist

- [X] Does your PR title have the correct [title format](<https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions>)?
- Does your PR have a breaking change?:  No

---

> \[!NOTE\]<br>**Low Risk**<br>Low risk: workflow-only change updating the Playwright Docker image used by CI E2E jobs; main potential impact is unexpected test environment differences or new browser dependencies affecting E2E stability.
>
> **Overview**<br>Updates the Playwright container image used by CI E2E workflows from `mcr.microsoft.com/playwright:v1.55.0` to `v1.59.1`.
>
> This applies to the standard `e2e` workflow, the session replay E2E workflow, and the `publish-v2` workflow’s E2E gate to address failures pulling the older container.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 933bd6d5f96343594927ff5ef5f5c76f63da064a. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).