### PR TITLE
feat(session-replay-browser): add page-level masking via urlMaskLevels (SR-3176)

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -174,6 +174,7 @@ export class SessionReplayJoinedConfigGenerator {
         maskAttributes: [
           ...new Set([...(localPrivacyConfig.maskAttributes ?? []), ...(remotePrivacyConfig.maskAttributes ?? [])]),
         ],
+        urlMaskLevels: [...(remotePrivacyConfig.urlMaskLevels ?? []), ...(localPrivacyConfig.urlMaskLevels ?? [])],
       };
 
       const privacyConfigSelectorMap = (privacyConfig: PrivacyConfig): Record<string, 'mask' | 'unmask' | 'block'> => {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -62,6 +62,7 @@ export type PrivacyConfig = {
   maskSelector?: string[];
   unmaskSelector?: string[];
   maskAttributes?: string[]; // HTML attribute names to mask (e.g. ["placeholder", "aria-label"])
+  urlMaskLevels?: Array<{ match: string; maskLevel: MaskLevel }>;
 };
 
 /**

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -48,6 +48,21 @@ const isMaskedForLevel = (elementType: 'input' | 'text', level: MaskLevel, eleme
 };
 
 /**
+ * Returns the effective mask level for a given URL by checking `urlMaskLevels`
+ * (first match wins) and falling back to `defaultMaskLevel`.
+ */
+export const getEffectiveMaskLevel = (url: string | undefined, config: PrivacyConfig): MaskLevel => {
+  if (url && config.urlMaskLevels) {
+    for (const rule of config.urlMaskLevels) {
+      if (globToRegex(rule.match).test(url)) {
+        return rule.maskLevel;
+      }
+    }
+  }
+  return config.defaultMaskLevel ?? DEFAULT_MASK_LEVEL;
+};
+
+/**
  * Checks if the given element set to be masked by rrweb
  *
  * Priority is:
@@ -58,6 +73,7 @@ export const isMasked = (
   elementType: 'input' | 'text',
   config: PrivacyConfig = { defaultMaskLevel: DEFAULT_MASK_LEVEL },
   element: HTMLElement | null,
+  currentUrl?: string,
 ): boolean => {
   if (element) {
     // Element or parent is explicitly instrumented in code to mask
@@ -84,16 +100,16 @@ export const isMasked = (
     }
   }
 
-  return isMaskedForLevel(elementType, config.defaultMaskLevel ?? DEFAULT_MASK_LEVEL, element);
+  return isMaskedForLevel(elementType, getEffectiveMaskLevel(currentUrl, config), element);
 };
 
 export const maskFn =
-  (elementType: 'text' | 'input', config?: PrivacyConfig) =>
+  (elementType: 'text' | 'input', config?: PrivacyConfig, getCurrentUrl?: () => string) =>
   (text: string, element: HTMLElement | null): string => {
-    return isMasked(elementType, config, element) ? text.replace(/[^\s]/g, '*') : text;
+    return isMasked(elementType, config, element, getCurrentUrl?.()) ? text.replace(/[^\s]/g, '*') : text;
   };
 
-export const maskAttributeFn = (config?: PrivacyConfig) => {
+export const maskAttributeFn = (config?: PrivacyConfig, getCurrentUrl?: () => string) => {
   return (key: string, value: string, element: HTMLElement): string => {
     // Never mask style — rrweb has a separate styleDiff path for attribute mutations
     // that reads directly from the DOM, bypassing maskAttributeFn.
@@ -104,7 +120,7 @@ export const maskAttributeFn = (config?: PrivacyConfig) => {
 
     // Recompute masking every call so class/ancestor mutations do not stale-cache
     // the decision for later attribute mutations on the same element.
-    return isMasked('text', config, element) ? value.replace(/[^\s]/g, '*') : value;
+    return isMasked('text', config, element, getCurrentUrl?.()) ? value.replace(/[^\s]/g, '*') : value;
   };
 };
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -35,7 +35,16 @@ import {
   SESSION_REPLAY_SERVER_URL,
   SESSION_REPLAY_STAGING_URL,
 } from './constants';
-import { getServerUrl, getDebugConfig, getPageUrl, getStorageSize, maskFn, maskAttributeFn } from './helpers';
+import {
+  getServerUrl,
+  getDebugConfig,
+  getEffectiveMaskLevel,
+  getPageUrl,
+  getStorageSize,
+  getCurrentUrl,
+  maskFn,
+  maskAttributeFn,
+} from './helpers';
 import { EventCompressor } from './events/event-compressor';
 import { createEventsManager, EventsManagerWithBeacon } from './events/events-manager';
 import { MultiEventManager } from './events/multi-manager';
@@ -88,6 +97,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
   // Cache the dynamically imported record function
   private recordFunction: RecordFunction | null = null;
 
+  /** Current page URL, kept in sync with SPA navigations for URL-based masking */
+  private currentPageUrl = '';
+
   /** Cleanup for URL change listener used to re-evaluate targeting on SPA route changes */
   private urlChangeCleanup: (() => void) | null = null;
   /** Monotonic counter to ignore stale URL-change targeting results */
@@ -137,6 +149,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     const onUrlChange = (href: string): void => {
+      this.currentPageUrl = href;
       const evaluationId = ++this.latestUrlChangeTargetingEvaluationId;
       void this.evaluateTargetingAndCapture(
         {
@@ -172,6 +185,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.loggerProvider = new SafeLoggerProvider(options.loggerProvider || new Logger());
     Object.prototype.hasOwnProperty.call(options, 'logLevel') &&
       this.loggerProvider.enable(options.logLevel as LogLevel);
+    this.currentPageUrl = getCurrentUrl();
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     const { joinedConfig, localConfig, remoteConfig } = await this.joinedConfigGenerator.generateJoinedConfig();
@@ -621,11 +635,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
   }
 
   getMaskTextSelectors(): string | undefined {
-    if (this.config?.privacyConfig?.defaultMaskLevel === 'conservative') {
+    const privacyConfig = this.config?.privacyConfig;
+    const effectiveLevel = privacyConfig ? getEffectiveMaskLevel(this.currentPageUrl, privacyConfig) : undefined;
+
+    if (effectiveLevel === 'conservative') {
       return '*';
     }
 
-    const maskSelector = this.config?.privacyConfig?.maskSelector;
+    const maskSelector = privacyConfig?.maskSelector;
     if (!maskSelector) {
       return;
     }
@@ -763,9 +780,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
         blockClass: BLOCK_CLASS,
         blockSelector: this.getBlockSelectors() as string | undefined,
         applyBackgroundColorToBlockedElements: config.applyBackgroundColorToBlockedElements,
-        maskInputFn: maskFn('input', privacyConfig),
-        maskTextFn: maskFn('text', privacyConfig),
-        maskAttributeFn: maskAttributeFn(privacyConfig),
+        maskInputFn: maskFn('input', privacyConfig, () => this.currentPageUrl),
+        maskTextFn: maskFn('text', privacyConfig, () => this.currentPageUrl),
+        maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
         maskTextSelector: this.getMaskTextSelectors(),
         recordCanvas: false,
         slimDOMOptions: {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -135,10 +135,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
   };
 
   /**
-   * Subscribes to SPA URL changes via the URL tracking plugin and re-evaluates targeting so we
-   * can start/stop recording when the user navigates to a page that matches or no longer matches.
+   * Subscribes to SPA URL changes via the URL tracking plugin. Always keeps
+   * `currentPageUrl` in sync (needed for URL-based masking). When a targeting
+   * config is present it also re-evaluates targeting on every navigation.
    */
-  private setupUrlChangeListenerForTargeting(): void {
+  private setupUrlChangeListener(): void {
     // If init() runs multiple times, remove the previous URL-change subscription first
     // so we don't leak callbacks and trigger duplicate targeting evaluations.
     this.urlChangeCleanup?.();
@@ -148,20 +149,25 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return;
     }
 
+    const hasTargeting = !!this.config?.targetingConfig;
+
     const onUrlChange = (href: string): void => {
       this.currentPageUrl = href;
-      const evaluationId = ++this.latestUrlChangeTargetingEvaluationId;
-      void this.evaluateTargetingAndCapture(
-        {
-          userProperties: {},
-          event: undefined,
-          page: { url: href },
-        },
-        false,
-        false,
-        true,
-      );
-      this.loggerProvider.debug(`Queued URL-change targeting re-evaluation #${evaluationId} for ${href}.`);
+
+      if (hasTargeting) {
+        const evaluationId = ++this.latestUrlChangeTargetingEvaluationId;
+        void this.evaluateTargetingAndCapture(
+          {
+            userProperties: {},
+            event: undefined,
+            page: { url: href },
+          },
+          false,
+          false,
+          true,
+        );
+        this.loggerProvider.debug(`Queued URL-change targeting re-evaluation #${evaluationId} for ${href}.`);
+      }
     };
     type UrlUnsubscribe = (scope: Window | undefined, cb: (href: string) => void) => () => void;
     const unsubscribe = (subscribeToUrlChanges as UrlUnsubscribe)(globalScope, onUrlChange);
@@ -322,8 +328,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
       true,
     );
 
-    if (this.config.targetingConfig) {
-      this.setupUrlChangeListenerForTargeting();
+    const needsUrlTracking = this.config.targetingConfig || (this.config.privacyConfig?.urlMaskLevels?.length ?? 0) > 0;
+    if (needsUrlTracking) {
+      this.setupUrlChangeListener();
     }
   }
 
@@ -639,6 +646,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const effectiveLevel = privacyConfig ? getEffectiveMaskLevel(this.currentPageUrl, privacyConfig) : undefined;
 
     if (effectiveLevel === 'conservative') {
+      return '*';
+    }
+
+    // If any urlMaskLevels rule uses 'conservative', always route all text nodes
+    // through maskTextFn so the dynamic URL getter can decide at call time.
+    // Without this, rrweb's static maskTextSelector would miss text nodes when
+    // the user navigates from a non-conservative page to a conservative one.
+    if (privacyConfig?.urlMaskLevels?.some((rule) => rule.maskLevel === 'conservative')) {
       return '*';
     }
 

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -31,6 +31,7 @@ const privacyConfig: Required<PrivacyConfig> = {
   maskSelector: [],
   unmaskSelector: [],
   maskAttributes: [],
+  urlMaskLevels: [],
 };
 
 const mockLoggerProvider: MockedLogger = {
@@ -277,6 +278,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
               maskSelector: undefined,
               unmaskSelector: undefined,
               maskAttributes: [],
+              urlMaskLevels: [],
             },
             ...{ [`${selectorType}Selector`]: ['.localClassName', '.remoteClassName'] },
           },
@@ -323,6 +325,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
             maskSelector: undefined,
             unmaskSelector: undefined,
             maskAttributes: [],
+            urlMaskLevels: [],
           },
         });
       });

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -395,6 +395,27 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           expect(config.privacyConfig?.maskAttributes).toEqual([]);
         });
       });
+
+      describe('with urlMaskLevels config', () => {
+        test('should prepend remote urlMaskLevels before local urlMaskLevels', async () => {
+          const remoteRule = { match: 'http://example.com/secure/*', maskLevel: 'conservative' as const };
+          const localRule = { match: 'http://example.com/other/*', maskLevel: 'light' as const };
+          const config = await privacySelectorTest(
+            { urlMaskLevels: [remoteRule] },
+            await createSessionReplayJoinedConfigGenerator('static_key', {
+              ...mockOptions,
+              privacyConfig: { urlMaskLevels: [localRule] },
+            }),
+          );
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([remoteRule, localRule]);
+        });
+
+        test('should use only remote urlMaskLevels when local has none', async () => {
+          const remoteRule = { match: 'http://example.com/secure/*', maskLevel: 'conservative' as const };
+          const config = await privacySelectorTest({ urlMaskLevels: [remoteRule] });
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([remoteRule]);
+        });
+      });
     });
 
     describe('with interaction config', () => {

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -10,8 +10,10 @@ import {
 } from '../src/constants';
 import { ServerZone } from '@amplitude/analytics-core';
 import {
+  getEffectiveMaskLevel,
   getServerUrl,
   getStorageSize,
+  isMasked,
   maskFn,
   maskAttributeFn,
   getPageUrl,
@@ -399,6 +401,163 @@ describe('SessionReplayPlugin helpers', () => {
       ];
       const result = getPageUrl(url, rules);
       expect(result).toBe('https://example.com/page');
+    });
+  });
+
+  describe('getEffectiveMaskLevel', () => {
+    test('should return defaultMaskLevel when no urlMaskLevels are configured', () => {
+      const config: PrivacyConfig = { defaultMaskLevel: 'light' };
+      expect(getEffectiveMaskLevel('https://example.com/page', config)).toBe('light');
+    });
+
+    test('should fall back to medium when no defaultMaskLevel and no urlMaskLevels match', () => {
+      const config: PrivacyConfig = {};
+      expect(getEffectiveMaskLevel('https://example.com/page', config)).toBe('medium');
+    });
+
+    test('should return matching urlMaskLevel for exact URL', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/settings', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/settings', config)).toBe('conservative');
+    });
+
+    test('should return matching urlMaskLevel for glob pattern', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/admin/users', config)).toBe('conservative');
+    });
+
+    test('should return first matching rule (first-match wins)', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [
+          { match: 'https://example.com/admin/*', maskLevel: 'conservative' },
+          { match: 'https://example.com/admin/*', maskLevel: 'light' },
+        ],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/admin/users', config)).toBe('conservative');
+    });
+
+    test('should fall back to defaultMaskLevel when no urlMaskLevels match', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/public/page', config)).toBe('light');
+    });
+
+    test('should fall back to defaultMaskLevel when url is undefined', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel(undefined, config)).toBe('light');
+    });
+
+    test('should fall back to defaultMaskLevel when url is empty', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('', config)).toBe('light');
+    });
+
+    test('should handle wildcard subdomain matching', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://*.example.com/checkout/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://shop.example.com/checkout/payment', config)).toBe('conservative');
+    });
+  });
+
+  describe('isMasked with currentUrl', () => {
+    test('should use urlMaskLevels when currentUrl is provided', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      // On /admin/*, effective level is conservative → text should be masked
+      expect(isMasked('text', config, element, 'https://example.com/admin/dashboard')).toBe(true);
+    });
+
+    test('should use defaultMaskLevel when currentUrl does not match any rule', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      // On /public, effective level is light → input without sensitive type should not be masked
+      expect(isMasked('input', config, element, 'https://example.com/public')).toBe(false);
+    });
+
+    test('should still respect per-element mask overrides over urlMaskLevels', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/public/*', maskLevel: 'light' }],
+        unmaskSelector: [],
+      };
+      const element = document.createElement('div');
+      element.classList.add(MASK_TEXT_CLASS);
+      // amp-mask class takes priority even though URL-level says light
+      expect(isMasked('input', config, element, 'https://example.com/public/page')).toBe(true);
+    });
+
+    test('should still respect per-element unmask overrides over urlMaskLevels', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      element.classList.add(UNMASK_TEXT_CLASS);
+      // amp-unmask class takes priority even though URL-level says conservative
+      expect(isMasked('text', config, element, 'https://example.com/page')).toBe(false);
+    });
+
+    test('should fall back to default behavior when currentUrl is not provided', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      // No URL → falls back to defaultMaskLevel (light), text is still masked by light
+      expect(isMasked('text', config, element)).toBe(true);
+      // Input with light level → not masked for non-sensitive inputs
+      expect(isMasked('input', config, element)).toBe(false);
+    });
+  });
+
+  describe('maskFn with getCurrentUrl', () => {
+    test('should use URL-aware masking when getCurrentUrl is provided', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      const fn = maskFn('input', config, () => 'https://example.com/admin/dashboard');
+      expect(fn('some text', element)).toEqual('**** ****');
+    });
+
+    test('should reflect URL changes dynamically via getter', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      let currentUrl = 'https://example.com/public/page';
+      const fn = maskFn('input', config, () => currentUrl);
+      const element = document.createElement('div');
+
+      // On /public, light level → non-sensitive input not masked
+      expect(fn('some text', element)).toEqual('some text');
+
+      // Simulate SPA navigation to /admin
+      currentUrl = 'https://example.com/admin/dashboard';
+      expect(fn('some text', element)).toEqual('**** ****');
     });
   });
 

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -278,6 +278,18 @@ describe('SessionReplayPlugin helpers', () => {
       wrapper.classList.remove('unmask-parent');
       expect(fn('placeholder', 'Enter name', dynamicElement)).toEqual('***** ****');
     });
+
+    test('returns value unchanged when getCurrentUrl is provided but element has unmask class', () => {
+      const unmaskedElement = document.createElement('input');
+      unmaskedElement.classList.add(UNMASK_TEXT_CLASS);
+      const getCurrentUrl = () => 'http://localhost/page';
+      const result = maskAttributeFn({ maskAttributes: ['placeholder'] }, getCurrentUrl)(
+        'placeholder',
+        'Enter name',
+        unmaskedElement,
+      );
+      expect(result).toEqual('Enter name');
+    });
   });
 
   describe('getServerUrl', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -3682,7 +3682,7 @@ describe('SessionReplay', () => {
       const sessionReplay = new SessionReplay();
       sessionReplay.config = { targetingConfig: {} } as any;
       sessionReplay.identifiers = { sessionId: 123 } as any;
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
+      (sessionReplay as any).setupUrlChangeListener();
       expect(subscribeToUrlChanges).not.toHaveBeenCalled();
     });
 
@@ -3691,7 +3691,7 @@ describe('SessionReplay', () => {
       const sessionReplay = new SessionReplay();
       sessionReplay.config = { targetingConfig: {} } as any;
       sessionReplay.identifiers = { sessionId: 123 } as any;
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
+      (sessionReplay as any).setupUrlChangeListener();
       expect(subscribeToUrlChanges).not.toHaveBeenCalled();
     });
 
@@ -3847,7 +3847,7 @@ describe('SessionReplay', () => {
       );
     });
 
-    test('should clean up existing URL subscription when setupUrlChangeListenerForTargeting is called again', () => {
+    test('should clean up existing URL subscription when setupUrlChangeListener is called again', () => {
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         location: { href: 'https://example.com/current' },
       } as any);
@@ -3858,14 +3858,14 @@ describe('SessionReplay', () => {
         .mockImplementationOnce(() => secondCleanup);
 
       const sessionReplay = new SessionReplay();
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
+      (sessionReplay as any).setupUrlChangeListener();
+      (sessionReplay as any).setupUrlChangeListener();
 
       expect(firstCleanup).toHaveBeenCalledTimes(1);
       expect(secondCleanup).not.toHaveBeenCalled();
     });
 
-    test('should not call subscribeToUrlChanges when init completes with no targetingConfig', async () => {
+    test('should not call subscribeToUrlChanges when init completes with no targetingConfig and no urlMaskLevels', async () => {
       (subscribeToUrlChanges as jest.Mock).mockClear();
       mockRemoteConfig = {
         sr_sampling_config: samplingConfig,

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -2428,6 +2428,33 @@ describe('SessionReplay', () => {
         expect(metaEvent.data.href).toBe(originalHref);
       });
     });
+
+    test('maskInputFn, maskTextFn, and maskAttributeFn closures read currentPageUrl dynamically', async () => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'medium',
+          maskAttributes: ['placeholder'],
+        },
+      }).promise;
+      await sessionReplay.recordEvents();
+      const recordArg = mockRecordFunction.mock.calls[0][0];
+
+      const inputEl = document.createElement('input');
+      const textEl = document.createElement('div');
+      const attrEl = document.createElement('input');
+
+      // Invoking the functions exercises the () => this.currentPageUrl closures on lines 798–800.
+      const maskedInput = recordArg.maskInputFn('secret', inputEl);
+      const maskedText = recordArg.maskTextFn('some text', textEl);
+      const maskedAttr = recordArg.maskAttributeFn('placeholder', 'hint', attrEl);
+
+      // Medium level masks all inputs and text; maskAttributes list includes 'placeholder'.
+      expect(maskedInput).toEqual('******');
+      expect(maskedText).toEqual('**** ****');
+      expect(maskedAttr).toEqual('****');
+    });
   });
 
   describe('getDeviceId', () => {
@@ -2569,6 +2596,17 @@ describe('SessionReplay', () => {
         ...mockOptions,
         privacyConfig: {
           defaultMaskLevel: 'conservative',
+        },
+      }).promise;
+      expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
+    });
+
+    test('should return * when a urlMaskLevels rule uses conservative mask level', async () => {
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'medium',
+          urlMaskLevels: [{ match: 'http://localhost/secure/*', maskLevel: 'conservative' }],
         },
       }).promise;
       expect(sessionReplay.getMaskTextSelectors()).toEqual('*');


### PR DESCRIPTION
## Summary

- Adds `urlMaskLevels` to `PrivacyConfig`, allowing masking level to be overridden per URL pattern (glob syntax)
- When the current page URL matches a `urlMaskLevels` rule, that rule's `maskLevel` is used as the baseline instead of `defaultMaskLevel`
- Per-element overrides (`amp-mask`, `maskSelector`, `unmaskSelector`) still apply on top, unchanged

## Changes

**`src/config/types.ts`** — Added `urlMaskLevels?: Array<{ match: string; maskLevel: MaskLevel }>` to `PrivacyConfig`.

**`src/helpers.ts`** — Added `getEffectiveMaskLevel(url, config)` using existing `globToRegex()` for pattern matching. Updated `isMasked`, `maskFn`, and `maskAttributeFn` to accept and forward the current URL for URL-aware masking decisions.

**`src/session-replay.ts`** — Tracks `currentPageUrl` (initialized on `init`, updated on SPA URL changes). Passes a URL getter to masking callbacks so they dynamically resolve the current URL. Updated `getMaskTextSelectors()` to use `getEffectiveMaskLevel`.

**`src/config/joined-config.ts`** — Concatenates `urlMaskLevels` during remote config merge (remote rules first for higher precedence in first-match order, then local).

**Tests** — 17 new tests covering `getEffectiveMaskLevel` (exact match, glob, first-match-wins, fallback, edge cases) and URL-aware `isMasked`/`maskFn` (per-element overrides still take priority, dynamic URL changes via getter).

## Test plan

- [x] All 658 existing + new tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual verification with sample `urlMaskLevels` config in a test app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core masking behavior by making it URL-dependent and adds SPA URL tracking for masking/targeting, which could affect what data is captured if patterns are misconfigured or URL change detection fails.
> 
> **Overview**
> Adds **page-level masking overrides** via `PrivacyConfig.urlMaskLevels`, allowing the effective `maskLevel` to be selected by first-matching URL glob instead of always using `defaultMaskLevel`.
> 
> Updates masking helpers to compute `getEffectiveMaskLevel()` and thread the current URL through `isMasked`, `maskFn`, and `maskAttributeFn`, with `SessionReplay` tracking `currentPageUrl` across SPA navigations and passing a URL getter into rrweb’s mask callbacks. Remote/local config merging now concatenates `urlMaskLevels` with **remote rules first** (higher precedence), and tests are expanded to cover rule ordering, matching/fallback behavior, and dynamic URL changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faac21795476412bc029ec51323d120b240d018a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->