### PR TITLE
ci(publish-v2): fail if ref advanced since e2e checkout

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -115,12 +115,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Verify main has not advanced since dispatch
+      - name: Verify ref has not advanced since dispatch
         if: ${{ github.event.inputs.skipLernaVersion != 'true' && (github.event.inputs.branch == '' || github.event.inputs.branch == github.ref_name) }}
         env:
           DISPATCH_SHA: ${{ github.sha }}
           REF: ${{ github.event.inputs.branch || github.ref_name }}
-        run: bash scripts/publish/check-main-not-advanced.sh
+        run: bash scripts/publish/check-ref-not-advanced.sh
 
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -115,6 +115,32 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Guard against the race where a PR merges to main between dispatch and
+      # the lerna version push. If main has advanced past the dispatch SHA, the
+      # chore(release): publish commit would land on top of code that this run
+      # never tested in E2E, making the git history misleading. Re-dispatch is
+      # the right recovery — it re-runs E2E against the new HEAD.
+      - name: Verify main has not advanced since dispatch
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' && (github.event.inputs.branch == '' || github.event.inputs.branch == github.ref_name) }}
+        run: |
+          DISPATCH_SHA="${{ github.sha }}"
+          REF="${{ github.event.inputs.branch || github.ref_name }}"
+          git fetch origin "$REF"
+          REMOTE_SHA=$(git rev-parse "origin/$REF")
+          if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
+            echo "❌ $REF has advanced since this publish was dispatched."
+            echo "   Dispatch SHA:      $DISPATCH_SHA"
+            echo "   Current $REF: $REMOTE_SHA"
+            echo ""
+            echo "A commit landed on $REF while this workflow was running. The"
+            echo "chore(release): publish commit would appear after it in history,"
+            echo "falsely implying the new commit was tested by this run's E2E."
+            echo ""
+            echo "Re-dispatch this workflow to include the new commits and re-run E2E."
+            exit 1
+          fi
+          echo "✅ $REF is still at dispatch SHA: $DISPATCH_SHA"
+
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags
       - name: Create release version

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -115,32 +115,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Guard against the race where a PR merges to main between dispatch and
-      # the lerna version push. If main has advanced past the dispatch SHA, the
-      # chore(release): publish commit would land on top of code that this run
-      # never tested in E2E, making the git history misleading. Re-dispatch is
-      # the right recovery — it re-runs E2E against the new HEAD.
       - name: Verify main has not advanced since dispatch
         if: ${{ github.event.inputs.skipLernaVersion != 'true' && (github.event.inputs.branch == '' || github.event.inputs.branch == github.ref_name) }}
         env:
           DISPATCH_SHA: ${{ github.sha }}
           REF: ${{ github.event.inputs.branch || github.ref_name }}
-        run: |
-          git fetch origin "$REF"
-          REMOTE_SHA=$(git rev-parse "origin/$REF")
-          if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
-            echo "❌ $REF has advanced since this publish was dispatched."
-            echo "   Dispatch SHA:      $DISPATCH_SHA"
-            echo "   Current $REF: $REMOTE_SHA"
-            echo ""
-            echo "A commit landed on $REF while this workflow was running. The"
-            echo "chore(release): publish commit would appear after it in history,"
-            echo "falsely implying the new commit was tested by this run's E2E."
-            echo ""
-            echo "Re-dispatch this workflow to include the new commits and re-run E2E."
-            exit 1
-          fi
-          echo "✅ $REF is still at dispatch SHA: $DISPATCH_SHA"
+        run: bash scripts/publish/check-main-not-advanced.sh
 
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -54,6 +54,8 @@ jobs:
     needs: [authorize]
     container:
       image: mcr.microsoft.com/playwright:v1.55.0
+    outputs:
+      head_sha: ${{ steps.head-sha.outputs.sha }}
 
     steps:
       - name: Skip E2E for recovery publish
@@ -66,6 +68,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch || github.ref_name }}
+
+      - name: Capture E2E HEAD SHA
+        id: head-sha
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
@@ -115,10 +122,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Verify ref has not advanced since dispatch
-        if: ${{ github.event.inputs.skipLernaVersion != 'true' && (github.event.inputs.branch == '' || github.event.inputs.branch == github.ref_name) }}
+      - name: Verify ref has not advanced since e2e checkout
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         env:
-          DISPATCH_SHA: ${{ github.sha }}
+          EXPECTED_SHA: ${{ needs.e2e.outputs.head_sha }}
           REF: ${{ github.event.inputs.branch || github.ref_name }}
         run: bash scripts/publish/check-ref-not-advanced.sh
 

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -122,9 +122,10 @@ jobs:
       # the right recovery — it re-runs E2E against the new HEAD.
       - name: Verify main has not advanced since dispatch
         if: ${{ github.event.inputs.skipLernaVersion != 'true' && (github.event.inputs.branch == '' || github.event.inputs.branch == github.ref_name) }}
+        env:
+          DISPATCH_SHA: ${{ github.sha }}
+          REF: ${{ github.event.inputs.branch || github.ref_name }}
         run: |
-          DISPATCH_SHA="${{ github.sha }}"
-          REF="${{ github.event.inputs.branch || github.ref_name }}"
           git fetch origin "$REF"
           REMOTE_SHA=$(git rev-parse "origin/$REF")
           if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then

--- a/scripts/publish/check-main-not-advanced.sh
+++ b/scripts/publish/check-main-not-advanced.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Guard against the race where a PR merges to the publish ref between
+# workflow dispatch and the lerna version push. If the ref has advanced
+# past the dispatch SHA, the chore(release): publish commit would land
+# on top of code that this run never tested in E2E, making the git
+# history misleading. Re-dispatch is the right recovery — it re-runs
+# E2E against the new HEAD.
+#
+# Required env vars:
+#   DISPATCH_SHA - the SHA captured at workflow dispatch (github.sha)
+#   REF          - the branch name to compare against (e.g. main)
+
+set -euo pipefail
+
+if [ -z "${DISPATCH_SHA:-}" ] || [ -z "${REF:-}" ]; then
+  echo "❌ DISPATCH_SHA and REF must be set in the environment."
+  exit 1
+fi
+
+git fetch origin "$REF"
+REMOTE_SHA=$(git rev-parse "origin/$REF")
+
+if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
+  echo "❌ $REF has advanced since this publish was dispatched."
+  echo "   Dispatch SHA:      $DISPATCH_SHA"
+  echo "   Current $REF: $REMOTE_SHA"
+  echo ""
+  echo "A commit landed on $REF while this workflow was running. The"
+  echo "chore(release): publish commit would appear after it in history,"
+  echo "falsely implying the new commit was tested by this run's E2E."
+  echo ""
+  echo "Re-dispatch this workflow to include the new commits and re-run E2E."
+  exit 1
+fi
+
+echo "✅ $REF is still at dispatch SHA: $DISPATCH_SHA"

--- a/scripts/publish/check-ref-not-advanced.sh
+++ b/scripts/publish/check-ref-not-advanced.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
 # Guard against the race where a PR merges to the publish ref between
-# workflow dispatch and the lerna version push. If the ref has advanced
-# past the dispatch SHA, the chore(release): publish commit would land
-# on top of code that this run never tested in E2E, making the git
-# history misleading. Re-dispatch is the right recovery — it re-runs
-# E2E against the new HEAD.
+# the e2e job's checkout and the lerna version push. If the ref has
+# advanced past the SHA E2E ran against, the chore(release): publish
+# commit would land on top of code this run never tested in E2E, making
+# the git history misleading. Re-dispatch is the right recovery — it
+# re-runs E2E against the new HEAD.
 #
 # Required env vars:
-#   DISPATCH_SHA - the SHA captured at workflow dispatch (github.sha)
+#   EXPECTED_SHA - the SHA the ref is expected to still be at
+#                  (typically the e2e job's HEAD after checkout)
 #   REF          - the branch name to compare against (e.g. main)
 
 set -euo pipefail
 
-if [ -z "${DISPATCH_SHA:-}" ] || [ -z "${REF:-}" ]; then
-  echo "❌ DISPATCH_SHA and REF must be set in the environment."
+if [ -z "${EXPECTED_SHA:-}" ] || [ -z "${REF:-}" ]; then
+  echo "❌ EXPECTED_SHA and REF must be set in the environment."
   exit 1
 fi
 
@@ -28,17 +29,26 @@ fi
 # Read the current remote SHA directly. A plain `git fetch <refspec>`
 # without an explicit destination is not guaranteed to update
 # refs/remotes/origin/$REF, so reading the remote-tracking ref afterwards
-# can return a stale SHA and defeat the guard.
-REMOTE_SHA=$(git ls-remote origin "refs/heads/$REF" | awk '{print $1}')
-
-if [ -z "$REMOTE_SHA" ]; then
-  echo "❌ Could not resolve remote SHA for refs/heads/$REF"
+# can return a stale SHA and defeat the guard. Capture the command's
+# exit status explicitly so transient/auth failures surface a
+# diagnosable error rather than just a bare non-zero exit from set -e.
+# stderr is left to flow to the runner log so git's own error message
+# (auth failure, network error, etc.) is visible above our own.
+if ! LS_OUTPUT=$(git ls-remote origin "refs/heads/$REF"); then
+  echo "❌ git ls-remote failed for origin refs/heads/$REF (see error above)"
   exit 1
 fi
 
-if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
-  echo "❌ $REF has advanced since this publish was dispatched."
-  echo "   Dispatch SHA:      $DISPATCH_SHA"
+REMOTE_SHA=$(echo "$LS_OUTPUT" | awk '{print $1}')
+
+if [ -z "$REMOTE_SHA" ]; then
+  echo "❌ Could not resolve remote SHA for refs/heads/$REF on origin"
+  exit 1
+fi
+
+if [ "$REMOTE_SHA" != "$EXPECTED_SHA" ]; then
+  echo "❌ $REF has advanced since this run's E2E checkout."
+  echo "   Expected SHA: $EXPECTED_SHA"
   echo "   Current $REF: $REMOTE_SHA"
   echo ""
   echo "A commit landed on $REF while this workflow was running. The"
@@ -49,4 +59,4 @@ if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
   exit 1
 fi
 
-echo "✅ $REF is still at dispatch SHA: $DISPATCH_SHA"
+echo "✅ $REF is still at expected SHA: $EXPECTED_SHA"

--- a/scripts/publish/check-ref-not-advanced.sh
+++ b/scripts/publish/check-ref-not-advanced.sh
@@ -18,8 +18,15 @@ if [ -z "${DISPATCH_SHA:-}" ] || [ -z "${REF:-}" ]; then
   exit 1
 fi
 
-git fetch origin "$REF"
-REMOTE_SHA=$(git rev-parse "origin/$REF")
+# Validate REF as a branch name to prevent it being interpreted as a git
+# flag (e.g. a value starting with '-') or a tag with the same short name.
+if ! git check-ref-format --branch "$REF" >/dev/null 2>&1; then
+  echo "❌ REF is not a valid branch name: $REF"
+  exit 1
+fi
+
+git fetch origin "refs/heads/$REF"
+REMOTE_SHA=$(git rev-parse "refs/remotes/origin/$REF")
 
 if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
   echo "❌ $REF has advanced since this publish was dispatched."

--- a/scripts/publish/check-ref-not-advanced.sh
+++ b/scripts/publish/check-ref-not-advanced.sh
@@ -25,8 +25,16 @@ if ! git check-ref-format --branch "$REF" >/dev/null 2>&1; then
   exit 1
 fi
 
-git fetch origin "refs/heads/$REF"
-REMOTE_SHA=$(git rev-parse "refs/remotes/origin/$REF")
+# Read the current remote SHA directly. A plain `git fetch <refspec>`
+# without an explicit destination is not guaranteed to update
+# refs/remotes/origin/$REF, so reading the remote-tracking ref afterwards
+# can return a stale SHA and defeat the guard.
+REMOTE_SHA=$(git ls-remote origin "refs/heads/$REF" | awk '{print $1}')
+
+if [ -z "$REMOTE_SHA" ]; then
+  echo "❌ Could not resolve remote SHA for refs/heads/$REF"
+  exit 1
+fi
 
 if [ "$REMOTE_SHA" != "$DISPATCH_SHA" ]; then
   echo "❌ $REF has advanced since this publish was dispatched."


### PR DESCRIPTION
## Summary
Fail the `publish-v2` deploy job before `lerna version` runs if the release ref has advanced past the SHA the `e2e` job actually ran Playwright against. Closes the race that let [#1699](https://github.com/amplitude/Amplitude-TypeScript/pull/1699) ship without ever running through Playwright E2E.

Complementary follow-up tracked in [SDKW-5](https://linear.app/amplitude/issue/SDKW-5/block-pr-merges-to-main-while-publish-v2x-is-running): a merge-side gate that blocks PR merges to `main` while a publish run is in flight, so the race window never opens in the first place. This PR is the deploy-side seatbelt and lands first.

## 1. How #1699 bypassed E2E

`publish-v2` has two relevant jobs: `e2e` (runs Playwright via `.github/actions/e2e-test`) and `deploy` (runs `.github/actions/build-and-test`, which is unit tests only — no Playwright). Each one checks out by branch name (`ref: main`), so each one resolves `main` independently at *its* checkout time.

Timeline ([run 25065411243](https://github.com/amplitude/Amplitude-TypeScript/actions/runs/25065411243)):

| Time (UTC) | Event |
| ---------- | ----- |
| 16:36:23 | `publish-v2` dispatched. `github.sha = 634ac979` (pre-#1699). |
| 16:36:47 | `e2e` job starts. |
| 16:37:19 | `e2e` checks out `main` → resolves to `634ac979`. Playwright runs against pre-#1699 code. |
| **16:40:52** | **#1699 (`98ecb9d`) merges to main.** |
| 16:44:18 | `e2e` finishes — passes (it never saw #1699). |
| 16:44:21 | `deploy` job starts. |
| ~16:44:30 | `deploy` checks out `main` → resolves to `98ecb9d` (now includes #1699). |
| ~16:44–16:59 | `Build and Test` runs `pnpm test` (unit tests). #1699 updated those tests itself, so they pass. |
| 16:59:37 | `lerna version` commits `chore(release): publish` (`7c363459`) on top of `98ecb9d` and pushes — fast-forward, succeeds. |
| ~17:00 | `pnpm deploy:publish` ships the SDK including #1699's compression-by-default change. |

The only check that would have caught the gzip behavior change was Playwright E2E, and Playwright never re-ran on the post-#1699 tree. Result: misleading git history (the release commit is a child of #1699) and a published artifact whose behavior change was never E2E-tested.

## 2. How this PR closes the race

The `e2e` job now exposes its post-checkout HEAD SHA as a job output (`needs.e2e.outputs.head_sha`). A new step in the deploy job, `Verify ref has not advanced since e2e checkout`, runs after `Build and Test` and before `Create release version`. It uses `git ls-remote` to read the current `origin/<ref>` SHA and compares it to E2E's HEAD; on mismatch it fails with a clear \"re-dispatch\" message.

Using E2E's actual HEAD as the comparison anchor (rather than `github.sha`) means the guard correctly covers hotfix releases dispatched with a `branch` input override — the anchor is *whatever E2E actually ran against*, regardless of what was current at workflow_dispatch time.

Three possible windows where a PR can land during the workflow, all closed:

| Window | Without this PR | With this PR |
| ------ | --------------- | ------------ |
| (a) Before deploy checkout | Deploy checks out post-PR ref, lerna fast-forwards, **silent bad publish** | Check sees `origin/<ref> ≠ e2e HEAD SHA` → **fails before lerna runs** |
| (b) Between deploy checkout and the new check | Same as (a) | Same as (a) — check fails |
| (c) Between the new check and `lerna` push (during the multi-minute version-hook build) | Same as (a) | Check passing implies `origin/<ref>` was still at e2e's HEAD SHA. Since refs are monotonic, the deploy checkout *also* got that SHA, so the local tree is anchored there. `lerna` commits on top of it; push to a now-advanced `origin/<ref>` **fails non-fast-forward**, `Publish Release to NPM` never runs. |

Skipped only for `skipLernaVersion=true` recovery runs (no lerna push, nothing to guard).

### Out of scope
- Bad code already merged into the release ref *before* `e2e` checkout — that's a test-coverage problem, not a race, and unaffected by this change.
- Force-pushes that rewind the ref to E2E's HEAD SHA would defeat the check, but force-pushes to release branches shouldn't happen.
- Adding `--force-push` to the `lerna version` invocation later would reopen window (c). Worth a code-owner note.

## Test plan
- [x] YAML parses locally
- [x] \`\${{ ... }}\` interpolations of user-controlled context (\`branch\`, \`ref_name\`) moved into \`env:\` to satisfy semgrep \`run-shell-injection\`
- [x] Script smoke-tested locally for: happy path, advanced ref, missing ref, invalid ref name (e.g. \`-evil\`), and \`ls-remote\` auth/network failure
- [ ] Next normal release dispatch succeeds (no PRs merge during the run — most common path, behavior unchanged)
- [ ] Manual race verification: dispatch publish-v2, push a no-op commit to main during the deploy window, confirm the deploy job fails on the new step with the \"re-dispatch\" message and that no \`chore(release): publish\` commit and no npm publish happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)