### PR TITLE
fix(plugin-autocapture-browser): strip URL params from Page URL in Viewport Content Updated

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
@@ -39,7 +39,7 @@ export function fireViewportContentUpdated({
   const eventProperties: Record<string, unknown> = {
     [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]:
       /* istanbul ignore next */
-      globalScope?.location?.href,
+      globalScope?.location?.href?.split('?')[0],
     [constants.AMPLITUDE_EVENT_PROP_MAX_PAGE_X]: pageScrollMaxState.maxX + viewportWidth,
     [constants.AMPLITUDE_EVENT_PROP_MAX_PAGE_Y]: pageScrollMaxState.maxY + viewportHeight,
     [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT]: viewportHeight,

--- a/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
@@ -1,4 +1,4 @@
-import { BrowserClient, getGlobalScope } from '@amplitude/analytics-core';
+import { BrowserClient, getDecodeURI, getGlobalScope } from '@amplitude/analytics-core';
 import * as constants from '../constants';
 import { getCurrentPageViewId } from '../helpers';
 
@@ -37,9 +37,10 @@ export function fireViewportContentUpdated({
   const viewportHeight = globalScope?.innerHeight ?? 0;
 
   const eventProperties: Record<string, unknown> = {
-    [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]:
+    [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: getDecodeURI(
       /* istanbul ignore next */
-      globalScope?.location?.href?.split('?')[0],
+      globalScope?.location?.href?.split('?')[0] ?? '',
+    ),
     [constants.AMPLITUDE_EVENT_PROP_MAX_PAGE_X]: pageScrollMaxState.maxX + viewportWidth,
     [constants.AMPLITUDE_EVENT_PROP_MAX_PAGE_Y]: pageScrollMaxState.maxY + viewportHeight,
     [constants.AMPLITUDE_EVENT_PROP_VIEWPORT_HEIGHT]: viewportHeight,

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
@@ -448,6 +448,92 @@ describe('fireViewportContentUpdated - early return when no changes', () => {
     );
   });
 
+  test('should strip URL query parameters from Page URL property', () => {
+    const originalLocation = window.location;
+    const locationMock = {
+      ...originalLocation,
+      href: 'https://www.test.com/path?foo=bar&baz=qux',
+    } as unknown as Location;
+    Object.defineProperty(window, 'location', {
+      value: locationMock,
+      writable: true,
+      configurable: true,
+    });
+
+    const currentElementExposed = new Set<string>(['element-1']);
+    const elementExposedForPage = new Set<string>(['element-1']);
+
+    try {
+      fireViewportContentUpdated({
+        amplitude: mockAmplitude,
+        scrollTracker: mockScrollTracker,
+        currentElementExposed,
+        elementExposedForPage,
+        exposureTracker: undefined,
+        isPageEnd: false,
+        lastScroll: { maxX: undefined, maxY: undefined },
+      });
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        '[Amplitude] Viewport Content Updated',
+        expect.objectContaining({
+          [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: 'https://www.test.com/path',
+        }),
+      );
+
+      const trackCall = trackSpy.mock.calls[0];
+      expect(trackCall[1][constants.AMPLITUDE_EVENT_PROP_PAGE_URL]).not.toContain('?');
+      expect(trackCall[1][constants.AMPLITUDE_EVENT_PROP_PAGE_URL]).not.toContain('foo=bar');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  test('should preserve Page URL when no query parameters are present', () => {
+    const originalLocation = window.location;
+    const locationMock = {
+      ...originalLocation,
+      href: 'https://www.test.com/path',
+    } as unknown as Location;
+    Object.defineProperty(window, 'location', {
+      value: locationMock,
+      writable: true,
+      configurable: true,
+    });
+
+    const currentElementExposed = new Set<string>(['element-1']);
+    const elementExposedForPage = new Set<string>(['element-1']);
+
+    try {
+      fireViewportContentUpdated({
+        amplitude: mockAmplitude,
+        scrollTracker: mockScrollTracker,
+        currentElementExposed,
+        elementExposedForPage,
+        exposureTracker: undefined,
+        isPageEnd: false,
+        lastScroll: { maxX: undefined, maxY: undefined },
+      });
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        '[Amplitude] Viewport Content Updated',
+        expect.objectContaining({
+          [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]: 'https://www.test.com/path',
+        }),
+      );
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
   test('should track when lastScroll has undefined values', () => {
     const currentElementExposed = new Set<string>();
     const elementExposedForPage = new Set<string>();

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
@@ -493,6 +493,48 @@ describe('fireViewportContentUpdated - early return when no changes', () => {
     }
   });
 
+  test('should decode URI-encoded characters in Page URL property', () => {
+    const originalLocation = window.location;
+    const locationMock = {
+      ...originalLocation,
+      href: 'https://www.topps.com/products/2025-bowman-chrome%C2%AE-baseball-mega-box?foo=bar',
+    } as unknown as Location;
+    Object.defineProperty(window, 'location', {
+      value: locationMock,
+      writable: true,
+      configurable: true,
+    });
+
+    const currentElementExposed = new Set<string>(['element-1']);
+    const elementExposedForPage = new Set<string>(['element-1']);
+
+    try {
+      fireViewportContentUpdated({
+        amplitude: mockAmplitude,
+        scrollTracker: mockScrollTracker,
+        currentElementExposed,
+        elementExposedForPage,
+        exposureTracker: undefined,
+        isPageEnd: false,
+        lastScroll: { maxX: undefined, maxY: undefined },
+      });
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        '[Amplitude] Viewport Content Updated',
+        expect.objectContaining({
+          [constants.AMPLITUDE_EVENT_PROP_PAGE_URL]:
+            'https://www.topps.com/products/2025-bowman-chrome®-baseball-mega-box',
+        }),
+      );
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
   test('should preserve Page URL when no query parameters are present', () => {
     const originalLocation = window.location;
     const locationMock = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

URL query parameters were being tracked in the `[Amplitude] Page URL` property of the `[Amplitude] Viewport Content Updated` event. This is inconsistent with other autocapture events (e.g. element clicked / element changed) which strip the query string before reporting the page URL (see `data-extractor.ts`).

This PR strips the query string from `globalScope?.location?.href` via `.split('?')[0]` in `fireViewportContentUpdated`, matching the convention used elsewhere in autocapture.

### Changes

- `packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts`: strip query params from the Page URL event property.
- `packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts`: added two tests — one verifying query params are stripped, another verifying URLs without params are preserved.

All 399 tests in `@amplitude/plugin-autocapture-browser` pass with 100% coverage.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-177bd005-6683-44a2-9c8c-74c34485f2ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-177bd005-6683-44a2-9c8c-74c34485f2ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

