### PR TITLE
feat(session-replay-browser): URL-aware masking via urlMaskLevels (SR-3176)

### DIFF
--- a/packages/session-replay-browser/e2e/helpers.ts
+++ b/packages/session-replay-browser/e2e/helpers.ts
@@ -63,6 +63,14 @@ export function getSnapshotRoot(rawBodies: string[]): SnapNode | null {
   return snap ? snap.data.node : null;
 }
 
+/** Returns the root of the LAST full snapshot across all collected bodies. */
+export function getLastSnapshotRoot(rawBodies: string[]): SnapNode | null {
+  const events = rawBodies.flatMap(decodeRrwebEvents) as Array<{ type: number; data: { node: SnapNode } }>;
+  const snaps = events.filter((e) => e.type === EVENT_FULL_SNAPSHOT);
+  const last = snaps[snaps.length - 1];
+  return last ? last.data.node : null;
+}
+
 export function findNode(node: SnapNode, predicate: (n: SnapNode) => boolean): SnapNode | undefined {
   if (predicate(node)) return node;
   for (const child of node.childNodes ?? []) {

--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -197,3 +197,134 @@ test.describe('privacy — remote sr_privacy_config', () => {
     expect(isMaskedText(getTextContent(el!))).toBe(true);
   });
 });
+
+// ─── urlMaskLevels — page-level masking overrides ─────────────────────────────
+//
+// The test page runs at http://localhost:5173/session-replay-browser/sr-privacy-test.html
+// Glob patterns are anchored full-URL matches (globToRegex wraps with ^...$).
+
+test.describe('privacy — urlMaskLevels (page-level masking)', () => {
+  // Pattern that matches the test page URL.
+  const MATCHING_PATTERN = 'http://localhost:5173/session-replay-browser/*';
+  // Pattern that does NOT match the test page URL.
+  const NON_MATCHING_PATTERN = 'http://localhost:5173/other-page/*';
+
+  test('URL matches rule with conservative → plain text is masked', async ({ page }) => {
+    // defaultMaskLevel is left at its default (medium) — the urlMaskLevels rule
+    // overrides it to conservative for this specific page.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        urlMaskLevels: [{ match: MATCHING_PATTERN, maskLevel: 'conservative' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // conservative mode masks all plain text
+    const el = findById(root!, 'plain-text');
+    expect(el).toBeDefined();
+    expect(isMaskedText(getTextContent(el!))).toBe(true);
+  });
+
+  test('URL matches rule with light → plain text input is not masked', async ({ page }) => {
+    // defaultMaskLevel is left at its default (medium) — the urlMaskLevels rule
+    // overrides it to light for this specific page.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        urlMaskLevels: [{ match: MATCHING_PATTERN, maskLevel: 'light' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // light mode does NOT mask plain text inputs
+    const textInput = findById(root!, 'text-input');
+    expect(textInput).toBeDefined();
+    const value = String(textInput!.attributes?.value ?? '');
+    expect(value).toBe('visible input value');
+    expect(isMaskedText(value)).toBe(false);
+  });
+
+  test('URL does not match any rule → defaultMaskLevel (light) applies to plain text input', async ({ page }) => {
+    // The urlMaskLevels rule targets a different page, so it never fires.
+    // defaultMaskLevel is 'light': plain text inputs are NOT masked, but password
+    // inputs remain masked. This distinguishes light from the no-match-at-all case.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: NON_MATCHING_PATTERN, maskLevel: 'conservative' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // Under light (the unmatched fallback), a plain text input is NOT masked
+    const textInput = findById(root!, 'text-input');
+    expect(textInput).toBeDefined();
+    const value = String(textInput!.attributes?.value ?? '');
+    expect(value).toBe('visible input value');
+    expect(isMaskedText(value)).toBe(false);
+
+    // password inputs are still masked under light
+    const passwordInput = findById(root!, 'password-input');
+    expect(passwordInput).toBeDefined();
+    expect(isMaskedText(String(passwordInput!.attributes?.value ?? ''))).toBe(true);
+  });
+
+  test('urlMaskLevels light rule wins over defaultMaskLevel conservative', async ({ page }) => {
+    // defaultMaskLevel is conservative but the urlMaskLevels rule overrides it to
+    // light for this specific page — the per-URL rule takes precedence.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: MATCHING_PATTERN, maskLevel: 'light' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // The urlMaskLevels light override wins: plain text input is NOT masked
+    const textInput = findById(root!, 'text-input');
+    expect(textInput).toBeDefined();
+    const value = String(textInput!.attributes?.value ?? '');
+    expect(value).toBe('visible input value');
+    expect(isMaskedText(value)).toBe(false);
+
+    // password inputs are always masked regardless of mask level
+    const passwordInput = findById(root!, 'password-input');
+    expect(passwordInput).toBeDefined();
+    expect(isMaskedText(String(passwordInput!.attributes?.value ?? ''))).toBe(true);
+  });
+});

--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -350,10 +350,11 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
     // Simulate SPA navigation to a URL that matches no urlMaskLevels rule.
+    // NOTE: MATCHING_PATTERN covers /session-replay-browser/*, so navigate outside that path.
     // The SDK's URL-change listener updates currentPageUrl; subsequent maskTextFn
     // calls then resolve to the conservative fallback.
     await page.evaluate(() => {
-      history.pushState({}, '', '/session-replay-browser/unmatched-page');
+      history.pushState({}, '', '/other-section/dashboard');
       // Dispatch a focus event to make rrweb take a new full snapshot with the updated URL context.
       window.dispatchEvent(new Event('focus'));
     });
@@ -367,5 +368,88 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     const el = findById(root!, 'plain-text');
     expect(el).toBeDefined();
     expect(isMaskedText(getTextContent(el!))).toBe(true);
+  });
+
+  test('SPA navigation from conservative URL to light URL unmasks text', async ({ page }) => {
+    // Verifies maskFn URL-awareness: session starts on a conservative URL rule, then navigates
+    // to a light URL rule. After navigation, maskTextFn should resolve to light level and NOT
+    // mask plain text in the new snapshot.
+    // Use exact URL patterns to avoid first-match-wins overlap with the wildcard MATCHING_PATTERN.
+    const CONSERVATIVE_PATTERN = 'http://localhost:5173/session-replay-browser/sr-privacy-test.html*';
+    const LIGHT_PATTERN = 'http://localhost:5173/section-light/*';
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [
+          { match: CONSERVATIVE_PATTERN, maskLevel: 'conservative' },
+          { match: LIGHT_PATTERN, maskLevel: 'light' },
+        ],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Initial snapshot: on the conservative URL — plain text should be masked.
+    await flushRecording(page);
+    const firstRoot = getSnapshotRoot(getBodies());
+    expect(firstRoot).not.toBeNull();
+    expect(isMaskedText(getTextContent(findById(firstRoot!, 'plain-text')!))).toBe(true);
+
+    // Navigate to the light URL rule page via SPA pushState.
+    await page.evaluate(() => {
+      history.pushState({}, '', '/section-light/dashboard');
+      window.dispatchEvent(new Event('focus'));
+    });
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    // The LAST full snapshot was taken on the light URL — plain text must NOT be masked.
+    const lastRoot = getLastSnapshotRoot(getBodies());
+    expect(lastRoot).not.toBeNull();
+    const plainEl = findById(lastRoot!, 'plain-text');
+    expect(plainEl).toBeDefined();
+    expect(isMaskedText(getTextContent(plainEl!))).toBe(false);
+  });
+
+  test('SPA navigation from light URL to conservative URL masks text', async ({ page }) => {
+    // Verifies maskFn URL-awareness in the other direction: session starts on a light URL,
+    // navigates to a conservative URL — maskTextFn should pick up the new URL and mask text.
+    // Use exact URL patterns to avoid first-match-wins overlap.
+    const LIGHT_PATTERN = 'http://localhost:5173/session-replay-browser/sr-privacy-test.html*';
+    const CONSERVATIVE_PATTERN = 'http://localhost:5173/section-secure/*';
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [
+          { match: LIGHT_PATTERN, maskLevel: 'light' },
+          { match: CONSERVATIVE_PATTERN, maskLevel: 'conservative' },
+        ],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Navigate to the conservative URL rule page via SPA pushState.
+    await page.evaluate(() => {
+      history.pushState({}, '', '/section-secure/checkout');
+      window.dispatchEvent(new Event('focus'));
+    });
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    // The LAST full snapshot was taken on the conservative URL — plain text must be masked.
+    const lastRoot = getLastSnapshotRoot(getBodies());
+    expect(lastRoot).not.toBeNull();
+    const plainEl = findById(lastRoot!, 'plain-text');
+    expect(plainEl).toBeDefined();
+    expect(isMaskedText(getTextContent(plainEl!))).toBe(true);
   });
 });

--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -197,6 +197,33 @@ test.describe('privacy — remote sr_privacy_config', () => {
     expect(el).toBeDefined();
     expect(isMaskedText(getTextContent(el!))).toBe(true);
   });
+
+  test('remote urlMaskLevels conservative rule masks plain text end-to-end', async ({ page }) => {
+    // P0: exercises the full remote → join → apply pipeline for urlMaskLevels.
+    // No local privacyConfig — the conservative urlMaskLevels rule comes entirely from
+    // sr_privacy_config. defaultMaskLevel is left at the default (medium) so text masking
+    // is driven solely by the URL rule matching the test page.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        urlMaskLevels: [{ match: 'http://localhost:5173/session-replay-browser/*', maskLevel: 'conservative' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // The conservative urlMaskLevels rule matches this page — plain text must be masked.
+    const el = findById(root!, 'plain-text');
+    expect(el).toBeDefined();
+    expect(isMaskedText(getTextContent(el!))).toBe(true);
+  });
 });
 
 // ─── urlMaskLevels — page-level masking overrides ─────────────────────────────
@@ -260,6 +287,34 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     const value = String(textInput!.attributes?.value ?? '');
     expect(value).toBe('visible input value');
     expect(isMaskedText(value)).toBe(false);
+  });
+
+  test('URL does not match any rule → defaultMaskLevel (conservative) masks plain text', async ({ page }) => {
+    // The urlMaskLevels rule targets a different page, so it never fires.
+    // defaultMaskLevel is 'conservative': plain text must still be masked even though
+    // no URL rule matched. Mirrors the redis.io homepage scenario where the homepage
+    // URL matches no rule and should fall back to conservative.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: NON_MATCHING_PATTERN, maskLevel: 'light' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // Under conservative (the unmatched fallback), plain text IS masked
+    const el = findById(root!, 'plain-text');
+    expect(el).toBeDefined();
+    expect(isMaskedText(getTextContent(el!))).toBe(true);
   });
 
   test('URL does not match any rule → defaultMaskLevel (light) applies to plain text input', async ({ page }) => {
@@ -451,5 +506,46 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     const plainEl = findById(lastRoot!, 'plain-text');
     expect(plainEl).toBeDefined();
     expect(isMaskedText(getTextContent(plainEl!))).toBe(true);
+  });
+
+  test('first-match-wins: second rule (light) applies when first rule does not match', async ({ page }) => {
+    // P1: regression guard for rule evaluation order.
+    // Three rules; only the second matches the test page URL.
+    // Rule 1 (conservative): targets a different path — must NOT match.
+    // Rule 2 (light):        targets the test page — MUST match and apply.
+    // Rule 3 (conservative): also targets the test page but comes after rule 2 — must NOT be evaluated.
+    // Effective level must be 'light': plain text input is NOT masked.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [
+          { match: 'http://localhost:5173/other-section/*', maskLevel: 'conservative' },
+          { match: 'http://localhost:5173/session-replay-browser/*', maskLevel: 'light' },
+          { match: 'http://localhost:5173/session-replay-browser/*', maskLevel: 'conservative' },
+        ],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // Rule 2 (light) wins: plain text input is NOT masked.
+    const textInput = findById(root!, 'text-input');
+    expect(textInput).toBeDefined();
+    const value = String(textInput!.attributes?.value ?? '');
+    expect(value).toBe('visible input value');
+    expect(isMaskedText(value)).toBe(false);
+
+    // Password inputs are always masked regardless of mask level.
+    const passwordInput = findById(root!, 'password-input');
+    expect(passwordInput).toBeDefined();
+    expect(isMaskedText(String(passwordInput!.attributes?.value ?? ''))).toBe(true);
   });
 });

--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -9,6 +9,7 @@ import {
   captureTrackRequests,
   flushRecording,
   getSnapshotRoot,
+  getLastSnapshotRoot,
   findById,
   getTextContent,
   isMaskedText,
@@ -326,5 +327,45 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     const passwordInput = findById(root!, 'password-input');
     expect(passwordInput).toBeDefined();
     expect(isMaskedText(String(passwordInput!.attributes?.value ?? ''))).toBe(true);
+  });
+
+  test('SPA navigation to unmatched URL falls back to conservative default and masks text', async ({ page }) => {
+    // Regression test for the bugbot-identified privacy gap:
+    // defaultMaskLevel:'conservative' + a non-conservative URL rule. Session starts on the test
+    // page (MATCHING_PATTERN → light). After a SPA pushState to an unmatched URL, the effective
+    // level falls back to 'conservative'. Because getMaskTextSelectors() now returns '*' in this
+    // config (fix applied), rrweb routes all text through maskTextFn — which picks up the new URL
+    // via the dynamic getter and masks text accordingly.
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithPrivacy({
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: MATCHING_PATTERN, maskLevel: 'light' }],
+      }),
+    );
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Simulate SPA navigation to a URL that matches no urlMaskLevels rule.
+    // The SDK's URL-change listener updates currentPageUrl; subsequent maskTextFn
+    // calls then resolve to the conservative fallback.
+    await page.evaluate(() => {
+      history.pushState({}, '', '/session-replay-browser/unmatched-page');
+      // Dispatch a focus event to make rrweb take a new full snapshot with the updated URL context.
+      window.dispatchEvent(new Event('focus'));
+    });
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await flushRecording(page);
+
+    // The LAST full snapshot was taken after the URL change — plain text must be masked.
+    const root = getLastSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    const el = findById(root!, 'plain-text');
+    expect(el).toBeDefined();
+    expect(isMaskedText(getTextContent(el!))).toBe(true);
   });
 });

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -174,6 +174,7 @@ export class SessionReplayJoinedConfigGenerator {
         maskAttributes: [
           ...new Set([...(localPrivacyConfig.maskAttributes ?? []), ...(remotePrivacyConfig.maskAttributes ?? [])]),
         ],
+        urlMaskLevels: [...(remotePrivacyConfig.urlMaskLevels ?? []), ...(localPrivacyConfig.urlMaskLevels ?? [])],
       };
 
       const privacyConfigSelectorMap = (privacyConfig: PrivacyConfig): Record<string, 'mask' | 'unmask' | 'block'> => {

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -62,6 +62,18 @@ export type PrivacyConfig = {
   maskSelector?: string[];
   unmaskSelector?: string[];
   maskAttributes?: string[]; // HTML attribute names to mask (e.g. ["placeholder", "aria-label"])
+  /**
+   * Per-URL overrides for `defaultMaskLevel`. Each entry contains a glob pattern (`match`)
+   * and a `maskLevel` to apply when the current page URL matches that pattern.
+   * Rules are evaluated in order; the first match wins. Remote rules take precedence
+   * over local rules (remote entries are prepended before local entries).
+   *
+   * @example
+   * urlMaskLevels: [
+   *   { match: 'https://example.com/checkout/*', maskLevel: 'conservative' },
+   *   { match: 'https://example.com/public/*',   maskLevel: 'light' },
+   * ]
+   */
   urlMaskLevels?: Array<{ match: string; maskLevel: MaskLevel }>;
 };
 

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -62,6 +62,7 @@ export type PrivacyConfig = {
   maskSelector?: string[];
   unmaskSelector?: string[];
   maskAttributes?: string[]; // HTML attribute names to mask (e.g. ["placeholder", "aria-label"])
+  urlMaskLevels?: Array<{ match: string; maskLevel: MaskLevel }>;
 };
 
 /**

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -41,6 +41,7 @@ const isMaskedForLevel = (elementType: 'input' | 'text', level: MaskLevel, eleme
       return false;
     }
     case 'medium':
+      return elementType === 'input';
     case 'conservative':
       return true;
     default:
@@ -121,7 +122,8 @@ export const maskAttributeFn = (config?: PrivacyConfig, getCurrentUrl?: () => st
 
     // Recompute masking every call so class/ancestor mutations do not stale-cache
     // the decision for later attribute mutations on the same element.
-    return isMasked('text', config, element, getCurrentUrl?.()) ? value.replace(/[^\s]/g, '*') : value;
+    const elementType = ['INPUT', 'SELECT', 'TEXTAREA'].includes(element.tagName) ? 'input' : 'text';
+    return isMasked(elementType, config, element, getCurrentUrl?.()) ? value.replace(/[^\s]/g, '*') : value;
   };
 };
 
@@ -147,13 +149,42 @@ const globToRegex = (glob: string): RegExp => {
   const cached = globRegexCache.get(glob);
   if (cached) return cached;
 
-  // Escape special regex characters, then convert globs
-  const escaped = glob
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape regex specials
-    .replace(/\*/g, '.*') // Convert * to .*
-    .replace(/\?/g, '.'); // Convert ? to .
+  // Glob → regex conversion. Glob substitution must happen BEFORE regex escaping so that
+  // the escaper does not corrupt the glob characters (e.g. turning `/**` into `/\*\*`).
+  // Placeholder tokens use null bytes, which are illegal in HTTP URLs and therefore can
+  // never collide with real pattern content.
+  //
+  // Substitution order (most-specific first):
+  //   trailing /**   → (/.*)?          — path with or without a trailing slash/subpath
+  //   middle  /**/   → /(.*\/)?        — zero-or-more path segments (including zero)
+  //   bare    **     → .*              — graceful fallback for ** not adjacent to /
+  //   single  *      → .*              — any characters (preserves existing behaviour)
+  //   ?              → .               — single character wildcard
+  const T_TRAILING = '\x00TRAIL\x00';
+  const T_MIDDLE = '\x00MID\x00';
+  const T_DSTAR = '\x00DS\x00';
+  const T_STAR = '\x00ST\x00';
+  const T_QUEST = '\x00QU\x00';
 
-  const regex = new RegExp(`^${escaped}$`);
+  let s = glob;
+  s = s.replace(/\/\*\*$/, T_TRAILING); // trailing /**
+  s = s.replace(/\/\*\*\//g, T_MIDDLE); // /**/ in the middle
+  s = s.replace(/\*\*/g, T_DSTAR); // bare ** (e.g. **.example.com)
+  s = s.replace(/\*/g, T_STAR); // single *
+  s = s.replace(/\?/g, T_QUEST); // ?
+
+  // Escape all remaining regex special characters.
+  s = s.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+
+  // Expand tokens into their regex equivalents.
+  // Use split/join (not regex) to avoid the no-control-regex lint rule on the token strings.
+  s = s.split(T_TRAILING).join('(/.*)?'); // /** → optional /anything
+  s = s.split(T_MIDDLE).join('/(.*\\/)?'); // /**/ → /zero-or-more-segments/
+  s = s.split(T_DSTAR).join('.*'); // bare ** → .*
+  s = s.split(T_STAR).join('.*'); // * → .*
+  s = s.split(T_QUEST).join('.'); // ? → .
+
+  const regex = new RegExp(`^${s}$`);
   globRegexCache.set(glob, regex);
   return regex;
 };

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -12,7 +12,7 @@ type ChromeStorageEstimate = {
 };
 
 /**
- * Light: Subset of inputs
+ * Light: Subset of inputs (sensitive types only — password, hidden, email, tel, cc-*)
  * Medium: All inputs
  * Conservative: All inputs and all texts
  */
@@ -20,7 +20,8 @@ const isMaskedForLevel = (elementType: 'input' | 'text', level: MaskLevel, eleme
   switch (level) {
     case 'light': {
       if (elementType !== 'input') {
-        return true;
+        // light only masks a subset of inputs; text nodes are not masked at this level.
+        return false;
       }
 
       const inputType = element ? getInputType(element) : '';
@@ -140,14 +141,21 @@ const isValidGlobUrl = (globUrl: string): boolean => {
   return true;
 };
 
+const globRegexCache = new Map<string, RegExp>();
+
 const globToRegex = (glob: string): RegExp => {
+  const cached = globRegexCache.get(glob);
+  if (cached) return cached;
+
   // Escape special regex characters, then convert globs
   const escaped = glob
     .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape regex specials
     .replace(/\*/g, '.*') // Convert * to .*
     .replace(/\?/g, '.'); // Convert ? to .
 
-  return new RegExp(`^${escaped}$`);
+  const regex = new RegExp(`^${escaped}$`);
+  globRegexCache.set(glob, regex);
+  return regex;
 };
 
 export const validateUGCFilterRules = (ugcFilterRules: UGCFilterRule[]) => {

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -122,8 +122,10 @@ export const maskAttributeFn = (config?: PrivacyConfig, getCurrentUrl?: () => st
 
     // Recompute masking every call so class/ancestor mutations do not stale-cache
     // the decision for later attribute mutations on the same element.
-    const elementType = ['INPUT', 'SELECT', 'TEXTAREA'].includes(element.tagName) ? 'input' : 'text';
-    return isMasked(elementType, config, element, getCurrentUrl?.()) ? value.replace(/[^\s]/g, '*') : value;
+    // Use 'input' as the element type: maskAttributes is an explicit override that applies
+    // to any element tag at medium/conservative level. At light level, isMaskedForLevel
+    // for 'input' returns false for non-sensitive types, naturally skipping masking.
+    return isMasked('input', config, element, getCurrentUrl?.()) ? value.replace(/[^\s]/g, '*') : value;
   };
 };
 

--- a/packages/session-replay-browser/src/helpers.ts
+++ b/packages/session-replay-browser/src/helpers.ts
@@ -48,6 +48,21 @@ const isMaskedForLevel = (elementType: 'input' | 'text', level: MaskLevel, eleme
 };
 
 /**
+ * Returns the effective mask level for a given URL by checking `urlMaskLevels`
+ * (first match wins) and falling back to `defaultMaskLevel`.
+ */
+export const getEffectiveMaskLevel = (url: string | undefined, config: PrivacyConfig): MaskLevel => {
+  if (url && config.urlMaskLevels) {
+    for (const rule of config.urlMaskLevels) {
+      if (globToRegex(rule.match).test(url)) {
+        return rule.maskLevel;
+      }
+    }
+  }
+  return config.defaultMaskLevel ?? DEFAULT_MASK_LEVEL;
+};
+
+/**
  * Checks if the given element set to be masked by rrweb
  *
  * Priority is:
@@ -58,6 +73,7 @@ export const isMasked = (
   elementType: 'input' | 'text',
   config: PrivacyConfig = { defaultMaskLevel: DEFAULT_MASK_LEVEL },
   element: HTMLElement | null,
+  currentUrl?: string,
 ): boolean => {
   if (element) {
     // Element or parent is explicitly instrumented in code to mask
@@ -84,16 +100,16 @@ export const isMasked = (
     }
   }
 
-  return isMaskedForLevel(elementType, config.defaultMaskLevel ?? DEFAULT_MASK_LEVEL, element);
+  return isMaskedForLevel(elementType, getEffectiveMaskLevel(currentUrl, config), element);
 };
 
 export const maskFn =
-  (elementType: 'text' | 'input', config?: PrivacyConfig) =>
+  (elementType: 'text' | 'input', config?: PrivacyConfig, getCurrentUrl?: () => string) =>
   (text: string, element: HTMLElement | null): string => {
-    return isMasked(elementType, config, element) ? text.replace(/[^\s]/g, '*') : text;
+    return isMasked(elementType, config, element, getCurrentUrl?.()) ? text.replace(/[^\s]/g, '*') : text;
   };
 
-export const maskAttributeFn = (config?: PrivacyConfig) => {
+export const maskAttributeFn = (config?: PrivacyConfig, getCurrentUrl?: () => string) => {
   return (key: string, value: string, element: HTMLElement): string => {
     // Never mask style — rrweb has a separate styleDiff path for attribute mutations
     // that reads directly from the DOM, bypassing maskAttributeFn.
@@ -104,7 +120,7 @@ export const maskAttributeFn = (config?: PrivacyConfig) => {
 
     // Recompute masking every call so class/ancestor mutations do not stale-cache
     // the decision for later attribute mutations on the same element.
-    return isMasked('text', config, element) ? value.replace(/[^\s]/g, '*') : value;
+    return isMasked('text', config, element, getCurrentUrl?.()) ? value.replace(/[^\s]/g, '*') : value;
   };
 };
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -35,7 +35,16 @@ import {
   SESSION_REPLAY_SERVER_URL,
   SESSION_REPLAY_STAGING_URL,
 } from './constants';
-import { getServerUrl, getDebugConfig, getPageUrl, getStorageSize, maskFn, maskAttributeFn } from './helpers';
+import {
+  getServerUrl,
+  getDebugConfig,
+  getEffectiveMaskLevel,
+  getPageUrl,
+  getStorageSize,
+  getCurrentUrl,
+  maskFn,
+  maskAttributeFn,
+} from './helpers';
 import { EventCompressor } from './events/event-compressor';
 import { createEventsManager, EventsManagerWithBeacon } from './events/events-manager';
 import { MultiEventManager } from './events/multi-manager';
@@ -88,6 +97,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
   // Cache the dynamically imported record function
   private recordFunction: RecordFunction | null = null;
 
+  /** Current page URL, kept in sync with SPA navigations for URL-based masking */
+  private currentPageUrl = '';
+
   /** Cleanup for URL change listener used to re-evaluate targeting on SPA route changes */
   private urlChangeCleanup: (() => void) | null = null;
   /** Monotonic counter to ignore stale URL-change targeting results */
@@ -137,6 +149,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
 
     const onUrlChange = (href: string): void => {
+      this.currentPageUrl = href;
       const evaluationId = ++this.latestUrlChangeTargetingEvaluationId;
       void this.evaluateTargetingAndCapture(
         {
@@ -172,6 +185,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.loggerProvider = new SafeLoggerProvider(options.loggerProvider || new Logger());
     Object.prototype.hasOwnProperty.call(options, 'logLevel') &&
       this.loggerProvider.enable(options.logLevel as LogLevel);
+    this.currentPageUrl = getCurrentUrl();
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     const { joinedConfig, localConfig, remoteConfig } = await this.joinedConfigGenerator.generateJoinedConfig();
@@ -621,11 +635,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
   }
 
   getMaskTextSelectors(): string | undefined {
-    if (this.config?.privacyConfig?.defaultMaskLevel === 'conservative') {
+    const privacyConfig = this.config?.privacyConfig;
+    const effectiveLevel = privacyConfig ? getEffectiveMaskLevel(this.currentPageUrl, privacyConfig) : undefined;
+
+    if (effectiveLevel === 'conservative') {
       return '*';
     }
 
-    const maskSelector = this.config?.privacyConfig?.maskSelector;
+    const maskSelector = privacyConfig?.maskSelector;
     if (!maskSelector) {
       return;
     }
@@ -763,9 +780,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
         blockClass: BLOCK_CLASS,
         blockSelector: this.getBlockSelectors() as string | undefined,
         applyBackgroundColorToBlockedElements: config.applyBackgroundColorToBlockedElements,
-        maskInputFn: maskFn('input', privacyConfig),
-        maskTextFn: maskFn('text', privacyConfig),
-        maskAttributeFn: maskAttributeFn(privacyConfig),
+        maskInputFn: maskFn('input', privacyConfig, () => this.currentPageUrl),
+        maskTextFn: maskFn('text', privacyConfig, () => this.currentPageUrl),
+        maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
         maskTextSelector: this.getMaskTextSelectors(),
         recordCanvas: false,
         slimDOMOptions: {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -657,6 +657,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return '*';
     }
 
+    // If defaultMaskLevel is 'conservative' and URL rules exist, always route text through
+    // maskTextFn — a page matching no rule falls back to the conservative default, and
+    // rrweb must be set up at start to call maskTextFn for those text nodes.
+    if (privacyConfig?.defaultMaskLevel === 'conservative' && privacyConfig?.urlMaskLevels?.length) {
+      return '*';
+    }
+
     const maskSelector = privacyConfig?.maskSelector;
     if (!maskSelector) {
       return;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -660,7 +660,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // If defaultMaskLevel is 'conservative' and URL rules exist, always route text through
     // maskTextFn — a page matching no rule falls back to the conservative default, and
     // rrweb must be set up at start to call maskTextFn for those text nodes.
-    if (privacyConfig?.defaultMaskLevel === 'conservative' && privacyConfig?.urlMaskLevels?.length) {
+    const urlMaskLevels = privacyConfig?.urlMaskLevels;
+    if (privacyConfig?.defaultMaskLevel === 'conservative' && urlMaskLevels && urlMaskLevels.length > 0) {
       return '*';
     }
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -135,10 +135,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
   };
 
   /**
-   * Subscribes to SPA URL changes via the URL tracking plugin and re-evaluates targeting so we
-   * can start/stop recording when the user navigates to a page that matches or no longer matches.
+   * Subscribes to SPA URL changes via the URL tracking plugin. Always keeps
+   * `currentPageUrl` in sync (needed for URL-based masking). When a targeting
+   * config is present it also re-evaluates targeting on every navigation.
    */
-  private setupUrlChangeListenerForTargeting(): void {
+  private setupUrlChangeListener(): void {
     // If init() runs multiple times, remove the previous URL-change subscription first
     // so we don't leak callbacks and trigger duplicate targeting evaluations.
     this.urlChangeCleanup?.();
@@ -148,20 +149,25 @@ export class SessionReplay implements AmplitudeSessionReplay {
       return;
     }
 
+    const hasTargeting = !!this.config?.targetingConfig;
+
     const onUrlChange = (href: string): void => {
       this.currentPageUrl = href;
-      const evaluationId = ++this.latestUrlChangeTargetingEvaluationId;
-      void this.evaluateTargetingAndCapture(
-        {
-          userProperties: {},
-          event: undefined,
-          page: { url: href },
-        },
-        false,
-        false,
-        true,
-      );
-      this.loggerProvider.debug(`Queued URL-change targeting re-evaluation #${evaluationId} for ${href}.`);
+
+      if (hasTargeting) {
+        const evaluationId = ++this.latestUrlChangeTargetingEvaluationId;
+        void this.evaluateTargetingAndCapture(
+          {
+            userProperties: {},
+            event: undefined,
+            page: { url: href },
+          },
+          false,
+          false,
+          true,
+        );
+        this.loggerProvider.debug(`Queued URL-change targeting re-evaluation #${evaluationId} for ${href}.`);
+      }
     };
     type UrlUnsubscribe = (scope: Window | undefined, cb: (href: string) => void) => () => void;
     const unsubscribe = (subscribeToUrlChanges as UrlUnsubscribe)(globalScope, onUrlChange);
@@ -322,8 +328,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
       true,
     );
 
-    if (this.config.targetingConfig) {
-      this.setupUrlChangeListenerForTargeting();
+    const needsUrlTracking = this.config.targetingConfig || (this.config.privacyConfig?.urlMaskLevels?.length ?? 0) > 0;
+    if (needsUrlTracking) {
+      this.setupUrlChangeListener();
     }
   }
 
@@ -639,6 +646,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const effectiveLevel = privacyConfig ? getEffectiveMaskLevel(this.currentPageUrl, privacyConfig) : undefined;
 
     if (effectiveLevel === 'conservative') {
+      return '*';
+    }
+
+    // If any urlMaskLevels rule uses 'conservative', always route all text nodes
+    // through maskTextFn so the dynamic URL getter can decide at call time.
+    // Without this, rrweb's static maskTextSelector would miss text nodes when
+    // the user navigates from a non-conservative page to a conservative one.
+    if (privacyConfig?.urlMaskLevels?.some((rule) => rule.maskLevel === 'conservative')) {
       return '*';
     }
 

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -395,6 +395,43 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           expect(config.privacyConfig?.maskAttributes).toEqual([]);
         });
       });
+
+      describe('with urlMaskLevels config', () => {
+        const remoteRule = { match: 'https://example.com/admin/*', maskLevel: 'conservative' as const };
+        const localRule = { match: 'https://example.com/public/*', maskLevel: 'light' as const };
+
+        test('should prepend remote urlMaskLevels before local (remote has priority)', async () => {
+          const config = await privacySelectorTest(
+            { urlMaskLevels: [remoteRule] },
+            await createSessionReplayJoinedConfigGenerator('static_key', {
+              ...mockOptions,
+              privacyConfig: { urlMaskLevels: [localRule] },
+            }),
+          );
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([remoteRule, localRule]);
+        });
+
+        test('should use only local urlMaskLevels when remote has none', async () => {
+          const config = await privacySelectorTest(
+            {},
+            await createSessionReplayJoinedConfigGenerator('static_key', {
+              ...mockOptions,
+              privacyConfig: { urlMaskLevels: [localRule] },
+            }),
+          );
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([localRule]);
+        });
+
+        test('should use only remote urlMaskLevels when local has none', async () => {
+          const config = await privacySelectorTest({ urlMaskLevels: [remoteRule] });
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([remoteRule]);
+        });
+
+        test('should produce empty urlMaskLevels when neither local nor remote has any', async () => {
+          const config = await privacySelectorTest({});
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([]);
+        });
+      });
     });
 
     describe('with interaction config', () => {

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -31,6 +31,7 @@ const privacyConfig: Required<PrivacyConfig> = {
   maskSelector: [],
   unmaskSelector: [],
   maskAttributes: [],
+  urlMaskLevels: [],
 };
 
 const mockLoggerProvider: MockedLogger = {
@@ -277,6 +278,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
               maskSelector: undefined,
               unmaskSelector: undefined,
               maskAttributes: [],
+              urlMaskLevels: [],
             },
             ...{ [`${selectorType}Selector`]: ['.localClassName', '.remoteClassName'] },
           },
@@ -323,6 +325,7 @@ describe('SessionReplayJoinedConfigGenerator', () => {
             maskSelector: undefined,
             unmaskSelector: undefined,
             maskAttributes: [],
+            urlMaskLevels: [],
           },
         });
       });

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -431,6 +431,35 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           const config = await privacySelectorTest({});
           expect(config.privacyConfig?.urlMaskLevels).toEqual([]);
         });
+
+        test('remote defaultMaskLevel wins over local defaultMaskLevel', async () => {
+          // P1: remote config must override local when both specify defaultMaskLevel.
+          // Local says 'conservative'; remote says 'light' — joined config must reflect 'light'.
+          const config = await privacySelectorTest(
+            { defaultMaskLevel: 'light' },
+            await createSessionReplayJoinedConfigGenerator('static_key', {
+              ...mockOptions,
+              privacyConfig: { defaultMaskLevel: 'conservative' },
+            }),
+          );
+          expect(config.privacyConfig?.defaultMaskLevel).toBe('light');
+        });
+
+        test('local urlMaskLevels are preserved when sr_privacy_config is absent from remote', async () => {
+          // P1: when the remote response has no sr_privacy_config key at all, the joined config
+          // should fall back to the local config as-is — local urlMaskLevels must not be lost.
+          const localRule = { match: 'https://example.com/admin/*', maskLevel: 'conservative' as const };
+          mockRemoteConfig = {
+            sr_sampling_config: samplingConfig,
+            // intentionally no sr_privacy_config key
+          };
+          const configGenerator = await createSessionReplayJoinedConfigGenerator('static_key', {
+            ...mockOptions,
+            privacyConfig: { urlMaskLevels: [localRule] },
+          });
+          const { joinedConfig: config } = await configGenerator.generateJoinedConfig();
+          expect(config.privacyConfig?.urlMaskLevels).toEqual([localRule]);
+        });
       });
     });
 

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -342,8 +342,8 @@ describe('SessionReplayPlugin helpers', () => {
     });
 
     test('still masks input placeholder at medium level (regression guard)', () => {
-      // After Fix 1, medium no longer masks text nodes. Fix 2 ensures input elements
-      // are still recognised as 'input' type so their attributes remain masked at medium.
+      // maskAttributeFn uses 'input' as elementType so isMaskedForLevel returns true at medium
+      // for any element (including actual <input> elements).
       const inputElement = document.createElement('input');
       const fn = maskAttributeFn({
         defaultMaskLevel: 'medium',
@@ -352,17 +352,15 @@ describe('SessionReplayPlugin helpers', () => {
       expect(fn('placeholder', 'Enter name', inputElement)).toEqual('***** ****');
     });
 
-    test('uses text elementType for non-form elements (div) — covers the else branch of tagName ternary', () => {
-      // maskAttributeFn computes elementType as 'input' for INPUT/SELECT/TEXTAREA and 'text' for
-      // everything else. This test exercises the 'text' branch using a div element, which is not
-      // masked at medium level (medium only masks inputs, not text nodes).
+    test('masks aria-label on non-form elements (div) at medium level', () => {
+      // maskAttributeFn uses 'input' as the element type for all elements so that medium level
+      // masks attributes listed in maskAttributes regardless of the element tag.
       const divElement = document.createElement('div');
       const fn = maskAttributeFn({
         defaultMaskLevel: 'medium',
         maskAttributes: ['aria-label'],
       });
-      // medium level does NOT mask text-type elements, so aria-label on a div is returned as-is.
-      expect(fn('aria-label', 'some label', divElement)).toEqual('some label');
+      expect(fn('aria-label', 'some label', divElement)).toEqual('**** *****');
     });
   });
 

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -10,8 +10,10 @@ import {
 } from '../src/constants';
 import { ServerZone } from '@amplitude/analytics-core';
 import {
+  getEffectiveMaskLevel,
   getServerUrl,
   getStorageSize,
+  isMasked,
   maskFn,
   maskAttributeFn,
   getPageUrl,
@@ -399,6 +401,163 @@ describe('SessionReplayPlugin helpers', () => {
       ];
       const result = getPageUrl(url, rules);
       expect(result).toBe('https://example.com/page');
+    });
+  });
+
+  describe('getEffectiveMaskLevel', () => {
+    test('should return defaultMaskLevel when no urlMaskLevels are configured', () => {
+      const config: PrivacyConfig = { defaultMaskLevel: 'light' };
+      expect(getEffectiveMaskLevel('https://example.com/page', config)).toBe('light');
+    });
+
+    test('should fall back to medium when no defaultMaskLevel and no urlMaskLevels match', () => {
+      const config: PrivacyConfig = {};
+      expect(getEffectiveMaskLevel('https://example.com/page', config)).toBe('medium');
+    });
+
+    test('should return matching urlMaskLevel for exact URL', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/settings', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/settings', config)).toBe('conservative');
+    });
+
+    test('should return matching urlMaskLevel for glob pattern', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/admin/users', config)).toBe('conservative');
+    });
+
+    test('should return first matching rule (first-match wins)', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [
+          { match: 'https://example.com/admin/*', maskLevel: 'conservative' },
+          { match: 'https://example.com/admin/*', maskLevel: 'light' },
+        ],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/admin/users', config)).toBe('conservative');
+    });
+
+    test('should fall back to defaultMaskLevel when no urlMaskLevels match', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/public/page', config)).toBe('light');
+    });
+
+    test('should fall back to defaultMaskLevel when url is undefined', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel(undefined, config)).toBe('light');
+    });
+
+    test('should fall back to defaultMaskLevel when url is empty', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('', config)).toBe('light');
+    });
+
+    test('should handle wildcard subdomain matching', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://*.example.com/checkout/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://shop.example.com/checkout/payment', config)).toBe('conservative');
+    });
+  });
+
+  describe('isMasked with currentUrl', () => {
+    test('should use urlMaskLevels when currentUrl is provided', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      // On /admin/*, effective level is conservative → text should be masked
+      expect(isMasked('text', config, element, 'https://example.com/admin/dashboard')).toBe(true);
+    });
+
+    test('should use defaultMaskLevel when currentUrl does not match any rule', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      // On /public, effective level is light → input without sensitive type should not be masked
+      expect(isMasked('input', config, element, 'https://example.com/public')).toBe(false);
+    });
+
+    test('should still respect per-element mask overrides over urlMaskLevels', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/public/*', maskLevel: 'light' }],
+        unmaskSelector: [],
+      };
+      const element = document.createElement('div');
+      element.classList.add(MASK_TEXT_CLASS);
+      // amp-mask class takes priority even though URL-level says light
+      expect(isMasked('input', config, element, 'https://example.com/public/page')).toBe(true);
+    });
+
+    test('should still respect per-element unmask overrides over urlMaskLevels', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      element.classList.add(UNMASK_TEXT_CLASS);
+      // amp-unmask class takes priority even though URL-level says conservative
+      expect(isMasked('text', config, element, 'https://example.com/page')).toBe(false);
+    });
+
+    test('should fall back to default behavior when currentUrl is not provided', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      // No URL → falls back to defaultMaskLevel (light), text is still masked by light
+      expect(isMasked('text', config, element)).toBe(true);
+      // Input with light level → not masked for non-sensitive inputs
+      expect(isMasked('input', config, element)).toBe(false);
+    });
+  });
+
+  describe('maskFn with getCurrentUrl', () => {
+    test('should use URL-aware masking when getCurrentUrl is provided', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      const element = document.createElement('div');
+      const fn = maskFn('input', config, () => 'https://example.com/admin/dashboard');
+      expect(fn('some text', element)).toEqual('**** ****');
+    });
+
+    test('should reflect URL changes dynamically via getter', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+      };
+      let currentUrl = 'https://example.com/public/page';
+      const fn = maskFn('input', config, () => currentUrl);
+      const element = document.createElement('div');
+
+      // On /public, light level → non-sensitive input not masked
+      expect(fn('some text', element)).toEqual('some text');
+
+      // Simulate SPA navigation to /admin
+      currentUrl = 'https://example.com/admin/dashboard';
+      expect(fn('some text', element)).toEqual('**** ****');
     });
   });
 

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -176,12 +176,11 @@ describe('SessionReplayPlugin helpers', () => {
       const result = maskFn('text', { defaultMaskLevel: 'conservative' })('some text', htmlElement);
       expect(result).toEqual('**** ****');
     });
-    // this will never happen in reality since rrweb will not call this
-    // function if we had not registered selectors
-    test('should mask an element on light mask level', () => {
+    test('should not mask a text element on light mask level', () => {
+      // light level only masks a subset of sensitive inputs; text nodes are never masked at light.
       const htmlElement = document.createElement('div');
       const result = maskFn('text', { defaultMaskLevel: 'light' })('some text', htmlElement);
-      expect(result).toEqual('**** ****');
+      expect(result).toEqual('some text');
     });
     test('should not mask an element whose class list has amp-unmask in it', () => {
       const htmlElement = document.createElement('div');
@@ -277,6 +276,34 @@ describe('SessionReplayPlugin helpers', () => {
       // After ancestor no longer matches, element should be masked.
       wrapper.classList.remove('unmask-parent');
       expect(fn('placeholder', 'Enter name', dynamicElement)).toEqual('***** ****');
+    });
+
+    test('masks attribute when getCurrentUrl returns a conservative URL via urlMaskLevels', () => {
+      const maskedElement = document.createElement('input');
+      const fn = maskAttributeFn(
+        {
+          defaultMaskLevel: 'light',
+          maskAttributes: ['placeholder'],
+          urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+        },
+        () => 'https://example.com/admin/settings',
+      );
+      expect(fn('placeholder', 'Enter name', maskedElement)).toEqual('***** ****');
+    });
+
+    test('returns value unmasked when getCurrentUrl returns a light URL via urlMaskLevels', () => {
+      // Exercises the false branch of the ternary on the isMasked call when getCurrentUrl is provided.
+      const element = document.createElement('input');
+      const fn = maskAttributeFn(
+        {
+          defaultMaskLevel: 'conservative',
+          maskAttributes: ['placeholder'],
+          urlMaskLevels: [{ match: 'https://example.com/public/*', maskLevel: 'light' }],
+        },
+        () => 'https://example.com/public/page',
+      );
+      // light level does not mask attributes (isMasked returns false for text-type at light)
+      expect(fn('placeholder', 'Enter name', element)).toEqual('Enter name');
     });
   });
 
@@ -547,8 +574,8 @@ describe('SessionReplayPlugin helpers', () => {
         urlMaskLevels: [{ match: 'https://example.com/*', maskLevel: 'conservative' }],
       };
       const element = document.createElement('div');
-      // No URL → falls back to defaultMaskLevel (light), text is still masked by light
-      expect(isMasked('text', config, element)).toBe(true);
+      // No URL → falls back to defaultMaskLevel (light); text is NOT masked at light level
+      expect(isMasked('text', config, element)).toBe(false);
       // Input with light level → not masked for non-sensitive inputs
       expect(isMasked('input', config, element)).toBe(false);
     });

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -351,6 +351,19 @@ describe('SessionReplayPlugin helpers', () => {
       });
       expect(fn('placeholder', 'Enter name', inputElement)).toEqual('***** ****');
     });
+
+    test('uses text elementType for non-form elements (div) — covers the else branch of tagName ternary', () => {
+      // maskAttributeFn computes elementType as 'input' for INPUT/SELECT/TEXTAREA and 'text' for
+      // everything else. This test exercises the 'text' branch using a div element, which is not
+      // masked at medium level (medium only masks inputs, not text nodes).
+      const divElement = document.createElement('div');
+      const fn = maskAttributeFn({
+        defaultMaskLevel: 'medium',
+        maskAttributes: ['aria-label'],
+      });
+      // medium level does NOT mask text-type elements, so aria-label on a div is returned as-is.
+      expect(fn('aria-label', 'some label', divElement)).toEqual('some label');
+    });
   });
 
   describe('getServerUrl', () => {

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -164,6 +164,41 @@ describe('SessionReplayPlugin helpers', () => {
     });
   });
 
+  describe('maskFn -- text (medium level)', () => {
+    test('should NOT mask text nodes at medium level', () => {
+      const htmlElement = document.createElement('div');
+      const result = maskFn('text', { defaultMaskLevel: 'medium' })('some text', htmlElement);
+      expect(result).toEqual('some text');
+    });
+
+    test('should mask inputs at medium level', () => {
+      const htmlElement = document.createElement('input');
+      const result = maskFn('input', { defaultMaskLevel: 'medium' })('some text', htmlElement);
+      expect(result).toEqual('**** ****');
+    });
+
+    test('maskFn with urlMaskLevels medium on matching URL does NOT mask text', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: 'https://example.com/docs/*', maskLevel: 'medium' }],
+      };
+      const element = document.createElement('div');
+      const fn = maskFn('text', config, () => 'https://example.com/docs/intro');
+      expect(fn('some text', element)).toEqual('some text');
+    });
+
+    test('maskFn with urlMaskLevels medium on non-matching URL falls through to defaultMaskLevel', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'conservative',
+        urlMaskLevels: [{ match: 'https://example.com/docs/*', maskLevel: 'medium' }],
+      };
+      const element = document.createElement('div');
+      const fn = maskFn('text', config, () => 'https://example.com/other/page');
+      // defaultMaskLevel is conservative, so text IS masked
+      expect(fn('some text', element)).toEqual('**** ****');
+    });
+  });
+
   describe('maskFn -- text', () => {
     test('should mask on amp mask', () => {
       const htmlElement = document.createElement('text');
@@ -304,6 +339,17 @@ describe('SessionReplayPlugin helpers', () => {
       );
       // light level does not mask attributes (isMasked returns false for text-type at light)
       expect(fn('placeholder', 'Enter name', element)).toEqual('Enter name');
+    });
+
+    test('still masks input placeholder at medium level (regression guard)', () => {
+      // After Fix 1, medium no longer masks text nodes. Fix 2 ensures input elements
+      // are still recognised as 'input' type so their attributes remain masked at medium.
+      const inputElement = document.createElement('input');
+      const fn = maskAttributeFn({
+        defaultMaskLevel: 'medium',
+        maskAttributes: ['placeholder'],
+      });
+      expect(fn('placeholder', 'Enter name', inputElement)).toEqual('***** ****');
     });
   });
 
@@ -521,6 +567,89 @@ describe('SessionReplayPlugin helpers', () => {
       expect(getEffectiveMaskLevel('https://example.com/checkout/payment', config)).toBe('conservative');
       // /public only matches the second rule
       expect(getEffectiveMaskLevel('https://example.com/public', config)).toBe('light');
+    });
+
+    // ── globToRegex /** behaviour (SR-3176 bug fix) ──────────────────────────
+
+    test('trailing /** matches the base path without a trailing slash', () => {
+      // Bug: docs/** previously required a literal / after docs, so https://example.com/docs
+      // (no trailing slash) did not match. The fix makes /** expand to (/.*)?
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs', config)).toBe('conservative');
+    });
+
+    test('trailing /** still matches the base path with a trailing slash', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs/', config)).toBe('conservative');
+    });
+
+    test('trailing /** matches deep subpaths', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs/latest/commands/get', config)).toBe('conservative');
+    });
+
+    test('trailing /** does not over-match a different path prefix', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/documentation', config)).toBe('medium');
+      expect(getEffectiveMaskLevel('https://example.com/docs-extra/foo', config)).toBe('medium');
+    });
+
+    test('middle /**/ matches zero intermediate path segments (docs/**/commands = docs/commands)', () => {
+      // Bug: docs/**/commands/** previously required at least one segment between docs and commands
+      // because ** expanded to .*.* which was greedy. The fix makes /**/ expand to /(.*\/)?
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**/commands/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs/commands', config)).toBe('conservative');
+      expect(getEffectiveMaskLevel('https://example.com/docs/commands/', config)).toBe('conservative');
+    });
+
+    test('middle /**/ matches one or more intermediate path segments', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**/commands/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs/v1/commands/get', config)).toBe('conservative');
+      expect(getEffectiveMaskLevel('https://example.com/docs/a/b/c/commands/set', config)).toBe('conservative');
+    });
+
+    test('middle /**/ does not match when required literal segment is absent', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/**/commands/**', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs/', config)).toBe('medium');
+      expect(getEffectiveMaskLevel('https://example.com/docs', config)).toBe('medium');
+    });
+
+    test('single /* does NOT match the base path without a trailing slash (/* is unchanged)', () => {
+      // /* still requires the literal / separator — only /** gets the optional-slash treatment.
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs', config)).toBe('medium');
+    });
+
+    test('single /* still matches when a trailing slash is present', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [{ match: 'https://example.com/docs/*', maskLevel: 'conservative' }],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/docs/', config)).toBe('conservative');
     });
   });
 

--- a/packages/session-replay-browser/test/helpers.test.ts
+++ b/packages/session-replay-browser/test/helpers.test.ts
@@ -473,6 +473,28 @@ describe('SessionReplayPlugin helpers', () => {
       };
       expect(getEffectiveMaskLevel('https://shop.example.com/checkout/payment', config)).toBe('conservative');
     });
+
+    test('should fall back to defaultMaskLevel when urlMaskLevels is an empty array', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'light',
+        urlMaskLevels: [],
+      };
+      expect(getEffectiveMaskLevel('https://example.com/page', config)).toBe('light');
+    });
+
+    test('first-match-wins: first rule matching different patterns selects the first', () => {
+      const config: PrivacyConfig = {
+        defaultMaskLevel: 'medium',
+        urlMaskLevels: [
+          { match: 'https://example.com/checkout/*', maskLevel: 'conservative' },
+          { match: 'https://example.com/*', maskLevel: 'light' },
+        ],
+      };
+      // /checkout/payment matches the first rule
+      expect(getEffectiveMaskLevel('https://example.com/checkout/payment', config)).toBe('conservative');
+      // /public only matches the second rule
+      expect(getEffectiveMaskLevel('https://example.com/public', config)).toBe('light');
+    });
   });
 
   describe('isMasked with currentUrl', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -2600,6 +2600,36 @@ describe('SessionReplay', () => {
       // No conservative rule → falls through to maskSelector logic (no selectors configured)
       expect(sessionReplay.getMaskTextSelectors()).toBeUndefined();
     });
+
+    test('should return * when defaultMaskLevel is conservative and urlMaskLevels are present', async () => {
+      // Bug scenario: session starts on a URL matching a non-conservative rule (effective level ≠
+      // conservative), so the first branch doesn't fire. No rule in urlMaskLevels is conservative,
+      // so the second branch doesn't fire either. But defaultMaskLevel is conservative, meaning any
+      // page that matches NO rule at all falls back to conservative masking — rrweb must be told to
+      // route all text through maskTextFn from the start.
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'conservative',
+          urlMaskLevels: [{ match: 'https://example.com/public/*', maskLevel: 'light' }],
+        },
+      }).promise;
+      expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
+    });
+
+    test('should return * when defaultMaskLevel is conservative and urlMaskLevels is non-empty even if current URL matches a non-conservative rule', async () => {
+      // Even if the recording-start URL happens to match a light rule (effectiveLevel = light),
+      // the fallback path (no rule match → conservative) still needs rrweb to call maskTextFn.
+      jest.spyOn(Helpers, 'getCurrentUrl').mockReturnValue('https://example.com/public/page');
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'conservative',
+          urlMaskLevels: [{ match: 'https://example.com/public/*', maskLevel: 'light' }],
+        },
+      }).promise;
+      expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
+    });
   });
 
   describe('getBlockSelectors', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -2573,6 +2573,33 @@ describe('SessionReplay', () => {
       }).promise;
       expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
     });
+
+    test('should return * when any urlMaskLevels rule is conservative, even if default is not', async () => {
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'light',
+          urlMaskLevels: [
+            { match: 'https://example.com/admin/*', maskLevel: 'conservative' },
+            { match: 'https://example.com/public/*', maskLevel: 'light' },
+          ],
+        },
+      }).promise;
+      // Any conservative URL rule → '*' so rrweb routes all text nodes through maskTextFn
+      expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
+    });
+
+    test('should not return * when urlMaskLevels has no conservative rule', async () => {
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'light',
+          urlMaskLevels: [{ match: 'https://example.com/checkout/*', maskLevel: 'medium' }],
+        },
+      }).promise;
+      // No conservative rule → falls through to maskSelector logic (no selectors configured)
+      expect(sessionReplay.getMaskTextSelectors()).toBeUndefined();
+    });
   });
 
   describe('getBlockSelectors', () => {
@@ -3874,6 +3901,47 @@ describe('SessionReplay', () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, mockOptions).promise;
       expect(subscribeToUrlChanges).not.toHaveBeenCalled();
+    });
+
+    test('should call subscribeToUrlChanges when urlMaskLevels has entries and there is no targetingConfig', async () => {
+      (subscribeToUrlChanges as jest.Mock).mockClear();
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_privacy_config: {},
+      };
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'light',
+          urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+        },
+      }).promise;
+      expect(subscribeToUrlChanges).toHaveBeenCalled();
+    });
+
+    test('should update currentPageUrl on URL change even without targetingConfig', async () => {
+      mockRemoteConfig = {
+        sr_sampling_config: samplingConfig,
+        sr_privacy_config: {},
+      };
+      const subscribeMock = subscribeToUrlChanges as jest.MockedFunction<typeof subscribeToUrlChanges>;
+      const callCountBefore = subscribeMock.mock.calls.length;
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'light',
+          urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+        },
+      }).promise;
+
+      const lastCall = subscribeMock.mock.calls[callCountBefore];
+      const onUrlChange = lastCall?.[1] as ((href: string) => void) | undefined;
+      expect(onUrlChange).toBeDefined();
+
+      onUrlChange?.('https://example.com/admin/dashboard');
+      expect((sessionReplay as any).currentPageUrl).toBe('https://example.com/admin/dashboard');
     });
   });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -2630,6 +2630,80 @@ describe('SessionReplay', () => {
       }).promise;
       expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
     });
+
+    test('should not return * when defaultMaskLevel is conservative but urlMaskLevels is empty', async () => {
+      // defaultMaskLevel: conservative with no URL rules → effectiveLevel is always conservative,
+      // which is handled by the first branch. The third branch only fires when urlMaskLevels is non-empty.
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'conservative',
+          urlMaskLevels: [],
+        },
+      }).promise;
+      // effectiveLevel = conservative → caught by the first branch, still returns '*'
+      expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
+    });
+
+    test('should return * when defaultMaskLevel is conservative and urlMaskLevels is undefined', async () => {
+      // urlMaskLevels not set at all (undefined) — exercises the ?. optional chain short-circuit path
+      // in the third guard of getMaskTextSelectors. With no urlMaskLevels, effectiveLevel is always
+      // conservative, so the first guard fires instead — result is still '*'.
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'conservative',
+          // urlMaskLevels intentionally absent
+        },
+      }).promise;
+      expect(sessionReplay.getMaskTextSelectors()).toEqual('*');
+    });
+  });
+
+  describe('mask function URL getters (currentPageUrl integration)', () => {
+    test('maskInputFn, maskTextFn, and maskAttributeFn closures expose currentPageUrl dynamically', async () => {
+      // This test exercises the three `() => this.currentPageUrl` arrow functions passed to
+      // maskFn/maskAttributeFn at lines 805-807 of session-replay.ts.
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        privacyConfig: {
+          defaultMaskLevel: 'light',
+          maskAttributes: ['placeholder'],
+          urlMaskLevels: [{ match: 'https://example.com/admin/*', maskLevel: 'conservative' }],
+        },
+      }).promise;
+
+      await sessionReplay.recordEvents();
+      expect(mockRecordFunction).toHaveBeenCalled();
+
+      const recordArg = mockRecordFunction.mock.calls[mockRecordFunction.mock.calls.length - 1][0];
+      const { maskInputFn, maskTextFn, maskAttributeFn: attrFn } = recordArg;
+      expect(maskInputFn).toBeDefined();
+      expect(maskTextFn).toBeDefined();
+      expect(attrFn).toBeDefined();
+
+      const divElement = document.createElement('div');
+      const inputElement = document.createElement('input');
+      inputElement.type = 'text';
+
+      // currentPageUrl starts as '' (jsdom has no real location) → light level → not conservative
+      // maskTextFn: light does not mask plain text
+      expect(maskTextFn('hello', divElement)).toEqual('hello');
+      // maskInputFn: light does not mask plain text inputs
+      expect(maskInputFn('hello', inputElement)).toEqual('hello');
+      // maskAttributeFn: attribute in allowlist but light level → not masked
+      expect(attrFn('placeholder', 'Enter name', inputElement)).toEqual('Enter name');
+
+      // Now simulate navigation to a conservative URL
+      (sessionReplay as any).currentPageUrl = 'https://example.com/admin/dashboard';
+
+      // maskTextFn: conservative URL → text IS masked
+      expect(maskTextFn('hello', divElement)).toEqual('*****');
+      // maskInputFn: conservative URL → input IS masked
+      expect(maskInputFn('hello', inputElement)).toEqual('*****');
+      // maskAttributeFn: conservative URL + attribute in allowlist → masked
+      expect(attrFn('placeholder', 'Enter name', inputElement)).toEqual('***** ****');
+    });
   });
 
   describe('getBlockSelectors', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -3682,7 +3682,7 @@ describe('SessionReplay', () => {
       const sessionReplay = new SessionReplay();
       sessionReplay.config = { targetingConfig: {} } as any;
       sessionReplay.identifiers = { sessionId: 123 } as any;
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
+      (sessionReplay as any).setupUrlChangeListener();
       expect(subscribeToUrlChanges).not.toHaveBeenCalled();
     });
 
@@ -3691,7 +3691,7 @@ describe('SessionReplay', () => {
       const sessionReplay = new SessionReplay();
       sessionReplay.config = { targetingConfig: {} } as any;
       sessionReplay.identifiers = { sessionId: 123 } as any;
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
+      (sessionReplay as any).setupUrlChangeListener();
       expect(subscribeToUrlChanges).not.toHaveBeenCalled();
     });
 
@@ -3847,7 +3847,7 @@ describe('SessionReplay', () => {
       );
     });
 
-    test('should clean up existing URL subscription when setupUrlChangeListenerForTargeting is called again', () => {
+    test('should clean up existing URL subscription when setupUrlChangeListener is called again', () => {
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
         location: { href: 'https://example.com/current' },
       } as any);
@@ -3858,14 +3858,14 @@ describe('SessionReplay', () => {
         .mockImplementationOnce(() => secondCleanup);
 
       const sessionReplay = new SessionReplay();
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
-      (sessionReplay as any).setupUrlChangeListenerForTargeting();
+      (sessionReplay as any).setupUrlChangeListener();
+      (sessionReplay as any).setupUrlChangeListener();
 
       expect(firstCleanup).toHaveBeenCalledTimes(1);
       expect(secondCleanup).not.toHaveBeenCalled();
     });
 
-    test('should not call subscribeToUrlChanges when init completes with no targetingConfig', async () => {
+    test('should not call subscribeToUrlChanges when init completes with no targetingConfig and no urlMaskLevels', async () => {
       (subscribeToUrlChanges as jest.Mock).mockClear();
       mockRemoteConfig = {
         sr_sampling_config: samplingConfig,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Customers need the ability to tighten or loosen privacy masking based on which page the user is on — for example, masking everything on `/checkout/*` (conservative) while leaving `/help/*` at the default level. Without per-URL overrides, the only options are global conservative masking (noisy replays everywhere) or no masking (risk on sensitive pages).

This PR adds `privacyConfig.urlMaskLevels`, a first-match-wins list of `{ match, maskLevel }` glob rules evaluated against the current page URL. Key design decisions and their motivations:

- **Remote config takes precedence** — remote `urlMaskLevels` entries are prepended before local ones so ops/security teams can enforce rules without a code deploy.
- **SPA-safe URL tracking** — `currentPageUrl` is kept in sync via the existing URL-tracking plugin, and a dynamic `() => this.currentPageUrl` getter is passed into rrweb's `maskInputFn`/`maskTextFn`/`maskAttributeFn` so masking re-evaluates on every node without requiring rrweb to re-init.
- **Static `maskTextSelector` set to `'*'` when needed** — rrweb decides at record-start which text nodes to route through `maskTextFn`. If any URL rule (or the default) is conservative, we set `maskTextSelector: '*'` upfront so text nodes are always routed through the dynamic function rather than being statically excluded.
- **`light` no longer masks text nodes** — the original `isMaskedForLevel` fell through to `conservative` for both `light` and `medium`, masking text everywhere. Fixed: `light` only masks a small set of sensitive input types (password, hidden, email, tel, cc-*); `medium` masks all inputs but not text nodes.
- **`maskAttributes` works on any element** — `maskAttributeFn` now passes `'input'` as the element type to `isMasked` so explicitly-listed attributes are masked at medium/conservative level regardless of whether the element is a form control or not (e.g. `aria-label` on a button). At `light` level, `isMaskedForLevel` still returns false for non-sensitive input types, preserving the lighter behavior.
- **Glob-to-regex caching + `/**` / `/**/` support** — repeated calls no longer recompile the same pattern, and path-wildcard patterns behave as users expect.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches privacy-critical masking logic and rrweb integration (including SPA URL tracking), so regressions could either over-mask (UX impact) or under-mask (data leakage) if any edge case is missed.
> 
> **Overview**
> Adds per-URL privacy overrides via `privacyConfig.urlMaskLevels`, merging remote+local rules (remote first) and computing an effective mask level per page.
> 
> Updates masking to be **URL-aware and SPA-safe** by tracking `currentPageUrl`, passing a dynamic URL getter into rrweb `maskInputFn`/`maskTextFn`/`maskAttributeFn`, and forcing `maskTextSelector: '*'` when conservative masking could apply after navigation.
> 
> Fixes masking semantics and matching edge cases: `light` no longer masks text nodes, `medium` masks inputs only (including attribute masking by correctly classifying input elements), and `globToRegex` is cached and enhanced to correctly handle `/**` and `/**/` patterns.
> 
> Expands unit + Playwright E2E coverage for remote-config-driven `urlMaskLevels`, first-match-wins behavior, and SPA navigation regressions; adds `getLastSnapshotRoot` to validate post-navigation snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7dbca41814ec9933a460da25e4b7efc43bdc27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->