### PR TITLE
feat(session-replay-browser): expose captureAdoptedStyleSheets option

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -107,6 +107,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         captureDocumentTitle: this.options.captureDocumentTitle,
         enableUrlChangePolling: this.options.enableUrlChangePolling,
         urlChangePollingInterval: this.options.urlChangePollingInterval,
+        captureAdoptedStyleSheets: this.options.captureAdoptedStyleSheets,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -172,4 +172,8 @@ export interface SessionReplayOptions {
    * @defaultValue false
    */
   captureDocumentTitle?: boolean;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.captureAdoptedStyleSheets}
+   */
+  captureAdoptedStyleSheets?: boolean;
 }

--- a/packages/session-replay-browser/e2e/shadow-dom.spec.ts
+++ b/packages/session-replay-browser/e2e/shadow-dom.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  captureTrackRequests,
+  getSnapshotRoot,
+  findById,
+  flushRecording,
+} from './helpers';
+
+/**
+ * E2E tests for captureAdoptedStyleSheets option.
+ *
+ * These tests verify that:
+ *   1. The option is accepted by the SDK without error (both true and false).
+ *   2. Shadow DOM elements are captured in the full snapshot regardless of the option value.
+ *
+ * Full inline-stylesheet assertion (verifying adoptedStyleSheets CSS rules appear
+ * inline in the snapshot node rather than as incremental events) requires an rrweb
+ * version that includes amplitude/rrweb#101. That assertion should be added here
+ * once the @amplitude/rrweb-* packages are bumped to include that fix.
+ */
+
+const SHADOW_DOM_PAGE = '/session-replay-browser/sr-shadow-dom-test.html';
+
+type SrWindow = Window & { srError?: string };
+
+test.describe('captureAdoptedStyleSheets option', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+  });
+
+  test('SDK initializes without error and captures shadow host with default (true)', async ({ page }) => {
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(SHADOW_DOM_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+
+    // Verify no initialization error
+    const srError = await page.evaluate(() => (window as SrWindow).srError);
+    expect(srError).toBeUndefined();
+
+    await flushRecording(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    // The shadow host div must appear in the snapshot
+    const shadowHost = findById(root!, 'shadow-host');
+    expect(shadowHost).toBeDefined();
+    // Shadow root childNodes are serialized as children of the host
+    expect((shadowHost?.childNodes ?? []).length).toBeGreaterThan(0);
+  });
+
+  test('SDK initializes without error and captures shadow host with captureAdoptedStyleSheets=false', async ({
+    page,
+  }) => {
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(
+      buildUrl(SHADOW_DOM_PAGE, {
+        sessionId: TEST_SESSION_ID,
+        captureAdoptedStyleSheets: 'false',
+      }),
+    );
+    await waitForReady(page);
+
+    // Verify no initialization error when opting out
+    const srError = await page.evaluate(() => (window as SrWindow).srError);
+    expect(srError).toBeUndefined();
+
+    await flushRecording(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+
+    const shadowHost = findById(root!, 'shadow-host');
+    expect(shadowHost).toBeDefined();
+    expect((shadowHost?.childNodes ?? []).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -99,8 +99,6 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     if (options.omitElementTags) {
       this.omitElementTags = options.omitElementTags;
     }
-    if (options.captureAdoptedStyleSheets !== undefined) {
-      this.captureAdoptedStyleSheets = options.captureAdoptedStyleSheets;
-    }
+    this.captureAdoptedStyleSheets = options.captureAdoptedStyleSheets ?? true;
   }
 }

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -44,6 +44,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   enableUrlChangePolling?: boolean;
   urlChangePollingInterval?: number;
   captureDocumentTitle?: boolean;
+  captureAdoptedStyleSheets?: boolean;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -97,6 +98,9 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     }
     if (options.omitElementTags) {
       this.omitElementTags = options.omitElementTags;
+    }
+    if (options.captureAdoptedStyleSheets !== undefined) {
+      this.captureAdoptedStyleSheets = options.captureAdoptedStyleSheets;
     }
   }
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -208,6 +208,19 @@ export interface SessionReplayLocalConfig extends IConfig {
    */
   captureDocumentTitle?: boolean;
   interactionConfig?: InteractionConfig;
+  /**
+   * When true (default), the CSS rules of any `adoptedStyleSheets` on shadow roots and
+   * the document are serialized **inline** within the full snapshot. This makes the snapshot
+   * self-contained so that shadow DOM styles are replayed correctly even if subsequent
+   * incremental `AdoptedStyleSheet` events are dropped in transit.
+   *
+   * Set to `false` to revert to the legacy behavior where adopted stylesheet rules are
+   * emitted as separate incremental events (which may be lost if delivery is unreliable).
+   * Only consider opting out if snapshot payload size is a critical concern.
+   *
+   * @defaultValue true
+   */
+  captureAdoptedStyleSheets?: boolean;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -830,6 +830,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
         maskTextSelector: this.getMaskTextSelectors(),
         recordCanvas: false,
+        captureAdoptedStyleSheets: config.captureAdoptedStyleSheets,
         slimDOMOptions: {
           script: config.omitElementTags?.script,
           comment: config.omitElementTags?.comment,

--- a/packages/session-replay-browser/src/utils/rrweb.ts
+++ b/packages/session-replay-browser/src/utils/rrweb.ts
@@ -41,6 +41,12 @@ export type RecordFunction = {
     errorHandler?: (error: unknown) => boolean;
     plugins?: any[];
     applyBackgroundColorToBlockedElements?: boolean;
+    /**
+     * When true (default), adoptedStyleSheets CSS rules are serialized inline in the full snapshot
+     * rather than emitted as separate incremental events that can be dropped in transit.
+     * Set to false to revert to the legacy incremental-event path if snapshot size is a concern.
+     */
+    captureAdoptedStyleSheets?: boolean;
   }): (() => void) | undefined;
   addCustomEvent: (eventName: string, eventData: any) => void;
   mirror: Mirror;

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -502,6 +502,27 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         expect(config.urlChangePollingInterval).toBe(0);
       });
 
+      test('should leave captureAdoptedStyleSheets undefined when not provided', () => {
+        const config = new SessionReplayLocalConfig('static_key', mockOptions);
+        expect(config.captureAdoptedStyleSheets).toBeUndefined();
+      });
+
+      test('should set captureAdoptedStyleSheets to true when provided', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          captureAdoptedStyleSheets: true,
+        });
+        expect(config.captureAdoptedStyleSheets).toBe(true);
+      });
+
+      test('should set captureAdoptedStyleSheets to false when provided', () => {
+        const config = new SessionReplayLocalConfig('static_key', {
+          ...mockOptions,
+          captureAdoptedStyleSheets: false,
+        });
+        expect(config.captureAdoptedStyleSheets).toBe(false);
+      });
+
       test('should throw error for invalid UGC filter rules with non-string selector', () => {
         const invalidRules = [{ selector: 123, replacement: 'replacement' }] as unknown as UGCFilterRule[];
         expect(() => {

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -502,9 +502,9 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         expect(config.urlChangePollingInterval).toBe(0);
       });
 
-      test('should leave captureAdoptedStyleSheets undefined when not provided', () => {
+      test('should default captureAdoptedStyleSheets to true when not provided', () => {
         const config = new SessionReplayLocalConfig('static_key', mockOptions);
-        expect(config.captureAdoptedStyleSheets).toBeUndefined();
+        expect(config.captureAdoptedStyleSheets).toBe(true);
       });
 
       test('should set captureAdoptedStyleSheets to true when provided', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -936,6 +936,34 @@ describe('SessionReplay', () => {
       expect(recordArg?.applyBackgroundColorToBlockedElements).toBe(expectedValue);
     });
 
+    test.each([
+      {
+        description: 'should pass captureAdoptedStyleSheets=true to rrweb when option is true',
+        options: { captureAdoptedStyleSheets: true },
+        expectedValue: true,
+      },
+      {
+        description: 'should pass captureAdoptedStyleSheets=false to rrweb when option is false',
+        options: { captureAdoptedStyleSheets: false },
+        expectedValue: false,
+      },
+      {
+        description: 'should pass captureAdoptedStyleSheets=undefined to rrweb when option is not provided',
+        options: {},
+        expectedValue: undefined,
+      },
+    ])('$description', async ({ options, expectedValue }) => {
+      const sessionReplay = new SessionReplay();
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        ...options,
+      }).promise;
+      await sessionReplay.recordEvents();
+
+      const recordArg = mockRecordFunction.mock.calls[0][0];
+      expect(recordArg?.captureAdoptedStyleSheets).toBe(expectedValue);
+    });
+
     describe('background capture', () => {
       let mockMessenger: { setup: jest.Mock };
       let getOrCreateSpy: jest.SpyInstance;

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -948,9 +948,9 @@ describe('SessionReplay', () => {
         expectedValue: false,
       },
       {
-        description: 'should pass captureAdoptedStyleSheets=undefined to rrweb when option is not provided',
+        description: 'should pass captureAdoptedStyleSheets=true to rrweb when option is not provided (default)',
         options: {},
-        expectedValue: undefined,
+        expectedValue: true,
       },
     ])('$description', async ({ options, expectedValue }) => {
       const sessionReplay = new SessionReplay();

--- a/test-server/session-replay-browser/sr-shadow-dom-test.html
+++ b/test-server/session-replay-browser/sr-shadow-dom-test.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SR Shadow DOM Test</title>
+  </head>
+  <body>
+    <div id="status">loading</div>
+    <!--
+      Shadow host: a custom element with an adoptedStyleSheet and content inside
+      the shadow root. Used to verify captureAdoptedStyleSheets wiring.
+    -->
+    <div id="shadow-host"></div>
+    <script type="module">
+      import * as sessionReplay from '@amplitude/session-replay-browser';
+
+      window.sessionReplay = sessionReplay;
+
+      const params = new URLSearchParams(location.search);
+      const sessionId = params.has('sessionId') ? Number(params.get('sessionId')) : Date.now();
+      const deviceId = params.get('deviceId') ?? 'test-device-id';
+      const logLevel = params.has('logLevel') ? Number(params.get('logLevel')) : 0;
+      // captureAdoptedStyleSheets: omit param → SDK default (true); pass 'false' to opt out
+      const captureAdoptedStyleSheetsParam = params.get('captureAdoptedStyleSheets');
+      const captureAdoptedStyleSheets =
+        captureAdoptedStyleSheetsParam === null ? undefined : captureAdoptedStyleSheetsParam !== 'false';
+
+      // Build a shadow root with an adoptedStyleSheet before the SDK initializes
+      // so that the full-snapshot captures it.
+      const host = document.getElementById('shadow-host');
+      const shadow = host.attachShadow({ mode: 'open' });
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync('#shadow-content { color: red; font-size: 14px; }');
+      shadow.adoptedStyleSheets = [sheet];
+      const inner = document.createElement('span');
+      inner.id = 'shadow-content';
+      inner.textContent = 'hello from shadow DOM';
+      shadow.appendChild(inner);
+
+      void (async () => {
+        try {
+          const initOptions = {
+            deviceId,
+            sessionId,
+            sampleRate: 1.0,
+            logLevel,
+          };
+          if (captureAdoptedStyleSheets !== undefined) {
+            initOptions.captureAdoptedStyleSheets = captureAdoptedStyleSheets;
+          }
+          await sessionReplay.init('d90c5cf09ca2546a1626272906b99a76', initOptions).promise;
+        } catch (err) {
+          document.getElementById('status').textContent = 'error: ' + err.message;
+          window.srError = err.message;
+        }
+
+        window.srReady = true;
+        document.getElementById('status').textContent = 'ready';
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Summary

Exposes `captureAdoptedStyleSheets` as a user-facing config option in both `session-replay-browser` (standalone) and `plugin-session-replay-browser` (Analytics plugin).

**Background:** [amplitude/rrweb#101](https://github.com/amplitude/rrweb/pull/101) fixes a production issue where `adoptedStyleSheets` on shadow roots were emitted as incremental events via `setTimeout(0)` after the full snapshot. If those events were dropped in transit, shadow DOM styles would be permanently missing from the replay. The fix serializes adopted stylesheet CSS rules **inline** in the full snapshot, making it self-contained.

The new rrweb option `captureAdoptedStyleSheets` (default `true`) controls this behavior. This PR wires it through so callers can opt out if snapshot payload size is a concern.

**Changes:**
- `session-replay-browser`: added `captureAdoptedStyleSheets?: boolean` to `SessionReplayLocalConfig`, `SessionReplayLocalConfig` class, `RecordFunction` type, and the `record()` call
- `plugin-session-replay-browser`: added `captureAdoptedStyleSheets?: boolean` to `SessionReplayOptions` and forwarded it to the standalone SDK init

**Note:** The option has no effect until the rrweb packages are bumped to a version containing amplitude/rrweb#101. Once that PR merges and a new `@amplitude/rrweb-*` alpha is published, the rrweb dependency versions in `packages/session-replay-browser/package.json` need to be updated. Default behavior (inline snapshot) will activate automatically on upgrade; `captureAdoptedStyleSheets: false` reverts to the legacy incremental-event path.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<details>
<summary>AI Prompt</summary>

can we update to this and make it available as an option with the session-replay-browser and the plugin-session-replay-browser? https://github.com/amplitude/rrweb/pull/101 you can create a new ticket for the session replay team if needed

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a backwards-compatible config plumbing change that only affects rrweb recording behavior when the underlying rrweb version supports the flag, with added unit/E2E tests to validate defaults and wiring.
> 
> **Overview**
> Adds a new `captureAdoptedStyleSheets` option (defaulting to `true`) to `session-replay-browser` config, passes it through to rrweb’s `record()` call, and exposes the same option on `plugin-session-replay-browser` while forwarding it into the standalone SDK `init`.
> 
> Extends test coverage with unit tests for default/explicit values, plus a new Playwright shadow DOM E2E and a dedicated `sr-shadow-dom-test.html` page to ensure SDK initialization and snapshot capture work with the option both enabled and disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c731e4d1c1377d30bf6f7a1da1d9d1b061645699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->