### PR TITLE
ci: skipLernaVersion should skip e2e too

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -16,6 +16,11 @@ on:
         type: string
         description: Branch to create pre-release from (only applies to prerelease/dry-run).
         required: false
+      publishOnly:
+        type: boolean
+        description: Skip `lerna version` and only run the publish step. Use this to recover from a partial publish where some packages were already released.
+        required: false
+        default: false
 
 jobs:
   authorize:
@@ -107,6 +112,7 @@ jobs:
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version
+        if: ${{ github.event.inputs.publishOnly != 'true' }}
         run: |
           echo "Running lerna version..."
           
@@ -195,7 +201,7 @@ jobs:
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
-        if: ${{ github.event.inputs.releaseType == 'prerelease' }}
+        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.publishOnly != 'true' }}
         run: |
             GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -18,7 +18,7 @@ on:
         required: false
       skipLernaVersion:
         type: boolean
-        description: Skip `lerna version` for release/prerelease and only run the publish step. Use this to recover from a partial npm publish where some packages were already released.
+        description: Skip `lerna version` and E2E for release/prerelease recovery runs, then only run the publish step. Use this to recover from a partial npm publish where some packages were already released.
         required: false
         default: false
 
@@ -56,13 +56,19 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.55.0
 
     steps:
+      - name: Skip E2E for recovery publish
+        if: ${{ github.event.inputs.skipLernaVersion == 'true' }}
+        run: echo "Skipping E2E because skipLernaVersion is true"
+
       - name: Check out git repository
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Run E2E tests
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         uses: ./.github/actions/e2e-test
         with:
           amplitude-api-key: ${{ secrets.AMPLITUDE_API_KEY }}

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -16,9 +16,9 @@ on:
         type: string
         description: Branch to create pre-release from (only applies to prerelease/dry-run).
         required: false
-      publishOnly:
+      skipLernaVersion:
         type: boolean
-        description: Skip `lerna version` and only run the publish step. Use this to recover from a partial publish where some packages were already released.
+        description: Skip `lerna version` for release/prerelease and only run the publish step. Use this to recover from a partial npm publish where some packages were already released.
         required: false
         default: false
 
@@ -112,7 +112,7 @@ jobs:
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version
-        if: ${{ github.event.inputs.publishOnly != 'true' }}
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         run: |
           echo "Running lerna version..."
           
@@ -201,7 +201,7 @@ jobs:
           GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
-        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.publishOnly != 'true' }}
+        if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
         run: |
             GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 


### PR DESCRIPTION
## Summary
- add a `skipLernaVersion` workflow input to `publish-v2.yml` for recovery runs after a partial npm publish
- skip the `lerna version` steps for release and prerelease when the flag is enabled
- skip E2E checkout and test steps in the `e2e` job when the flag is enabled while preserving the existing job structure

## Testing
- Not run (not requested)