### PR TITLE
feat: remove experimental request body compression backdoor

### DIFF
--- a/packages/analytics-browser/src/browser-client-factory.ts
+++ b/packages/analytics-browser/src/browser-client-factory.ts
@@ -148,12 +148,6 @@ export const createInstance = (): BrowserClient => {
       getClientLogConfig(client),
       getClientStates(client, ['config']),
     ),
-    _enableRequestBodyCompressionExperimental: debugWrapper(
-      client._enableRequestBodyCompressionExperimental.bind(client),
-      '_enableRequestBodyCompressionExperimental',
-      getClientLogConfig(client),
-      getClientStates(client, ['config']),
-    ),
   };
 };
 

--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -92,10 +92,6 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
   // by calling amplitude._setDiagnosticsSampleRate(1); before amplitude.init()
   _diagnosticsSampleRate = 0;
 
-  // Backdoor to test request body compression
-  // by calling amplitude._enableRequestBodyCompressionExperimental(true); before amplitude.init()
-  _enableRequestBodyCompressionExperimentalValue = false;
-
   init(apiKey = '', userIdOrOptions?: string | BrowserOptions, maybeOptions?: BrowserOptions) {
     let userId: string | undefined;
     let options: BrowserOptions | undefined;
@@ -696,19 +692,6 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
     // Set diagnostics sample rate before initializing the config
     if (!this.config) {
       this._diagnosticsSampleRate = sampleRate;
-      return;
-    }
-  }
-
-  /**
-   * @experimental
-   * WARNING: This method is for internal testing only and is not part of the public API.
-   * It may be changed or removed at any time without notice.
-   */
-  _enableRequestBodyCompressionExperimental(enabled: boolean): void {
-    // Set request body compression experimental config before initializing the config
-    if (!this.config) {
-      this._enableRequestBodyCompressionExperimentalValue = enabled;
       return;
     }
   }

--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -111,7 +111,6 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     public remoteConfig?: RemoteConfigOptions,
     public topLevelDomain?: string,
     public enableRequestBodyCompression: boolean = false,
-    public _enableRequestBodyCompressionExperimental: boolean = false,
     public customEnrichment?: boolean | CustomEnrichmentOptions,
   ) {
     super({ apiKey, storageProvider, transportProvider: createTransport(transport) });
@@ -421,7 +420,6 @@ export const useBrowserConfig = async (
     options.remoteConfig,
     defaultCookieDomain,
     options.enableRequestBodyCompression,
-    amplitudeInstance._enableRequestBodyCompressionExperimentalValue,
     options.customEnrichment,
   );
 

--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -26,7 +26,6 @@ export const {
   setUserId,
   track,
   _setDiagnosticsSampleRate,
-  _enableRequestBodyCompressionExperimental,
 } = client;
 export { AmplitudeBrowser } from './browser-client';
 export { runQueuedFunctions } from './utils/snippet-helper';

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -2655,27 +2655,4 @@ describe('browser-client', () => {
       expect(ctx.config.loggerProvider.error).not.toHaveBeenCalled();
     });
   });
-
-  describe('_enableRequestBodyCompressionExperimental', () => {
-    test('should default to false', async () => {
-      await client.init(apiKey).promise;
-      expect(client.config._enableRequestBodyCompressionExperimental).toBe(false);
-    });
-
-    test('should set experimental request body compression when config is not initialized', async () => {
-      client._enableRequestBodyCompressionExperimental(true);
-
-      await client.init(apiKey).promise;
-
-      expect(client.config._enableRequestBodyCompressionExperimental).toBe(true);
-    });
-
-    test('should not set experimental request body compression when config is already initialized', async () => {
-      await client.init(apiKey).promise;
-
-      client._enableRequestBodyCompressionExperimental(true);
-
-      expect(client.config._enableRequestBodyCompressionExperimental).toBe(false);
-    });
-  });
 });

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -157,7 +157,6 @@ describe('config', () => {
         },
         topLevelDomain: '.amplitude.com',
         enableRequestBodyCompression: false,
-        _enableRequestBodyCompressionExperimental: false,
       });
       expect(getTopLevelDomain).toHaveBeenCalledTimes(1);
     });
@@ -286,7 +285,6 @@ describe('config', () => {
           },
           topLevelDomain: 'amplitude.com',
           enableRequestBodyCompression: false,
-          _enableRequestBodyCompressionExperimental: false,
         });
       });
     });

--- a/packages/analytics-browser/test/helpers/mock.ts
+++ b/packages/analytics-browser/test/helpers/mock.ts
@@ -33,7 +33,6 @@ export const createAmplitudeMock = (): jest.MockedObject<BrowserClient> => ({
   reset: jest.fn(),
   setTransport: jest.fn(),
   _setDiagnosticsSampleRate: jest.fn(),
-  _enableRequestBodyCompressionExperimental: jest.fn(),
 });
 
 export const createConfigurationMock = (options?: Partial<BrowserConfig>) => {

--- a/packages/analytics-browser/test/utils/fake-browser-client.ts
+++ b/packages/analytics-browser/test/utils/fake-browser-client.ts
@@ -190,8 +190,4 @@ export class FakeBrowserClient implements BrowserClient {
   _setDiagnosticsSampleRate(sampleRate: number): void {
     console.log('FakeBrowserClient.setDiagnosticsSampleRate called with:', { sampleRate });
   }
-
-  _enableRequestBodyCompressionExperimental(enabled: boolean): void {
-    console.log('FakeBrowserClient.enableRequestBodyCompressionExperimental called with:', { enabled });
-  }
 }

--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -242,11 +242,7 @@ export class Destination implements DestinationPlugin {
         serverUrl,
         this.config.enableRequestBodyCompression,
       );
-      const res = await this.config.transportProvider.send(
-        serverUrl,
-        payload,
-        this.config._enableRequestBodyCompressionExperimental && shouldCompressUploadBody,
-      );
+      const res = await this.config.transportProvider.send(serverUrl, payload, shouldCompressUploadBody);
       if (res === null) {
         this.fulfillRequest(list, 0, UNEXPECTED_ERROR_MESSAGE);
         return;

--- a/packages/analytics-core/src/types/client/browser-client.ts
+++ b/packages/analytics-core/src/types/client/browser-client.ts
@@ -116,11 +116,4 @@ export interface BrowserClient extends Client {
    * @param sampleRate - The sample rate to set
    */
   _setDiagnosticsSampleRate(sampleRate: number): void;
-
-  /**
-   * @experimental
-   * WARNING: This method is for internal testing only and is not part of the public API.
-   * It may be changed or removed at any time without notice.
-   */
-  _enableRequestBodyCompressionExperimental(enabled: boolean): void;
 }

--- a/packages/analytics-core/src/types/config/browser-config.ts
+++ b/packages/analytics-core/src/types/config/browser-config.ts
@@ -123,7 +123,6 @@ interface InternalBrowserConfig {
   remoteConfigClient?: IRemoteConfigClient;
   deferredSessionId?: number;
   topLevelDomain?: string;
-  _enableRequestBodyCompressionExperimental?: boolean;
 }
 
 /**
@@ -347,7 +346,7 @@ export interface CookieOptions {
   upgrade?: boolean;
 }
 
-type HiddenOptions = 'apiKey' | 'transportProvider' | 'requestMetadata' | '_enableRequestBodyCompressionExperimental';
+type HiddenOptions = 'apiKey' | 'transportProvider' | 'requestMetadata';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface BrowserOptions extends Omit<Partial<ExternalBrowserConfig>, HiddenOptions> {}

--- a/packages/analytics-core/src/types/config/core-config.ts
+++ b/packages/analytics-core/src/types/config/core-config.ts
@@ -73,12 +73,6 @@ export interface IConfig {
    */
   enableRequestBodyCompression?: boolean;
   /**
-   * @experimental
-   * WARNING: This config is for internal testing only and is not part of the public API.
-   * It may be changed or removed at any time without notice.
-   */
-  _enableRequestBodyCompressionExperimental?: boolean;
-  /**
    * The URL where events are upload to.
    */
   serverUrl?: string;

--- a/packages/analytics-core/src/types/config/node-config.ts
+++ b/packages/analytics-core/src/types/config/node-config.ts
@@ -2,4 +2,4 @@ import { IConfig } from './core-config';
 
 export type NodeConfig = IConfig;
 
-export type NodeOptions = Omit<Partial<NodeConfig>, 'apiKey' | '_enableRequestBodyCompressionExperimental'>;
+export type NodeOptions = Omit<Partial<NodeConfig>, 'apiKey'>;

--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -2,7 +2,7 @@ import { IConfig } from './core-config';
 import { Storage } from '../storage';
 import { UserSession } from '../user-session';
 
-type HiddenOptions = 'apiKey' | 'lastEventId' | '_enableRequestBodyCompressionExperimental';
+type HiddenOptions = 'apiKey' | 'lastEventId';
 
 export type ReactNativeOptions = Omit<Partial<ReactNativeConfig>, HiddenOptions>;
 

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -565,50 +565,38 @@ describe('destination', () => {
       });
     });
 
-    test.each([
-      [false, false],
-      [true, true],
-    ])(
-      'should keep compression enabled for default server URL (experimental=%s)',
-      async (enableRequestBodyCompressionExperimental, expectedShouldCompress) => {
-        const destination = new Destination();
-        const callback = jest.fn();
-        const event = { event_type: 'event_type' };
-        const context = {
-          attempts: 0,
-          callback,
-          event,
-          timeout: 0,
-        };
-        const transportProvider = {
-          send: jest.fn().mockResolvedValueOnce({
-            status: Status.Success,
-            statusCode: 200,
-            body: {
-              eventsIngested: 1,
-              payloadSizeBytes: 1,
-              serverUploadTime: 1,
-            },
-          }),
-        };
-        await destination.setup({
-          ...useDefaultConfig(),
-          transportProvider,
-          apiKey: API_KEY,
-          serverUrl: AMPLITUDE_SERVER_URL,
-          enableRequestBodyCompression: true,
-          _enableRequestBodyCompressionExperimental: enableRequestBodyCompressionExperimental,
-        });
+    test('should keep compression enabled for default server URL', async () => {
+      const destination = new Destination();
+      const callback = jest.fn();
+      const event = { event_type: 'event_type' };
+      const context = {
+        attempts: 0,
+        callback,
+        event,
+        timeout: 0,
+      };
+      const transportProvider = {
+        send: jest.fn().mockResolvedValueOnce({
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        }),
+      };
+      await destination.setup({
+        ...useDefaultConfig(),
+        transportProvider,
+        apiKey: API_KEY,
+        serverUrl: AMPLITUDE_SERVER_URL,
+      });
 
-        await destination.send([context]);
+      await destination.send([context]);
 
-        expect(transportProvider.send).toHaveBeenCalledWith(
-          AMPLITUDE_SERVER_URL,
-          expect.any(Object),
-          expectedShouldCompress,
-        );
-      },
-    );
+      expect(transportProvider.send).toHaveBeenCalledWith(AMPLITUDE_SERVER_URL, expect.any(Object), true);
+    });
 
     test.each([
       [false, false],
@@ -643,53 +631,6 @@ describe('destination', () => {
           apiKey: API_KEY,
           serverUrl: customServerUrl,
           enableRequestBodyCompression,
-          _enableRequestBodyCompressionExperimental: true, // Delete this when enableRequestBodyCompressionExperimental is deleted
-        });
-
-        await destination.send([context]);
-
-        expect(transportProvider.send).toHaveBeenCalledWith(
-          customServerUrl,
-          expect.any(Object),
-          expectedShouldCompress,
-        );
-      },
-    );
-
-    test.each([
-      [false, false, false],
-      [true, false, false],
-    ])(
-      'should OR experimental override with custom server URL setting (experimental=%s, enable=%s)',
-      async (enableRequestBodyCompressionExperimental, enableRequestBodyCompression, expectedShouldCompress) => {
-        const destination = new Destination();
-        const callback = jest.fn();
-        const event = { event_type: 'event_type' };
-        const context = {
-          attempts: 0,
-          callback,
-          event,
-          timeout: 0,
-        };
-        const transportProvider = {
-          send: jest.fn().mockResolvedValueOnce({
-            status: Status.Success,
-            statusCode: 200,
-            body: {
-              eventsIngested: 1,
-              payloadSizeBytes: 1,
-              serverUploadTime: 1,
-            },
-          }),
-        };
-        const customServerUrl = 'https://custom.example.com/2/httpapi';
-        await destination.setup({
-          ...useDefaultConfig(),
-          transportProvider,
-          apiKey: API_KEY,
-          serverUrl: customServerUrl,
-          enableRequestBodyCompression,
-          _enableRequestBodyCompressionExperimental: enableRequestBodyCompressionExperimental,
         });
 
         await destination.send([context]);

--- a/packages/plugin-autocapture-browser/test/mock-browser-client.ts
+++ b/packages/plugin-autocapture-browser/test/mock-browser-client.ts
@@ -27,7 +27,6 @@ export const createMockBrowserClient = (): jest.Mocked<BrowserClient> => {
     getIdentity: jest.fn(),
     setIdentity: jest.fn(),
     _setDiagnosticsSampleRate: jest.fn(),
-    _enableRequestBodyCompressionExperimental: jest.fn(),
   } as jest.Mocked<BrowserClient>;
 
   // Set up default return values for methods that return promises

--- a/packages/plugin-event-property-attribution-browser/test/event-property-tracking.test.ts
+++ b/packages/plugin-event-property-attribution-browser/test/event-property-tracking.test.ts
@@ -46,7 +46,6 @@ const createMockBrowserClient = (): jest.Mocked<BrowserClient> =>
     reset: jest.fn(),
     setTransport: jest.fn(),
     _setDiagnosticsSampleRate: jest.fn(),
-    _enableRequestBodyCompressionExperimental: jest.fn(),
   } as unknown as jest.Mocked<BrowserClient>);
 
 const createConfigurationMock = (overrides: Partial<BrowserConfig> = {}): BrowserConfig =>

--- a/packages/plugin-network-capture-browser/test/mock-browser-client.ts
+++ b/packages/plugin-network-capture-browser/test/mock-browser-client.ts
@@ -27,7 +27,6 @@ export const createMockBrowserClient = (): jest.Mocked<BrowserClient> => {
     getIdentity: jest.fn(),
     setIdentity: jest.fn(),
     _setDiagnosticsSampleRate: jest.fn(),
-    _enableRequestBodyCompressionExperimental: jest.fn(),
   } as jest.Mocked<BrowserClient>;
 
   // Set up default return values for methods that return promises

--- a/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
+++ b/packages/plugin-page-view-tracking-browser/test/page-view-tracking.test.ts
@@ -54,7 +54,6 @@ const createMockBrowserClient = (): jest.Mocked<BrowserClient> => {
     getIdentity: jest.fn(),
     setIdentity: jest.fn(),
     _setDiagnosticsSampleRate: jest.fn(),
-    _enableRequestBodyCompressionExperimental: jest.fn(),
   } as jest.Mocked<BrowserClient>;
 
   // Set up default return values for methods that return promises

--- a/packages/unified/src/index.ts
+++ b/packages/unified/src/index.ts
@@ -4,7 +4,6 @@ export { createInstance } from './unified-client-factory';
 export type { UnifiedClient, UnifiedOptions, UnifiedSharedOptions } from './unified';
 export const {
   _setDiagnosticsSampleRate,
-  _enableRequestBodyCompressionExperimental,
   initAll,
   experiment,
   sessionReplay,

--- a/packages/unified/src/unified-client-factory.ts
+++ b/packages/unified/src/unified-client-factory.ts
@@ -10,12 +10,6 @@ export const createInstance = (): UnifiedClient => {
       getClientLogConfig(client),
       getClientStates(client, ['config']),
     ),
-    _enableRequestBodyCompressionExperimental: debugWrapper(
-      client._enableRequestBodyCompressionExperimental.bind(client),
-      '_enableRequestBodyCompressionExperimental',
-      getClientLogConfig(client),
-      getClientStates(client, ['config']),
-    ),
     experiment: debugWrapper(
       client.experiment.bind(client),
       'experiment',

--- a/test-server/analytics-browser-local.html
+++ b/test-server/analytics-browser-local.html
@@ -25,8 +25,6 @@
           return;
         }
 
-        //amplitude._enableRequestBodyCompressionExperimental(true);
-
         // Use test defaults; set VITE_AMPLITUDE_API_KEY in .env when using the Vite dev server with module-based pages
         var apiKey = import.meta.env.VITE_AMPLITUDE_API_KEY;
         var userId = import.meta.env.VITE_AMPLITUDE_USER_ID || 'analytics-browser-local-test-user';

--- a/test-server/browser-sdk/request-compression.html
+++ b/test-server/browser-sdk/request-compression.html
@@ -157,7 +157,6 @@
         const { transport, enableRequestBodyCompression, serverUrl } = getConfig();
         try {
           amplitude.reset();
-          amplitude._enableRequestBodyCompressionExperimental(true);
           amplitude.init(
             import.meta.env.VITE_AMPLITUDE_API_KEY,
             import.meta.env.VITE_AMPLITUDE_USER_ID || 'request-compression-test-user',


### PR DESCRIPTION
## Summary
- Remove the `_enableRequestBodyCompressionExperimental` internal API and config option across all packages (browser, core, unified, plugins)
- Simplify destination plugin to use `shouldCompressUploadBody` directly instead of gating on the experimental flag
- Clean up related tests, mocks, and test-server HTML pages

Now that request body compression is GA, the experimental backdoor is no longer needed.

## Test plan
- [ ] Verify existing compression tests pass with only the public `enableRequestBodyCompression` config
- [ ] Confirm no TypeScript compilation errors across all packages
- [ ] Validate that request compression still works end-to-end against default Amplitude server URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)