### PR TITLE
feat(session-replay-browser): merge consecutive mutation incremental snapshots

### DIFF
--- a/packages/session-replay-browser/e2e/mutation-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/mutation-merge.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * End-to-end tests for the mutation-merge feature (SR-3752).
+ *
+ * DRAIN STRATEGY
+ * ──────────────
+ * The EventCompressor routes non-snapshot events through a pendingQueue that
+ * is processed (merged) only by two paths:
+ *   1. An idle-callback call to processQueue()
+ *   2. A FullSnapshot event, which synchronously drains pendingQueue via
+ *      mergeMutationTasks() before emitting the snapshot.
+ *
+ * Relying on path 1 is inherently timing-sensitive: requestIdleCallback can
+ * fire between Playwright evaluate() calls (during the ~2 ms CDP roundtrip),
+ * splitting events into separate merge windows.  All tests here instead
+ * trigger a focus event — which causes the SDK to take a FullSnapshot — to
+ * reliably flush pendingQueue through the merge path before calling flush().
+ *
+ * MO BATCH NOTES
+ * ──────────────
+ * Mutations made synchronously within a single evaluate() call all land in
+ * one MutationObserver batch → one rrweb event.  Tests that exercise the
+ * multi-event merge path (cross-batch) use separate evaluate() calls so MO
+ * fires between them.  The pre-existing-transient test is intentionally
+ * structured with separate calls and is proven correct for any timing split
+ * of the three events.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  captureTrackRequests,
+} from './helpers';
+
+const MUTATION_SOURCE = 0; // IncrementalSource.Mutation
+const EVENT_INCREMENTAL_SNAPSHOT = 3;
+
+interface RrwebAdd {
+  parentId: number;
+  nextId: number | null;
+  node: {
+    id: number;
+    attributes?: Record<string, string>;
+    [key: string]: unknown;
+  };
+}
+
+interface RrwebRemove {
+  parentId: number;
+  id: number;
+}
+
+interface MutationData {
+  source: number;
+  adds: RrwebAdd[];
+  removes: RrwebRemove[];
+  texts: unknown[];
+  attributes: unknown[];
+}
+
+function decodeMutationEvents(rawBodies: string[]): MutationData[] {
+  const results: MutationData[] = [];
+  for (const body of rawBodies) {
+    if (!body) continue;
+    let payload: { events?: unknown[] };
+    try {
+      payload = JSON.parse(body) as { events?: unknown[] };
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(payload.events)) continue;
+    for (const eventStr of payload.events) {
+      if (typeof eventStr !== 'string') continue;
+      try {
+        const event = JSON.parse(eventStr) as { type: number; data: MutationData };
+        if (event.type === EVENT_INCREMENTAL_SNAPSHOT && event.data.source === MUTATION_SOURCE) {
+          results.push(event.data);
+        }
+      } catch {
+        // skip unparseable
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Triggers a window focus event, causing the SDK to take a FullSnapshot.
+ * The FullSnapshot path in EventCompressor synchronously drains pendingQueue
+ * through mergeMutationTasks(), so all pending mutation events are processed
+ * (and merged) before this call returns.
+ */
+async function drainPendingMutations(page: Page): Promise<void> {
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+}
+
+async function flushAndCapture(page: Page): Promise<void> {
+  await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+  await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+}
+
+// ─── mutation merge — SR-3752 ──────────────────────────────────────────────────
+
+test.describe('mutation merge', () => {
+  /**
+   * Basic capture smoke test: multiple synchronous DOM mutations (one MO batch →
+   * one rrweb event) are captured and delivered to the track API.
+   */
+  test('captures synchronous DOM mutations and delivers them to the API', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // All three mutations are synchronous → one MO batch → one rrweb event.
+    await page.evaluate(() => {
+      document.body.appendChild(Object.assign(document.createElement('div'), { id: 'mm-node-1' }));
+      document.body.appendChild(Object.assign(document.createElement('div'), { id: 'mm-node-2' }));
+      document.body.appendChild(Object.assign(document.createElement('div'), { id: 'mm-node-3' }));
+    });
+
+    await drainPendingMutations(page);
+    await flushAndCapture(page);
+
+    const allAdds = decodeMutationEvents(getBodies()).flatMap((e) => e.adds);
+
+    expect(allAdds.some((a) => a.node.attributes?.id === 'mm-node-1')).toBe(true);
+    expect(allAdds.some((a) => a.node.attributes?.id === 'mm-node-2')).toBe(true);
+    expect(allAdds.some((a) => a.node.attributes?.id === 'mm-node-3')).toBe(true);
+  });
+
+  /**
+   * A node added and removed within the same MO batch is purely transient.
+   * rrweb's own mutation handler elides same-batch transient nodes, so no add
+   * or remove for the node should appear in the captured events.
+   */
+  test('elides transient node added and removed in the same MO batch', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Synchronous add then remove → same MO batch; rrweb sees net zero for this node.
+    await page.evaluate(() => {
+      const el = Object.assign(document.createElement('div'), { id: 'mm-transient' });
+      document.body.appendChild(el);
+      document.body.removeChild(el);
+    });
+
+    await drainPendingMutations(page);
+    await flushAndCapture(page);
+
+    const mutationEvents = decodeMutationEvents(getBodies());
+    const allAdds = mutationEvents.flatMap((e) => e.adds);
+    const allRemoves = mutationEvents.flatMap((e) => e.removes);
+
+    // Transient node must not appear in adds or removes.
+    expect(allAdds.some((a) => a.node.attributes?.id === 'mm-transient')).toBe(false);
+    // No other mutations occurred; removes should be empty too.
+    expect(allRemoves).toHaveLength(0);
+  });
+
+  /**
+   * A pre-existing DOM node (present in the initial full snapshot) that is
+   * removed, re-added, then removed again: our merge code should cancel the
+   * re-add cycle while preserving the original removal.
+   *
+   * This test uses three separate evaluate() calls so that each mutation lands
+   * in its own MO batch (→ separate rrweb events), exercising the cross-event
+   * merge path.
+   *
+   * requestIdleCallback is frozen before the mutations so that all three events
+   * accumulate in pendingQueue rather than being split across multiple merge
+   * windows by the idle scheduler firing between evaluate() calls.
+   * drainPendingMutations then flushes the complete window via the FullSnapshot
+   * path, which synchronously merges all three events together.
+   */
+  test('preserves pre-existing node original removal when re-add is cancelled', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Freeze idle processing so all three mutation events accumulate in
+    // pendingQueue and are merged together by drainPendingMutations below.
+    // Without this, requestIdleCallback can fire in the ~2 ms CDP gap between
+    // evaluate() calls, processing events 1+2 as a partial window and
+    // misclassifying test-input as "ultimately present".
+    await page.evaluate(() => {
+      window.requestIdleCallback = () => 0;
+    });
+
+    // Stash a reference to the pre-existing element so it survives removal from the DOM.
+    await page.evaluate(() => {
+      (window as any).__preEl = document.getElementById('test-input') as HTMLElement;
+      document.body.removeChild((window as any).__preEl as Node); // original remove
+    });
+    await page.evaluate(() => {
+      document.body.appendChild((window as any).__preEl as Node);
+    }); // re-add
+    await page.evaluate(() => {
+      document.body.removeChild((window as any).__preEl as Node);
+    }); // final remove
+
+    // drainPendingMutations triggers a FullSnapshot which synchronously flushes
+    // pendingQueue through mergeMutationTasks(), merging the three events.
+    await drainPendingMutations(page);
+    await flushAndCapture(page);
+
+    const mutationEvents = decodeMutationEvents(getBodies());
+    const allAdds = mutationEvents.flatMap((e) => e.adds);
+    const allRemoves = mutationEvents.flatMap((e) => e.removes);
+
+    // The re-add should be cancelled — test-input must not appear in any adds.
+    expect(allAdds.some((a) => a.node.attributes?.id === 'test-input')).toBe(false);
+    // The original removal should be preserved — exactly one remove entry.
+    expect(allRemoves).toHaveLength(1);
+  });
+
+  /**
+   * A DOM move (remove from one parent, add under a different parent) is not
+   * a transient operation: both the remove and the re-add must be preserved so
+   * the replayer can reproduce the move.
+   */
+  test('preserves DOM moves (remove from one parent, add under another)', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // All mutations synchronous → one MO batch → one rrweb event containing
+    // both the new container (add) and the moved node (remove + add).
+    await page.evaluate(() => {
+      const container = Object.assign(document.createElement('div'), { id: 'mm-move-target' });
+      document.body.appendChild(container);
+      const el = document.getElementById('test-input') as HTMLElement;
+      document.body.removeChild(el);
+      container.appendChild(el);
+    });
+
+    await drainPendingMutations(page);
+    await flushAndCapture(page);
+
+    const mutationEvents = decodeMutationEvents(getBodies());
+    const allAdds = mutationEvents.flatMap((e) => e.adds);
+    const allRemoves = mutationEvents.flatMap((e) => e.removes);
+
+    // New container should be in adds.
+    expect(allAdds.some((a) => a.node.attributes?.id === 'mm-move-target')).toBe(true);
+    // Moved node should appear in both adds (new location) and removes (old location).
+    expect(allAdds.some((a) => a.node.attributes?.id === 'test-input')).toBe(true);
+    expect(allRemoves.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/session-replay-browser/e2e/mutation-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/mutation-merge.spec.ts
@@ -187,7 +187,9 @@ test.describe('mutation merge', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID, mergeMutations: true }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 

--- a/packages/session-replay-browser/e2e/mutation-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/mutation-merge.spec.ts
@@ -20,9 +20,9 @@
  * Mutations made synchronously within a single evaluate() call all land in
  * one MutationObserver batch → one rrweb event.  Tests that exercise the
  * multi-event merge path (cross-batch) use separate evaluate() calls so MO
- * fires between them.  The pre-existing-transient test is intentionally
- * structured with separate calls and is proven correct for any timing split
- * of the three events.
+ * fires between them.  The pre-existing-transient test freezes
+ * requestIdleCallback before the mutations to guarantee all three events
+ * accumulate in pendingQueue and are merged in a single window.
  */
 
 import { test, expect, Page } from '@playwright/test';

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -276,6 +276,12 @@ export interface SessionReplayPerformanceConfig {
    */
   timeout?: number;
   /**
+   * If enabled, consecutive mutation events will be merged into a single event before
+   * compression, reducing stored event count without changing replay semantics.
+   * Defaults to false.
+   */
+  mergeMutations?: boolean;
+  /**
    * Performance configuration for interaction tracking (clicks, scrolls).
    */
   interaction?: InteractionPerformanceConfig;

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -13,6 +13,7 @@ interface TaskQueue {
 const DEFAULT_TIMEOUT = 2000;
 export class EventCompressor {
   taskQueue: TaskQueue[] = [];
+  pendingQueue: TaskQueue[] = [];
   isProcessing = false;
   eventsManager?: SessionReplayEventsManager<'replay' | 'interaction', string>;
   config: SessionReplayJoinedConfig;
@@ -89,8 +90,9 @@ export class EventCompressor {
       // Those events reference the pre-snapshot DOM and must be sent before
       // the full snapshot; if we let them be processed later they'd arrive at
       // the server after the snapshot and cause "node not found" replay errors.
-      if (this.taskQueue.length > 0) {
-        for (const task of this.mergeMutationTasks(this.taskQueue.splice(0))) {
+      if (this.taskQueue.length > 0 || this.pendingQueue.length > 0) {
+        const allTasks = [...this.taskQueue.splice(0), ...this.mergeMutationTasks(this.pendingQueue.splice(0))];
+        for (const task of allTasks) {
           const compressed = this.compressEvent(task.event);
           this.addCompressedEventToManager(compressed, task.sessionId);
         }
@@ -104,7 +106,7 @@ export class EventCompressor {
 
     if (this.canUseIdleCallback && this.config.performanceConfig?.enabled) {
       this.config.loggerProvider.debug('Enqueuing event for processing during idle time.');
-      this.taskQueue.push({ event, sessionId });
+      this.pendingQueue.push({ event, sessionId });
       this.scheduleIdleProcessing();
     } else {
       this.config.loggerProvider.debug('Processing event without idle callback.');
@@ -114,7 +116,12 @@ export class EventCompressor {
 
   // Process the task queue during idle time
   public processQueue(idleDeadline: IdleDeadline): void {
-    this.taskQueue = this.mergeMutationTasks(this.taskQueue);
+    // Merge newly-arrived pending events and append to the already-merged taskQueue.
+    // Keeping them separate prevents re-merging already-merged tasks on subsequent calls,
+    // which would corrupt move semantics for nodes that appear in multiple merge passes.
+    if (this.pendingQueue.length > 0) {
+      this.taskQueue.push(...this.mergeMutationTasks(this.pendingQueue.splice(0)));
+    }
     // Process tasks while there's idle time or until the max number of tasks is reached
     while (this.taskQueue.length > 0 && (idleDeadline.timeRemaining() > 0 || idleDeadline.didTimeout)) {
       const task = this.taskQueue.shift();
@@ -125,7 +132,7 @@ export class EventCompressor {
     }
 
     // If there are still tasks in the queue, schedule the next idle callback
-    if (this.taskQueue.length > 0) {
+    if (this.taskQueue.length > 0 || this.pendingQueue.length > 0) {
       requestIdleCallback(
         (idleDeadline) => {
           this.processQueue(idleDeadline);

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -187,7 +187,9 @@ export class EventCompressor {
 
   // Merge consecutive mutation tasks with the same sessionId before processing,
   // reducing the number of events serialized and stored without changing replay semantics.
+  // Only runs when performanceConfig.mergeMutations is explicitly enabled.
   private mergeMutationTasks(tasks: TaskQueue[]): TaskQueue[] {
+    if (!this.config.performanceConfig?.mergeMutations) return tasks;
     if (tasks.length <= 1) return tasks;
 
     const result: TaskQueue[] = [];

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -3,6 +3,7 @@ import { EventType as RRWebEventType } from '@amplitude/rrweb-types';
 import type { eventWithTime } from '@amplitude/rrweb-types';
 import { SessionReplayJoinedConfig } from '../config/types';
 import { SessionReplayEventsManager } from '../typings/session-replay';
+import { mergeMutationEvents } from './merge-mutation-events';
 
 interface TaskQueue {
   event: eventWithTime;
@@ -89,7 +90,7 @@ export class EventCompressor {
       // the full snapshot; if we let them be processed later they'd arrive at
       // the server after the snapshot and cause "node not found" replay errors.
       if (this.taskQueue.length > 0) {
-        for (const task of this.taskQueue.splice(0)) {
+        for (const task of this.mergeMutationTasks(this.taskQueue.splice(0))) {
           const compressed = this.compressEvent(task.event);
           this.addCompressedEventToManager(compressed, task.sessionId);
         }
@@ -113,6 +114,7 @@ export class EventCompressor {
 
   // Process the task queue during idle time
   public processQueue(idleDeadline: IdleDeadline): void {
+    this.taskQueue = this.mergeMutationTasks(this.taskQueue);
     // Process tasks while there's idle time or until the max number of tasks is reached
     while (this.taskQueue.length > 0 && (idleDeadline.timeRemaining() > 0 || idleDeadline.didTimeout)) {
       const task = this.taskQueue.shift();
@@ -175,6 +177,35 @@ export class EventCompressor {
       this.addCompressedEventToManager(compressedEvent, sessionId);
     }
   };
+
+  // Merge consecutive mutation tasks with the same sessionId before processing,
+  // reducing the number of events serialized and stored without changing replay semantics.
+  private mergeMutationTasks(tasks: TaskQueue[]): TaskQueue[] {
+    if (tasks.length <= 1) return tasks;
+
+    const result: TaskQueue[] = [];
+    let i = 0;
+
+    while (i < tasks.length) {
+      const sessionId = tasks[i].sessionId;
+
+      // Find the end of the current session run
+      let j = i + 1;
+      while (j < tasks.length && tasks[j].sessionId === sessionId) {
+        j++;
+      }
+
+      // Merge consecutive mutations within this session run; non-mutations pass through unchanged
+      const merged = mergeMutationEvents(tasks.slice(i, j).map((t) => t.event));
+      for (const event of merged) {
+        result.push({ event, sessionId });
+      }
+
+      i = j;
+    }
+
+    return result;
+  }
 
   public terminate = () => {
     this.worker?.terminate();

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -75,7 +75,17 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
           !preExistingTransientIds.has(nodeId) &&
           (transientIds.has(parentId) || preExistingTransientIds.has(parentId))
         ) {
-          transientIds.add(nodeId);
+          const nodeFirstRemoveIdx = firstRemoveEventIndex.get(nodeId);
+          const nodeFirstAddIdx = firstAddEventIndex.get(nodeId);
+          if (
+            nodeFirstRemoveIdx !== undefined &&
+            nodeFirstAddIdx !== undefined &&
+            nodeFirstRemoveIdx < nodeFirstAddIdx
+          ) {
+            preExistingTransientIds.add(nodeId);
+          } else {
+            transientIds.add(nodeId);
+          }
           changed = true;
         }
       }

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -17,12 +17,30 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   // would otherwise have its remove execute before its add (since we put all removes
   // first), leaving the node permanently in the DOM. Cancel both the add and the remove,
   // and cascade to any adds whose parent is also transient.
-  const removedIds = new Set(allRemoves.map((r) => r.id));
+  //
+  // Order matters: a node removed in event1 and re-added in event2 (a DOM move) must NOT
+  // be elided. We track the first event index each node is added and the last event index
+  // it is removed; a node is transient only when addIdx < removeIdx.
+  const firstAddEventIndex = new Map<number, number>();
+  const lastRemoveEventIndex = new Map<number, number>();
+  events.forEach((e, i) => {
+    const data = e.data as mutationData;
+    for (const add of data.adds) {
+      if (!firstAddEventIndex.has(add.node.id)) firstAddEventIndex.set(add.node.id, i);
+    }
+    for (const remove of data.removes) {
+      lastRemoveEventIndex.set(remove.id, i);
+    }
+  });
+
   const transientIds = new Set<number>();
-  for (const add of allAdds) {
-    if (removedIds.has(add.node.id)) transientIds.add(add.node.id);
+  for (const [id, addIdx] of firstAddEventIndex) {
+    const removeIdx = lastRemoveEventIndex.get(id);
+    if (removeIdx !== undefined && addIdx < removeIdx) transientIds.add(id);
   }
+
   if (transientIds.size > 0) {
+    // Cascade: children of a transient parent would be orphaned after elision
     let changed = true;
     while (changed) {
       changed = false;
@@ -35,12 +53,15 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
     }
   }
 
+  const allTexts = events.flatMap((e) => (e.data as mutationData).texts);
+  const allAttributes = events.flatMap((e) => (e.data as mutationData).attributes);
+
   const merged: mutationData = {
     source: IncrementalSource.Mutation,
     removes: transientIds.size > 0 ? allRemoves.filter((r) => !transientIds.has(r.id)) : allRemoves,
     adds: transientIds.size > 0 ? allAdds.filter((a) => !transientIds.has(a.node.id)) : allAdds,
-    texts: events.flatMap((e) => (e.data as mutationData).texts),
-    attributes: events.flatMap((e) => (e.data as mutationData).attributes),
+    texts: transientIds.size > 0 ? allTexts.filter((t) => !transientIds.has(t.id)) : allTexts,
+    attributes: transientIds.size > 0 ? allAttributes.filter((a) => !transientIds.has(a.id)) : allAttributes,
   };
   return { ...first, data: merged } as eventWithTime;
 }

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -10,27 +10,12 @@ function isMergeableMutation(event: eventWithTime): boolean {
 function mergeGroup(events: eventWithTime[]): eventWithTime {
   const first = events[0];
 
-  const allRemoves = events.flatMap((e) => (e.data as mutationData).removes);
-  const allAdds = events.flatMap((e) => (e.data as mutationData).adds);
-
-  // Elide transient nodes: a node added in an earlier event and removed in a later one
-  // would otherwise have its remove execute before its add (since we put all removes
-  // first), leaving the node permanently in the DOM. Cancel both the add and the remove,
-  // and cascade to any adds whose parent is also transient.
-  //
-  // Order matters: a node removed in event1 and re-added in event2 (a DOM move) must NOT
-  // be elided. We track the LAST event index each node is added and the last event index
-  // it is removed; a node is transient only when lastAddIdx < lastRemoveIdx.
-  //
-  // Using lastAddIdx (not firstAddIdx) correctly handles add-then-move sequences: when a
-  // node is created in event0 and moved (remove+re-add) in event1, lastAddIdx=1 equals
-  // lastRemoveIdx=1 so the node is not transient and the move is preserved.
+  // Track first/last event index for each node's adds and removes.
+  // lastParentById: final parent from most recent add (last-write-wins).
   const firstAddEventIndex = new Map<number, number>();
   const lastAddEventIndex = new Map<number, number>();
   const firstRemoveEventIndex = new Map<number, number>();
   const lastRemoveEventIndex = new Map<number, number>();
-  // lastParentById: a node's parentId from its most recent add (last-write-wins).
-  // Used in the cascade so a child moved away from a transient parent is not wrongly elided.
   const lastParentById = new Map<number, number>();
   events.forEach((e, i) => {
     const data = e.data as mutationData;
@@ -45,27 +30,49 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
     }
   });
 
+  // Classify nodes that appear in both adds and removes within this window:
+  //
+  // Pure transient:          created here (firstAddIdx < firstRemoveIdx) and ultimately removed
+  //                          (lastAddIdx < lastRemoveIdx). Cancel all adds + all removes.
+  //
+  // Pre-existing transient:  pre-existed in DOM (firstRemoveIdx < firstAddIdx — removed before
+  //                          first add), then re-added, then removed again (lastAddIdx < lastRemoveIdx).
+  //                          The rrweb replayer processes all removes first: the re-add would still
+  //                          execute after both removes, leaving the node present when it should be
+  //                          absent. Fix: cancel the re-add and all post-add removes; keep only the
+  //                          pre-add removes (they represent the legitimate removal from the original
+  //                          location).
   const transientIds = new Set<number>();
-  for (const [id, addIdx] of lastAddEventIndex) {
-    const removeIdx = lastRemoveEventIndex.get(id);
-    if (removeIdx === undefined) continue;
-    // A node is transient only when it was first seen as an add (not pre-existing).
-    // If firstRemoveIdx < firstAddIdx the node pre-existed and was removed before being
-    // re-added; marking it transient would incorrectly drop the pre-existing remove.
-    const firstAddIdx = firstAddEventIndex.get(id)!;
-    const firstRemoveIdx = firstRemoveEventIndex.get(id)!;
-    if (addIdx < removeIdx && firstAddIdx < firstRemoveIdx) transientIds.add(id);
+  const preExistingTransientIds = new Set<number>();
+
+  for (const [id, firstAddIdx] of firstAddEventIndex) {
+    const firstRemoveIdx = firstRemoveEventIndex.get(id);
+    if (firstRemoveIdx === undefined) continue;
+    const lastAddIdx = lastAddEventIndex.get(id)!;
+    const lastRemoveIdx = lastRemoveEventIndex.get(id)!;
+    if (lastAddIdx >= lastRemoveIdx) continue; // ultimately present — keep as-is
+
+    if (firstAddIdx < firstRemoveIdx) {
+      transientIds.add(id);
+    } else {
+      // firstRemoveIdx < firstAddIdx: pre-existing node removed, re-added, then removed again
+      preExistingTransientIds.add(id);
+    }
   }
 
-  if (transientIds.size > 0) {
-    // Cascade: children whose FINAL parent is transient would be orphaned after elision.
-    // Use lastParentById (not allAdds) so a node moved away from a transient parent
-    // to a non-transient parent is not incorrectly elided.
+  // Cascade: nodes whose FINAL parent is effectively cancelled (transient or pre-existing-transient)
+  // would be orphaned, so treat them as pure transients too.
+  // Use lastParentById so a node moved away from a cancelled parent to a live one is not wrongly elided.
+  if (transientIds.size > 0 || preExistingTransientIds.size > 0) {
     let changed = true;
     while (changed) {
       changed = false;
       for (const [nodeId, parentId] of lastParentById) {
-        if (!transientIds.has(nodeId) && transientIds.has(parentId)) {
+        if (
+          !transientIds.has(nodeId) &&
+          !preExistingTransientIds.has(nodeId) &&
+          (transientIds.has(parentId) || preExistingTransientIds.has(parentId))
+        ) {
           transientIds.add(nodeId);
           changed = true;
         }
@@ -73,15 +80,37 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
     }
   }
 
+  const needsFilter = transientIds.size > 0 || preExistingTransientIds.size > 0;
+
+  // Build filtered removes by iterating per event so we know each remove's event index.
+  // Pure transients:          drop all removes.
+  // Pre-existing transients:  drop removes at eventIdx >= firstAddIdx (the cancelled re-add cycle);
+  //                           keep removes at eventIdx < firstAddIdx (legitimate pre-window removal).
+  const filteredRemoves: mutationData['removes'][0][] = [];
+  events.forEach((e, eventIdx) => {
+    for (const r of (e.data as mutationData).removes) {
+      if (transientIds.has(r.id)) continue;
+      if (preExistingTransientIds.has(r.id) && eventIdx >= firstAddEventIndex.get(r.id)!) continue;
+      filteredRemoves.push(r);
+    }
+  });
+
+  const allAdds = events.flatMap((e) => (e.data as mutationData).adds);
   const allTexts = events.flatMap((e) => (e.data as mutationData).texts);
   const allAttributes = events.flatMap((e) => (e.data as mutationData).attributes);
 
   const merged: mutationData = {
     source: IncrementalSource.Mutation,
-    removes: transientIds.size > 0 ? allRemoves.filter((r) => !transientIds.has(r.id)) : allRemoves,
-    adds: transientIds.size > 0 ? allAdds.filter((a) => !transientIds.has(a.node.id)) : allAdds,
-    texts: transientIds.size > 0 ? allTexts.filter((t) => !transientIds.has(t.id)) : allTexts,
-    attributes: transientIds.size > 0 ? allAttributes.filter((a) => !transientIds.has(a.id)) : allAttributes,
+    removes: filteredRemoves,
+    adds: needsFilter
+      ? allAdds.filter((a) => !transientIds.has(a.node.id) && !preExistingTransientIds.has(a.node.id))
+      : allAdds,
+    texts: needsFilter
+      ? allTexts.filter((t) => !transientIds.has(t.id) && !preExistingTransientIds.has(t.id))
+      : allTexts,
+    attributes: needsFilter
+      ? allAttributes.filter((a) => !transientIds.has(a.id) && !preExistingTransientIds.has(a.id))
+      : allAttributes,
   };
   return { ...first, data: merged } as eventWithTime;
 }

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -1,0 +1,52 @@
+import { EventType, IncrementalSource } from '@amplitude/rrweb-types';
+import type { eventWithTime, mutationData } from '@amplitude/rrweb-types';
+
+function isMergeableMutation(event: eventWithTime): boolean {
+  if (event.type !== EventType.IncrementalSnapshot) return false;
+  const data = event.data as mutationData;
+  return data.source === IncrementalSource.Mutation && !data.isAttachIframe;
+}
+
+function mergeGroup(events: eventWithTime[]): eventWithTime {
+  const first = events[0];
+  const merged: mutationData = {
+    source: IncrementalSource.Mutation,
+    removes: events.flatMap((e) => (e.data as mutationData).removes),
+    adds: events.flatMap((e) => (e.data as mutationData).adds),
+    texts: events.flatMap((e) => (e.data as mutationData).texts),
+    attributes: events.flatMap((e) => (e.data as mutationData).attributes),
+  };
+  return { ...first, data: merged } as eventWithTime;
+}
+
+/**
+ * Merges consecutive IncrementalSnapshot mutation events into a single event,
+ * reducing overall event count without changing replay semantics.
+ *
+ * isAttachIframe events are never merged — they carry a full iframe document
+ * tree and must remain isolated.
+ */
+export function mergeMutationEvents(events: eventWithTime[]): eventWithTime[] {
+  if (events.length <= 1) return events;
+
+  const result: eventWithTime[] = [];
+  let i = 0;
+
+  while (i < events.length) {
+    if (!isMergeableMutation(events[i])) {
+      result.push(events[i]);
+      i++;
+      continue;
+    }
+
+    let j = i + 1;
+    while (j < events.length && isMergeableMutation(events[j])) {
+      j++;
+    }
+
+    result.push(j > i + 1 ? mergeGroup(events.slice(i, j)) : events[i]);
+    i = j;
+  }
+
+  return result;
+}

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -54,10 +54,12 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
 
     if (firstAddIdx < firstRemoveIdx) {
       transientIds.add(id);
-    } else {
+    } else if (firstRemoveIdx < firstAddIdx) {
       // firstRemoveIdx < firstAddIdx: pre-existing node removed, re-added, then removed again
       preExistingTransientIds.add(id);
     }
+    // firstAddIdx === firstRemoveIdx: same-event move (remove+add in one rrweb event) followed
+    // by a later remove — keep all operations so the move and final removal survive
   }
 
   // Cascade: nodes whose FINAL parent is effectively cancelled (transient or pre-existing-transient)

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -27,10 +27,14 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   // lastRemoveIdx=1 so the node is not transient and the move is preserved.
   const lastAddEventIndex = new Map<number, number>();
   const lastRemoveEventIndex = new Map<number, number>();
+  // lastParentById: a node's parentId from its most recent add (last-write-wins).
+  // Used in the cascade so a child moved away from a transient parent is not wrongly elided.
+  const lastParentById = new Map<number, number>();
   events.forEach((e, i) => {
     const data = e.data as mutationData;
     for (const add of data.adds) {
       lastAddEventIndex.set(add.node.id, i);
+      lastParentById.set(add.node.id, add.parentId);
     }
     for (const remove of data.removes) {
       lastRemoveEventIndex.set(remove.id, i);
@@ -44,13 +48,15 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   }
 
   if (transientIds.size > 0) {
-    // Cascade: children of a transient parent would be orphaned after elision
+    // Cascade: children whose FINAL parent is transient would be orphaned after elision.
+    // Use lastParentById (not allAdds) so a node moved away from a transient parent
+    // to a non-transient parent is not incorrectly elided.
     let changed = true;
     while (changed) {
       changed = false;
-      for (const add of allAdds) {
-        if (!transientIds.has(add.node.id) && transientIds.has(add.parentId)) {
-          transientIds.add(add.node.id);
+      for (const [nodeId, parentId] of lastParentById) {
+        if (!transientIds.has(nodeId) && transientIds.has(parentId)) {
+          transientIds.add(nodeId);
           changed = true;
         }
       }

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -19,14 +19,18 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   // and cascade to any adds whose parent is also transient.
   //
   // Order matters: a node removed in event1 and re-added in event2 (a DOM move) must NOT
-  // be elided. We track the first event index each node is added and the last event index
-  // it is removed; a node is transient only when addIdx < removeIdx.
-  const firstAddEventIndex = new Map<number, number>();
+  // be elided. We track the LAST event index each node is added and the last event index
+  // it is removed; a node is transient only when lastAddIdx < lastRemoveIdx.
+  //
+  // Using lastAddIdx (not firstAddIdx) correctly handles add-then-move sequences: when a
+  // node is created in event0 and moved (remove+re-add) in event1, lastAddIdx=1 equals
+  // lastRemoveIdx=1 so the node is not transient and the move is preserved.
+  const lastAddEventIndex = new Map<number, number>();
   const lastRemoveEventIndex = new Map<number, number>();
   events.forEach((e, i) => {
     const data = e.data as mutationData;
     for (const add of data.adds) {
-      if (!firstAddEventIndex.has(add.node.id)) firstAddEventIndex.set(add.node.id, i);
+      lastAddEventIndex.set(add.node.id, i);
     }
     for (const remove of data.removes) {
       lastRemoveEventIndex.set(remove.id, i);
@@ -34,7 +38,7 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   });
 
   const transientIds = new Set<number>();
-  for (const [id, addIdx] of firstAddEventIndex) {
+  for (const [id, addIdx] of lastAddEventIndex) {
     const removeIdx = lastRemoveEventIndex.get(id);
     if (removeIdx !== undefined && addIdx < removeIdx) transientIds.add(id);
   }

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -25,7 +25,9 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   // Using lastAddIdx (not firstAddIdx) correctly handles add-then-move sequences: when a
   // node is created in event0 and moved (remove+re-add) in event1, lastAddIdx=1 equals
   // lastRemoveIdx=1 so the node is not transient and the move is preserved.
+  const firstAddEventIndex = new Map<number, number>();
   const lastAddEventIndex = new Map<number, number>();
+  const firstRemoveEventIndex = new Map<number, number>();
   const lastRemoveEventIndex = new Map<number, number>();
   // lastParentById: a node's parentId from its most recent add (last-write-wins).
   // Used in the cascade so a child moved away from a transient parent is not wrongly elided.
@@ -33,10 +35,12 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   events.forEach((e, i) => {
     const data = e.data as mutationData;
     for (const add of data.adds) {
+      if (!firstAddEventIndex.has(add.node.id)) firstAddEventIndex.set(add.node.id, i);
       lastAddEventIndex.set(add.node.id, i);
       lastParentById.set(add.node.id, add.parentId);
     }
     for (const remove of data.removes) {
+      if (!firstRemoveEventIndex.has(remove.id)) firstRemoveEventIndex.set(remove.id, i);
       lastRemoveEventIndex.set(remove.id, i);
     }
   });
@@ -44,7 +48,13 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   const transientIds = new Set<number>();
   for (const [id, addIdx] of lastAddEventIndex) {
     const removeIdx = lastRemoveEventIndex.get(id);
-    if (removeIdx !== undefined && addIdx < removeIdx) transientIds.add(id);
+    if (removeIdx === undefined) continue;
+    // A node is transient only when it was first seen as an add (not pre-existing).
+    // If firstRemoveIdx < firstAddIdx the node pre-existed and was removed before being
+    // re-added; marking it transient would incorrectly drop the pre-existing remove.
+    const firstAddIdx = firstAddEventIndex.get(id)!;
+    const firstRemoveIdx = firstRemoveEventIndex.get(id)!;
+    if (addIdx < removeIdx && firstAddIdx < firstRemoveIdx) transientIds.add(id);
   }
 
   if (transientIds.size > 0) {

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -63,8 +63,15 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
   }
 
   // Cascade: nodes whose FINAL parent is effectively cancelled (transient or pre-existing-transient)
-  // would be orphaned, so treat them as pure transients too.
+  // would be orphaned, so treat them as cancelled too.
   // Use lastParentById so a node moved away from a cancelled parent to a live one is not wrongly elided.
+  //
+  // Three cascade outcomes mirror the main-loop classification:
+  //   transientIds:            no pre-existing removes (node created in window), or no remove/add overlap
+  //   preExistingTransientIds: nodeFirstRemoveIdx < nodeFirstAddIdx (pre-existing, removed before re-add)
+  //   cascadeDropAddsOnlyIds:  nodeFirstRemoveIdx === nodeFirstAddIdx (same-event move to cancelled parent)
+  //                            → drop adds but preserve removes from non-cancelled parents
+  const cascadeDropAddsOnlyIds = new Set<number>();
   if (transientIds.size > 0 || preExistingTransientIds.size > 0) {
     let changed = true;
     while (changed) {
@@ -73,7 +80,8 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
         if (
           !transientIds.has(nodeId) &&
           !preExistingTransientIds.has(nodeId) &&
-          (transientIds.has(parentId) || preExistingTransientIds.has(parentId))
+          !cascadeDropAddsOnlyIds.has(nodeId) &&
+          (transientIds.has(parentId) || preExistingTransientIds.has(parentId) || cascadeDropAddsOnlyIds.has(parentId))
         ) {
           const nodeFirstRemoveIdx = firstRemoveEventIndex.get(nodeId);
           const nodeFirstAddIdx = firstAddEventIndex.get(nodeId);
@@ -83,6 +91,12 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
             nodeFirstRemoveIdx < nodeFirstAddIdx
           ) {
             preExistingTransientIds.add(nodeId);
+          } else if (
+            nodeFirstRemoveIdx !== undefined &&
+            nodeFirstAddIdx !== undefined &&
+            nodeFirstRemoveIdx === nodeFirstAddIdx
+          ) {
+            cascadeDropAddsOnlyIds.add(nodeId);
           } else {
             transientIds.add(nodeId);
           }
@@ -92,17 +106,27 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
     }
   }
 
-  const needsFilter = transientIds.size > 0 || preExistingTransientIds.size > 0;
+  const needsFilter = transientIds.size > 0 || preExistingTransientIds.size > 0 || cascadeDropAddsOnlyIds.size > 0;
 
   // Build filtered removes by iterating per event so we know each remove's event index.
   // Pure transients:          drop all removes.
   // Pre-existing transients:  drop removes at eventIdx >= firstAddIdx (the cancelled re-add cycle);
   //                           keep removes at eventIdx < firstAddIdx (legitimate pre-window removal).
+  // Cascade drop-adds-only:   keep removes from non-cancelled parents; drop removes from cancelled parents
+  //                           (the cancelled parent is never added in the replay, so a remove from it
+  //                           would reference a non-existent node in the replayer).
   const filteredRemoves: mutationData['removes'][0][] = [];
   events.forEach((e, eventIdx) => {
     for (const r of (e.data as mutationData).removes) {
       if (transientIds.has(r.id)) continue;
       if (preExistingTransientIds.has(r.id) && eventIdx >= firstAddEventIndex.get(r.id)!) continue;
+      if (
+        cascadeDropAddsOnlyIds.has(r.id) &&
+        (transientIds.has(r.parentId) ||
+          preExistingTransientIds.has(r.parentId) ||
+          cascadeDropAddsOnlyIds.has(r.parentId))
+      )
+        continue;
       filteredRemoves.push(r);
     }
   });
@@ -115,13 +139,22 @@ function mergeGroup(events: eventWithTime[]): eventWithTime {
     source: IncrementalSource.Mutation,
     removes: filteredRemoves,
     adds: needsFilter
-      ? allAdds.filter((a) => !transientIds.has(a.node.id) && !preExistingTransientIds.has(a.node.id))
+      ? allAdds.filter(
+          (a) =>
+            !transientIds.has(a.node.id) &&
+            !preExistingTransientIds.has(a.node.id) &&
+            !cascadeDropAddsOnlyIds.has(a.node.id),
+        )
       : allAdds,
     texts: needsFilter
-      ? allTexts.filter((t) => !transientIds.has(t.id) && !preExistingTransientIds.has(t.id))
+      ? allTexts.filter(
+          (t) => !transientIds.has(t.id) && !preExistingTransientIds.has(t.id) && !cascadeDropAddsOnlyIds.has(t.id),
+        )
       : allTexts,
     attributes: needsFilter
-      ? allAttributes.filter((a) => !transientIds.has(a.id) && !preExistingTransientIds.has(a.id))
+      ? allAttributes.filter(
+          (a) => !transientIds.has(a.id) && !preExistingTransientIds.has(a.id) && !cascadeDropAddsOnlyIds.has(a.id),
+        )
       : allAttributes,
   };
   return { ...first, data: merged } as eventWithTime;

--- a/packages/session-replay-browser/src/events/merge-mutation-events.ts
+++ b/packages/session-replay-browser/src/events/merge-mutation-events.ts
@@ -9,10 +9,36 @@ function isMergeableMutation(event: eventWithTime): boolean {
 
 function mergeGroup(events: eventWithTime[]): eventWithTime {
   const first = events[0];
+
+  const allRemoves = events.flatMap((e) => (e.data as mutationData).removes);
+  const allAdds = events.flatMap((e) => (e.data as mutationData).adds);
+
+  // Elide transient nodes: a node added in an earlier event and removed in a later one
+  // would otherwise have its remove execute before its add (since we put all removes
+  // first), leaving the node permanently in the DOM. Cancel both the add and the remove,
+  // and cascade to any adds whose parent is also transient.
+  const removedIds = new Set(allRemoves.map((r) => r.id));
+  const transientIds = new Set<number>();
+  for (const add of allAdds) {
+    if (removedIds.has(add.node.id)) transientIds.add(add.node.id);
+  }
+  if (transientIds.size > 0) {
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const add of allAdds) {
+        if (!transientIds.has(add.node.id) && transientIds.has(add.parentId)) {
+          transientIds.add(add.node.id);
+          changed = true;
+        }
+      }
+    }
+  }
+
   const merged: mutationData = {
     source: IncrementalSource.Mutation,
-    removes: events.flatMap((e) => (e.data as mutationData).removes),
-    adds: events.flatMap((e) => (e.data as mutationData).adds),
+    removes: transientIds.size > 0 ? allRemoves.filter((r) => !transientIds.has(r.id)) : allRemoves,
+    adds: transientIds.size > 0 ? allAdds.filter((a) => !transientIds.has(a.node.id)) : allAdds,
     texts: events.flatMap((e) => (e.data as mutationData).texts),
     attributes: events.flatMap((e) => (e.data as mutationData).attributes),
   };

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -3,7 +3,7 @@ import { SessionReplayLocalConfig } from '../src/config/local-config';
 import { EventCompressor } from '../src/events/event-compressor';
 import { createEventsManager } from '../src/events/events-manager';
 import { SessionReplayEventsManager } from '../src/typings/session-replay';
-import { eventWithTime } from '@amplitude/rrweb-types';
+import { EventType, IncrementalSource, eventWithTime, mutationData } from '@amplitude/rrweb-types';
 
 const mockEvent = {
   type: 4, // Meta — not a FullSnapshot
@@ -547,6 +547,50 @@ describe('EventCompressor', () => {
       const keys = Object.keys(serialized);
       expect(keys[0]).toBe('type');
       expect(keys[1]).toBe('timestamp');
+    });
+  });
+
+  describe('mergeMutationTasks via processQueue', () => {
+    function makeMutationEvent(timestamp: number): eventWithTime {
+      return {
+        type: EventType.IncrementalSnapshot,
+        timestamp,
+        data: { source: IncrementalSource.Mutation, texts: [], attributes: [], removes: [], adds: [] } as mutationData,
+      };
+    }
+
+    test('merges pending mutation events into a single task before processing', () => {
+      const addEventMock = jest.spyOn(eventsManager, 'addEvent');
+      const m1 = makeMutationEvent(100);
+      const m2 = makeMutationEvent(200);
+      eventCompressor.pendingQueue.push({ event: m1, sessionId });
+      eventCompressor.pendingQueue.push({ event: m2, sessionId });
+
+      const mockIdleDeadline = { timeRemaining: () => 50, didTimeout: false } as IdleDeadline;
+      eventCompressor.processQueue(mockIdleDeadline);
+
+      // Two pending mutations → merged into one → one compressed event
+      expect(addEventMock).toHaveBeenCalledTimes(1);
+      expect(eventCompressor.pendingQueue).toHaveLength(0);
+    });
+
+    test('keeps tasks from different sessions separate when merging', () => {
+      const addEventMock = jest.spyOn(eventsManager, 'addEvent');
+      const sessionA = 111;
+      const sessionB = 222;
+      const m1 = makeMutationEvent(100);
+      const m2 = makeMutationEvent(200);
+      const m3 = makeMutationEvent(300);
+      // Two mutations for sessionA, one for sessionB — sessionA run merges; sessionB stays as-is
+      eventCompressor.pendingQueue.push({ event: m1, sessionId: sessionA });
+      eventCompressor.pendingQueue.push({ event: m2, sessionId: sessionA });
+      eventCompressor.pendingQueue.push({ event: m3, sessionId: sessionB });
+
+      const mockIdleDeadline = { timeRemaining: () => 50, didTimeout: false } as IdleDeadline;
+      eventCompressor.processQueue(mockIdleDeadline);
+
+      // sessionA: 2 → 1 merged; sessionB: 1 stays → 2 total compressed events
+      expect(addEventMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -560,6 +560,7 @@ describe('EventCompressor', () => {
     }
 
     test('merges pending mutation events into a single task before processing', () => {
+      eventCompressor.config.performanceConfig = { enabled: true, mergeMutations: true };
       const addEventMock = jest.spyOn(eventsManager, 'addEvent');
       const m1 = makeMutationEvent(100);
       const m2 = makeMutationEvent(200);
@@ -575,6 +576,7 @@ describe('EventCompressor', () => {
     });
 
     test('keeps tasks from different sessions separate when merging', () => {
+      eventCompressor.config.performanceConfig = { enabled: true, mergeMutations: true };
       const addEventMock = jest.spyOn(eventsManager, 'addEvent');
       const sessionA = 111;
       const sessionB = 222;

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -559,6 +559,19 @@ describe('EventCompressor', () => {
       };
     }
 
+    test('passes through a single pending event unchanged when merging is enabled', () => {
+      eventCompressor.config.performanceConfig = { enabled: true, mergeMutations: true };
+      const addEventMock = jest.spyOn(eventsManager, 'addEvent');
+      const m1 = makeMutationEvent(100);
+      eventCompressor.pendingQueue.push({ event: m1, sessionId });
+
+      const mockIdleDeadline = { timeRemaining: () => 50, didTimeout: false } as IdleDeadline;
+      eventCompressor.processQueue(mockIdleDeadline);
+
+      expect(addEventMock).toHaveBeenCalledTimes(1);
+      expect(eventCompressor.pendingQueue).toHaveLength(0);
+    });
+
     test('merges pending mutation events into a single task before processing', () => {
       eventCompressor.config.performanceConfig = { enabled: true, mergeMutations: true };
       const addEventMock = jest.spyOn(eventsManager, 'addEvent');

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -396,6 +396,28 @@ describe('mergeMutationEvents', () => {
       expect(data.adds.some((a) => (a.node as any).id === 100)).toBe(false);
     });
 
+    test('preserves pre-existing child original remove when cascaded from a transient parent', () => {
+      // Node 10 is pure transient (added then removed within window).
+      // Node 11 pre-existed: removed from parent 5 in e1, then re-added under transient 10 in e2.
+      // Cascade classifies 11 as pre-existing transient (not pure transient) so its e1 remove is kept.
+      const e1 = makeMutation(1000, {
+        adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }], // 10: pure transient
+        removes: [{ parentId: 5, id: 11 }], // 11: removed from original parent
+      });
+      const e2 = makeMutation(1010, {
+        adds: [{ parentId: 10, nextId: null, node: { id: 11 } as any }], // 11: re-added under 10
+        removes: [{ parentId: 1, id: 10 }], // 10: removed
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+      const data = result[0].data as mutationData;
+
+      expect(data.adds.some((a) => (a.node as any).id === 10)).toBe(false); // 10 erased
+      expect(data.removes.some((r) => r.id === 10)).toBe(false); // 10 erased
+      expect(data.adds.some((a) => (a.node as any).id === 11)).toBe(false); // 11 re-add cancelled
+      expect(data.removes.some((r) => r.id === 11 && r.parentId === 5)).toBe(true); // 11 original remove kept
+    });
+
     test('only elides the transient node, keeps non-transient adds and removes', () => {
       const e1 = makeMutation(1000, {
         adds: [

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -396,6 +396,88 @@ describe('mergeMutationEvents', () => {
       expect(data.adds.some((a) => (a.node as any).id === 100)).toBe(false);
     });
 
+    test('preserves same-event-moved pre-existing node remove when final parent is transient (cascadeDropAddsOnly)', () => {
+      // B (id=11) is pre-existing. In e0, B is same-event moved: removed from Q (parentId=5)
+      // and added to C (id=10) in the SAME rrweb event. C is a new node added to body in e0.
+      // In e1, C is removed — making C a pure transient.
+      // Cascade fires: B's lastParent C is transient. nodeFirstRemoveIdx(B) === nodeFirstAddIdx(B)
+      // (both 0) → cascadeDropAddsOnlyIds. B's add to C is dropped; B's remove from Q is kept.
+      const e0 = makeMutation(1000, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 10 } as any }, // C: new node
+          { parentId: 10, nextId: null, node: { id: 11 } as any }, // B: same-event add to C
+        ],
+        removes: [{ parentId: 5, id: 11 }], // B: same-event remove from Q
+      });
+      const e1 = makeMutation(1010, {
+        removes: [{ parentId: 1, id: 10 }], // C removed → pure transient
+      });
+
+      const result = mergeMutationEvents([e0, e1]);
+      const data = result[0].data as mutationData;
+
+      // C (id=10) is pure transient — elided entirely
+      expect(data.adds.some((a) => (a.node as any).id === 10)).toBe(false);
+      expect(data.removes.some((r) => r.id === 10)).toBe(false);
+      // B (id=11): add to C must be dropped (C is cancelled)
+      expect(data.adds.some((a) => (a.node as any).id === 11)).toBe(false);
+      // B (id=11): remove from Q (parentId=5) must be preserved
+      expect(data.removes.some((r) => r.id === 11 && r.parentId === 5)).toBe(true);
+    });
+
+    test('filters texts and attributes for cascadeDropAddsOnly nodes', () => {
+      // B (id=11) is same-event moved to transient C (id=10).
+      // A text and attribute mutation on B during the re-add phase should be dropped.
+      const e0 = makeMutation(1000, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 10 } as any },
+          { parentId: 10, nextId: null, node: { id: 11 } as any },
+        ],
+        removes: [{ parentId: 5, id: 11 }],
+        texts: [{ id: 11, value: 'during move' }],
+        attributes: [{ id: 11, attributes: { class: 'moved' } }],
+      });
+      const e1 = makeMutation(1010, { removes: [{ parentId: 1, id: 10 }] });
+
+      const result = mergeMutationEvents([e0, e1]);
+      const data = result[0].data as mutationData;
+
+      expect(data.texts).toHaveLength(0);
+      expect(data.attributes).toHaveLength(0);
+      expect(data.removes.some((r) => r.id === 11 && r.parentId === 5)).toBe(true);
+    });
+
+    test('drops remove from cancelled parent for cascadeDropAddsOnly node', () => {
+      // B (id=11) is same-event moved to C (id=10) in e0, then explicitly removed from C in e1,
+      // then C is removed in e2. Because the "remove from C" is from a cancelled parent (transient C),
+      // it should be dropped — keeping only the original remove from Q (parentId=5).
+      const e0 = makeMutation(1000, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 10 } as any }, // C: new node
+          { parentId: 10, nextId: null, node: { id: 11 } as any }, // B: same-event add to C
+        ],
+        removes: [{ parentId: 5, id: 11 }], // B: same-event remove from Q
+      });
+      const e1 = makeMutation(1010, {
+        removes: [{ parentId: 10, id: 11 }], // B explicitly removed from C
+      });
+      const e2 = makeMutation(1020, {
+        removes: [{ parentId: 1, id: 10 }], // C removed → pure transient
+      });
+
+      const result = mergeMutationEvents([e0, e1, e2]);
+      const data = result[0].data as mutationData;
+
+      // C (id=10) is pure transient — elided
+      expect(data.adds.some((a) => (a.node as any).id === 10)).toBe(false);
+      expect(data.removes.some((r) => r.id === 10)).toBe(false);
+      // B (id=11): add to C and remove from C (cancelled parent) must both be dropped
+      expect(data.adds.some((a) => (a.node as any).id === 11)).toBe(false);
+      expect(data.removes.some((r) => r.id === 11 && r.parentId === 10)).toBe(false);
+      // B (id=11): original remove from Q must be preserved
+      expect(data.removes.some((r) => r.id === 11 && r.parentId === 5)).toBe(true);
+    });
+
     test('preserves pre-existing child original remove when cascaded from a transient parent', () => {
       // Node 10 is pure transient (added then removed within window).
       // Node 11 pre-existed: removed from parent 5 in e1, then re-added under transient 10 in e2.

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -308,10 +308,11 @@ describe('mergeMutationEvents', () => {
       expect(data.adds.some((a) => (a.node as any).id === 11 && a.parentId === 2)).toBe(true);
     });
 
-    test('does not mark as transient a pre-existing node removed, re-added, then removed again', () => {
-      // Node 99 pre-exists: removed in e1, re-added in e2, removed again in e3.
-      // lastAddIdx(1) < lastRemoveIdx(2) would be true, but firstRemoveIdx(0) < firstAddIdx(1)
-      // indicates the node was not created within this window — must not be elided.
+    test('cancels re-add and post-add remove for pre-existing node removed, re-added, and removed again', () => {
+      // Node 99 pre-exists: removed from parent1 in e1, re-added to parent2 in e2, removed from parent2 in e3.
+      // The rrweb replayer applies all removes first: both removes fire, then the add re-creates the node
+      // at parent2 — leaving it present when it should be absent.
+      // Fix: cancel the re-add and the post-add remove; keep only the original pre-add remove.
       const e1 = makeMutation(1000, { removes: [{ parentId: 1, id: 99 }] });
       const e2 = makeMutation(1010, { adds: [{ parentId: 2, nextId: null, node: { id: 99 } as any }] });
       const e3 = makeMutation(1020, { removes: [{ parentId: 2, id: 99 }] });
@@ -319,8 +320,60 @@ describe('mergeMutationEvents', () => {
       const result = mergeMutationEvents([e1, e2, e3]);
 
       const data = result[0].data as mutationData;
-      expect(data.removes.some((r) => r.id === 99)).toBe(true);
-      expect(data.adds.some((a) => (a.node as any).id === 99)).toBe(true);
+      // Original remove (from parent1) must survive
+      expect(data.removes.some((r) => r.id === 99 && r.parentId === 1)).toBe(true);
+      // Re-add and post-add remove must be cancelled
+      expect(data.removes.some((r) => r.id === 99 && r.parentId === 2)).toBe(false);
+      expect(data.adds.some((a) => (a.node as any).id === 99)).toBe(false);
+    });
+
+    test('filters texts belonging to pre-existing-transient nodes', () => {
+      const e1 = makeMutation(1000, { removes: [{ parentId: 1, id: 99 }] });
+      const e2 = makeMutation(1010, {
+        adds: [{ parentId: 2, nextId: null, node: { id: 99 } as any }],
+        texts: [{ id: 99, value: 'during re-add' }],
+      });
+      const e3 = makeMutation(1020, { removes: [{ parentId: 2, id: 99 }] });
+
+      const result = mergeMutationEvents([e1, e2, e3]);
+
+      const data = result[0].data as mutationData;
+      expect(data.texts).toHaveLength(0);
+    });
+
+    test('filters attributes belonging to pre-existing-transient nodes', () => {
+      const e1 = makeMutation(1000, { removes: [{ parentId: 1, id: 99 }] });
+      const e2 = makeMutation(1010, {
+        adds: [{ parentId: 2, nextId: null, node: { id: 99 } as any }],
+        attributes: [{ id: 99, attributes: { class: 'during-readd' } }],
+      });
+      const e3 = makeMutation(1020, { removes: [{ parentId: 2, id: 99 }] });
+
+      const result = mergeMutationEvents([e1, e2, e3]);
+
+      const data = result[0].data as mutationData;
+      expect(data.attributes).toHaveLength(0);
+    });
+
+    test('cascades elision to children added under a pre-existing-transient re-add', () => {
+      // Node 99 pre-exists: removed in e1, re-added in e2 with a new child 100, removed in e3.
+      // The re-add of 99 is cancelled; child 100 (whose final parent is the cancelled re-add)
+      // is also elided.
+      const e1 = makeMutation(1000, { removes: [{ parentId: 1, id: 99 }] });
+      const e2 = makeMutation(1010, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 99 } as any },
+          { parentId: 99, nextId: null, node: { id: 100 } as any },
+        ],
+      });
+      const e3 = makeMutation(1020, { removes: [{ parentId: 1, id: 99 }] });
+
+      const result = mergeMutationEvents([e1, e2, e3]);
+
+      const data = result[0].data as mutationData;
+      expect(data.removes.some((r) => r.id === 99 && r.parentId === 1)).toBe(true);
+      expect(data.adds.some((a) => (a.node as any).id === 99)).toBe(false);
+      expect(data.adds.some((a) => (a.node as any).id === 100)).toBe(false);
     });
 
     test('only elides the transient node, keeps non-transient adds and removes', () => {

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -268,6 +268,33 @@ describe('mergeMutationEvents', () => {
       expect(data.attributes).toHaveLength(0);
     });
 
+    test('does not elide a child that was moved away from a transient parent', () => {
+      // Child C is added under transient parent P, then moved to non-transient parent Q.
+      // P is added then removed (transient). C ends up under Q and must survive.
+      const e1 = makeMutation(1000, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 10 } as any }, // transient parent P
+          { parentId: 10, nextId: null, node: { id: 11 } as any }, // child C under P
+        ],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [
+          { parentId: 1, id: 10 }, // remove P (transient)
+          { parentId: 10, id: 11 }, // move C away from P
+        ],
+        adds: [{ parentId: 2, nextId: null, node: { id: 11 } as any }], // C re-added under Q
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      // P (id=10) should be elided (add + remove cancelled)
+      expect(data.adds.some((a) => (a.node as any).id === 10)).toBe(false);
+      expect(data.removes.some((r) => r.id === 10)).toBe(false);
+      // C (id=11) should survive at its final parent Q (parentId=2)
+      expect(data.adds.some((a) => (a.node as any).id === 11 && a.parentId === 2)).toBe(true);
+    });
+
     test('only elides the transient node, keeps non-transient adds and removes', () => {
       const e1 = makeMutation(1000, {
         adds: [

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -148,4 +148,76 @@ describe('mergeMutationEvents', () => {
   test('empty array returns empty array', () => {
     expect(mergeMutationEvents([])).toEqual([]);
   });
+
+  describe('transient node elision', () => {
+    test('elides a node added then removed in the same merge window', () => {
+      const e1 = makeMutation(1000, {
+        adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [{ parentId: 1, id: 10 }],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      expect(result).toHaveLength(1);
+      const data = result[0].data as mutationData;
+      expect(data.adds).toHaveLength(0);
+      expect(data.removes).toHaveLength(0);
+    });
+
+    test('keeps removes for pre-existing nodes not in the adds set', () => {
+      const e1 = makeMutation(1000, {
+        removes: [{ parentId: 1, id: 99 }], // pre-existing node
+      });
+      const e2 = makeMutation(1010, {
+        adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      expect(data.removes).toEqual([{ parentId: 1, id: 99 }]);
+      expect(data.adds).toHaveLength(1);
+    });
+
+    test('cascades elision to children of a transient parent', () => {
+      const e1 = makeMutation(1000, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 10 } as any }, // parent
+          { parentId: 10, nextId: null, node: { id: 11 } as any }, // child of transient parent
+        ],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [{ parentId: 1, id: 10 }], // removes the parent
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      expect(data.adds).toHaveLength(0); // parent and child both elided
+      expect(data.removes).toHaveLength(0);
+    });
+
+    test('only elides the transient node, keeps non-transient adds and removes', () => {
+      const e1 = makeMutation(1000, {
+        adds: [
+          { parentId: 1, nextId: null, node: { id: 10 } as any }, // transient
+          { parentId: 1, nextId: null, node: { id: 20 } as any }, // stays
+        ],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [
+          { parentId: 1, id: 10 }, // removes transient
+          { parentId: 1, id: 99 }, // removes pre-existing node
+        ],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      expect(data.adds).toEqual([{ parentId: 1, nextId: null, node: { id: 20 } as any }]);
+      expect(data.removes).toEqual([{ parentId: 1, id: 99 }]);
+    });
+  });
 });

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -216,6 +216,24 @@ describe('mergeMutationEvents', () => {
       expect((data.adds[0].node as any).id).toBe(10);
     });
 
+    test('does not elide a node added then moved (add-then-move)', () => {
+      // add in event1, move (remove+re-add to new parent) in event2 — node should survive at new parent
+      const e1 = makeMutation(1000, {
+        adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [{ parentId: 1, id: 10 }],
+        adds: [{ parentId: 2, nextId: null, node: { id: 10 } as any }],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      // Node 10 should appear as a remove from parent 1 and add to parent 2
+      expect(data.removes.some((r) => r.id === 10)).toBe(true);
+      expect(data.adds.some((a) => (a.node as any).id === 10 && a.parentId === 2)).toBe(true);
+    });
+
     test('filters texts for transient node IDs', () => {
       const e1 = makeMutation(1000, {
         adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -1,0 +1,151 @@
+import { EventType, IncrementalSource } from '@amplitude/rrweb-types';
+import type { eventWithTime, mutationData, scrollData } from '@amplitude/rrweb-types';
+import { mergeMutationEvents } from '../src/events/merge-mutation-events';
+
+function makeMutation(timestamp: number, overrides: Partial<mutationData> = {}): eventWithTime {
+  return {
+    type: EventType.IncrementalSnapshot,
+    timestamp,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [],
+      adds: [],
+      ...overrides,
+    } as mutationData,
+  };
+}
+
+function makeScroll(timestamp: number): eventWithTime {
+  return {
+    type: EventType.IncrementalSnapshot,
+    timestamp,
+    data: { source: IncrementalSource.Scroll, id: 1, x: 0, y: 100 } as scrollData,
+  };
+}
+
+function makeFullSnapshot(timestamp: number): eventWithTime {
+  return {
+    type: EventType.FullSnapshot,
+    timestamp,
+    data: { node: {} as any, initialOffset: { top: 0, left: 0 } },
+  };
+}
+
+describe('mergeMutationEvents', () => {
+  test('returns single-element array unchanged', () => {
+    const event = makeMutation(1000);
+    expect(mergeMutationEvents([event])).toEqual([event]);
+  });
+
+  test('merges two consecutive mutations into one', () => {
+    const e1 = makeMutation(1000, {
+      adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],
+      removes: [{ parentId: 1, id: 5 }],
+      texts: [{ id: 2, value: 'hello' }],
+      attributes: [{ id: 3, attributes: { class: 'foo' } }],
+    });
+    const e2 = makeMutation(1050, {
+      adds: [{ parentId: 10, nextId: null, node: { id: 11 } as any }],
+      removes: [{ parentId: 1, id: 6 }],
+      texts: [{ id: 4, value: 'world' }],
+      attributes: [{ id: 7, attributes: { class: 'bar' } }],
+    });
+
+    const result = mergeMutationEvents([e1, e2]);
+
+    expect(result).toHaveLength(1);
+    const data = result[0].data as mutationData;
+    // Removes from both events, in order
+    expect(data.removes).toEqual([
+      { parentId: 1, id: 5 },
+      { parentId: 1, id: 6 },
+    ]);
+    // Adds from both events, in order
+    expect(data.adds).toEqual([(e1.data as mutationData).adds[0], (e2.data as mutationData).adds[0]]);
+    // Texts concatenated
+    expect(data.texts).toEqual([
+      { id: 2, value: 'hello' },
+      { id: 4, value: 'world' },
+    ]);
+    // Attributes concatenated (replayer applies last-write-wins)
+    expect(data.attributes).toEqual([
+      { id: 3, attributes: { class: 'foo' } },
+      { id: 7, attributes: { class: 'bar' } },
+    ]);
+    // Timestamp from first event
+    expect(result[0].timestamp).toBe(1000);
+  });
+
+  test('merges three consecutive mutations into one', () => {
+    const events = [makeMutation(1000), makeMutation(1010), makeMutation(1020)];
+    const result = mergeMutationEvents(events);
+    expect(result).toHaveLength(1);
+  });
+
+  test('does not merge mutations separated by a non-mutation event', () => {
+    const e1 = makeMutation(1000);
+    const scroll = makeScroll(1010);
+    const e2 = makeMutation(1020);
+
+    const result = mergeMutationEvents([e1, scroll, e2]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(e1);
+    expect(result[1]).toBe(scroll);
+    expect(result[2]).toBe(e2);
+  });
+
+  test('passes non-mutation IncrementalSnapshot events through unchanged', () => {
+    const scroll = makeScroll(1000);
+    const result = mergeMutationEvents([scroll]);
+    expect(result).toEqual([scroll]);
+  });
+
+  test('passes FullSnapshot events through unchanged', () => {
+    const full = makeFullSnapshot(1000);
+    const result = mergeMutationEvents([full]);
+    expect(result).toEqual([full]);
+  });
+
+  test('does not merge isAttachIframe mutations', () => {
+    const e1 = makeMutation(1000, { isAttachIframe: true });
+    const e2 = makeMutation(1010, { isAttachIframe: true });
+
+    const result = mergeMutationEvents([e1, e2]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(e1);
+    expect(result[1]).toBe(e2);
+  });
+
+  test('does not merge a normal mutation with an isAttachIframe mutation', () => {
+    const normal = makeMutation(1000);
+    const iframe = makeMutation(1010, { isAttachIframe: true });
+
+    const result = mergeMutationEvents([normal, iframe]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test('merges runs correctly in a mixed sequence', () => {
+    const m1 = makeMutation(1000);
+    const m2 = makeMutation(1010);
+    const scroll = makeScroll(1020);
+    const m3 = makeMutation(1030);
+    const m4 = makeMutation(1040);
+    const m5 = makeMutation(1050);
+
+    const result = mergeMutationEvents([m1, m2, scroll, m3, m4, m5]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].timestamp).toBe(1000); // merged m1+m2
+    expect(result[1]).toBe(scroll);
+    expect(result[2].timestamp).toBe(1030); // merged m3+m4+m5
+  });
+
+  test('empty array returns empty array', () => {
+    expect(mergeMutationEvents([])).toEqual([]);
+  });
+});

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -199,6 +199,57 @@ describe('mergeMutationEvents', () => {
       expect(data.removes).toHaveLength(0);
     });
 
+    test('does not elide a node removed then re-added (DOM move)', () => {
+      // remove in event1, re-add in event2 — this is a cross-event DOM move, not transient
+      const e1 = makeMutation(1000, {
+        removes: [{ parentId: 1, id: 10 }],
+      });
+      const e2 = makeMutation(1010, {
+        adds: [{ parentId: 2, nextId: null, node: { id: 10 } as any }],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      expect(data.removes).toEqual([{ parentId: 1, id: 10 }]);
+      expect(data.adds).toHaveLength(1);
+      expect((data.adds[0].node as any).id).toBe(10);
+    });
+
+    test('filters texts for transient node IDs', () => {
+      const e1 = makeMutation(1000, {
+        adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],
+        texts: [{ id: 10, value: 'hello' }],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [{ parentId: 1, id: 10 }],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      expect(data.adds).toHaveLength(0);
+      expect(data.removes).toHaveLength(0);
+      expect(data.texts).toHaveLength(0);
+    });
+
+    test('filters attributes for transient node IDs', () => {
+      const e1 = makeMutation(1000, {
+        adds: [{ parentId: 1, nextId: null, node: { id: 10 } as any }],
+        attributes: [{ id: 10, attributes: { class: 'foo' } }],
+      });
+      const e2 = makeMutation(1010, {
+        removes: [{ parentId: 1, id: 10 }],
+      });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      expect(data.adds).toHaveLength(0);
+      expect(data.removes).toHaveLength(0);
+      expect(data.attributes).toHaveLength(0);
+    });
+
     test('only elides the transient node, keeps non-transient adds and removes', () => {
       const e1 = makeMutation(1000, {
         adds: [

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -308,6 +308,26 @@ describe('mergeMutationEvents', () => {
       expect(data.adds.some((a) => (a.node as any).id === 11 && a.parentId === 2)).toBe(true);
     });
 
+    test('preserves same-event move followed by a later remove (does not misclassify as pre-existing transient)', () => {
+      // Node 10 is moved (remove+add in e1 — same event index) then removed in e2.
+      // firstAddIdx === firstRemoveIdx (both 0): must NOT be classified as pre-existing transient.
+      // All operations must survive so the move and final removal are both applied.
+      const e1 = makeMutation(1000, {
+        removes: [{ parentId: 1, id: 10 }],
+        adds: [{ parentId: 2, nextId: null, node: { id: 10 } as any }],
+      });
+      const e2 = makeMutation(1010, { removes: [{ parentId: 2, id: 10 }] });
+
+      const result = mergeMutationEvents([e1, e2]);
+
+      const data = result[0].data as mutationData;
+      // Both removes must survive (not erased by pre-existing-transient misclassification)
+      expect(data.removes.some((r) => r.id === 10 && r.parentId === 1)).toBe(true);
+      expect(data.removes.some((r) => r.id === 10 && r.parentId === 2)).toBe(true);
+      // The add (move destination) must survive
+      expect(data.adds.some((a) => (a.node as any).id === 10 && a.parentId === 2)).toBe(true);
+    });
+
     test('cancels re-add and post-add remove for pre-existing node removed, re-added, and removed again', () => {
       // Node 99 pre-exists: removed from parent1 in e1, re-added to parent2 in e2, removed from parent2 in e3.
       // The rrweb replayer applies all removes first: both removes fire, then the add re-creates the node

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -295,6 +295,21 @@ describe('mergeMutationEvents', () => {
       expect(data.adds.some((a) => (a.node as any).id === 11 && a.parentId === 2)).toBe(true);
     });
 
+    test('does not mark as transient a pre-existing node removed, re-added, then removed again', () => {
+      // Node 99 pre-exists: removed in e1, re-added in e2, removed again in e3.
+      // lastAddIdx(1) < lastRemoveIdx(2) would be true, but firstRemoveIdx(0) < firstAddIdx(1)
+      // indicates the node was not created within this window — must not be elided.
+      const e1 = makeMutation(1000, { removes: [{ parentId: 1, id: 99 }] });
+      const e2 = makeMutation(1010, { adds: [{ parentId: 2, nextId: null, node: { id: 99 } as any }] });
+      const e3 = makeMutation(1020, { removes: [{ parentId: 2, id: 99 }] });
+
+      const result = mergeMutationEvents([e1, e2, e3]);
+
+      const data = result[0].data as mutationData;
+      expect(data.removes.some((r) => r.id === 99)).toBe(true);
+      expect(data.adds.some((a) => (a.node as any).id === 99)).toBe(true);
+    });
+
     test('only elides the transient node, keeps non-transient adds and removes', () => {
       const e1 = makeMutation(1000, {
         adds: [

--- a/packages/session-replay-browser/test/merge-mutation-events.test.ts
+++ b/packages/session-replay-browser/test/merge-mutation-events.test.ts
@@ -97,6 +97,19 @@ describe('mergeMutationEvents', () => {
     expect(result[2]).toBe(e2);
   });
 
+  test('does not merge mutations separated by a FullSnapshot event', () => {
+    const e1 = makeMutation(1000);
+    const full = makeFullSnapshot(1010);
+    const e2 = makeMutation(1020);
+
+    const result = mergeMutationEvents([e1, full, e2]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(e1);
+    expect(result[1]).toBe(full);
+    expect(result[2]).toBe(e2);
+  });
+
   test('passes non-mutation IncrementalSnapshot events through unchanged', () => {
     const scroll = makeScroll(1000);
     const result = mergeMutationEvents([scroll]);

--- a/test-server/session-replay-browser/sr-capture-test.html
+++ b/test-server/session-replay-browser/sr-capture-test.html
@@ -21,6 +21,7 @@
       const deviceId = params.get('deviceId') ?? 'test-device-id';
       const logLevel = params.has('logLevel') ? Number(params.get('logLevel')) : 0;
       const useWebWorker = params.get('useWebWorker') === 'true';
+      const mergeMutations = params.get('mergeMutations') === 'true';
 
       void (async () => {
         try {
@@ -31,6 +32,7 @@
             optOut,
             logLevel,
             useWebWorker,
+            performanceConfig: { enabled: true, mergeMutations },
           }).promise;
         } catch (err) {
           document.getElementById('status').textContent = 'error: ' + err.message;


### PR DESCRIPTION
## Summary

- Adds `mergeMutationEvents` utility that coalesces consecutive rrweb `IncrementalSnapshot` mutation events into a single equivalent event
- Wires the merge into `EventCompressor.processQueue` and the full-snapshot drain path
- `isAttachIframe` events are never merged — they carry a full iframe document tree and must remain isolated
- Opt-in via `performanceConfig.mergeMutations` (defaults to `false`); existing customers are unaffected until they enable it

Resolves [SR-3752](https://linear.app/amplitude/issue/SR-3752)

## How merging is safe

Verified against the rrweb source at `~/repos/rrweb`:

| Field | Merge rule | Why safe |
|---|---|---|
| `removes` | concatenate in event order | replayer always applies removes before adds; IDs never reused within a session |
| `adds` | concatenate in event order | replayer's `queue`/retry loop already handles forward `nextId` references within a single event's adds list |
| `texts` | concatenate in event order | replayer calls `uniqueTextMutations()` which deduplicates keeping last-per-node-ID |
| `attributes` | concatenate in event order | last write per `(nodeId, attributeName)` wins — correct final state |
| `isAttachIframe` | never merged | these events deliver a whole iframe document tree and must stay isolated |

## Risk

**The main risk is node moves across event boundaries.** rrweb handles intra-callback moves via `movedMap` (remove from old parent + add to new parent in same event), but cross-event moves appear as a plain remove in one event and an add in another. When merged, both land in the same event — the replayer handles this correctly, but if the moved node's `nextId` also moved in the same batch, sibling ordering could resolve incorrectly. This isn't covered by unit tests and would only surface through manual replay validation.

**Timestamp precision:** merged events use the timestamp of the first event in the group. Intermediate DOM states within the merge window appear to happen at one instant, slightly degrading scrubbing precision during high-mutation periods.

## Testing

### Unit tests (26 tests, `test/merge-mutation-events.test.ts`)

- Basic merge: single event passthrough, two-event merge, three-event merge, empty array
- Non-mutation events: `isAttachIframe` isolation, non-mutation `IncrementalSnapshot` passthrough, `FullSnapshot` passthrough
- Mixed sequences: mutations separated by scroll events, multi-run sequences
- Transient node elision: add+remove cancelled, cascade to orphaned children, texts/attributes filtered for elided nodes
- DOM move correctness: remove-then-re-add (cross-event move) preserved, add-then-move preserved at new parent, pre-existing node removed/re-added/removed not misidentified as transient, child moved away from transient parent survives at final parent

### E2E tests (4 tests, `e2e/mutation-merge.spec.ts`)

- Synchronous mutations captured and delivered to the API
- Transient node (add+remove in same MO batch) elided by rrweb — no add or remove in output
- Pre-existing node removed/re-added/removed: re-add cancelled, original removal preserved
- DOM move (remove from one parent, add under another): both operations preserved

### Automated review (Cursor Bugbot — 5 rounds)

Issues found and fixed iteratively before opening for human review:

| Round | Severity | Issue | Fix |
|---|---|---|---|
| 1 | Medium | Naive merge puts removes before adds; add-then-remove leaves stale node in DOM | Transient node elision: cancel both the add and remove for nodes created and removed within the window |
| 2a | Medium | Order-blind transient detection wrongly elides DOM moves (remove-then-re-add) | Track `lastAddEventIndex` + `lastRemoveEventIndex`; only transient when `addIdx < removeIdx` |
| 2b | Low | `texts` and `attributes` not filtered for transient node IDs | Filter all four arrays by the transient set |
| 3a | Medium | `firstAddEventIndex` breaks add-then-move (add in event0, move in event1 sets `lastRemoveIdx` = 1 = `lastAddIdx`) | Switch to `lastAddEventIndex` (last-write-wins) so the post-move re-add index equals the remove index |
| 3b | Low | Re-merging already-merged `taskQueue` entries on subsequent idle callbacks corrupts move semantics | Split into `pendingQueue` (new arrivals) and `taskQueue` (already merged); only merge the pending batch each pass |
| 4 | Medium | Cascade used `allAdds` (historical parentIds including pre-move positions); child moved from transient parent to stable parent wrongly elided | Track `lastParentById` (final parent only); cascade iterates that map instead |
| 5 | Medium | Pre-existing node removed in event1, re-added in event2, removed in event3: `lastAddIdx(1) < lastRemoveIdx(2)` falsely marks it transient, dropping the event1 remove | Also track `firstAddEventIndex`/`firstRemoveEventIndex`; require `firstAddIdx < firstRemoveIdx` as a second gate |

### Remaining manual validation
- [ ] Manual replay on a React-heavy app — confirm no "node not found" errors in the player
- [ ] Monitor event count reduction in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in change to how rrweb mutation events are buffered and emitted, which can subtly affect replay correctness/timing (especially around DOM moves) despite added test coverage.
> 
> **Overview**
> Adds an opt-in `performanceConfig.mergeMutations` flag that merges consecutive rrweb mutation `IncrementalSnapshot` events into a single equivalent event before compression.
> 
> Updates `EventCompressor` to buffer events in a new `pendingQueue`, merge pending mutation runs (per `sessionId`) during idle processing and when draining prior to `FullSnapshot`, and avoid re-merging already-merged tasks.
> 
> Introduces `mergeMutationEvents` with logic to preserve replay semantics by filtering transient add/remove cycles (including cascades) and skipping `isAttachIframe` mutations, plus adds unit and Playwright E2E coverage and a test harness toggle (`sr-capture-test.html?mergeMutations=true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412093587fe9a20b379fd4cffcf9ff05dd55ff10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

