### PR TITLE
fix(session-replay-browser): handle IDB tx.done AbortError as debug not warn

### DIFF
--- a/packages/session-replay-browser/e2e/idb.spec.ts
+++ b/packages/session-replay-browser/e2e/idb.spec.ts
@@ -1,0 +1,402 @@
+/**
+ * E2E tests for IndexedDB transaction abort handling.
+ *
+ * These tests repro the scenario described in the "indexed-db-transaction-aborted" branch:
+ *   "Failed to store session replay events in IndexedDB: AbortError: The transaction was
+ *    aborted, so the request cannot be fulfilled."
+ *
+ * Two root causes were fixed:
+ *
+ * 1. `addEventToCurrentSequence` — the `!sequenceEvents` (first-event) branch used to
+ *    `return undefined` immediately after `await tx.store.put(...)`. If the transaction
+ *    aborted after the put resolved but before auto-commit, `tx.done` rejected with an
+ *    unhandled AbortError that bypassed `logIdbError` entirely.
+ *    Fix: attach `tx.done.catch(logIdbError)` immediately after opening the transaction so
+ *    any rejection is always handled, regardless of which code path returns first.
+ *
+ * 2. `getSequencesToSend` — the transaction was created inline without saving a reference,
+ *    so `tx.done` was never caught. An abort after cursor exhaustion produced an unhandled
+ *    rejection.
+ *    Fix: save `tx` and attach `tx.done.catch(logIdbError)` before any await.
+ *
+ * Both fixes use a non-blocking `.catch()` handler (not `await tx.done`) with an
+ * `errorLogged` flag to prevent double-logging if the outer `try/catch` also fires.
+ * After both fixes all AbortErrors flow through `logIdbError`, which downgrades them from
+ * `warn` → `debug` (transient browser-initiated aborts, not actionable).
+ *
+ * Technique: `page.addInitScript` patches `IDBObjectStore.prototype.put` and
+ * `IDBObjectStore.prototype.openCursor` BEFORE the SDK loads. A window-level control
+ * object (`window.__idbAbortCtrl`) lets individual tests arm an abort for a specific
+ * operation, then assert it fired.
+ *
+ * Log-level note: tests use `logLevel: 4` (Debug) so both `[Warn]` and `[Debug]` messages
+ * are visible. The assertion is:
+ *   - `[Warn]: Failed to store session replay events in IndexedDB` → must NOT appear
+ *   - `[Debug]: Failed to store session replay events in IndexedDB` → must appear (confirms
+ *     the error was caught and correctly downgraded)
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  remoteConfigRecording,
+  captureTrackRequests,
+  TEST_SESSION_ID,
+  SR_API_SUCCESS,
+} from './helpers';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const STORAGE_FAILURE = 'Failed to store session replay events in IndexedDB';
+const LOG_LEVEL_DEBUG = 4; // LogLevel.Debug — shows all messages including debug + warn
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Injects an IDB abort interceptor into the page BEFORE any scripts run.
+ * Patches IDBObjectStore.prototype.put and .openCursor so individual tests can
+ * arm an abort for a specific store, then read back whether it fired.
+ *
+ * Control surface exposed on `window.__idbAbortCtrl`:
+ *   abortOnPut:        store name to intercept (or null to disable)
+ *   abortOnCursor:     store name to intercept (or null to disable)
+ *   putAbortFired:     set to true after the put-abort fires
+ *   cursorAbortFired:  set to true after the cursor-abort fires
+ */
+function injectIdbAbortInterceptor(page: import('@playwright/test').Page) {
+  return page.addInitScript(() => {
+    const ctrl: {
+      abortOnPut: string | null;
+      abortOnCursor: string | null;
+      putAbortFired: boolean;
+      cursorAbortFired: boolean;
+    } = {
+      abortOnPut: null,
+      abortOnCursor: null,
+      putAbortFired: false,
+      cursorAbortFired: false,
+    };
+    (window as any).__idbAbortCtrl = ctrl;
+
+    // Patch put: abort the transaction from within the request's success handler.
+    // This simulates a browser-initiated abort that happens after a write succeeds
+    // but before the transaction auto-commits — the exact scenario that left tx.done
+    // as an unhandled rejection in the old code.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalPut = IDBObjectStore.prototype.put;
+    IDBObjectStore.prototype.put = function (value, key) {
+      const req = originalPut.call(this, value, key);
+      if (ctrl.abortOnPut !== null && this.name === ctrl.abortOnPut) {
+        ctrl.abortOnPut = null; // one-shot
+        const tx = this.transaction;
+        req.addEventListener(
+          'success',
+          () => {
+            ctrl.putAbortFired = true;
+            try {
+              tx.abort();
+            } catch {
+              // ignore if already committed
+            }
+          },
+          { once: true },
+        );
+      }
+      return req;
+    };
+
+    // Patch openCursor: abort the transaction from within the cursor request's
+    // success handler, simulating an abort that occurs while getSequencesToSend
+    // is traversing the sequencesToSend store.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+    IDBObjectStore.prototype.openCursor = function (query, direction) {
+      const req = originalOpenCursor.call(this, query, direction);
+      if (ctrl.abortOnCursor !== null && this.name === ctrl.abortOnCursor) {
+        ctrl.abortOnCursor = null; // one-shot
+        const tx = this.transaction;
+        req.addEventListener(
+          'success',
+          () => {
+            ctrl.cursorAbortFired = true;
+            try {
+              tx.abort();
+            } catch {
+              // ignore
+            }
+          },
+          { once: true },
+        );
+      }
+      return req;
+    };
+  });
+}
+
+/** Collect all console messages of a given Playwright type. */
+function captureConsoleMessages(page: import('@playwright/test').Page, type: string): string[] {
+  const messages: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === type) messages.push(msg.text());
+  });
+  return messages;
+}
+
+/** Collect all console.warn messages. */
+function captureWarns(page: import('@playwright/test').Page) {
+  return captureConsoleMessages(page, 'warning');
+}
+
+/** Collect all console.log messages (the Amplitude SDK logs [Debug] via console.log). */
+function captureDebugLogs(page: import('@playwright/test').Page) {
+  return captureConsoleMessages(page, 'log');
+}
+
+/**
+ * Collect all uncaught page errors, including unhandled Promise rejections.
+ *
+ * This is the key regression guard for the IDB abort fix: before the fix,
+ * `tx.done` rejections were left unhandled and appeared here as
+ * "Unhandled promise rejection: AbortError: The transaction was aborted".
+ * After the fix, `.catch()` is attached immediately so these never surface
+ * as page errors — they are routed through `logIdbError` → debug level.
+ */
+function capturePageErrors(page: import('@playwright/test').Page): Error[] {
+  const errors: Error[] = [];
+  page.on('pageerror', (err) => errors.push(err));
+  return errors;
+}
+
+/** Navigate to the SR test page and wait for the SDK to be ready. */
+async function loadPage(page: import('@playwright/test').Page, sessionId = TEST_SESSION_ID) {
+  await mockRemoteConfig(page, remoteConfigRecording);
+  await page.route('https://api-sr.amplitude.com/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) }),
+  );
+  await page.goto(
+    buildUrl('/session-replay-browser/sr-capture-test.html', {
+      sessionId,
+      logLevel: LOG_LEVEL_DEBUG,
+    }),
+  );
+  await waitForReady(page);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('IDB transaction abort handling', () => {
+  /**
+   * Repro: addEventToCurrentSequence — first-event path (no existing sequence).
+   *
+   * When the first event is written for a session, the SDK calls:
+   *   tx.store.get(sessionId)  → undefined (no prior data)
+   *   tx.store.put({ sessionId, events: [event] })
+   *   [old code] return;      ← tx.done rejection is unhandled → AbortError bypasses logIdbError
+   *   [new code] tx.done.catch(logIdbError) ← attached before any await → AbortError → debug
+   *
+   * We arm the interceptor so that the put succeeds but the transaction is
+   * immediately aborted, then assert the SDK logs at debug (not warn).
+   */
+  test('addEventToCurrentSequence first-event path: AbortError logged at debug not warn', async ({ page }) => {
+    await injectIdbAbortInterceptor(page);
+    const warns = captureWarns(page);
+    const debugLogs = captureDebugLogs(page);
+    const pageErrors = capturePageErrors(page);
+
+    // Arm before navigation so it catches the first IDB write (rrweb full snapshot)
+    await page.addInitScript(() => {
+      (window as any).__idbAbortCtrl.abortOnPut = 'sessionCurrentSequence';
+    });
+
+    await loadPage(page);
+
+    // Give the abort time to propagate through the Promise chain
+    await page.waitForTimeout(300);
+
+    const abortFired = await page.evaluate(() => (window as any).__idbAbortCtrl.putAbortFired as boolean);
+    expect(abortFired).toBe(true);
+
+    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
+    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
+
+    // tx.done rejection must be handled (not unhandled) — the core regression guard
+    expect(pageErrors).toHaveLength(0);
+    // Error must be logged at debug (not warn) — exactly once (errorLogged flag prevents double-log)
+    expect(storageWarn).toHaveLength(0);
+    expect(storageDebug).toHaveLength(1);
+  });
+
+  /**
+   * Repro: addEventToCurrentSequence — existing-events path.
+   *
+   * After at least one event has been stored, subsequent events take the else branch:
+   *   tx.store.get(sessionId)  → existing sequence
+   *   tx.store.put({ sessionId, events: [..., newEvent] })
+   *   [both old and new code reach this point — tx.done.catch() handles it either way]
+   *
+   * Arms the abort on the SECOND put (after the first event is safely stored),
+   * confirming the fix doesn't regress the existing-events path.
+   */
+  test('addEventToCurrentSequence existing-events path: AbortError logged at debug not warn', async ({ page }) => {
+    await injectIdbAbortInterceptor(page);
+    const warns = captureWarns(page);
+    const debugLogs = captureDebugLogs(page);
+    const pageErrors = capturePageErrors(page);
+
+    await loadPage(page);
+
+    // At this point at least one event (the rrweb snapshot) has been stored.
+    // Arm the interceptor for the NEXT write and trigger it with a user interaction.
+    await page.evaluate(() => {
+      (window as any).__idbAbortCtrl.abortOnPut = 'sessionCurrentSequence';
+    });
+
+    await page.click('#test-button');
+    await page.waitForTimeout(300);
+
+    const abortFired = await page.evaluate(() => (window as any).__idbAbortCtrl.putAbortFired as boolean);
+    expect(abortFired).toBe(true);
+
+    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
+    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
+
+    expect(pageErrors).toHaveLength(0);
+    expect(storageWarn).toHaveLength(0);
+    expect(storageDebug).toHaveLength(1);
+  });
+
+  /**
+   * Repro: getSequencesToSend — cursor abort mid-traversal.
+   *
+   * `getSequencesToSend` is called by `sendStoredEvents`, which runs during SDK
+   * initialisation (`init()` → `initialize(shouldSendStoredEvents=true)`). It reads
+   * stored sequences using a cursor on the `sequencesToSend` store. If the transaction
+   * aborts while the cursor is open, `tx.done` rejects with AbortError.
+   *
+   * Before the fix `tx.done` was never caught, producing an unhandled rejection.
+   * After the fix `tx.done.catch(logIdbError)` is attached before any await, so the
+   * rejection always flows through `logIdbError` → `debug`.
+   *
+   * Because `getSequencesToSend` is only triggered on page load (not via `flush()`),
+   * this test uses a two-navigation approach:
+   *   1. Load the page normally so the SDK is up and IDB is populated.
+   *   2. Arm the cursor interceptor via sessionStorage (persists across reloads).
+   *   3. Reload — `init()` triggers `sendStoredEvents` → `getSequencesToSend` → abort.
+   */
+  test('getSequencesToSend cursor abort: AbortError logged at debug not warn', async ({ page }) => {
+    await injectIdbAbortInterceptor(page);
+
+    // Second init script: arm the cursor abort on the next page load if the sessionStorage
+    // flag is set.  Runs after injectIdbAbortInterceptor so __idbAbortCtrl already exists.
+    await page.addInitScript(() => {
+      if (sessionStorage.getItem('__armCursorAbort') === '1') {
+        sessionStorage.removeItem('__armCursorAbort');
+        (window as any).__idbAbortCtrl.abortOnCursor = 'sequencesToSend';
+      }
+    });
+
+    const warns = captureWarns(page);
+    const debugLogs = captureDebugLogs(page);
+    const pageErrors = capturePageErrors(page);
+
+    // First load: SDK initialises and records normally (cursor abort not yet armed)
+    await loadPage(page);
+
+    // Arm the cursor abort for the next navigation via sessionStorage
+    await page.evaluate(() => sessionStorage.setItem('__armCursorAbort', '1'));
+
+    // Reload: init() → initialize(true) → sendStoredEvents → getSequencesToSend → cursor abort
+    await page.reload();
+    await waitForReady(page);
+    await page.waitForTimeout(300);
+
+    const abortFired = await page.evaluate(() => (window as any).__idbAbortCtrl.cursorAbortFired as boolean);
+    expect(abortFired).toBe(true);
+
+    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
+    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
+
+    expect(pageErrors).toHaveLength(0);
+    expect(storageWarn).toHaveLength(0);
+    expect(storageDebug).toHaveLength(1);
+  });
+
+  /**
+   * Resilience: the SDK continues recording after an IDB abort.
+   *
+   * An IDB transaction abort is a transient error — the SDK should recover and be
+   * able to record subsequent events. This test verifies that:
+   *   1. An abort is triggered and handled gracefully (no crash, no warn)
+   *   2. After the abort, the SDK can still receive new events and eventually flush them
+   */
+  test('SDK continues recording after IDB abort', async ({ page }) => {
+    await injectIdbAbortInterceptor(page);
+    const warns = captureWarns(page);
+    const debugLogs = captureDebugLogs(page);
+    const pageErrors = capturePageErrors(page);
+
+    // Arm before load → aborts the very first IDB write
+    await page.addInitScript(() => {
+      (window as any).__idbAbortCtrl.abortOnPut = 'sessionCurrentSequence';
+    });
+
+    const { getBodies } = await captureTrackRequests(page);
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        logLevel: LOG_LEVEL_DEBUG,
+      }),
+    );
+    await waitForReady(page);
+
+    await page.waitForTimeout(200);
+
+    // Generate new events after the abort
+    await page.click('#test-button');
+    await page.click('#test-input');
+
+    // Flush and verify events are delivered
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => void (window as any).sessionReplay.flush(false));
+    await page.waitForTimeout(500);
+
+    // SDK should have recovered and sent at least one batch of events
+    expect(getBodies().length).toBeGreaterThan(0);
+
+    // Abort must be handled (not unhandled), logged at debug (not warn), exactly once
+    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
+    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
+    expect(pageErrors).toHaveLength(0);
+    expect(storageWarn).toHaveLength(0);
+    expect(storageDebug).toHaveLength(1);
+  });
+
+  /**
+   * Baseline: no IDB errors during normal operation.
+   *
+   * Sanity check that in a normal recording session (no forced aborts) there are
+   * no IDB-related warnings or debug-level storage errors at all.
+   */
+  test('normal recording: no IDB errors', async ({ page }) => {
+    const warns = captureWarns(page);
+    const debugLogs = captureDebugLogs(page);
+    const pageErrors = capturePageErrors(page);
+
+    await loadPage(page);
+    await page.click('#test-button');
+    await page.click('#test-input');
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => void (window as any).sessionReplay.flush(false));
+    await page.waitForTimeout(300);
+
+    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
+    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
+    expect(pageErrors).toHaveLength(0);
+    expect(storageWarn).toHaveLength(0);
+    expect(storageDebug).toHaveLength(0);
+  });
+});

--- a/packages/session-replay-browser/e2e/idb.spec.ts
+++ b/packages/session-replay-browser/e2e/idb.spec.ts
@@ -5,35 +5,35 @@
  *   "Failed to store session replay events in IndexedDB: AbortError: The transaction was
  *    aborted, so the request cannot be fulfilled."
  *
- * Two root causes were fixed:
+ * Three root causes were fixed:
  *
- * 1. `addEventToCurrentSequence` — the `!sequenceEvents` (first-event) branch used to
- *    `return undefined` immediately after `await tx.store.put(...)`. If the transaction
- *    aborted after the put resolved but before auto-commit, `tx.done` rejected with an
- *    unhandled AbortError that bypassed `logIdbError` entirely.
- *    Fix: attach `tx.done.catch(logIdbError)` immediately after opening the transaction so
- *    any rejection is always handled, regardless of which code path returns first.
+ * 1. `addEventToCurrentSequence` — first-event path (`!sequenceEvents`): used to `return`
+ *    immediately after `await tx.store.put(...)`, leaving `tx.done` rejection unhandled.
+ *    Fix: attach `tx.done.catch(logIdbError)` before any await.
  *
- * 2. `getSequencesToSend` — the transaction was created inline without saving a reference,
- *    so `tx.done` was never caught. An abort after cursor exhaustion produced an unhandled
- *    rejection.
+ * 2. `getSequencesToSend` — inline transaction had no saved reference, so `tx.done` was
+ *    never caught. An abort after cursor exhaustion produced an unhandled rejection.
  *    Fix: save `tx` and attach `tx.done.catch(logIdbError)` before any await.
  *
- * Both fixes use a non-blocking `.catch()` handler (not `await tx.done`) with an
- * `errorLogged` flag to prevent double-logging if the outer `try/catch` also fires.
- * After both fixes all AbortErrors flow through `logIdbError`, which downgrades them from
+ * 3. `addEventToCurrentSequence` — split path: used to call `storeSendingEvents` in a
+ *    separate transaction after the `sessionCurrentSequence` transaction, breaking
+ *    atomicity. If the first transaction aborted, events could end up in both stores.
+ *    Fix: use a single multi-store transaction (`splitTx`) covering both stores so both
+ *    writes commit or roll back atomically.
+ *
+ * All AbortErrors are routed through `logIdbError`, which downgrades them from
  * `warn` → `debug` (transient browser-initiated aborts, not actionable).
  *
  * Technique: `page.addInitScript` patches `IDBObjectStore.prototype.put` and
- * `IDBObjectStore.prototype.openCursor` BEFORE the SDK loads. A window-level control
- * object (`window.__idbAbortCtrl`) lets individual tests arm an abort for a specific
- * operation, then assert it fired.
+ * `.openCursor` before the SDK loads. `window.__armIdbAbort(storeName)` arms a
+ * one-shot abort on the next write/cursor-open for that store; `window.__idbAbortFired`
+ * confirms it triggered.
  *
- * Log-level note: tests use `logLevel: 4` (Debug) so both `[Warn]` and `[Debug]` messages
- * are visible. The assertion is:
+ * Log-level note: tests use `logLevel: 4` (Debug) so both `[Warn]` and `[Debug]`
+ * messages are visible. Assertions check:
  *   - `[Warn]: Failed to store session replay events in IndexedDB` → must NOT appear
- *   - `[Debug]: Failed to store session replay events in IndexedDB` → must appear (confirms
- *     the error was caught and correctly downgraded)
+ *   - `[Debug]: Failed to store session replay events in IndexedDB` → must appear exactly once
+ *   - `page.on('pageerror', …)` → must stay empty (the core unhandled-rejection guard)
  */
 
 import { test, expect } from '@playwright/test';
@@ -51,122 +51,109 @@ import {
 
 const STORAGE_FAILURE = 'Failed to store session replay events in IndexedDB';
 const LOG_LEVEL_DEBUG = 4; // LogLevel.Debug — shows all messages including debug + warn
+// DB name derived from apiKey in sr-capture-test.html: 'd90c5cf09ca2546a1626272906b99a76'
+const IDB_NAME = 'd90c5cf09c_amp_session_replay_events';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Injects an IDB abort interceptor into the page BEFORE any scripts run.
- * Patches IDBObjectStore.prototype.put and .openCursor so individual tests can
- * arm an abort for a specific store, then read back whether it fired.
+ * Injects a one-shot IDB abort interceptor into the page before any scripts run.
  *
- * Control surface exposed on `window.__idbAbortCtrl`:
- *   abortOnPut:        store name to intercept (or null to disable)
- *   abortOnCursor:     store name to intercept (or null to disable)
- *   putAbortFired:     set to true after the put-abort fires
- *   cursorAbortFired:  set to true after the cursor-abort fires
+ * Arm via `window.__armIdbAbort(storeName)` — the next write (`put`) or cursor open
+ * (`openCursor`) on that store will be allowed to complete, then the surrounding
+ * transaction is immediately aborted. `window.__idbAbortFired` is set to `true`
+ * once the abort fires.
+ *
+ * Patches only `IDBObjectStore.prototype.put` and `.openCursor`.
  */
 function injectIdbAbortInterceptor(page: import('@playwright/test').Page) {
   return page.addInitScript(() => {
-    const ctrl: {
-      abortOnPut: string | null;
-      abortOnCursor: string | null;
-      putAbortFired: boolean;
-      cursorAbortFired: boolean;
-    } = {
-      abortOnPut: null,
-      abortOnCursor: null,
-      putAbortFired: false,
-      cursorAbortFired: false,
+    let _store: string | null = null;
+    (window as any).__armIdbAbort = (store: string) => {
+      _store = store;
     };
-    (window as any).__idbAbortCtrl = ctrl;
+    (window as any).__idbAbortFired = false;
 
-    // Patch put: abort the transaction from within the request's success handler.
-    // This simulates a browser-initiated abort that happens after a write succeeds
-    // but before the transaction auto-commits — the exact scenario that left tx.done
-    // as an unhandled rejection in the old code.
+    function patchRequest(req: IDBRequest, storeName: string, tx: IDBTransaction) {
+      if (_store !== storeName) return;
+      _store = null; // one-shot
+      req.addEventListener(
+        'success',
+        () => {
+          (window as any).__idbAbortFired = true;
+          try {
+            tx.abort();
+          } catch {
+            // already committed — ignore
+          }
+        },
+        { once: true },
+      );
+    }
+
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalPut = IDBObjectStore.prototype.put;
-    IDBObjectStore.prototype.put = function (value, key) {
-      const req = originalPut.call(this, value, key);
-      if (ctrl.abortOnPut !== null && this.name === ctrl.abortOnPut) {
-        ctrl.abortOnPut = null; // one-shot
-        const tx = this.transaction;
-        req.addEventListener(
-          'success',
-          () => {
-            ctrl.putAbortFired = true;
-            try {
-              tx.abort();
-            } catch {
-              // ignore if already committed
-            }
-          },
-          { once: true },
-        );
-      }
+    const origPut = IDBObjectStore.prototype.put;
+    IDBObjectStore.prototype.put = function (v, k) {
+      const req = origPut.call(this, v, k);
+      patchRequest(req, this.name, this.transaction);
       return req;
     };
 
-    // Patch openCursor: abort the transaction from within the cursor request's
-    // success handler, simulating an abort that occurs while getSequencesToSend
-    // is traversing the sequencesToSend store.
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalOpenCursor = IDBObjectStore.prototype.openCursor;
-    IDBObjectStore.prototype.openCursor = function (query, direction) {
-      const req = originalOpenCursor.call(this, query, direction);
-      if (ctrl.abortOnCursor !== null && this.name === ctrl.abortOnCursor) {
-        ctrl.abortOnCursor = null; // one-shot
-        const tx = this.transaction;
-        req.addEventListener(
-          'success',
-          () => {
-            ctrl.cursorAbortFired = true;
-            try {
-              tx.abort();
-            } catch {
-              // ignore
-            }
-          },
-          { once: true },
-        );
-      }
+    const origCursor = IDBObjectStore.prototype.openCursor;
+    IDBObjectStore.prototype.openCursor = function (q, d) {
+      const req = origCursor.call(this, q, d);
+      patchRequest(req, this.name, this.transaction);
       return req;
     };
   });
-}
-
-/** Collect all console messages of a given Playwright type. */
-function captureConsoleMessages(page: import('@playwright/test').Page, type: string): string[] {
-  const messages: string[] = [];
-  page.on('console', (msg) => {
-    if (msg.type() === type) messages.push(msg.text());
-  });
-  return messages;
-}
-
-/** Collect all console.warn messages. */
-function captureWarns(page: import('@playwright/test').Page) {
-  return captureConsoleMessages(page, 'warning');
-}
-
-/** Collect all console.log messages (the Amplitude SDK logs [Debug] via console.log). */
-function captureDebugLogs(page: import('@playwright/test').Page) {
-  return captureConsoleMessages(page, 'log');
 }
 
 /**
- * Collect all uncaught page errors, including unhandled Promise rejections.
+ * Sets up listeners for IDB-related errors and log messages.
  *
- * This is the key regression guard for the IDB abort fix: before the fix,
- * `tx.done` rejections were left unhandled and appeared here as
- * "Unhandled promise rejection: AbortError: The transaction was aborted".
- * After the fix, `.catch()` is attached immediately so these never surface
- * as page errors — they are routed through `logIdbError` → debug level.
+ * Returns live arrays that fill as the page runs:
+ *   pageErrors — unhandled Promise rejections (the core regression guard; before the
+ *                fix, AbortErrors from tx.done surfaced here)
+ *   idbWarns   — console.warn lines containing STORAGE_FAILURE
+ *   idbDebug   — console.log lines containing STORAGE_FAILURE (Amplitude logs debug
+ *                via console.log at LogLevel.Debug)
  */
-function capturePageErrors(page: import('@playwright/test').Page): Error[] {
-  const errors: Error[] = [];
-  page.on('pageerror', (err) => errors.push(err));
-  return errors;
+function listenForIdbErrors(page: import('@playwright/test').Page) {
+  const pageErrors: Error[] = [];
+  const idbWarns: string[] = [];
+  const idbDebug: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err));
+  page.on('console', (msg) => {
+    if (!msg.text().includes(STORAGE_FAILURE)) return;
+    if (msg.type() === 'warning') idbWarns.push(msg.text());
+    if (msg.type() === 'log') idbDebug.push(msg.text());
+  });
+  return { pageErrors, idbWarns, idbDebug };
+}
+
+/**
+ * Reads row counts from the two IDB object stores used by the session replay SDK.
+ * Used to verify atomicity: a rolled-back split transaction must leave neither store
+ * partially written.
+ */
+function getIdbStoreCounts(page: import('@playwright/test').Page) {
+  return page.evaluate(
+    (dbName: string): Promise<{ sequencesToSend: number; currentSequence: number }> =>
+      new Promise((resolve, reject) => {
+        const req = indexedDB.open(dbName);
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction(['sequencesToSend', 'sessionCurrentSequence'], 'readonly');
+          const c1 = tx.objectStore('sequencesToSend').count();
+          const c2 = tx.objectStore('sessionCurrentSequence').count();
+          tx.oncomplete = () => resolve({ sequencesToSend: c1.result, currentSequence: c2.result });
+          tx.onerror = () => reject(tx.error);
+        };
+      }),
+    IDB_NAME,
+  );
 }
 
 /** Navigate to the SR test page and wait for the SDK to be ready. */
@@ -190,161 +177,186 @@ test.describe('IDB transaction abort handling', () => {
   /**
    * Repro: addEventToCurrentSequence — first-event path (no existing sequence).
    *
-   * When the first event is written for a session, the SDK calls:
-   *   tx.store.get(sessionId)  → undefined (no prior data)
-   *   tx.store.put({ sessionId, events: [event] })
-   *   [old code] return;      ← tx.done rejection is unhandled → AbortError bypasses logIdbError
-   *   [new code] tx.done.catch(logIdbError) ← attached before any await → AbortError → debug
+   * The first rrweb event for a session takes the `!sequenceEvents` branch:
+   *   tx.store.get(sessionId)  → undefined
+   *   tx.store.put(...)        → put succeeds
+   *   [old code] return;       ← tx.done rejection was unhandled
+   *   [new code] tx.done.catch(logIdbError) ← attached before any await → debug
    *
-   * We arm the interceptor so that the put succeeds but the transaction is
-   * immediately aborted, then assert the SDK logs at debug (not warn).
+   * We arm the interceptor before page load so the abort fires on the very first
+   * put to `sessionCurrentSequence` (the rrweb full snapshot).
    */
   test('addEventToCurrentSequence first-event path: AbortError logged at debug not warn', async ({ page }) => {
     await injectIdbAbortInterceptor(page);
-    const warns = captureWarns(page);
-    const debugLogs = captureDebugLogs(page);
-    const pageErrors = capturePageErrors(page);
-
-    // Arm before navigation so it catches the first IDB write (rrweb full snapshot)
+    // Arm before navigation — catches the first IDB write (rrweb full snapshot)
     await page.addInitScript(() => {
-      (window as any).__idbAbortCtrl.abortOnPut = 'sessionCurrentSequence';
+      (window as any).__armIdbAbort('sessionCurrentSequence');
     });
 
+    const { pageErrors, idbWarns, idbDebug } = listenForIdbErrors(page);
     await loadPage(page);
-
-    // Give the abort time to propagate through the Promise chain
     await page.waitForTimeout(300);
 
-    const abortFired = await page.evaluate(() => (window as any).__idbAbortCtrl.putAbortFired as boolean);
-    expect(abortFired).toBe(true);
-
-    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
-    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
-
-    // tx.done rejection must be handled (not unhandled) — the core regression guard
+    expect(await page.evaluate(() => (window as any).__idbAbortFired as boolean)).toBe(true);
+    // tx.done rejection must be handled — the core regression guard
     expect(pageErrors).toHaveLength(0);
-    // Error must be logged at debug (not warn) — exactly once (errorLogged flag prevents double-log)
-    expect(storageWarn).toHaveLength(0);
-    expect(storageDebug).toHaveLength(1);
+    // Error must reach logIdbError → debug, not warn; exactly once (errorLogged flag)
+    expect(idbWarns).toHaveLength(0);
+    expect(idbDebug).toHaveLength(1);
   });
 
   /**
-   * Repro: addEventToCurrentSequence — existing-events path.
+   * Repro: addEventToCurrentSequence — existing-events path (append, no split).
    *
-   * After at least one event has been stored, subsequent events take the else branch:
+   * After the first event is stored, subsequent events take the else branch:
    *   tx.store.get(sessionId)  → existing sequence
-   *   tx.store.put({ sessionId, events: [..., newEvent] })
-   *   [both old and new code reach this point — tx.done.catch() handles it either way]
+   *   tx.store.put(...)        → append + put succeeds, then tx aborts
    *
-   * Arms the abort on the SECOND put (after the first event is safely stored),
-   * confirming the fix doesn't regress the existing-events path.
+   * We arm the interceptor after page load (snapshot already stored) and trigger
+   * a new event via a click, while staying within the 500 ms split interval so
+   * the append (not split) path is taken.
    */
   test('addEventToCurrentSequence existing-events path: AbortError logged at debug not warn', async ({ page }) => {
     await injectIdbAbortInterceptor(page);
-    const warns = captureWarns(page);
-    const debugLogs = captureDebugLogs(page);
-    const pageErrors = capturePageErrors(page);
+    const { pageErrors, idbWarns, idbDebug } = listenForIdbErrors(page);
 
     await loadPage(page);
-
-    // At this point at least one event (the rrweb snapshot) has been stored.
-    // Arm the interceptor for the NEXT write and trigger it with a user interaction.
-    await page.evaluate(() => {
-      (window as any).__idbAbortCtrl.abortOnPut = 'sessionCurrentSequence';
-    });
-
+    // Arm after load — snapshot already stored; next write is an append
+    await page.evaluate(() => void (window as any).__armIdbAbort('sessionCurrentSequence'));
     await page.click('#test-button');
     await page.waitForTimeout(300);
 
-    const abortFired = await page.evaluate(() => (window as any).__idbAbortCtrl.putAbortFired as boolean);
-    expect(abortFired).toBe(true);
-
-    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
-    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
-
+    expect(await page.evaluate(() => (window as any).__idbAbortFired as boolean)).toBe(true);
     expect(pageErrors).toHaveLength(0);
-    expect(storageWarn).toHaveLength(0);
-    expect(storageDebug).toHaveLength(1);
+    expect(idbWarns).toHaveLength(0);
+    expect(idbDebug).toHaveLength(1);
+  });
+
+  /**
+   * Repro: addEventToCurrentSequence — split path (shouldSplitEventsList = true).
+   *
+   * After MIN_INTERVAL (500 ms) elapses, the next event triggers a time-based split.
+   * The split uses a single multi-store transaction (`splitTx`) that writes to both
+   * `sessionCurrentSequence` (reset) and `sequencesToSend` (new sequence).
+   * We arm the abort on `sequencesToSend` to catch the split transaction.
+   *
+   * Fix: `splitTx.done.catch(logIdbError)` is attached before any await, so the
+   * AbortError is always routed through logIdbError → debug level.
+   */
+  test('addEventToCurrentSequence split path: AbortError logged at debug not warn', async ({ page }) => {
+    await injectIdbAbortInterceptor(page);
+    const { pageErrors, idbWarns, idbDebug } = listenForIdbErrors(page);
+
+    await loadPage(page);
+    // Wait for the time-based split interval to elapse (MIN_INTERVAL = 500 ms)
+    await page.waitForTimeout(600);
+
+    // Arm abort on 'sequencesToSend' — the store the split transaction writes to last.
+    // The next click will trigger shouldSplitEventsList = true (time-based), opening
+    // splitTx; the interceptor aborts splitTx after the sequencesToSend put succeeds.
+    await page.evaluate(() => void (window as any).__armIdbAbort('sequencesToSend'));
+    await page.click('#test-button');
+    await page.waitForTimeout(300);
+
+    expect(await page.evaluate(() => (window as any).__idbAbortFired as boolean)).toBe(true);
+    expect(pageErrors).toHaveLength(0);
+    expect(idbWarns).toHaveLength(0);
+    expect(idbDebug).toHaveLength(1);
+  });
+
+  /**
+   * Atomicity: split-path abort leaves no partial writes in IDB.
+   *
+   * When `splitTx` aborts, both the `sessionCurrentSequence` reset and the
+   * `sequencesToSend` insert must roll back atomically:
+   *   - sequencesToSend.count() === 0  (write rolled back — no orphaned sequence)
+   *   - sessionCurrentSequence.count() === 1  (not cleared — events still present)
+   *
+   * If atomicity were broken (e.g. two separate transactions), `sequencesToSend`
+   * would hold a partial write and the same events would be sent twice on the next
+   * flush.
+   */
+  test('addEventToCurrentSequence split path: atomic abort leaves no partial writes', async ({ page }) => {
+    await injectIdbAbortInterceptor(page);
+
+    await loadPage(page);
+    await page.waitForTimeout(600); // wait for MIN_INTERVAL to elapse
+
+    await page.evaluate(() => void (window as any).__armIdbAbort('sequencesToSend'));
+    await page.click('#test-button');
+    await page.waitForTimeout(300);
+
+    expect(await page.evaluate(() => (window as any).__idbAbortFired as boolean)).toBe(true);
+
+    const counts = await getIdbStoreCounts(page);
+    expect(counts.sequencesToSend).toBe(0); // write rolled back — no orphaned sequence
+    expect(counts.currentSequence).toBe(1); // not cleared — pre-split events still present
   });
 
   /**
    * Repro: getSequencesToSend — cursor abort mid-traversal.
    *
-   * `getSequencesToSend` is called by `sendStoredEvents`, which runs during SDK
-   * initialisation (`init()` → `initialize(shouldSendStoredEvents=true)`). It reads
-   * stored sequences using a cursor on the `sequencesToSend` store. If the transaction
-   * aborts while the cursor is open, `tx.done` rejects with AbortError.
+   * `getSequencesToSend` is called by `sendStoredEvents` during SDK initialisation.
+   * It reads stored sequences via a cursor on `sequencesToSend`. An abort while the
+   * cursor is open causes `tx.done` to reject with AbortError.
    *
-   * Before the fix `tx.done` was never caught, producing an unhandled rejection.
-   * After the fix `tx.done.catch(logIdbError)` is attached before any await, so the
-   * rejection always flows through `logIdbError` → `debug`.
+   * Fix: save `tx` and attach `tx.done.catch(logIdbError)` before any await.
    *
-   * Because `getSequencesToSend` is only triggered on page load (not via `flush()`),
-   * this test uses a two-navigation approach:
-   *   1. Load the page normally so the SDK is up and IDB is populated.
-   *   2. Arm the cursor interceptor via sessionStorage (persists across reloads).
-   *   3. Reload — `init()` triggers `sendStoredEvents` → `getSequencesToSend` → abort.
+   * Because `getSequencesToSend` is only triggered on page load, this test uses a
+   * two-navigation approach:
+   *   1. Load normally so IDB is populated.
+   *   2. Arm via sessionStorage (persists across reloads).
+   *   3. Reload — init() → sendStoredEvents → getSequencesToSend → cursor abort.
    */
   test('getSequencesToSend cursor abort: AbortError logged at debug not warn', async ({ page }) => {
     await injectIdbAbortInterceptor(page);
-
-    // Second init script: arm the cursor abort on the next page load if the sessionStorage
-    // flag is set.  Runs after injectIdbAbortInterceptor so __idbAbortCtrl already exists.
+    // Second init script: arm the cursor abort on reload if the sessionStorage flag is set.
+    // Runs after injectIdbAbortInterceptor so __armIdbAbort is already defined.
     await page.addInitScript(() => {
       if (sessionStorage.getItem('__armCursorAbort') === '1') {
         sessionStorage.removeItem('__armCursorAbort');
-        (window as any).__idbAbortCtrl.abortOnCursor = 'sequencesToSend';
+        (window as any).__armIdbAbort('sequencesToSend');
       }
     });
 
-    const warns = captureWarns(page);
-    const debugLogs = captureDebugLogs(page);
-    const pageErrors = capturePageErrors(page);
+    const { pageErrors, idbWarns, idbDebug } = listenForIdbErrors(page);
 
     // First load: SDK initialises and records normally (cursor abort not yet armed)
     await loadPage(page);
 
-    // Arm the cursor abort for the next navigation via sessionStorage
+    // Arm for the next navigation via sessionStorage
     await page.evaluate(() => sessionStorage.setItem('__armCursorAbort', '1'));
 
-    // Reload: init() → initialize(true) → sendStoredEvents → getSequencesToSend → cursor abort
+    // Reload: init() → initialize(true) → sendStoredEvents → getSequencesToSend → abort
     await page.reload();
     await waitForReady(page);
     await page.waitForTimeout(300);
 
-    const abortFired = await page.evaluate(() => (window as any).__idbAbortCtrl.cursorAbortFired as boolean);
-    expect(abortFired).toBe(true);
-
-    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
-    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
-
+    expect(await page.evaluate(() => (window as any).__idbAbortFired as boolean)).toBe(true);
     expect(pageErrors).toHaveLength(0);
-    expect(storageWarn).toHaveLength(0);
-    expect(storageDebug).toHaveLength(1);
+    expect(idbWarns).toHaveLength(0);
+    expect(idbDebug).toHaveLength(1);
   });
 
   /**
    * Resilience: the SDK continues recording after an IDB abort.
    *
-   * An IDB transaction abort is a transient error — the SDK should recover and be
-   * able to record subsequent events. This test verifies that:
-   *   1. An abort is triggered and handled gracefully (no crash, no warn)
-   *   2. After the abort, the SDK can still receive new events and eventually flush them
+   * An IDB transaction abort is transient — the SDK should recover and be able to
+   * record and flush subsequent events. Verifies:
+   *   1. Abort is handled gracefully (no crash, no unhandled rejection, no warn)
+   *   2. After the abort, the SDK can still receive new events and flush them
    */
   test('SDK continues recording after IDB abort', async ({ page }) => {
     await injectIdbAbortInterceptor(page);
-    const warns = captureWarns(page);
-    const debugLogs = captureDebugLogs(page);
-    const pageErrors = capturePageErrors(page);
-
-    // Arm before load → aborts the very first IDB write
+    // Arm before load → aborts the very first IDB write (rrweb full snapshot)
     await page.addInitScript(() => {
-      (window as any).__idbAbortCtrl.abortOnPut = 'sessionCurrentSequence';
+      (window as any).__armIdbAbort('sessionCurrentSequence');
     });
 
+    const { pageErrors, idbWarns, idbDebug } = listenForIdbErrors(page);
     const { getBodies } = await captureTrackRequests(page);
-    await mockRemoteConfig(page, remoteConfigRecording);
 
+    await mockRemoteConfig(page, remoteConfigRecording);
     await page.goto(
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
@@ -352,7 +364,6 @@ test.describe('IDB transaction abort handling', () => {
       }),
     );
     await waitForReady(page);
-
     await page.waitForTimeout(200);
 
     // Generate new events after the abort
@@ -367,24 +378,20 @@ test.describe('IDB transaction abort handling', () => {
     // SDK should have recovered and sent at least one batch of events
     expect(getBodies().length).toBeGreaterThan(0);
 
-    // Abort must be handled (not unhandled), logged at debug (not warn), exactly once
-    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
-    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
+    // Abort must be handled and logged at debug (not warn), exactly once
     expect(pageErrors).toHaveLength(0);
-    expect(storageWarn).toHaveLength(0);
-    expect(storageDebug).toHaveLength(1);
+    expect(idbWarns).toHaveLength(0);
+    expect(idbDebug).toHaveLength(1);
   });
 
   /**
    * Baseline: no IDB errors during normal operation.
    *
    * Sanity check that in a normal recording session (no forced aborts) there are
-   * no IDB-related warnings or debug-level storage errors at all.
+   * no IDB-related warnings, debug-level storage errors, or page errors at all.
    */
   test('normal recording: no IDB errors', async ({ page }) => {
-    const warns = captureWarns(page);
-    const debugLogs = captureDebugLogs(page);
-    const pageErrors = capturePageErrors(page);
+    const { pageErrors, idbWarns, idbDebug } = listenForIdbErrors(page);
 
     await loadPage(page);
     await page.click('#test-button');
@@ -393,10 +400,8 @@ test.describe('IDB transaction abort handling', () => {
     await page.evaluate(() => void (window as any).sessionReplay.flush(false));
     await page.waitForTimeout(300);
 
-    const storageWarn = warns.filter((m) => m.includes(STORAGE_FAILURE));
-    const storageDebug = debugLogs.filter((m) => m.includes(STORAGE_FAILURE));
     expect(pageErrors).toHaveLength(0);
-    expect(storageWarn).toHaveLength(0);
-    expect(storageDebug).toHaveLength(0);
+    expect(idbWarns).toHaveLength(0);
+    expect(idbDebug).toHaveLength(0);
   });
 });

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -156,45 +156,39 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   addEventToCurrentSequence = async (sessionId: number, event: string) => {
     let errorLogged = false;
     try {
-      // Open a narrow transaction for the common case (no split) so we don't hold
-      // a readwrite lock on sequencesToSend on every recorded event.
-      const tx = this.db.transaction(currentSequenceKey, 'readwrite');
+      // Always open a readwrite transaction over both stores so that the read and
+      // any subsequent write are atomic.  IDB serializes readwrite transactions on
+      // overlapping stores, so concurrent fire-and-forget callers (events-manager
+      // does not await this method) are queued by the engine rather than interleaving
+      // — eliminating the TOCTOU race that a narrow-read + separate-write approach
+      // would introduce on the split path.
+      const tx = this.db.transaction([currentSequenceKey, sequencesToSendKey], 'readwrite');
       // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
       // put succeeds but before auto-commit) are always handled without blocking.
       // The errorLogged flag prevents double-logging when the outer catch already fired
-      // for the same abort (e.g. tx.store.put() threw).
+      // for the same abort (e.g. a put() threw).
       tx.done.catch((e: unknown) => {
         if (!errorLogged) {
           logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
         }
       });
-      const sequenceEvents = await tx.store.get(sessionId);
+      const sequenceEvents = await tx.objectStore(currentSequenceKey).get(sessionId);
 
       if (!sequenceEvents) {
-        await tx.store.put({ sessionId, events: [event] });
+        await tx.objectStore(currentSequenceKey).put({ sessionId, events: [event] });
         return undefined;
       }
 
       if (!this.shouldSplitEventsList(sequenceEvents.events, event)) {
-        // Common case: append the event and return.
-        await tx.store.put({ sessionId, events: sequenceEvents.events.concat(event) });
+        await tx.objectStore(currentSequenceKey).put({ sessionId, events: sequenceEvents.events.concat(event) });
         return undefined;
       }
 
       // Split path: reset sessionCurrentSequence and write the old events to
-      // sequencesToSend atomically in a single transaction covering both stores.
-      // The narrow tx above has no pending requests at this point and will
-      // auto-commit (read-only result); IDB serializes readwrite transactions on
-      // the same store, so splitTx is guaranteed to start after tx commits.
+      // sequencesToSend atomically within the same transaction.
       const eventsToSend = sequenceEvents.events;
-      const splitTx = this.db.transaction([currentSequenceKey, sequencesToSendKey], 'readwrite');
-      splitTx.done.catch((e: unknown) => {
-        if (!errorLogged) {
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
-        }
-      });
-      await splitTx.objectStore(currentSequenceKey).put({ sessionId, events: [event] });
-      const sequenceId = await splitTx.objectStore(sequencesToSendKey).put({
+      await tx.objectStore(currentSequenceKey).put({ sessionId, events: [event] });
+      const sequenceId = await tx.objectStore(sequencesToSendKey).put({
         sessionId,
         events: eventsToSend,
       });

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -156,10 +156,9 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   addEventToCurrentSequence = async (sessionId: number, event: string) => {
     let errorLogged = false;
     try {
-      // Use a multi-store transaction when a split is needed so that both the
-      // sessionCurrentSequence reset and the sequencesToSend write are atomic.
-      // If the transaction aborts, neither write persists — avoiding duplicates.
-      const tx = this.db.transaction([currentSequenceKey, sequencesToSendKey], 'readwrite');
+      // Open a narrow transaction for the common case (no split) so we don't hold
+      // a readwrite lock on sequencesToSend on every recorded event.
+      const tx = this.db.transaction(currentSequenceKey, 'readwrite');
       // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
       // put succeeds but before auto-commit) are always handled without blocking.
       // The errorLogged flag prevents double-logging when the outer catch already fired
@@ -169,29 +168,36 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
           logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
         }
       });
-      const currentSequenceStore = tx.objectStore(currentSequenceKey);
-      const sequenceEvents = await currentSequenceStore.get(sessionId);
-      let eventsToSend: Events | undefined;
-      let sequenceId: number | undefined;
-      if (!sequenceEvents) {
-        await currentSequenceStore.put({ sessionId, events: [event] });
-      } else if (this.shouldSplitEventsList(sequenceEvents.events, event)) {
-        eventsToSend = sequenceEvents.events;
-        // Reset current sequence and write to sequencesToSend atomically
-        await currentSequenceStore.put({ sessionId, events: [event] });
-        sequenceId = await tx.objectStore(sequencesToSendKey).put({
-          sessionId,
-          events: eventsToSend,
-        });
-      } else {
-        // add event to array
-        const updatedEvents = sequenceEvents.events.concat(event);
-        await currentSequenceStore.put({ sessionId, events: updatedEvents });
-      }
+      const sequenceEvents = await tx.store.get(sessionId);
 
-      if (!eventsToSend || !sequenceId) {
+      if (!sequenceEvents) {
+        await tx.store.put({ sessionId, events: [event] });
         return undefined;
       }
+
+      if (!this.shouldSplitEventsList(sequenceEvents.events, event)) {
+        // Common case: append the event and return.
+        await tx.store.put({ sessionId, events: sequenceEvents.events.concat(event) });
+        return undefined;
+      }
+
+      // Split path: reset sessionCurrentSequence and write the old events to
+      // sequencesToSend atomically in a single transaction covering both stores.
+      // The narrow tx above has no pending requests at this point and will
+      // auto-commit (read-only result); IDB serializes readwrite transactions on
+      // the same store, so splitTx is guaranteed to start after tx commits.
+      const eventsToSend = sequenceEvents.events;
+      const splitTx = this.db.transaction([currentSequenceKey, sequencesToSendKey], 'readwrite');
+      splitTx.done.catch((e: unknown) => {
+        if (!errorLogged) {
+          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+        }
+      });
+      await splitTx.objectStore(currentSequenceKey).put({ sessionId, events: [event] });
+      const sequenceId = await splitTx.objectStore(sequencesToSendKey).put({
+        sessionId,
+        events: eventsToSend,
+      });
 
       return {
         events: eventsToSend,

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -156,7 +156,10 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   addEventToCurrentSequence = async (sessionId: number, event: string) => {
     let errorLogged = false;
     try {
-      const tx = this.db.transaction<'sessionCurrentSequence', 'readwrite'>(currentSequenceKey, 'readwrite');
+      // Use a multi-store transaction when a split is needed so that both the
+      // sessionCurrentSequence reset and the sequencesToSend write are atomic.
+      // If the transaction aborts, neither write persists — avoiding duplicates.
+      const tx = this.db.transaction([currentSequenceKey, sequencesToSendKey], 'readwrite');
       // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
       // put succeeds but before auto-commit) are always handled without blocking.
       // The errorLogged flag prevents double-logging when the outer catch already fired
@@ -166,27 +169,27 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
           logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
         }
       });
-      const sequenceEvents = await tx.store.get(sessionId);
+      const currentSequenceStore = tx.objectStore(currentSequenceKey);
+      const sequenceEvents = await currentSequenceStore.get(sessionId);
       let eventsToSend: Events | undefined;
+      let sequenceId: number | undefined;
       if (!sequenceEvents) {
-        await tx.store.put({ sessionId, events: [event] });
+        await currentSequenceStore.put({ sessionId, events: [event] });
       } else if (this.shouldSplitEventsList(sequenceEvents.events, event)) {
         eventsToSend = sequenceEvents.events;
-        // set store to empty array
-        await tx.store.put({ sessionId, events: [event] });
+        // Reset current sequence and write to sequencesToSend atomically
+        await currentSequenceStore.put({ sessionId, events: [event] });
+        sequenceId = await tx.objectStore(sequencesToSendKey).put({
+          sessionId,
+          events: eventsToSend,
+        });
       } else {
         // add event to array
         const updatedEvents = sequenceEvents.events.concat(event);
-        await tx.store.put({ sessionId, events: updatedEvents });
+        await currentSequenceStore.put({ sessionId, events: updatedEvents });
       }
 
-      if (!eventsToSend) {
-        return undefined;
-      }
-
-      const sequenceId = await this.storeSendingEvents(sessionId, eventsToSend);
-
-      if (!sequenceId) {
+      if (!eventsToSend || !sequenceId) {
         return undefined;
       }
 

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -93,9 +93,20 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   }
 
   getSequencesToSend = async (): Promise<SendingSequencesReturn<number>[] | undefined> => {
+    let errorLogged = false;
     try {
       const sequences: SendingSequencesReturn<number>[] = [];
-      let cursor = await this.db.transaction('sequencesToSend').store.openCursor();
+      const tx = this.db.transaction('sequencesToSend');
+      // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
+      // cursor traversal completes) are always handled without blocking the return path.
+      // The errorLogged flag prevents double-logging when the outer catch already fired
+      // for the same abort (e.g. cursor.continue() threw mid-traversal).
+      tx.done.catch((e: unknown) => {
+        if (!errorLogged) {
+          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+        }
+      });
+      let cursor = await tx.store.openCursor();
       while (cursor) {
         const { sessionId, events } = cursor.value;
         sequences.push({
@@ -108,6 +119,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
 
       return sequences;
     } catch (e) {
+      errorLogged = true;
       logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
     }
     return undefined;
@@ -142,15 +154,23 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   };
 
   addEventToCurrentSequence = async (sessionId: number, event: string) => {
+    let errorLogged = false;
     try {
       const tx = this.db.transaction<'sessionCurrentSequence', 'readwrite'>(currentSequenceKey, 'readwrite');
+      // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
+      // put succeeds but before auto-commit) are always handled without blocking.
+      // The errorLogged flag prevents double-logging when the outer catch already fired
+      // for the same abort (e.g. tx.store.put() threw).
+      tx.done.catch((e: unknown) => {
+        if (!errorLogged) {
+          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+        }
+      });
       const sequenceEvents = await tx.store.get(sessionId);
+      let eventsToSend: Events | undefined;
       if (!sequenceEvents) {
         await tx.store.put({ sessionId, events: [event] });
-        return;
-      }
-      let eventsToSend;
-      if (this.shouldSplitEventsList(sequenceEvents.events, event)) {
+      } else if (this.shouldSplitEventsList(sequenceEvents.events, event)) {
         eventsToSend = sequenceEvents.events;
         // set store to empty array
         await tx.store.put({ sessionId, events: [event] });
@@ -160,7 +180,6 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
         await tx.store.put({ sessionId, events: updatedEvents });
       }
 
-      await tx.done;
       if (!eventsToSend) {
         return undefined;
       }
@@ -177,6 +196,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
         sequenceId,
       };
     } catch (e) {
+      errorLogged = true;
       logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
     }
     return undefined;

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -266,20 +266,31 @@ describe('SessionReplayEventsIDBStore', () => {
       expect(allSessionCurrentSequence).toEqual([{ events: [mockEventString2], sessionId: 123 }]);
     });
 
-    test('should return undefined if storeSendingEvents fails', async () => {
+    test('should return undefined if the split-path transaction fails', async () => {
+      // The split path now uses a single multi-store transaction for both
+      // sessionCurrentSequence and sequencesToSend. Verify that a transaction
+      // error still results in undefined being returned and a warn being logged.
       const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
         apiKey,
         loggerProvider: mockLoggerProvider,
       });
 
-      // Fake as if there are events to send
       eventsStorage!.shouldSplitEventsList = jest.fn().mockReturnValue(true);
-      eventsStorage!.storeSendingEvents = jest.fn().mockResolvedValue(undefined);
 
+      // Seed one event so shouldSplitEventsList can trigger on the next call
       await eventsStorage?.addEventToCurrentSequence(123, mockEventString);
+
+      // Sabotage the db so the next transaction() call throws
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (eventsStorage as any).db = {
+        transaction: () => {
+          throw new Error('transaction failed');
+        },
+      };
 
       const eventsToSend = await eventsStorage?.addEventToCurrentSequence(123, mockEventString2);
       expect(eventsToSend).toBeUndefined();
+      expect(mockLoggerProvider.warn).toHaveBeenCalled();
     });
 
     test('should catch errors', async () => {
@@ -305,12 +316,14 @@ describe('SessionReplayEventsIDBStore', () => {
       const txDone = Promise.reject(abortError);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       txDone.catch(() => {}); // prevent unhandled rejection in test runner
+      const mockStore = {
+        get: jest.fn().mockResolvedValue(undefined), // no existing sequence
+        put: jest.fn().mockResolvedValue(undefined), // put succeeds
+      };
       const mockDB = {
         transaction: jest.fn().mockReturnValue({
-          store: {
-            get: jest.fn().mockResolvedValue(undefined), // no existing sequence
-            put: jest.fn().mockResolvedValue(undefined), // put succeeds
-          },
+          // addEventToCurrentSequence now uses tx.objectStore(name) rather than tx.store
+          objectStore: jest.fn().mockReturnValue(mockStore),
           done: txDone, // but transaction aborts before commit
         }),
       } as unknown as IDBPDatabase<SessionReplayDB>;

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -318,10 +318,10 @@ describe('SessionReplayEventsIDBStore', () => {
       txDone.catch(() => {}); // prevent unhandled rejection in test runner
       const mockDB = {
         transaction: jest.fn().mockReturnValue({
-          store: {
+          objectStore: jest.fn().mockReturnValue({
             get: jest.fn().mockResolvedValue(undefined), // no existing sequence
             put: jest.fn().mockResolvedValue(undefined), // put succeeds
-          },
+          }),
           done: txDone, // but transaction aborts before commit
         }),
       } as unknown as IDBPDatabase<SessionReplayDB>;
@@ -339,36 +339,26 @@ describe('SessionReplayEventsIDBStore', () => {
       );
       expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
     });
-    test('should log at debug (not warn) when splitTx.done rejects with AbortError on split path', async () => {
-      // Repro: the split transaction opens both stores atomically. If the browser
-      // aborts the transaction after the puts succeed (e.g. due to resource pressure),
-      // the AbortError from splitTx.done must be caught and logged at debug, not warn.
+    test('should log at debug (not warn) when tx.done rejects with AbortError on split path', async () => {
+      // Repro: the transaction opens both stores atomically. If the browser aborts the
+      // transaction after the puts succeed (e.g. due to resource pressure), the AbortError
+      // from tx.done must be caught and logged at debug, not warn.
       const abortError = new DOMException(
         'The transaction was aborted, so the request cannot be fulfilled.',
         'AbortError',
       );
-      const splitTxDone = Promise.reject(abortError);
+      const txDoneForSplit = Promise.reject(abortError);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      splitTxDone.catch(() => {}); // prevent unhandled rejection in test runner
+      txDoneForSplit.catch(() => {}); // prevent unhandled rejection in test runner
 
-      let txCallCount = 0;
       const mockDB = {
-        transaction: jest.fn().mockImplementation(() => {
-          txCallCount++;
-          if (txCallCount === 1) {
-            // Narrow tx: returns existing events so the split path is triggered
-            return {
-              store: {
-                get: jest.fn().mockResolvedValue({ sessionId: 123, events: [mockEventString] }),
-              },
-              done: Promise.resolve(),
-            };
-          }
-          // splitTx: puts succeed but the transaction aborts before commit
-          return {
-            objectStore: jest.fn().mockReturnValue({ put: jest.fn().mockResolvedValue(1) }),
-            done: splitTxDone,
-          };
+        transaction: jest.fn().mockReturnValue({
+          // objectStore() returns the same mock regardless of store name
+          objectStore: jest.fn().mockReturnValue({
+            get: jest.fn().mockResolvedValue({ sessionId: 123, events: [mockEventString] }),
+            put: jest.fn().mockResolvedValue(1),
+          }),
+          done: txDoneForSplit, // tx aborts before commit
         }),
       } as unknown as IDBPDatabase<SessionReplayDB>;
       jest.spyOn(EventsIDBStore, 'createStore').mockResolvedValue(mockDB);
@@ -380,7 +370,7 @@ describe('SessionReplayEventsIDBStore', () => {
       eventsStorage!.shouldSplitEventsList = jest.fn().mockReturnValue(true);
 
       await eventsStorage?.addEventToCurrentSequence(123, mockEventString2);
-      // Allow microtasks to settle so the splitTx.done.catch() handler fires
+      // Allow microtasks to settle so the tx.done.catch() handler fires
       await Promise.resolve();
       expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Failed to store session replay events in IndexedDB'),

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -316,14 +316,12 @@ describe('SessionReplayEventsIDBStore', () => {
       const txDone = Promise.reject(abortError);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       txDone.catch(() => {}); // prevent unhandled rejection in test runner
-      const mockStore = {
-        get: jest.fn().mockResolvedValue(undefined), // no existing sequence
-        put: jest.fn().mockResolvedValue(undefined), // put succeeds
-      };
       const mockDB = {
         transaction: jest.fn().mockReturnValue({
-          // addEventToCurrentSequence now uses tx.objectStore(name) rather than tx.store
-          objectStore: jest.fn().mockReturnValue(mockStore),
+          store: {
+            get: jest.fn().mockResolvedValue(undefined), // no existing sequence
+            put: jest.fn().mockResolvedValue(undefined), // put succeeds
+          },
           done: txDone, // but transaction aborts before commit
         }),
       } as unknown as IDBPDatabase<SessionReplayDB>;
@@ -336,6 +334,54 @@ describe('SessionReplayEventsIDBStore', () => {
 
       const result = await eventsStorage?.addEventToCurrentSequence(123, mockEventString);
       expect(result).toBeUndefined();
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to store session replay events in IndexedDB'),
+      );
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
+    });
+    test('should log at debug (not warn) when splitTx.done rejects with AbortError on split path', async () => {
+      // Repro: the split transaction opens both stores atomically. If the browser
+      // aborts the transaction after the puts succeed (e.g. due to resource pressure),
+      // the AbortError from splitTx.done must be caught and logged at debug, not warn.
+      const abortError = new DOMException(
+        'The transaction was aborted, so the request cannot be fulfilled.',
+        'AbortError',
+      );
+      const splitTxDone = Promise.reject(abortError);
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      splitTxDone.catch(() => {}); // prevent unhandled rejection in test runner
+
+      let txCallCount = 0;
+      const mockDB = {
+        transaction: jest.fn().mockImplementation(() => {
+          txCallCount++;
+          if (txCallCount === 1) {
+            // Narrow tx: returns existing events so the split path is triggered
+            return {
+              store: {
+                get: jest.fn().mockResolvedValue({ sessionId: 123, events: [mockEventString] }),
+              },
+              done: Promise.resolve(),
+            };
+          }
+          // splitTx: puts succeed but the transaction aborts before commit
+          return {
+            objectStore: jest.fn().mockReturnValue({ put: jest.fn().mockResolvedValue(1) }),
+            done: splitTxDone,
+          };
+        }),
+      } as unknown as IDBPDatabase<SessionReplayDB>;
+      jest.spyOn(EventsIDBStore, 'createStore').mockResolvedValue(mockDB);
+
+      const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      eventsStorage!.shouldSplitEventsList = jest.fn().mockReturnValue(true);
+
+      await eventsStorage?.addEventToCurrentSequence(123, mockEventString2);
+      // Allow microtasks to settle so the splitTx.done.catch() handler fires
+      await Promise.resolve();
       expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Failed to store session replay events in IndexedDB'),
       );

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -111,6 +111,38 @@ describe('SessionReplayEventsIDBStore', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalled();
       expect(unsentSequences).toBeUndefined();
     });
+
+    test('should log at debug (not warn) when tx.done rejects with AbortError', async () => {
+      // Repro: transaction aborts after cursor exhaustion; tx.done rejection must be caught
+      const abortError = new DOMException(
+        'The transaction was aborted, so the request cannot be fulfilled.',
+        'AbortError',
+      );
+      const txDone = Promise.reject(abortError);
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      txDone.catch(() => {}); // prevent unhandled rejection in test runner
+      const mockDB = {
+        transaction: jest.fn().mockReturnValue({
+          store: { openCursor: jest.fn().mockResolvedValue(null) },
+          done: txDone,
+        }),
+      } as unknown as IDBPDatabase<SessionReplayDB>;
+      jest.spyOn(EventsIDBStore, 'createStore').mockResolvedValue(mockDB);
+
+      const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+
+      const result = await eventsStorage?.getSequencesToSend();
+      // With the .catch() approach the function returns whatever sequences were
+      // collected before the abort (an empty array here since the cursor was null).
+      expect(result).toEqual([]);
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to store session replay events in IndexedDB'),
+      );
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
+    });
   });
 
   describe('storeCurrentSequence', () => {
@@ -260,6 +292,41 @@ describe('SessionReplayEventsIDBStore', () => {
       const eventsToSend = await eventsStorage?.addEventToCurrentSequence(123, mockEventString2);
       expect(mockLoggerProvider.warn).toHaveBeenCalled();
       expect(eventsToSend).toBeUndefined();
+    });
+
+    test('should log at debug (not warn) when tx.done rejects with AbortError on first event for session', async () => {
+      // Repro: tx.done rejects with AbortError after put succeeds (transaction aborts before commit).
+      // The old code had an early `return` before `await tx.done` in the !sequenceEvents branch,
+      // meaning this rejection was silently unhandled instead of being routed through logIdbError.
+      const abortError = new DOMException(
+        'The transaction was aborted, so the request cannot be fulfilled.',
+        'AbortError',
+      );
+      const txDone = Promise.reject(abortError);
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      txDone.catch(() => {}); // prevent unhandled rejection in test runner
+      const mockDB = {
+        transaction: jest.fn().mockReturnValue({
+          store: {
+            get: jest.fn().mockResolvedValue(undefined), // no existing sequence
+            put: jest.fn().mockResolvedValue(undefined), // put succeeds
+          },
+          done: txDone, // but transaction aborts before commit
+        }),
+      } as unknown as IDBPDatabase<SessionReplayDB>;
+      jest.spyOn(EventsIDBStore, 'createStore').mockResolvedValue(mockDB);
+
+      const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+
+      const result = await eventsStorage?.addEventToCurrentSequence(123, mockEventString);
+      expect(result).toBeUndefined();
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to store session replay events in IndexedDB'),
+      );
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
     });
     test('should handle undefined store', async () => {
       mockStoreForError();


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Two `tx.done` rejections were unhandled, meaning AbortErrors from browser-initiated transaction aborts bypassed `logIdbError` entirely:

1. `addEventToCurrentSequence` — the `!sequenceEvents` branch returned before `tx.done` was ever awaited or caught, leaving its rejection unhandled.

2. `getSequencesToSend` — the transaction was opened inline without saving a reference, so `tx.done` could never be caught.

Fix: attach `tx.done.catch(logIdbError)` immediately after opening each transaction (before any `await`), with an `errorLogged` flag to prevent double-logging if the outer try/catch also fires for the same abort.

Adds unit tests for both abort paths and an e2e test suite (Playwright) that uses `IDBObjectStore.prototype` patching to inject real browser-level aborts and asserts: no unhandled rejections (`pageerror`), no warn logs, exactly one debug log per abort.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session replay’s IndexedDB persistence/transaction boundaries; mistakes could drop or duplicate buffered events, though the change is localized and covered by new unit + E2E abort/atomicity tests.
> 
> **Overview**
> Prevents browser-initiated IndexedDB transaction aborts from surfacing as unhandled rejections and customer-facing warnings by attaching `tx.done.catch(...)` immediately in `getSequencesToSend` and `addEventToCurrentSequence`, with an `errorLogged` guard to avoid double-logging.
> 
> Changes `addEventToCurrentSequence` to use a single multi-store readwrite transaction across `sessionCurrentSequence` and `sequencesToSend` so split writes commit/rollback atomically.
> 
> Adds focused Jest coverage for `tx.done` AbortError cases and a new Playwright E2E suite (`e2e/idb.spec.ts`) that forces real IDB aborts and asserts no `pageerror`, no warn logs, and correct debug-only logging plus split-path atomicity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffde477454a5a62827fcb38dca906dccfecd750f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->