### PR TITLE
fix(analytics-browser): make autocapture opt-in within Chrome Extension

### DIFF
--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -11,6 +11,7 @@ import {
   FrustrationInteractionsOptions,
   CustomEnrichmentOptions,
   PerformanceTrackingOptions,
+  isChromeExtension,
 } from '@amplitude/analytics-core';
 
 /**
@@ -35,6 +36,10 @@ const isTrackingEnabled = (
   }
 
   if (autocapture?.[event] === false) {
+    return false;
+  }
+
+  if (isChromeExtension()) {
     return false;
   }
 

--- a/packages/analytics-browser/src/default-tracking.ts
+++ b/packages/analytics-browser/src/default-tracking.ts
@@ -40,7 +40,7 @@ const isTrackingEnabled = (
   }
 
   if (isChromeExtension()) {
-    return false;
+    return !!autocapture?.[event];
   }
 
   return true;

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -1,3 +1,4 @@
+import * as analyticsCoreModule from '@amplitude/analytics-core';
 import {
   getAttributionTrackingConfig,
   getElementInteractionsConfig,
@@ -373,6 +374,16 @@ describe('isSessionTrackingEnabled', () => {
         sessions: false,
       }),
     ).toBe(false);
+  });
+
+  describe('when environment is a Chrome extension', () => {
+    beforeEach(() => {
+      jest.spyOn(analyticsCoreModule, 'isChromeExtension').mockReturnValue(true);
+    });
+
+    test('should return false', () => {
+      expect(isSessionTrackingEnabled(undefined)).toBe(false);
+    });
   });
 });
 

--- a/packages/analytics-browser/test/default-tracking.test.ts
+++ b/packages/analytics-browser/test/default-tracking.test.ts
@@ -381,8 +381,12 @@ describe('isSessionTrackingEnabled', () => {
       jest.spyOn(analyticsCoreModule, 'isChromeExtension').mockReturnValue(true);
     });
 
-    test('should return false', () => {
+    test('should return false if not set', () => {
       expect(isSessionTrackingEnabled(undefined)).toBe(false);
+    });
+
+    test('should return true if set to true', () => {
+      expect(isSessionTrackingEnabled({ sessions: true })).toBe(true);
     });
   });
 });

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -171,3 +171,4 @@ export { ExcludeInternalReferrersOptions, EXCLUDE_INTERNAL_REFERRERS_CONDITIONS 
 
 export { VideoObserver, State as VideoState, type VideoObserverParams } from './observers/video';
 export { EmbeddedVideoPlayer, type Vendor as VideoVendor } from './video-analytics/types';
+export { isChromeExtension } from './utils/environment';

--- a/packages/analytics-core/src/utils/environment.ts
+++ b/packages/analytics-core/src/utils/environment.ts
@@ -1,0 +1,6 @@
+import { getGlobalScope } from '../global-scope';
+
+export function isChromeExtension(): boolean {
+  const globalScope = getGlobalScope() as { chrome?: { runtime?: { id?: string } } };
+  return typeof globalScope?.chrome?.runtime?.id === 'string';
+}

--- a/packages/analytics-core/test/utils/environment.test.ts
+++ b/packages/analytics-core/test/utils/environment.test.ts
@@ -1,0 +1,42 @@
+import * as analyticsCoreModule from '../../src/index';
+import * as globalScopeModule from '../../src/global-scope';
+
+type ChromeStub = { runtime?: { id?: string | number } };
+
+describe('isChromeExtension', () => {
+  const originalChrome = (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalChrome === undefined) {
+      delete (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome;
+    } else {
+      (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome = originalChrome;
+    }
+  });
+
+  test('returns false when globalScope is undefined', () => {
+    jest.spyOn(globalScopeModule, 'getGlobalScope').mockReturnValue(undefined);
+    expect(analyticsCoreModule.isChromeExtension()).toBe(false);
+  });
+
+  test('returns false when chrome is undefined', () => {
+    delete (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome;
+    expect(analyticsCoreModule.isChromeExtension()).toBe(false);
+  });
+
+  test('returns false when chrome.runtime is undefined', () => {
+    (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome = {};
+    expect(analyticsCoreModule.isChromeExtension()).toBe(false);
+  });
+
+  test('returns false when runtime.id is not a string', () => {
+    (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome = { runtime: { id: 1 } };
+    expect(analyticsCoreModule.isChromeExtension()).toBe(false);
+  });
+
+  test('returns true when chrome.runtime.id is a string', () => {
+    (globalThis as typeof globalThis & { chrome?: ChromeStub }).chrome = { runtime: { id: 'ext-abc' } };
+    expect(analyticsCoreModule.isChromeExtension()).toBe(true);
+  });
+});


### PR DESCRIPTION
### Summary

Changes the default behaviour of the Analytics SDK when it is in a Chrome Extension context so that `autocapture` needs to be explicitly enabled (opt-in).

Rationale: because Chrome Extensions are able to run across tabs, the data that it collects is potentially a lot more sensitive than what is collected from a regular Browser Window. So better to require users of the SDK to "opt-in" to avoid surprises.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default-tracking behavior to automatically disable several autocapture defaults when running in a Chrome extension, which may alter event volume/behavior for existing extension integrations. Adds a new cross-package environment check, so risk is moderate but localized.
> 
> **Overview**
> **Disables default autocapture features in Chrome extension contexts.** The browser SDK’s `isTrackingEnabled` now returns `false` when `isChromeExtension()` is detected, making default-enabled tracking (e.g., sessions/page views/attribution/file downloads/form interactions/page URL enrichment when `autocapture` is `undefined`) effectively opt-in for extensions.
> 
> Adds `isChromeExtension()` to `analytics-core` (exported from the public index) and new unit tests in both `analytics-core` and `analytics-browser` to validate the environment detection and the new default-tracking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d31fccdecbf3bb5b688056708cca0e63ea095b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->