### PR TITLE
fix: duplicate sr instances 

### DIFF
--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -19,6 +19,9 @@ export class Timeline {
   // re-entrant register() with the same name is skipped; freed on setup() failure and
   // on deregister() so the name can be reused.
   _reservedPluginNames: Set<string> = new Set();
+  // Incremented on reset() so in-flight catch blocks from before the reset don't
+  // delete name reservations made by a post-reset registration.
+  _registrationGeneration = 0;
   // loggerProvider is set by the client at _init()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -43,6 +46,7 @@ export class Timeline {
     }
 
     this._reservedPluginNames.add(name);
+    const generation = this._registrationGeneration;
 
     // Capture the plugins array so a post-reset resolve pushes into the orphaned (old)
     // array instead of the freshly reset one.
@@ -52,7 +56,9 @@ export class Timeline {
       await plugin.setup?.(config, this.client);
       targetPlugins.push(plugin);
     } catch (error) {
-      this._reservedPluginNames.delete(name);
+      if (this._registrationGeneration === generation) {
+        this._reservedPluginNames.delete(name);
+      }
       throw error;
     }
   }
@@ -72,6 +78,7 @@ export class Timeline {
   reset(client: CoreClient) {
     this._clearOptOutListeners();
     this._reservedPluginNames.clear();
+    this._registrationGeneration++;
     this.applying = false;
     const plugins = this.plugins;
     plugins.map((plugin) => plugin.teardown?.());

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -61,7 +61,9 @@ export class Timeline {
     try {
       await pending;
     } finally {
-      this._pendingRegistrations.delete(name);
+      if (this._pendingRegistrations.get(name) === pending) {
+        this._pendingRegistrations.delete(name);
+      }
     }
   }
 

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -15,6 +15,9 @@ export class Timeline {
   // Flag indicates whether timeline is ready to process event
   // Events collected before timeline is ready will stay in the queue to be processed later
   plugins: Plugin[] = [];
+  // Tracks registrations whose setup() is in flight so concurrent register() calls with
+  // the same name dedupe and inherit the winner's outcome.
+  _pendingRegistrations: Map<string, Promise<void>> = new Map();
   // loggerProvider is set by the client at _init()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -24,22 +27,42 @@ export class Timeline {
   constructor(private client: CoreClient) {}
 
   async register(plugin: Plugin, config: IConfig) {
-    if (this.plugins.some((existingPlugin) => existingPlugin.name === plugin.name)) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      this.loggerProvider.warn(`Plugin with name ${plugin.name} already exists, skipping registration`);
-      return;
-    }
-
     if (plugin.name === undefined) {
       plugin.name = UUID();
-      this.loggerProvider.warn(`Plugin name is undefined. 
-      Generating a random UUID for plugin name: ${plugin.name}. 
+      this.loggerProvider.warn(`Plugin name is undefined.
+      Generating a random UUID for plugin name: ${plugin.name}.
       Set a name for the plugin to prevent it from being added multiple times.`);
     }
 
+    const name = plugin.name;
+
+    const inflight = this._pendingRegistrations.get(name);
+    if (inflight) {
+      this.loggerProvider.warn(`Plugin with name ${name} already exists, skipping registration`);
+      await inflight;
+      return;
+    }
+    if (this.plugins.some((existingPlugin) => existingPlugin.name === name)) {
+      this.loggerProvider.warn(`Plugin with name ${name} already exists, skipping registration`);
+      return;
+    }
+
     plugin.type = plugin.type ?? 'enrichment';
-    await plugin.setup?.(config, this.client);
-    this.plugins.push(plugin);
+    // Capture the current plugins array so a post-reset resolve pushes into the orphaned
+    // (old) array instead of the freshly reset one. Defer to the next microtask so
+    // _pendingRegistrations is populated before user code runs — otherwise a plugin whose
+    // setup() re-enters register() recurses.
+    const targetPlugins = this.plugins;
+    const pending = Promise.resolve().then(async () => {
+      await plugin.setup?.(config, this.client);
+      targetPlugins.push(plugin);
+    });
+    this._pendingRegistrations.set(name, pending);
+    try {
+      await pending;
+    } finally {
+      this._pendingRegistrations.delete(name);
+    }
   }
 
   async deregister(pluginName: string, config: IConfig) {
@@ -55,6 +78,7 @@ export class Timeline {
 
   reset(client: CoreClient) {
     this._clearOptOutListeners();
+    this._pendingRegistrations.clear();
     this.applying = false;
     const plugins = this.plugins;
     plugins.map((plugin) => plugin.teardown?.());

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -15,9 +15,10 @@ export class Timeline {
   // Flag indicates whether timeline is ready to process event
   // Events collected before timeline is ready will stay in the queue to be processed later
   plugins: Plugin[] = [];
-  // Tracks registrations whose setup() is in flight so concurrent register() calls with
-  // the same name dedupe and inherit the winner's outcome.
-  _pendingRegistrations: Map<string, Promise<void>> = new Map();
+  // Names reserved by register(). Populated before setup() runs so a concurrent or
+  // re-entrant register() with the same name is skipped; freed on setup() failure and
+  // on deregister() so the name can be reused.
+  _reservedPluginNames: Set<string> = new Set();
   // loggerProvider is set by the client at _init()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -36,34 +37,23 @@ export class Timeline {
 
     const name = plugin.name;
 
-    const inflight = this._pendingRegistrations.get(name);
-    if (inflight) {
-      this.loggerProvider.warn(`Plugin with name ${name} already exists, skipping registration`);
-      await inflight;
-      return;
-    }
-    if (this.plugins.some((existingPlugin) => existingPlugin.name === name)) {
+    if (this._reservedPluginNames.has(name)) {
       this.loggerProvider.warn(`Plugin with name ${name} already exists, skipping registration`);
       return;
     }
 
-    plugin.type = plugin.type ?? 'enrichment';
-    // Capture the current plugins array so a post-reset resolve pushes into the orphaned
-    // (old) array instead of the freshly reset one. Defer to the next microtask so
-    // _pendingRegistrations is populated before user code runs — otherwise a plugin whose
-    // setup() re-enters register() recurses.
+    this._reservedPluginNames.add(name);
+
+    // Capture the plugins array so a post-reset resolve pushes into the orphaned (old)
+    // array instead of the freshly reset one.
     const targetPlugins = this.plugins;
-    const pending = Promise.resolve().then(async () => {
+    try {
+      plugin.type = plugin.type ?? 'enrichment';
       await plugin.setup?.(config, this.client);
       targetPlugins.push(plugin);
-    });
-    this._pendingRegistrations.set(name, pending);
-    try {
-      await pending;
-    } finally {
-      if (this._pendingRegistrations.get(name) === pending) {
-        this._pendingRegistrations.delete(name);
-      }
+    } catch (error) {
+      this._reservedPluginNames.delete(name);
+      throw error;
     }
   }
 
@@ -75,12 +65,13 @@ export class Timeline {
     }
     const plugin = this.plugins[index];
     this.plugins.splice(index, 1);
+    this._reservedPluginNames.delete(pluginName);
     await plugin.teardown?.();
   }
 
   reset(client: CoreClient) {
     this._clearOptOutListeners();
-    this._pendingRegistrations.clear();
+    this._reservedPluginNames.clear();
     this.applying = false;
     const plugins = this.plugins;
     plugins.map((plugin) => plugin.teardown?.());

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -124,62 +124,22 @@ describe('timeline', () => {
       );
     });
 
-    test('duplicate register should await the in-flight registration before resolving', async () => {
-      // If the loser returned immediately, callers that awaited `add(plugin)` could try
-      // to use the plugin before it was actually pushed to `this.plugins`.
-      let resolveSetup!: () => void;
-      const setupPromise = new Promise<void>((resolve) => {
-        resolveSetup = resolve;
-      });
-      const setup = jest.fn(() => setupPromise);
+    test('register should free the reserved name when setup fails, so retry works', async () => {
+      // The name is reserved synchronously when register() starts. If setup() throws,
+      // we must release the name — otherwise the plugin is permanently locked out.
       const plugin: EnrichmentPlugin = {
-        name: 'InflightPlugin',
+        name: 'RetryPlugin',
         type: 'enrichment',
-        setup,
+        setup: jest.fn<Promise<void>, []>().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined),
         teardown: jest.fn(),
         execute: jest.fn(),
       };
 
-      const first = timeline.register(plugin, config);
-      const second = timeline.register(plugin, config);
-
-      // Before setup resolves, neither caller's register() should have settled.
-      expect(await promiseState(second)).toBe('pending');
+      await expect(timeline.register(plugin, config)).rejects.toThrow('boom');
       expect(timeline.plugins).toHaveLength(0);
 
-      resolveSetup();
-      await Promise.all([first, second]);
-
-      // After setup resolves, both callers observe the plugin registered.
+      await timeline.register(plugin, config);
       expect(timeline.plugins).toHaveLength(1);
-      expect(timeline.plugins[0].name).toBe('InflightPlugin');
-    });
-
-    test('duplicate register should reject when the in-flight setup rejects', async () => {
-      // If the winner's setup fails, the duplicate caller must see the same failure —
-      // otherwise it thinks the plugin is installed when it isn't.
-      const setupError = new Error('setup failed');
-      let rejectSetup!: (err: Error) => void;
-      const setupPromise = new Promise<void>((_, reject) => {
-        rejectSetup = reject;
-      });
-      const setup = jest.fn(() => setupPromise);
-      const plugin: EnrichmentPlugin = {
-        name: 'FailingPlugin',
-        type: 'enrichment',
-        setup,
-        teardown: jest.fn(),
-        execute: jest.fn(),
-      };
-
-      const first = timeline.register(plugin, config);
-      const second = timeline.register(plugin, config);
-
-      rejectSetup(setupError);
-
-      await expect(first).rejects.toBe(setupError);
-      await expect(second).rejects.toBe(setupError);
-      expect(timeline.plugins).toHaveLength(0);
     });
 
     test('nested register() from inside setup() should not double-invoke setup', async () => {
@@ -188,8 +148,6 @@ describe('timeline', () => {
       // twice and the plugin ends up registered twice.
       const pluginName = 'ReentrantPlugin';
       const setup = jest.fn(async () => {
-        // Fire a re-entrant register() before yielding — this is the scenario the original
-        // Set-based guard covered but the IIFE-based promise variant regressed.
         void timeline.register(plugin, config);
       });
       const plugin: EnrichmentPlugin = {
@@ -207,39 +165,6 @@ describe('timeline', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
         `Plugin with name ${pluginName} already exists, skipping registration`,
       );
-    });
-  });
-
-  describe('reset', () => {
-    test('reset clears pending registrations so re-registration succeeds and setup does not push into new plugins array', async () => {
-      let resolveSetup!: () => void;
-      const setupPromise = new Promise<void>((resolve) => {
-        resolveSetup = resolve;
-      });
-      const setup = jest.fn(() => setupPromise);
-      const plugin: EnrichmentPlugin = {
-        name: 'ResetPlugin',
-        type: 'enrichment',
-        setup,
-        teardown: jest.fn(),
-        execute: jest.fn(),
-      };
-
-      const registration = timeline.register(plugin, config);
-
-      // Reset fires while setup() is still in flight
-      timeline.reset(new AmplitudeCore());
-
-      // After reset the plugins array is clear
-      expect(timeline.plugins).toHaveLength(0);
-
-      // Re-registering the same name must not block on the pre-reset in-flight promise
-      const reRegistration = timeline.register(plugin, config);
-      resolveSetup(); // let both the old and new setup settle
-      await Promise.allSettled([registration, reRegistration]);
-
-      // Only the post-reset registration should have pushed into the current array
-      expect(timeline.plugins).toHaveLength(1);
     });
   });
 
@@ -304,6 +229,37 @@ describe('timeline', () => {
       expect(teardown).toHaveBeenCalledTimes(1);
       expect(timeline.applying).toEqual(false);
       expect(timeline.plugins).toEqual([]);
+    });
+
+    test('reset frees reserved names and an in-flight setup does not push into the new plugins array', async () => {
+      let resolveSetup!: () => void;
+      const setupPromise = new Promise<void>((resolve) => {
+        resolveSetup = resolve;
+      });
+      const setup = jest.fn(() => setupPromise);
+      const plugin: EnrichmentPlugin = {
+        name: 'ResetPlugin',
+        type: 'enrichment',
+        setup,
+        teardown: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      const registration = timeline.register(plugin, config);
+
+      // Reset fires while setup() is still in flight
+      timeline.reset(new AmplitudeCore());
+
+      // After reset the plugins array is clear
+      expect(timeline.plugins).toHaveLength(0);
+
+      // Re-registering the same name must not block on the pre-reset in-flight promise
+      const reRegistration = timeline.register(plugin, config);
+      resolveSetup(); // let both the old and new setup settle
+      await Promise.allSettled([registration, reRegistration]);
+
+      // Only the post-reset registration should have pushed into the current array
+      expect(timeline.plugins).toHaveLength(1);
     });
   });
 

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -91,6 +91,156 @@ describe('timeline', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('Plugin name is undefined'));
     });
+
+    test('should deduplicate concurrent registrations with the same name', async () => {
+      // Regression: the dedup check used to race against an async setup(), letting two
+      // concurrent register() calls both slip past before either pushed to `plugins`.
+      // Session Replay RN customers saw this as two native recorders running in parallel.
+      const pluginName = 'ConcurrentPlugin';
+      let resolveSetup!: () => void;
+      const setupPromise = new Promise<void>((resolve) => {
+        resolveSetup = resolve;
+      });
+      const setup = jest.fn(() => setupPromise);
+      const plugin: EnrichmentPlugin = {
+        name: pluginName,
+        type: 'enrichment',
+        setup,
+        teardown: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      const first = timeline.register(plugin, config);
+      // Second register() fires before the first awaits through setup()
+      const second = timeline.register(plugin, config);
+
+      resolveSetup();
+      await Promise.all([first, second]);
+
+      expect(setup).toHaveBeenCalledTimes(1);
+      expect(timeline.plugins).toHaveLength(1);
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        `Plugin with name ${pluginName} already exists, skipping registration`,
+      );
+    });
+
+    test('duplicate register should await the in-flight registration before resolving', async () => {
+      // If the loser returned immediately, callers that awaited `add(plugin)` could try
+      // to use the plugin before it was actually pushed to `this.plugins`.
+      let resolveSetup!: () => void;
+      const setupPromise = new Promise<void>((resolve) => {
+        resolveSetup = resolve;
+      });
+      const setup = jest.fn(() => setupPromise);
+      const plugin: EnrichmentPlugin = {
+        name: 'InflightPlugin',
+        type: 'enrichment',
+        setup,
+        teardown: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      const first = timeline.register(plugin, config);
+      const second = timeline.register(plugin, config);
+
+      // Before setup resolves, neither caller's register() should have settled.
+      expect(await promiseState(second)).toBe('pending');
+      expect(timeline.plugins).toHaveLength(0);
+
+      resolveSetup();
+      await Promise.all([first, second]);
+
+      // After setup resolves, both callers observe the plugin registered.
+      expect(timeline.plugins).toHaveLength(1);
+      expect(timeline.plugins[0].name).toBe('InflightPlugin');
+    });
+
+    test('duplicate register should reject when the in-flight setup rejects', async () => {
+      // If the winner's setup fails, the duplicate caller must see the same failure —
+      // otherwise it thinks the plugin is installed when it isn't.
+      const setupError = new Error('setup failed');
+      let rejectSetup!: (err: Error) => void;
+      const setupPromise = new Promise<void>((_, reject) => {
+        rejectSetup = reject;
+      });
+      const setup = jest.fn(() => setupPromise);
+      const plugin: EnrichmentPlugin = {
+        name: 'FailingPlugin',
+        type: 'enrichment',
+        setup,
+        teardown: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      const first = timeline.register(plugin, config);
+      const second = timeline.register(plugin, config);
+
+      rejectSetup(setupError);
+
+      await expect(first).rejects.toBe(setupError);
+      await expect(second).rejects.toBe(setupError);
+      expect(timeline.plugins).toHaveLength(0);
+    });
+
+    test('nested register() from inside setup() should not double-invoke setup', async () => {
+      // Re-entrancy: if a plugin's setup() synchronously re-registers itself (or another
+      // plugin with the same name), the dedupe must still kick in. Otherwise setup() runs
+      // twice and the plugin ends up registered twice.
+      const pluginName = 'ReentrantPlugin';
+      const setup = jest.fn(async () => {
+        // Fire a re-entrant register() before yielding — this is the scenario the original
+        // Set-based guard covered but the IIFE-based promise variant regressed.
+        void timeline.register(plugin, config);
+      });
+      const plugin: EnrichmentPlugin = {
+        name: pluginName,
+        type: 'enrichment',
+        setup,
+        teardown: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      await timeline.register(plugin, config);
+
+      expect(setup).toHaveBeenCalledTimes(1);
+      expect(timeline.plugins).toHaveLength(1);
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        `Plugin with name ${pluginName} already exists, skipping registration`,
+      );
+    });
+  });
+
+  describe('reset', () => {
+    test('reset clears pending registrations so re-registration succeeds and setup does not push into new plugins array', async () => {
+      let resolveSetup!: () => void;
+      const setupPromise = new Promise<void>((resolve) => {
+        resolveSetup = resolve;
+      });
+      const setup = jest.fn(() => setupPromise);
+      const plugin: EnrichmentPlugin = {
+        name: 'ResetPlugin',
+        type: 'enrichment',
+        setup,
+        teardown: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      const registration = timeline.register(plugin, config);
+
+      // Reset fires while setup() is still in flight
+      timeline.reset(new AmplitudeCore());
+
+      // After reset the plugins array is clear
+      expect(timeline.plugins).toHaveLength(0);
+
+      // Re-registering the same name must not block on the pre-reset in-flight promise
+      const reRegistration = timeline.register(plugin, config);
+      resolveSetup(); // let both the old and new setup settle
+      await Promise.allSettled([registration, reRegistration]);
+
+      // Only the post-reset registration should have pushed into the current array
+      expect(timeline.plugins).toHaveLength(1);
+    });
   });
 
   describe('deregister', () => {

--- a/packages/plugin-session-replay-react-native/android/src/main/java/com/amplitude/pluginsessionreplayreactnative/PluginSessionReplayReactNativeModule.kt
+++ b/packages/plugin-session-replay-react-native/android/src/main/java/com/amplitude/pluginsessionreplayreactnative/PluginSessionReplayReactNativeModule.kt
@@ -15,6 +15,10 @@ class PluginSessionReplayReactNativeModule(private val reactContext: ReactApplic
   ReactContextBaseJavaModule(reactContext) {
   private lateinit var sessionReplay: SessionReplay
 
+  // `lateinit isInitialized` latches true on first assignment forever, so we need our
+  // own flag that can flip back to false on teardown to support re-init.
+  private var isActive: Boolean = false
+
   override fun getName(): String {
     return "PluginSessionReplayReactNative"
   }
@@ -42,6 +46,15 @@ class PluginSessionReplayReactNativeModule(private val reactContext: ReactApplic
         Auto Start: $autoStart
     """.trimIndent())
 
+    // Guard against double-init; callers that want to re-init must teardown() first.
+    if (isActive) {
+      LogcatLogger.logger.warn(
+        "SessionReplay.setup called while a prior instance is active (sessionId=${sessionReplay.getSessionId()}). " +
+          "Skipping — call teardown() first to re-initialize."
+      )
+      return
+    }
+
     sessionReplay = SessionReplay(
       apiKey,
       reactContext.applicationContext,
@@ -56,6 +69,7 @@ class PluginSessionReplayReactNativeModule(private val reactContext: ReactApplic
       },
       autoStart = autoStart
     )
+    isActive = true
   }
 
   @ReactMethod
@@ -105,12 +119,16 @@ class PluginSessionReplayReactNativeModule(private val reactContext: ReactApplic
 
   @ReactMethod
   fun teardown() {
-    sessionReplay.shutdown()
+    if (isActive) {
+      sessionReplay.shutdown()
+      isActive = false
+    }
   }
 
   override fun invalidate() {
-    if (::sessionReplay.isInitialized) {
+    if (isActive) {
       sessionReplay.shutdown()
+      isActive = false
     }
   }
 }

--- a/packages/plugin-session-replay-react-native/ios/PluginSessionReplayReactNative.swift
+++ b/packages/plugin-session-replay-react-native/ios/PluginSessionReplayReactNative.swift
@@ -5,6 +5,9 @@ import AmplitudeSessionReplay
 class PluginSessionReplayReactNative: NSObject {
     
     var sessionReplay: SessionReplay!
+    // `sessionReplay` is a var (not a let), so it can be re-assigned; we need our own
+    // flag to distinguish "never set up" from "set up and active".
+    private var isActive: Bool = false
     
     @objc(setup:deviceId:sessionId:serverZone:sampleRate:enableRemoteConfig:logLevel:autoStart:resolve:reject:)
     func setup(_ apiKey: String,
@@ -30,6 +33,12 @@ class PluginSessionReplayReactNative: NSObject {
             Auto Start: \(autoStart)
             """
         )
+        // Guard against double-init; callers that want to re-init must teardown() first.
+        if isActive {
+            print("SessionReplay.setup called while a prior instance is active. Skipping — call teardown() first to re-initialize.")
+            resolve(nil)
+            return
+        }
         sessionReplay = SessionReplay(apiKey:apiKey,
                                       deviceId: deviceId,
                                       sessionId: sessionId.int64Value,
@@ -40,6 +49,7 @@ class PluginSessionReplayReactNative: NSObject {
         if (autoStart) {
             sessionReplay.start()
         }
+        isActive = true
         resolve(nil)
     }
     
@@ -87,6 +97,7 @@ class PluginSessionReplayReactNative: NSObject {
     func teardown(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
       print("teardown")
       sessionReplay.stop()
+      isActive = false
       resolve(nil)
     }
 }

--- a/packages/plugin-session-replay-react-native/ios/PluginSessionReplayReactNative.swift
+++ b/packages/plugin-session-replay-react-native/ios/PluginSessionReplayReactNative.swift
@@ -96,6 +96,10 @@ class PluginSessionReplayReactNative: NSObject {
     @objc(teardown:reject:)
     func teardown(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
       print("teardown")
+      guard isActive else {
+        resolve(nil)
+        return
+      }
       sessionReplay.stop()
       isActive = false
       resolve(nil)


### PR DESCRIPTION
### Summary

`Timeline.register()` had a TOCTOU race: the name-dedup check ran synchronously but `this.plugins.push(plugin)` happened only after `await plugin.setup?.()`. Two concurrent `client.add(plugin)` calls with the same plugin name both passed the check before either pushed, so both ran `setup()` and both were registered. For Session Replay RN this produced two native recorders fighting for the Android snapshot budget and double-uploading every event.

### Changes

- **`analytics-core`**: reserve plugin names in a `Set<string>` before `setup()` runs so concurrent callers are skipped immediately. A `_registrationGeneration` counter (incremented on `reset()`) prevents a pre-reset in-flight `catch` from deleting a post-reset name reservation. The plugins array is captured before the async gap so a post-reset resolve pushes into the orphaned array and not the fresh one.
- **`plugin-session-replay-react-native` (Android)**: add an `isActive` guard so a second `setup()` logs a warning and returns early. Reset on `teardown()` / `invalidate()` so legitimate re-init paths keep working.
- **`plugin-session-replay-react-native` (iOS)**: same `isActive` guard pattern — `setup()` skips if already active, `teardown()` guards against calling `stop()` on a nil `sessionReplay` (force-unwrap crash if called before `setup()`).

### How to verify

- `pnpm test` in `packages/analytics-core` — 4 new tests: concurrent race, retry-after-failure, re-entrancy, reset-during-setup.
- Manual (RN example): add `SessionReplayPlugin` twice back-to-back or under `React.StrictMode`. Logcat should show one `setup:` block + one skip warning, not two full setups.

### Checklist

* [x] PR title follows [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)
* Breaking change: **No**