### PR TITLE
fix(session-replay-browser): use takeFullSnapshot on focus instead of full rrweb restart (SR-3531)

### DIFF
--- a/packages/session-replay-browser/e2e/guard.spec.ts
+++ b/packages/session-replay-browser/e2e/guard.spec.ts
@@ -68,6 +68,42 @@ test.describe('recordEventsInFlight guard (SR-3531)', () => {
   });
 
   /**
+   * Guard test: dispatch a focus event immediately after page load (while the
+   * async init chain — getRecordFunction / initializeNetworkObservers — is still
+   * in flight). The focusListener calls recordEvents(false), which should be
+   * dropped by the in-flight guard so that only one FullSnapshot is emitted.
+   */
+  test('focus event during async init does not produce a duplicate FullSnapshot', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    const rawBodies: string[] = [];
+    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+      rawBodies.push(readRouteBody(route));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+
+    // Register the listener early so the immediate flush doesn't escape.
+    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+
+    // Fire focus immediately — before waitForReady — to race with the async init chain.
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+    await waitForReady(page);
+    await requestPromise;
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Extra flush to capture any delayed events
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    const count = countFullSnapshots(rawBodies);
+    expect(count).toBe(1);
+  });
+
+  /**
    * Known limitation (follow-up PR): a focus event fired AFTER recording is
    * fully stable causes focusListener to call recordEvents(false), which stops
    * and restarts rrweb — producing a second FullSnapshot. The guard does NOT

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -96,11 +96,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   // Cache the dynamically imported record function
   private recordFunction: RecordFunction | null = null;
+  private recordEventsInFlight = false;
 
   /** Current page URL, kept in sync with SPA navigations for URL-based masking */
   private currentPageUrl = '';
 
-  private recordEventsInFlight = false;
   private recordEventsPendingShouldLogMetadata: boolean | null = null;
 
   /** Cleanup for URL change listener used to re-evaluate targeting on SPA route changes */
@@ -423,9 +423,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
   };
 
   focusListener = () => {
-    // Restart recording on focus to ensure that when user
-    // switches tabs, we take a full snapshot
-    void this.recordEvents(false);
+    if (this.recordCancelCallback && this.recordFunction) {
+      this.recordFunction.takeFullSnapshot(true);
+    } else if (!this.recordEventsInFlight) {
+      void this.recordEvents(false);
+    }
   };
 
   /**

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -424,7 +424,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   focusListener = () => {
     if (this.recordCancelCallback && this.recordFunction) {
-      this.recordFunction.takeFullSnapshot(true);
+      try {
+        this.recordFunction.takeFullSnapshot(true);
+      } catch (error) {
+        this.loggerProvider.warn('Failed to take full snapshot on focus:', error);
+      }
     } else if (!this.recordEventsInFlight) {
       void this.recordEvents(false);
     }

--- a/packages/session-replay-browser/src/utils/rrweb.ts
+++ b/packages/session-replay-browser/src/utils/rrweb.ts
@@ -43,5 +43,6 @@ export type RecordFunction = {
     applyBackgroundColorToBlockedElements?: boolean;
   }): (() => void) | undefined;
   addCustomEvent: (eventName: string, eventData: any) => void;
+  takeFullSnapshot: (isCheckout?: boolean) => void;
   mirror: Mirror;
 };

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -165,9 +165,11 @@ describe('SessionReplay', () => {
   function createMockRecordFunction() {
     const mockRecordFn = jest.fn().mockReturnValue(jest.fn()) as jest.Mock & {
       addCustomEvent: jest.Mock;
+      takeFullSnapshot: jest.Mock;
       mirror: { getNode: jest.Mock };
     };
     mockRecordFn.addCustomEvent = jest.fn();
+    mockRecordFn.takeFullSnapshot = jest.fn();
     mockRecordFn.mirror = {
       getNode: jest.fn().mockReturnValue(null),
     };
@@ -844,8 +846,12 @@ describe('SessionReplay', () => {
     test('should set up blur and focus event listeners', async () => {
       const initialize = jest.spyOn(sessionReplay, 'initialize');
       await sessionReplay.init(apiKey, mockOptions).promise;
-      const recordMock = jest.fn();
+      const recordMock = jest.fn().mockResolvedValue(undefined);
       sessionReplay.recordEvents = recordMock;
+      // Clear recordCancelCallback and recordEventsInFlight so focusListener takes the fallback recordEvents path
+      sessionReplay.recordCancelCallback = null;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (sessionReplay as any).recordEventsInFlight = false;
       initialize.mockReset();
       expect(addEventListenerMock).toHaveBeenCalledTimes(3);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -861,8 +867,56 @@ describe('SessionReplay', () => {
       const focusCallback = addEventListenerMock.mock.calls[1][1];
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       focusCallback();
-      expect(recordMock).toHaveBeenCalled();
+      expect(recordMock).toHaveBeenCalledWith(false);
     });
+
+    describe('focusListener', () => {
+      test('calls takeFullSnapshot(true) when already recording, does not call recordEvents', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        const takeFullSnapshotMock = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = { takeFullSnapshot: takeFullSnapshotMock };
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+
+        sessionReplay.focusListener();
+
+        expect(takeFullSnapshotMock).toHaveBeenCalledWith(true);
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+      });
+
+      test('calls recordEvents(false) when not recording and not in-flight', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = null;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordEventsInFlight = false;
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents').mockResolvedValue(undefined);
+
+        sessionReplay.focusListener();
+
+        expect(recordEventsSpy).toHaveBeenCalledWith(false);
+      });
+
+      test('does nothing when not recording but already in-flight', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = null;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordEventsInFlight = true;
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+        const takeFullSnapshotMock = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = { takeFullSnapshot: takeFullSnapshotMock };
+
+        sessionReplay.focusListener();
+
+        expect(takeFullSnapshotMock).not.toHaveBeenCalled();
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+      });
+    });
+
     test('it should not call initialize if the document does not have focus', () => {
       const initialize = jest.spyOn(sessionReplay, 'initialize');
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -915,6 +915,24 @@ describe('SessionReplay', () => {
         expect(takeFullSnapshotMock).not.toHaveBeenCalled();
         expect(recordEventsSpy).not.toHaveBeenCalled();
       });
+
+      test('warns via loggerProvider when takeFullSnapshot throws', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        const warnSpy = jest.spyOn(sessionReplay.loggerProvider, 'warn');
+        const testError = new Error('rrweb snapshot failed');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = {
+          takeFullSnapshot: jest.fn().mockImplementation(() => {
+            throw testError;
+          }),
+        };
+
+        sessionReplay.focusListener();
+
+        expect(warnSpy).toHaveBeenCalledWith('Failed to take full snapshot on focus:', testError);
+      });
     });
 
     test('it should not call initialize if the document does not have focus', () => {


### PR DESCRIPTION
## Summary

- **Root Cause 2 fix for SR-3531** (follow-up to #1686 which fixed Root Cause 1)
- `focusListener` was unconditionally calling `recordEvents(false)` on every tab focus, which stops rrweb, resets the mirror, and takes a full DOM snapshot (~900 KB re-walk) — even when recording was already active and healthy
- Replaces the stop+restart with `record.takeFullSnapshot(true)` when rrweb is already recording, emitting a lightweight checkout snapshot without tearing down and rebuilding the recorder
- Falls back to `recordEvents(false)` only when no recording is active and no restart is already in flight
- Adds `takeFullSnapshot: (isCheckout?: boolean) => void` to the `RecordFunction` type in `utils/rrweb.ts`
- Also includes the `recordEventsInFlight` concurrency guard from #1686 (needed here since this branch is off `main`, not off that PR)

## Details

**Before:** every tab focus → `stopRecordingEvents()` → full rrweb `record()` restart → full DOM snapshot emitted

**After:** every tab focus (while recording) → `takeFullSnapshot(true)` → single checkout-tagged FullSnapshot emitted, no recorder teardown

## Merge order

> Merge #1686 first, then this PR. If merged in order, the `recordEventsInFlight` guard in this PR is a no-op duplicate that can be cleaned up, but it does not cause harm.

## Test plan

- [ ] Tab away and tab back during an active session — confirm a single checkout FullSnapshot is emitted, not a Meta + FullSnapshot pair from a recorder restart
- [ ] Tab back when no recording is active — confirm `recordEvents(false)` is still called as the fallback
- [ ] Concurrent focus events (rapid alt-tab) — confirm `recordEventsInFlight` guard prevents double-init when fallback path is taken
- [ ] Type check: `npx tsc --noEmit` in `packages/session-replay-browser` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `focusListener` behavior during active session replay recording, which can affect snapshot cadence and event capture on tab refocus. Risk is mitigated by added unit/E2E coverage but still touches core recording lifecycle logic.
> 
> **Overview**
> Updates session replay tab-focus handling to avoid stopping/restarting rrweb when recording is already active: `focusListener` now calls `record.takeFullSnapshot(true)` and only falls back to `recordEvents(false)` when not currently recording (and not already initializing).
> 
> Extends the rrweb `RecordFunction` type with `takeFullSnapshot` and adds/updates unit + Playwright E2E tests to validate no duplicate FullSnapshots during async init/focus races and the new focus snapshot behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9548a982c98880d048c663b671ac0cf92381c739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->