### PR TITLE
docs(analytics-browser): add request body compression documentation

### DIFF
--- a/packages/analytics-browser/README.md
+++ b/packages/analytics-browser/README.md
@@ -68,4 +68,36 @@ Once the SDK is initialize, you can start tracking events.
 amplitude.track('Page Viewed');
 ```
 
+## Configuration
+
+### Request body compression
+
+The SDK supports gzip compression for event upload request bodies to reduce network bandwidth usage. This feature is automatically enabled for Amplitude's default ingestion endpoints and can be optionally enabled for custom proxy servers.
+
+#### How it works
+
+- **Default Amplitude endpoints**: Compression is automatically enabled when using Amplitude's standard ingestion URLs
+- **Custom `serverUrl`**: Compression is disabled by default but can be enabled via the `enableRequestBodyCompression` configuration option
+- **Size threshold**: Payloads are only compressed if they are 2KB or larger
+- **Browser support**: Compression requires the browser to support the `CompressionStream` API (available in modern browsers)
+- **Transport compatibility**: Compression works with `fetch` and `xhr` transports but not with `beacon` (which cannot set custom headers)
+
+#### Configuration options
+
+```ts
+// Enable compression for custom proxy servers
+amplitude.init('<YOUR_API_KEY>', {
+  serverUrl: 'https://your-proxy-server.com/events',
+  enableRequestBodyCompression: true,
+});
+```
+
+```ts
+// Compression is automatic for default Amplitude endpoints
+amplitude.init('<YOUR_API_KEY>');
+// No configuration needed - compression is enabled by default
+```
+
+**Note**: When using the `beacon` transport, compression is not applied even if enabled, as the `sendBeacon` API does not support setting custom headers required for gzip encoding.
+
 For in-depth documentation, please visit to our [Developer Center](https://www.docs.developers.amplitude.com/data/sdks/sdk-quickstart/#browser).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

This PR updates the Browser SDK 2.0 documentation to document the new gzip request body compression feature introduced in PR #1542.

**Documentation changes:**
- Added comprehensive section on request body compression in the Browser SDK README
- Documented the `enableRequestBodyCompression` configuration option
- Explained automatic compression behavior for default Amplitude endpoints
- Described opt-in compression for custom proxy servers
- Detailed technical requirements: 2KB size threshold, browser support (`CompressionStream` API), and transport compatibility
- Included code examples demonstrating configuration usage

**Key points documented:**
- Compression is automatically enabled for Amplitude's default ingestion endpoints
- For custom `serverUrl` values, compression must be explicitly enabled via `enableRequestBodyCompression: true`
- Payloads are only compressed if they are 2KB or larger
- Compression requires browser support for the `CompressionStream` API
- Works with `fetch` and `xhr` transports, but not with `beacon` (which cannot set custom headers)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://amplitude.slack.com/archives/C09KNBJQTNV/p1775775118237469?thread_ts=1775775118.237469&cid=C09KNBJQTNV)

<div><a href="https://cursor.com/agents/bc-772431ef-e876-5772-b9fd-39d32a360dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-772431ef-e876-5772-b9fd-39d32a360dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

