### PR TITLE
test(gtm-snippet): decompress gzipped request bodies in e2e

### DIFF
--- a/packages/gtm-snippet/e2e/gtm-snippet.spec.ts
+++ b/packages/gtm-snippet/e2e/gtm-snippet.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { parseRequestBody } from './helpers';
 
 test.describe('GTM Snippet Page', () => {
   let requests: any[] = [];
@@ -8,9 +9,8 @@ test.describe('GTM Snippet Page', () => {
     // Intercept Amplitude API calls
     await page.route('https://api2.amplitude.com/2/httpapi', async (route) => {
       const request = route.request();
-      const postData = request.postData();
-      if (postData) {
-        const data = JSON.parse(postData);
+      const data = parseRequestBody(request);
+      if (data) {
         requests.push(data);
       }
       await route.continue();

--- a/packages/gtm-snippet/e2e/helpers.ts
+++ b/packages/gtm-snippet/e2e/helpers.ts
@@ -1,0 +1,21 @@
+import { gunzipSync } from 'zlib';
+import type { Request } from '@playwright/test';
+
+/**
+ * Parse request body as JSON. Decompresses gzip when Content-Encoding: gzip is set.
+ * Uses postDataBuffer() for gzip so we get raw bytes; uses postData() for plain JSON.
+ */
+export function parseRequestBody(request: Request): Record<string, unknown> | undefined {
+  const contentEncoding = request.headers()['content-encoding'];
+
+  if (contentEncoding === 'gzip') {
+    const buffer = request.postDataBuffer();
+    if (!buffer || buffer.length === 0) return undefined;
+    const bodyStr = gunzipSync(buffer).toString('utf8');
+    return JSON.parse(bodyStr) as Record<string, unknown>;
+  }
+
+  const postData = request.postData();
+  if (!postData) return undefined;
+  return JSON.parse(postData) as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- The GTM snippet e2e test fails after [#1699](https://github.com/amplitude/Amplitude-TypeScript/pull/1699) because it does `JSON.parse(request.postData())` on responses that are now gzip-compressed by default for the default Amplitude server URLs (`https://api2.amplitude.com/2/httpapi`). `SyntaxError: Unexpected token '\x1f', ... is not valid JSON`.
- Add a parallel `parseRequestBody` helper in `packages/gtm-snippet/e2e/helpers.ts` (mirroring the existing one in `packages/analytics-browser/e2e/helpers.ts`) and route the GTM snippet test's interceptor through it so it transparently handles both plain and `Content-Encoding: gzip` bodies.

<img width="2168" height="1241" alt="image" src="https://github.com/user-attachments/assets/5477e870-aa52-47ae-80a2-e37a42e7a83c" />


## Test plan
- [x] Reproduced the failure locally (`SyntaxError: Unexpected token '', "�      "... is not valid JSON`)
- [x] Verified the fixed test passes locally: `npx playwright test packages/gtm-snippet/e2e/gtm-snippet.spec.ts --project chromium` — `1 passed (3.0s)`
- [ ] CI E2E run is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)