### PR TITLE
ci: allow publish-v2 to skip lerna version

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -16,6 +16,11 @@ on:
         type: string
         description: Branch to create pre-release from (only applies to prerelease/dry-run).
         required: false
+      publishOnly:
+        type: boolean
+        description: Skip `lerna version` and only run the publish step. Use this to recover from a partial publish where some packages were already released.
+        required: false
+        default: false
 
 jobs:
   authorize:
@@ -107,6 +112,7 @@ jobs:
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version
+        if: ${{ github.event.inputs.publishOnly != 'true' }}
         run: |
           echo "Running lerna version..."
           
@@ -195,7 +201,7 @@ jobs:
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
-        if: ${{ github.event.inputs.releaseType == 'prerelease' }}
+        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.publishOnly != 'true' }}
         run: |
             GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -16,9 +16,9 @@ on:
         type: string
         description: Branch to create pre-release from (only applies to prerelease/dry-run).
         required: false
-      publishOnly:
+      skipLernaVersion:
         type: boolean
-        description: Skip `lerna version` and only run the publish step. Use this to recover from a partial publish where some packages were already released.
+        description: Skip `lerna version` for release/prerelease and only run the publish step. Use this to recover from a partial npm publish where some packages were already released.
         required: false
         default: false
 
@@ -112,7 +112,7 @@ jobs:
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version
-        if: ${{ github.event.inputs.publishOnly != 'true' }}
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         run: |
           echo "Running lerna version..."
           
@@ -201,7 +201,7 @@ jobs:
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
-        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.publishOnly != 'true' }}
+        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
         run: |
             GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 


### PR DESCRIPTION
## Summary
- add a `publishOnly` workflow input to `publish-v2.yml`
- skip the release and prerelease `lerna version` steps when `publishOnly` is enabled
- preserve the existing publish flow so partial publish failures can be retried without re-versioning

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that conditionally skips `lerna version`/tag creation; main risk is misconfiguration leading to publishing without bumping versions or creating releases.
> 
> **Overview**
> Adds a new manual-dispatch input `publishOnly` to the `publish-v2.yml` workflow to support retrying a partial publish.
> 
> When `publishOnly` is enabled, the workflow skips the release and prerelease versioning steps (the `pnpm deploy:version`/`lerna version` phase) while keeping the existing NPM publish steps unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36adaf5ba30790040247bf250e8538dbd5f844b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->