### PR TITLE
feat(session-replay-browser): add @since annotation for urlMaskLevels (SR-3716)

### DIFF
--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -73,6 +73,8 @@ export type PrivacyConfig = {
    *   { match: 'https://example.com/checkout/*', maskLevel: 'conservative' },
    *   { match: 'https://example.com/public/*',   maskLevel: 'light' },
    * ]
+   *
+   * @since session-replay-browser@1.37.0 / plugin-session-replay-browser@1.27.10
    */
   urlMaskLevels?: Array<{ match: string; maskLevel: MaskLevel }>;
 };


### PR DESCRIPTION
## Summary

Adds a `@since` JSDoc annotation to the `urlMaskLevels` property in `PrivacyConfig` so IDE users see the minimum SDK version required to use this option.

**Minimum version requirements:**

| Package | Minimum Version |
|---|---|
| `@amplitude/session-replay-browser` | `1.37.0` |
| `@amplitude/plugin-session-replay-browser` | `1.27.10` |

Resolves [SR-3716](https://linear.app/amplitude/issue/SR-3716).

## Changes

- `packages/session-replay-browser/src/config/types.ts`: added `@since session-replay-browser@1.37.0 / plugin-session-replay-browser@1.27.10` to the existing JSDoc block for `urlMaskLevels`.

## Test plan

- [ ] Verify IDE (VSCode / WebStorm) shows the `@since` tooltip when hovering over `urlMaskLevels` in a consuming project
- [ ] Confirm no TS compilation errors (`tsc --noEmit`)
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a documentation-only JSDoc change and does not affect runtime behavior or TypeScript types.
> 
> **Overview**
> Adds a JSDoc `@since` annotation to `PrivacyConfig.urlMaskLevels` to document the minimum supported SDK versions (`session-replay-browser@1.37.0` / `plugin-session-replay-browser@1.27.10`) for IDE/tooling visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca13e4078a6d29eab9193b9c86450c1e17a240e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->