### PR TITLE
fix(autocapture): add code lines to event properties for long task

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
@@ -45,7 +45,9 @@ function buildLoAFProperties(entry: PerformanceLongAnimationFrameTiming, measure
 
   const scriptURLs = scripts.map((s) => s.sourceURL).filter(Boolean);
   const scriptFunctions = scripts.map((s) => s.sourceFunctionName).filter(Boolean);
-  const scriptPositions = scripts.map((s) => s.sourceCharPosition).filter((p): p is number => typeof p === 'number');
+  const scriptPositions = scripts
+    .map((s) => s.sourceCharPosition)
+    .filter((p): p is number => typeof p === 'number' && p >= 0);
   const invokerTypes = scripts.map((s) => s.invokerType).filter(Boolean);
   const invokers = scripts.map((s) => s.invoker).filter(Boolean);
 

--- a/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-long-task.ts
@@ -9,6 +9,10 @@ const MEASURE_BUFFER_WINDOW_MS = 10_000;
 interface PerformanceScriptTiming extends PerformanceEntry {
   sourceURL: string;
   sourceFunctionName: string;
+  // Character offset into the source URL's script where the function was defined.
+  // Used downstream for sourcemap resolution. Optional because coverage varies
+  // across browsers and entry origins (inline handlers, new Function, etc.).
+  sourceCharPosition?: number;
   invokerType: string;
   invoker: string;
 }
@@ -41,6 +45,7 @@ function buildLoAFProperties(entry: PerformanceLongAnimationFrameTiming, measure
 
   const scriptURLs = scripts.map((s) => s.sourceURL).filter(Boolean);
   const scriptFunctions = scripts.map((s) => s.sourceFunctionName).filter(Boolean);
+  const scriptPositions = scripts.map((s) => s.sourceCharPosition).filter((p): p is number => typeof p === 'number');
   const invokerTypes = scripts.map((s) => s.invokerType).filter(Boolean);
   const invokers = scripts.map((s) => s.invoker).filter(Boolean);
 
@@ -55,6 +60,7 @@ function buildLoAFProperties(entry: PerformanceLongAnimationFrameTiming, measure
     '[Amplitude] Main Thread Block Script Count': scripts.length,
     ...(scriptURLs.length > 0 && { '[Amplitude] Main Thread Block Script URLs': scriptURLs }),
     ...(scriptFunctions.length > 0 && { '[Amplitude] Main Thread Block Script Functions': scriptFunctions }),
+    ...(scriptPositions.length > 0 && { '[Amplitude] Main Thread Block Script Positions': scriptPositions }),
     ...(invokerTypes.length > 0 && { '[Amplitude] Main Thread Block Invoker Types': invokerTypes }),
     ...(invokers.length > 0 && { '[Amplitude] Main Thread Block Invokers': invokers }),
   };

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-long-task.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-long-task.test.ts
@@ -166,6 +166,39 @@ describe('trackMainThreadBlock', () => {
       expect(call['[Amplitude] Main Thread Block Script Positions']).toBeUndefined();
     });
 
+    it('should filter out -1 sentinel values from sourceCharPosition', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [
+            {
+              sourceURL: 'app.js',
+              sourceFunctionName: 'onClick',
+              sourceCharPosition: 42,
+              invokerType: 'event-listener',
+              invoker: 'click',
+            },
+            {
+              sourceURL: 'vendor.js',
+              sourceFunctionName: 'handle',
+              sourceCharPosition: -1,
+              invokerType: 'event-listener',
+              invoker: 'scroll',
+            },
+          ],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Script Positions']).toEqual([42]);
+    });
+
     it('should include overlapping measures', () => {
       trackMainThreadBlock({ amplitude, options: {} });
 

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-long-task.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-long-task.test.ts
@@ -107,8 +107,63 @@ describe('trackMainThreadBlock', () => {
       const call = (amplitude.track as jest.Mock).mock.calls[0][1];
       expect(call['[Amplitude] Main Thread Block Script URLs']).toBeUndefined();
       expect(call['[Amplitude] Main Thread Block Script Functions']).toBeUndefined();
+      expect(call['[Amplitude] Main Thread Block Script Positions']).toBeUndefined();
       expect(call['[Amplitude] Main Thread Block Invoker Types']).toBeUndefined();
       expect(call['[Amplitude] Main Thread Block Invokers']).toBeUndefined();
+    });
+
+    it('should include script positions when sourceCharPosition is present', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [
+            {
+              sourceURL: 'app.js',
+              sourceFunctionName: 'onClick',
+              sourceCharPosition: 1234,
+              invokerType: 'event-listener',
+              invoker: 'click',
+            },
+            {
+              sourceURL: 'vendor.js',
+              sourceFunctionName: 'handle',
+              // 0 is a valid character position and must not be filtered out
+              sourceCharPosition: 0,
+              invokerType: 'event-listener',
+              invoker: 'scroll',
+            },
+          ],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Script Positions']).toEqual([1234, 0]);
+    });
+
+    it('should omit script positions when sourceCharPosition is missing on all scripts', () => {
+      trackMainThreadBlock({ amplitude, options: {} });
+
+      getBlockObserver().fire([
+        {
+          duration: 150,
+          startTime: 1000,
+          blockingDuration: 120,
+          renderStart: 1050,
+          styleAndLayoutStart: 1080,
+          scripts: [
+            { sourceURL: 'app.js', sourceFunctionName: 'onClick', invokerType: 'event-listener', invoker: 'click' },
+          ],
+        } as any,
+      ]);
+
+      const call = (amplitude.track as jest.Mock).mock.calls[0][1];
+      expect(call['[Amplitude] Main Thread Block Script Positions']).toBeUndefined();
     });
 
     it('should include overlapping measures', () => {


### PR DESCRIPTION
### Summary

Missing char position field from long task. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to emitted analytics properties for LoAF events; main risk is minor downstream schema/expectation changes for consumers of these event properties.
> 
> **Overview**
> Adds optional `sourceCharPosition` support to long-animation-frame (LoAF) script timings and, when present, emits it as a new event property: `[Amplitude] Main Thread Block Script Positions`.
> 
> Updates tests to cover inclusion/omission behavior, ensuring `0` is preserved and `-1` sentinel values are filtered out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e203c29e34f50a79887d8ccb174e45fbf71507ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->