### PR TITLE
feat(session-replay-browser): cross-origin iframe recording (SR-4094)

### DIFF
--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -104,6 +104,91 @@ sessionReplay.shutdown()
 |`performanceConfig.enabled`|`boolean`|No|`true`|If enabled, event compression will be deferred to occur during the browser's idle periods.|
 |`performanceConfig.timeout`|`number`|No|`undefined`|Optional timeout in milliseconds for the `requestIdleCallback` API. If specified, this value will be used to set a maximum time for the browser to wait before executing the deferred compression task, even if the browser is not idle.|
 |`useWebWorker`|`boolean`|No|`false`|If true, the SDK will compress replay events using a web worker. This offloads compression to a separate thread, improving performance on the main thread.|
+|`crossOriginIframes.enabled`|`boolean`|No|`false`|Enables cross-origin iframe recording. Must be set to `true` on both the parent page and each child iframe page. See [Cross-Origin Iframe Recording](#cross-origin-iframe-recording).|
+|`crossOriginIframes.coordinateChildren`|`boolean`|No|`true`|When `true`, the parent SDK automatically sends start/stop signals to child iframes via `postMessage`. Set to `false` to manage child recording lifecycle yourself.|
+
+## Cross-Origin Iframe Recording
+
+The SDK can capture events inside cross-origin `<iframe>` elements and merge them into the parent page's session replay.
+
+### How it works
+
+Both the parent page and each iframe page must load the SDK with `crossOriginIframes.enabled: true`. The parent SDK coordinates recording across all child iframes using `postMessage` signals and rrweb's built-in cross-origin relay.
+
+```
+Parent page (yoursite.com)
+┌─────────────────────────────────────────────────────────────────┐
+│  sessionReplay.init(API_KEY, { crossOriginIframes: { enabled: true } })
+│                                                                   │
+│  CrossOriginIframeCoordinator                                     │
+│  ┌────────────────────────┐                                       │
+│  │ MutationObserver       │  postMessage("start") ──────────────► │
+│  │ watches for <iframe>   │                                       │
+│  │ additions/removals     │  postMessage("stop")  ──────────────► │
+│  └────────────────────────┘                                       │
+│                                                                   │
+│  rrweb (recordCrossOriginIframes: true)                           │
+│  ◄─────────────── child rrweb events relayed via postMessage ──── │
+│  Merges child events into parent snapshot stream                  │
+└─────────────────────────────────────────────────────────────────┘
+         │ postMessage("start" / "stop")
+         ▼
+Child iframe page (payments.example.com)
+┌─────────────────────────────────────────────────────────────────┐
+│  sessionReplay.init(API_KEY, { crossOriginIframes: { enabled: true } })
+│                                                                   │
+│  isInIframe() === true → child mode                               │
+│  listenForParentSignals()                                         │
+│  ┌──────────────────────────────────┐                            │
+│  │ Waits for "start" signal         │                            │
+│  │   → initialises rrweb recording  │                            │
+│  │ On "stop" signal                 │                            │
+│  │   → stops rrweb, flushes events  │                            │
+│  └──────────────────────────────────┘                            │
+│                                                                   │
+│  rrweb events ──► postMessage relay ──► parent rrweb             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Child events are serialized by the child page's own rrweb instance and relayed to the parent via `postMessage`. The parent rrweb stream stores them inline, so the replay viewer can reconstruct both frames from a single session.
+
+### Setup
+
+**Parent page:**
+```typescript
+sessionReplay.init(API_KEY, {
+  deviceId: DEVICE_ID,
+  sessionId: SESSION_ID,
+  crossOriginIframes: { enabled: true },
+});
+```
+
+**Child iframe page** (must also load the SDK):
+```typescript
+sessionReplay.init(API_KEY, {
+  deviceId: DEVICE_ID,
+  sessionId: SESSION_ID,
+  crossOriginIframes: { enabled: true },
+});
+```
+
+The child SDK detects it is running inside an iframe and automatically enters child mode — it will wait for a start signal from the parent rather than begin recording immediately.
+
+### Options
+
+| Name | Type | Required | Default | Description |
+|-|-|-|-|-|
+| `crossOriginIframes.enabled` | `boolean` | Yes | — | Enables cross-origin iframe recording on both parent and child pages. |
+| `crossOriginIframes.coordinateChildren` | `boolean` | No | `true` | When `true`, the parent SDK sends start/stop signals to child iframes and keeps their recording lifecycle in sync. Set to `false` to manage child recording yourself. |
+
+### Privacy
+
+The child page's rrweb instance performs its own DOM serialisation. The parent's privacy config (mask levels, block selectors, etc.) does **not** automatically apply inside the iframe — configure privacy settings independently on the child page.
+
+### Limitations
+
+- **Third-party iframes** (e.g. Stripe, Google Maps) cannot be captured. Both the parent and child pages must load the SDK with `crossOriginIframes.enabled: true`.
+- `coordinateChildren: false` opts out of the coordinator; in this mode the child SDK will not start recording until you manage its lifecycle directly.
 
 ## Network Request Capture
 

--- a/packages/session-replay-browser/e2e/cross-origin-iframe.spec.ts
+++ b/packages/session-replay-browser/e2e/cross-origin-iframe.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  captureTrackRequests,
+  flushRecording,
+  getSnapshotRoot,
+  findById,
+} from './helpers';
+
+const PARENT_PAGE = '/session-replay-browser/sr-cross-origin-iframe-parent.html';
+const CHILD_PAGE = '/session-replay-browser/sr-cross-origin-iframe-child.html';
+
+/** Wait for the child iframe to appear and return the matching Playwright Frame. */
+async function getChildFrame(page: import('@playwright/test').Page) {
+  await page.waitForSelector('#child-frame');
+  await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+  const childFrame = page.frames().find((f) => f.url().includes('sr-cross-origin-iframe-child'));
+  if (!childFrame) throw new Error('Child frame not found');
+  return childFrame;
+}
+
+test.describe('cross-origin iframe recording', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+  });
+
+  test('parent initializes without error with crossOriginIframes enabled', async ({ page }) => {
+    const { getBodies } = await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PARENT_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+
+    const srError = await page.evaluate(() => (window as any).srError as string | undefined);
+    expect(srError).toBeUndefined();
+
+    await flushRecording(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    expect(getBodies().length).toBeGreaterThan(0);
+    const root = getSnapshotRoot(getBodies());
+    expect(root).not.toBeNull();
+    expect(findById(root!, 'parent-content')).toBeDefined();
+  });
+
+  test('coordinator sends start signal to dynamically-added child iframe', async ({ page }) => {
+    await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PARENT_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+
+    const childFrame = await getChildFrame(page);
+
+    // The child's raw onmessage listener (set before the SDK loads) must have
+    // received the start postMessage from the parent's CrossOriginIframeCoordinator.
+    const receivedStart = await childFrame.evaluate(() => (window as any).receivedStartSignal as boolean);
+    expect(receivedStart).toBe(true);
+  });
+
+  test('child page detects it is inside an iframe', async ({ page }) => {
+    await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PARENT_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+
+    const childFrame = await getChildFrame(page);
+
+    const childModeDetected = await childFrame.evaluate(() => (window as any).childModeDetected as boolean);
+    expect(childModeDetected).toBe(true);
+  });
+
+  test('coordinateChildren: false — child iframe does not receive start signal', async ({ page }) => {
+    await captureTrackRequests(page);
+
+    await page.goto(buildUrl(PARENT_PAGE, { sessionId: TEST_SESSION_ID, coordinateChildren: 'false' }));
+    await waitForReady(page);
+
+    const childFrame = await getChildFrame(page);
+
+    // No start signal expected: coordinator is not started when coordinateChildren=false.
+    const receivedStart = await childFrame.evaluate(() => (window as any).receivedStartSignal as boolean);
+    expect(receivedStart).toBe(false);
+  });
+
+  test('child page initializes without error when loaded directly (not in an iframe)', async ({ page }) => {
+    await captureTrackRequests(page);
+
+    await page.goto(buildUrl(CHILD_PAGE, { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+
+    const srError = await page.evaluate(() => (window as any).srError as string | undefined);
+    expect(srError).toBeUndefined();
+
+    // Not in an iframe context, so child mode should not be detected.
+    const childModeDetected = await page.evaluate(() => (window as any).childModeDetected as boolean);
+    expect(childModeDetected).toBe(false);
+  });
+});

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -8,6 +8,7 @@ import {
 import { SessionReplayOptions, StoreType } from '../typings/session-replay';
 import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
+  CrossOriginIframesConfig,
   InteractionConfig,
   PrivacyConfig,
   SessionReplayPerformanceConfig,
@@ -45,6 +46,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   urlChangePollingInterval?: number;
   captureDocumentTitle?: boolean;
   captureAdoptedStyleSheets?: boolean;
+  crossOriginIframes?: CrossOriginIframesConfig;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -100,5 +102,8 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
       this.omitElementTags = options.omitElementTags;
     }
     this.captureAdoptedStyleSheets = options.captureAdoptedStyleSheets ?? true;
+    if (options.crossOriginIframes) {
+      this.crossOriginIframes = options.crossOriginIframes;
+    }
   }
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -91,6 +91,25 @@ export type UGCFilterRule = {
   replacement: string;
 };
 
+export interface CrossOriginIframesConfig {
+  enabled: boolean;
+  /**
+   * When true (default), the parent SDK sends start/stop signals to child iframes via
+   * postMessage, keeping their recording lifecycle in sync with the parent.
+   *
+   * **Privacy note:** The child page's rrweb instance performs its own DOM serialization,
+   * so the parent's privacy config (mask levels, block selectors) does NOT automatically
+   * apply inside the iframe. Privacy settings must be configured independently on the child page.
+   *
+   * **Third-party iframes:** Cannot capture iframes you don't control (e.g. Stripe, Google
+   * Maps) — both parent and child pages must load the SDK with `crossOriginIframes.enabled: true`.
+   *
+   * Set to `false` to skip coordination and manage the child recording lifecycle yourself.
+   * @defaultValue true
+   */
+  coordinateChildren?: boolean;
+}
+
 export interface SessionReplayLocalConfig extends IConfig {
   apiKey: string;
   loggerProvider: ILogger;
@@ -221,6 +240,14 @@ export interface SessionReplayLocalConfig extends IConfig {
    * @defaultValue true
    */
   captureAdoptedStyleSheets?: boolean;
+  /**
+   * Enables recording of cross-origin iframes. Both the parent page and each child iframe
+   * page must load the Amplitude Session Replay SDK with this option enabled.
+   *
+   * When enabled, rrweb uses `postMessage` to relay child DOM events to the parent, which
+   * merges them into a single unified event stream.
+   */
+  crossOriginIframes?: CrossOriginIframesConfig;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -29,6 +29,8 @@ export const KB_SIZE = 1024;
 export const MAX_URL_LENGTH = 1000;
 export const RETRY_TIMEOUT_MS = 1000;
 
+export const CROSS_ORIGIN_IFRAME_MESSAGE_TYPE = 'amplitude-sr-iframe';
+
 export enum CustomRRwebEvent {
   GET_SR_PROPS = 'get-sr-props',
   DEBUG_INFO = 'debug-info',

--- a/packages/session-replay-browser/src/cross-origin-iframes.ts
+++ b/packages/session-replay-browser/src/cross-origin-iframes.ts
@@ -1,0 +1,99 @@
+import { getGlobalScope } from '@amplitude/analytics-core';
+import { CROSS_ORIGIN_IFRAME_MESSAGE_TYPE } from './constants';
+
+export function isInIframe(): boolean {
+  try {
+    const globalScope = getGlobalScope() as Window | undefined;
+    if (!globalScope) {
+      return false;
+    }
+    return globalScope.parent !== globalScope;
+  } catch {
+    // SecurityError accessing window.parent in some sandboxed environments
+    return true;
+  }
+}
+
+type IframeMessage = { type: typeof CROSS_ORIGIN_IFRAME_MESSAGE_TYPE; action: 'start' | 'stop' };
+
+/**
+ * Manages the parent side of cross-origin iframe recording coordination.
+ *
+ * When the parent starts recording, it sends a start signal to all current child
+ * iframes and watches for dynamically added iframes via MutationObserver. When the
+ * parent stops, it sends a stop signal.
+ */
+export class CrossOriginIframeCoordinator {
+  private mutationObserver: MutationObserver | undefined;
+
+  start() {
+    const globalScope = getGlobalScope();
+    if (!globalScope) {
+      return;
+    }
+    this.sendToAllIframes({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+    this.mutationObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (node instanceof HTMLIFrameElement) {
+            this.sendToIframe(node, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+          }
+        }
+      }
+    });
+    this.mutationObserver.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  stop() {
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = undefined;
+    this.sendToAllIframes({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' });
+  }
+
+  private sendToAllIframes(message: IframeMessage) {
+    const iframes = document.querySelectorAll<HTMLIFrameElement>('iframe');
+    iframes.forEach((iframe) => this.sendToIframe(iframe, message));
+  }
+
+  private sendToIframe(iframe: HTMLIFrameElement, message: IframeMessage) {
+    try {
+      iframe.contentWindow?.postMessage(message, '*');
+    } catch {
+      // Cross-origin postMessage can throw in some sandboxed environments; ignore.
+    }
+  }
+}
+
+/**
+ * Listens for start/stop signals from the parent page and invokes the provided
+ * callbacks. Only messages from `window.parent` are accepted.
+ *
+ * Returns a cleanup function that removes the message listener.
+ */
+export function listenForParentSignals(callbacks: { onStart: () => void; onStop: () => void }): () => void {
+  const globalScope = getGlobalScope() as Window | undefined;
+  if (!globalScope) {
+    return () => undefined;
+  }
+
+  const parentFrame = globalScope.parent;
+
+  function handler(event: MessageEvent) {
+    // Only accept messages from the direct parent frame.
+    if (event.source !== parentFrame) {
+      return;
+    }
+    const data = event.data as Partial<IframeMessage>;
+    if (data?.type !== CROSS_ORIGIN_IFRAME_MESSAGE_TYPE) {
+      return;
+    }
+    if (data.action === 'start') {
+      callbacks.onStart();
+    } else if (data.action === 'stop') {
+      callbacks.onStop();
+    }
+  }
+
+  globalScope.addEventListener('message', handler);
+  return () => globalScope.removeEventListener('message', handler);
+}

--- a/packages/session-replay-browser/src/cross-origin-iframes.ts
+++ b/packages/session-replay-browser/src/cross-origin-iframes.ts
@@ -25,8 +25,11 @@ type IframeMessage = { type: typeof CROSS_ORIGIN_IFRAME_MESSAGE_TYPE; action: 's
  */
 export class CrossOriginIframeCoordinator {
   private mutationObserver: MutationObserver | undefined;
+  // Tracks pending load listeners for dynamically added iframes so stop() can cancel them.
+  private pendingLoadListeners = new Map<HTMLIFrameElement, () => void>();
 
   start() {
+    this.mutationObserver?.disconnect(); // guard against double-start
     const globalScope = getGlobalScope();
     if (!globalScope) {
       return;
@@ -36,7 +39,11 @@ export class CrossOriginIframeCoordinator {
       for (const mutation of mutations) {
         for (const node of Array.from(mutation.addedNodes)) {
           if (node instanceof HTMLIFrameElement) {
-            this.sendToIframe(node, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+            // Send the start signal after the child page has loaded, not at insertion
+            // time. At insertion the contentWindow is still about:blank; the message
+            // sent there is discarded when the iframe navigates to its src, and the
+            // child SDK never receives it.
+            this.sendToIframeAfterLoad(node);
           }
         }
       }
@@ -47,7 +54,21 @@ export class CrossOriginIframeCoordinator {
   stop() {
     this.mutationObserver?.disconnect();
     this.mutationObserver = undefined;
+    // Cancel any start signals that were waiting for a pending iframe load.
+    this.pendingLoadListeners.forEach((listener, iframe) => {
+      iframe.removeEventListener('load', listener);
+    });
+    this.pendingLoadListeners.clear();
     this.sendToAllIframes({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' });
+  }
+
+  private sendToIframeAfterLoad(iframe: HTMLIFrameElement) {
+    const sendStart = () => {
+      this.pendingLoadListeners.delete(iframe);
+      this.sendToIframe(iframe, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+    };
+    this.pendingLoadListeners.set(iframe, sendStart);
+    iframe.addEventListener('load', sendStart, { once: true });
   }
 
   private sendToAllIframes(message: IframeMessage) {

--- a/packages/session-replay-browser/src/cross-origin-iframes.ts
+++ b/packages/session-replay-browser/src/cross-origin-iframes.ts
@@ -54,6 +54,15 @@ export class CrossOriginIframeCoordinator {
             });
           }
         }
+        for (const node of Array.from(mutation.removedNodes)) {
+          if (node instanceof HTMLIFrameElement) {
+            const listener = this.pendingLoadListeners.get(node);
+            if (listener) {
+              node.removeEventListener('load', listener);
+              this.pendingLoadListeners.delete(node);
+            }
+          }
+        }
       }
     });
     this.mutationObserver.observe(document.documentElement, { childList: true, subtree: true });

--- a/packages/session-replay-browser/src/cross-origin-iframes.ts
+++ b/packages/session-replay-browser/src/cross-origin-iframes.ts
@@ -44,6 +44,14 @@ export class CrossOriginIframeCoordinator {
             // sent there is discarded when the iframe navigates to its src, and the
             // child SDK never receives it.
             this.sendToIframeAfterLoad(node);
+          } else if (node instanceof Element) {
+            // A container element (e.g. a React-rendered div) may already have
+            // iframe descendants when it is inserted. These iframes do NOT appear
+            // in addedNodes — only the container does. Query the subtree so we
+            // don't miss them.
+            node.querySelectorAll<HTMLIFrameElement>('iframe').forEach((iframe) => {
+              this.sendToIframeAfterLoad(iframe);
+            });
           }
         }
       }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -819,11 +819,18 @@ export class SessionReplay implements AmplitudeSessionReplay {
         this.crossOriginParentSignalCleanup = listenForParentSignals({
           onStart: () => this._recordEventsInChildMode(recordFunction, sessionId, config, hooks),
           onStop: () => {
-            // Only cancel the rrweb recording — do NOT call stopRecordingEvents() here,
-            // which would clear crossOriginParentSignalCleanup and make the child deaf
-            // to subsequent start/stop cycles from the parent.
-            this.recordCancelCallback && this.recordCancelCallback();
-            this.recordCancelCallback = null;
+            try {
+              // Only cancel the rrweb recording — do NOT call stopRecordingEvents() here,
+              // which would clear crossOriginParentSignalCleanup and make the child deaf
+              // to subsequent start/stop cycles from the parent.
+              this.recordCancelCallback && this.recordCancelCallback();
+              this.recordCancelCallback = null;
+            } catch (error) {
+              const typedError = error as Error;
+              this.loggerProvider.warn(
+                `Error occurred while stopping child iframe replay capture: ${typedError.toString()}`,
+              );
+            }
           },
         });
         return;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -785,7 +785,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       if (ignoredUrls.some((url) => event.url.startsWith(url))) return;
       void this.addCustomRRWebEvent(CustomRRwebEvent.FETCH_REQUEST, event);
     }, networkLoggingConfig);
-    const { privacyConfig, interactionConfig, loggingConfig } = config;
+    const { interactionConfig, loggingConfig } = config;
 
     const hooks = interactionConfig?.enabled
       ? {
@@ -837,59 +837,28 @@ export class SessionReplay implements AmplitudeSessionReplay {
       }
 
       this.recordCancelCallback = recordFunction({
-        emit: (event: eventWithTime) => {
-          if (this.shouldOptOut()) {
-            this.loggerProvider.log(`Opting session ${sessionId} out of recording due to optOut config.`);
-            this.stopRecordingEvents();
-            this.sendEvents();
-            return;
-          }
+        ...this.buildRRWebRecordOptions(
+          config,
+          hooks,
+          (event: eventWithTime) => {
+            if (this.shouldOptOut()) {
+              this.loggerProvider.log(`Opting session ${sessionId} out of recording due to optOut config.`);
+              this.stopRecordingEvents();
+              this.sendEvents();
+              return;
+            }
 
-          if (event.type === RRWebEventType.Meta) {
-            event.data.href = getPageUrl(event.data.href, ugcFilterRules);
-          }
+            if (event.type === RRWebEventType.Meta) {
+              event.data.href = getPageUrl(event.data.href, ugcFilterRules);
+            }
 
-          if (this.eventCompressor) {
-            // Schedule processing during idle time if the browser supports requestIdleCallback
-            this.eventCompressor.enqueueEvent(event, sessionId);
-          }
-        },
-        inlineStylesheet: config.shouldInlineStylesheet,
-        hooks,
-        maskAllInputs: true,
-        maskTextClass: MASK_TEXT_CLASS,
-        blockClass: BLOCK_CLASS,
-        blockSelector: this.getBlockSelectors() as string | undefined,
-        applyBackgroundColorToBlockedElements: config.applyBackgroundColorToBlockedElements,
-        maskInputFn: maskFn('input', privacyConfig, () => this.currentPageUrl),
-        maskTextFn: maskFn('text', privacyConfig, () => this.currentPageUrl),
-        maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
-        maskTextSelector: this.getMaskTextSelectors(),
-        recordCanvas: false,
-        captureAdoptedStyleSheets: config.captureAdoptedStyleSheets,
-        slimDOMOptions: {
-          script: config.omitElementTags?.script,
-          comment: config.omitElementTags?.comment,
-        },
-        errorHandler: (error: unknown) => {
-          const typedError = error as Error & { _external_?: boolean };
-
-          // styled-components relies on this error being thrown and bubbled up, rrweb is otherwise suppressing it
-          if (typedError.message.includes('insertRule') && typedError.message.includes('CSSStyleSheet')) {
-            throw typedError;
-          }
-
-          // rrweb does monkey patching on certain window functions such as CSSStyleSheet.proptype.insertRule,
-          // and errors from external clients calling these functions can get suppressed. Styled components depend
-          // on these errors being re-thrown.
-          if (typedError._external_) {
-            throw typedError;
-          }
-
-          this.loggerProvider.warn('Error while capturing replay: ', typedError.toString());
-          // Return true so that we don't clutter user's consoles with internal rrweb errors
-          return true;
-        },
+            if (this.eventCompressor) {
+              // Schedule processing during idle time if the browser supports requestIdleCallback
+              this.eventCompressor.enqueueEvent(event, sessionId);
+            }
+          },
+          'Error while capturing replay: ',
+        ),
         plugins: await this.getRecordingPlugins(loggingConfig),
         recordCrossOriginIframes: crossOriginIframesEnabled,
       });
@@ -910,6 +879,50 @@ export class SessionReplay implements AmplitudeSessionReplay {
     }
   }
 
+  private buildRRWebRecordOptions(
+    config: SessionReplayJoinedConfig,
+    hooks: { mouseInteraction?: any; scroll?: scrollCallback },
+    emit: (event: eventWithTime) => void,
+    errorLogPrefix: string,
+  ): Parameters<RecordFunction>[0] {
+    const { privacyConfig } = config;
+    return {
+      emit,
+      inlineStylesheet: config.shouldInlineStylesheet,
+      hooks,
+      maskAllInputs: true,
+      maskTextClass: MASK_TEXT_CLASS,
+      blockClass: BLOCK_CLASS,
+      blockSelector: this.getBlockSelectors() as string | undefined,
+      applyBackgroundColorToBlockedElements: config.applyBackgroundColorToBlockedElements,
+      maskInputFn: maskFn('input', privacyConfig, () => this.currentPageUrl),
+      maskTextFn: maskFn('text', privacyConfig, () => this.currentPageUrl),
+      maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
+      maskTextSelector: this.getMaskTextSelectors(),
+      recordCanvas: false,
+      captureAdoptedStyleSheets: config.captureAdoptedStyleSheets,
+      slimDOMOptions: {
+        script: config.omitElementTags?.script,
+        comment: config.omitElementTags?.comment,
+      },
+      errorHandler: (error: unknown) => {
+        const typedError = error as Error & { _external_?: boolean };
+        // styled-components relies on this error being thrown and bubbled up, rrweb is otherwise suppressing it
+        if (typedError.message.includes('insertRule') && typedError.message.includes('CSSStyleSheet')) {
+          throw typedError;
+        }
+        // rrweb monkey-patches window functions like CSSStyleSheet.insertRule; errors from external callers
+        // (e.g. styled-components) must be re-thrown so they aren't silently swallowed.
+        if (typedError._external_) {
+          throw typedError;
+        }
+        this.loggerProvider.warn(errorLogPrefix, typedError.toString());
+        // Return true so that we don't clutter user's consoles with internal rrweb errors
+        return true;
+      },
+    };
+  }
+
   private _recordEventsInChildMode(
     recordFunction: RecordFunction,
     sessionId: string | number,
@@ -927,39 +940,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
       // this method — making the child permanently deaf to subsequent stop/start cycles.
       this.recordCancelCallback && this.recordCancelCallback();
       this.recordCancelCallback = null;
-      const { privacyConfig } = config;
       this.recordCancelCallback = recordFunction({
-        emit: () => {
-          // no-op: child events are forwarded to parent via postMessage by rrweb
-        },
-        inlineStylesheet: config.shouldInlineStylesheet,
-        hooks,
-        maskAllInputs: true,
-        maskTextClass: MASK_TEXT_CLASS,
-        blockClass: BLOCK_CLASS,
-        blockSelector: this.getBlockSelectors() as string | undefined,
-        applyBackgroundColorToBlockedElements: config.applyBackgroundColorToBlockedElements,
-        maskInputFn: maskFn('input', privacyConfig, () => this.currentPageUrl),
-        maskTextFn: maskFn('text', privacyConfig, () => this.currentPageUrl),
-        maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
-        maskTextSelector: this.getMaskTextSelectors(),
-        recordCanvas: false,
-        captureAdoptedStyleSheets: config.captureAdoptedStyleSheets,
-        slimDOMOptions: {
-          script: config.omitElementTags?.script,
-          comment: config.omitElementTags?.comment,
-        },
-        errorHandler: (error: unknown) => {
-          const typedError = error as Error & { _external_?: boolean };
-          if (typedError.message.includes('insertRule') && typedError.message.includes('CSSStyleSheet')) {
-            throw typedError;
-          }
-          if (typedError._external_) {
-            throw typedError;
-          }
-          this.loggerProvider.warn('Error while capturing replay (child iframe): ', typedError.toString());
-          return true;
-        },
+        ...this.buildRRWebRecordOptions(
+          config,
+          hooks,
+          () => {
+            // no-op: child events are forwarded to parent via postMessage by rrweb
+          },
+          'Error while capturing replay (child iframe): ',
+        ),
         recordCrossOriginIframes: true, // child mode is only entered when crossOriginIframes.enabled is true
       });
       this.loggerProvider.log(`Session Replay child iframe capture beginning for session ${sessionId}.`);

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -818,7 +818,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
         // (The previous listener, if any, was already removed by stopRecordingEvents above.)
         this.crossOriginParentSignalCleanup = listenForParentSignals({
           onStart: () => this._recordEventsInChildMode(recordFunction, sessionId, config, hooks),
-          onStop: () => this.stopRecordingEvents(),
+          onStop: () => {
+            // Only cancel the rrweb recording — do NOT call stopRecordingEvents() here,
+            // which would clear crossOriginParentSignalCleanup and make the child deaf
+            // to subsequent start/stop cycles from the parent.
+            this.recordCancelCallback && this.recordCancelCallback();
+            this.recordCancelCallback = null;
+          },
         });
         return;
       }
@@ -909,7 +915,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // here — the child's events are merged into the parent stream, so URL changes inside
     // the iframe should not be recorded as parent page-view events.
     try {
-      this.stopRecordingEvents();
+      // Stop only the previous rrweb recording. Do NOT call stopRecordingEvents() here:
+      // that would clear crossOriginParentSignalCleanup — the very listener that invoked
+      // this method — making the child permanently deaf to subsequent stop/start cycles.
+      this.recordCancelCallback && this.recordCancelCallback();
+      this.recordCancelCallback = null;
       const { privacyConfig } = config;
       this.recordCancelCallback = recordFunction({
         emit: () => {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -905,6 +905,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
   ) {
     // In child mode, rrweb detects window.parent !== window and routes events via
     // postMessage to the parent instead of calling emit. The emit callback is unused.
+    // Note: recording plugins (URL tracking, console capture) are intentionally omitted
+    // here — the child's events are merged into the parent stream, so URL changes inside
+    // the iframe should not be recorded as parent page-view events.
     try {
       this.stopRecordingEvents();
       const { privacyConfig } = config;
@@ -940,7 +943,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
           this.loggerProvider.warn('Error while capturing replay (child iframe): ', typedError.toString());
           return true;
         },
-        recordCrossOriginIframes: true,
+        recordCrossOriginIframes: true, // child mode is only entered when crossOriginIframes.enabled is true
       });
       this.loggerProvider.log(`Session Replay child iframe capture beginning for session ${sessionId}.`);
     } catch (error) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -70,6 +70,7 @@ import { VERSION } from './version';
 import type { NetworkObservers, NetworkRequestEvent } from './observers';
 import { createUrlTrackingPlugin, subscribeToUrlChanges } from './plugins/url-tracking-plugin';
 import type { RecordFunction } from './utils/rrweb';
+import { isInIframe, CrossOriginIframeCoordinator, listenForParentSignals } from './cross-origin-iframes';
 
 type PageLeaveFn = (e: PageTransitionEvent | Event) => void;
 
@@ -105,6 +106,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   /** Cleanup for URL change listener used to re-evaluate targeting on SPA route changes */
   private urlChangeCleanup: (() => void) | null = null;
+  private crossOriginIframeCoordinator: CrossOriginIframeCoordinator | null = null;
+  private crossOriginParentSignalCleanup: (() => void) | null = null;
   /** Monotonic counter to ignore stale URL-change targeting results */
   private latestUrlChangeTargetingEvaluationId = 0;
 
@@ -806,6 +809,20 @@ export class SessionReplay implements AmplitudeSessionReplay {
     this.loggerProvider.log(`Session Replay capture beginning for ${sessionId}.`);
 
     try {
+      const crossOriginIframesEnabled = !!config.crossOriginIframes?.enabled;
+      const coordinateChildren = config.crossOriginIframes?.coordinateChildren !== false;
+      const childMode = crossOriginIframesEnabled && isInIframe();
+
+      if (childMode && coordinateChildren) {
+        // Child mode: don't self-start; wait for a start signal from the parent.
+        this.crossOriginParentSignalCleanup?.();
+        this.crossOriginParentSignalCleanup = listenForParentSignals({
+          onStart: () => this._recordEventsInChildMode(recordFunction, sessionId, config, hooks),
+          onStop: () => this.stopRecordingEvents(),
+        });
+        return;
+      }
+
       this.recordCancelCallback = recordFunction({
         emit: (event: eventWithTime) => {
           if (this.shouldOptOut()) {
@@ -861,7 +878,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
           return true;
         },
         plugins: await this.getRecordingPlugins(loggingConfig),
+        recordCrossOriginIframes: crossOriginIframesEnabled,
       });
+
+      if (crossOriginIframesEnabled && !childMode && coordinateChildren) {
+        if (!this.crossOriginIframeCoordinator) {
+          this.crossOriginIframeCoordinator = new CrossOriginIframeCoordinator();
+        }
+        this.crossOriginIframeCoordinator.start();
+      }
 
       void this.addCustomRRWebEvent(CustomRRwebEvent.DEBUG_INFO);
       if (shouldLogMetadata) {
@@ -869,6 +894,57 @@ export class SessionReplay implements AmplitudeSessionReplay {
       }
     } catch (error) {
       this.loggerProvider.warn('Failed to initialize session replay:', error);
+    }
+  }
+
+  private _recordEventsInChildMode(
+    recordFunction: RecordFunction,
+    sessionId: string | number,
+    config: SessionReplayJoinedConfig,
+    hooks: { mouseInteraction?: any; scroll?: scrollCallback },
+  ) {
+    // In child mode, rrweb detects window.parent !== window and routes events via
+    // postMessage to the parent instead of calling emit. The emit callback is unused.
+    try {
+      this.stopRecordingEvents();
+      const { privacyConfig } = config;
+      this.recordCancelCallback = recordFunction({
+        emit: () => {
+          // no-op: child events are forwarded to parent via postMessage by rrweb
+        },
+        inlineStylesheet: config.shouldInlineStylesheet,
+        hooks,
+        maskAllInputs: true,
+        maskTextClass: MASK_TEXT_CLASS,
+        blockClass: BLOCK_CLASS,
+        blockSelector: this.getBlockSelectors() as string | undefined,
+        applyBackgroundColorToBlockedElements: config.applyBackgroundColorToBlockedElements,
+        maskInputFn: maskFn('input', privacyConfig, () => this.currentPageUrl),
+        maskTextFn: maskFn('text', privacyConfig, () => this.currentPageUrl),
+        maskAttributeFn: maskAttributeFn(privacyConfig, () => this.currentPageUrl),
+        maskTextSelector: this.getMaskTextSelectors(),
+        recordCanvas: false,
+        captureAdoptedStyleSheets: config.captureAdoptedStyleSheets,
+        slimDOMOptions: {
+          script: config.omitElementTags?.script,
+          comment: config.omitElementTags?.comment,
+        },
+        errorHandler: (error: unknown) => {
+          const typedError = error as Error & { _external_?: boolean };
+          if (typedError.message.includes('insertRule') && typedError.message.includes('CSSStyleSheet')) {
+            throw typedError;
+          }
+          if (typedError._external_) {
+            throw typedError;
+          }
+          this.loggerProvider.warn('Error while capturing replay (child iframe): ', typedError.toString());
+          return true;
+        },
+        recordCrossOriginIframes: true,
+      });
+      this.loggerProvider.log(`Session Replay child iframe capture beginning for session ${sessionId}.`);
+    } catch (error) {
+      this.loggerProvider.warn('Failed to initialize session replay in child iframe mode:', error);
     }
   }
 
@@ -916,6 +992,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.recordCancelCallback && this.recordCancelCallback();
       this.recordCancelCallback = null;
       this.networkObservers?.stop();
+      this.crossOriginIframeCoordinator?.stop();
+      this.crossOriginIframeCoordinator = null;
     } catch (error) {
       const typedError = error as Error;
       this.loggerProvider.warn(`Error occurred while stopping replay capture: ${typedError.toString()}`);
@@ -936,6 +1014,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   shutdown() {
     this.urlChangeCleanup?.();
+    this.crossOriginParentSignalCleanup?.();
+    this.crossOriginParentSignalCleanup = null;
     this.teardownEventListeners(true);
     this.stopRecordingEvents();
     this.sendEvents();

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -815,7 +815,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
       if (childMode && coordinateChildren) {
         // Child mode: don't self-start; wait for a start signal from the parent.
-        this.crossOriginParentSignalCleanup?.();
+        // (The previous listener, if any, was already removed by stopRecordingEvents above.)
         this.crossOriginParentSignalCleanup = listenForParentSignals({
           onStart: () => this._recordEventsInChildMode(recordFunction, sessionId, config, hooks),
           onStop: () => this.stopRecordingEvents(),
@@ -997,6 +997,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.networkObservers?.stop();
       this.crossOriginIframeCoordinator?.stop();
       this.crossOriginIframeCoordinator = null;
+      // Remove the child-mode parent signal listener so a later mode change
+      // (e.g. crossOriginIframes disabled) does not leave a stale listener.
+      this.crossOriginParentSignalCleanup?.();
+      this.crossOriginParentSignalCleanup = null;
     } catch (error) {
       const typedError = error as Error;
       this.loggerProvider.warn(`Error occurred while stopping replay capture: ${typedError.toString()}`);

--- a/packages/session-replay-browser/src/utils/rrweb.ts
+++ b/packages/session-replay-browser/src/utils/rrweb.ts
@@ -47,6 +47,7 @@ export type RecordFunction = {
      * Set to false to revert to the legacy incremental-event path if snapshot size is a concern.
      */
     captureAdoptedStyleSheets?: boolean;
+    recordCrossOriginIframes?: boolean;
   }): (() => void) | undefined;
   addCustomEvent: (eventName: string, eventData: any) => void;
   takeFullSnapshot: (isCheckout?: boolean) => void;

--- a/packages/session-replay-browser/test/cross-origin-iframes.test.ts
+++ b/packages/session-replay-browser/test/cross-origin-iframes.test.ts
@@ -173,6 +173,42 @@ describe('CrossOriginIframeCoordinator', () => {
     wrapper.remove();
   });
 
+  it('cancels pending load listener when iframe is removed from DOM before loading', async () => {
+    coordinator.start();
+
+    const dynamicIframe = document.createElement('iframe');
+    const mockPostMessage = jest.fn();
+    Object.defineProperty(dynamicIframe, 'contentWindow', {
+      value: { postMessage: mockPostMessage },
+      configurable: true,
+    });
+    document.body.appendChild(dynamicIframe);
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Remove the iframe before it loads — pending listener should be cleaned up
+    dynamicIframe.remove();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Simulate the load event firing anyway (shouldn't send start)
+    dynamicIframe.dispatchEvent(new Event('load'));
+
+    expect(mockPostMessage).not.toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
+  });
+
+  it('ignores removed non-iframe nodes', async () => {
+    coordinator.start();
+    const pm1 = (iframe1.contentWindow as any).postMessage as jest.Mock;
+    pm1.mockClear();
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    await new Promise((r) => setTimeout(r, 0));
+    div.remove();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(pm1).not.toHaveBeenCalled();
+  });
+
   it('ignores non-element added nodes such as text nodes', async () => {
     coordinator.start();
     const pm1 = (iframe1.contentWindow as any).postMessage as jest.Mock;

--- a/packages/session-replay-browser/test/cross-origin-iframes.test.ts
+++ b/packages/session-replay-browser/test/cross-origin-iframes.test.ts
@@ -70,7 +70,7 @@ describe('CrossOriginIframeCoordinator', () => {
     expect(pm2).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
   });
 
-  it('sends start signal to dynamically added iframes', async () => {
+  it('sends start signal to dynamically added iframes after they load', async () => {
     coordinator.start();
 
     const dynamicIframe = document.createElement('iframe');
@@ -84,7 +84,14 @@ describe('CrossOriginIframeCoordinator', () => {
     // MutationObserver callbacks fire asynchronously
     await new Promise((r) => setTimeout(r, 0));
 
+    // No message before the iframe's load event — it would go to about:blank otherwise
+    expect(mockPostMessage).not.toHaveBeenCalled();
+
+    // Simulate the child page finishing its load
+    dynamicIframe.dispatchEvent(new Event('load'));
+
     expect(mockPostMessage).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
     dynamicIframe.remove();
   });
 
@@ -98,9 +105,8 @@ describe('CrossOriginIframeCoordinator', () => {
     expect(pm2).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' }, '*');
   });
 
-  it('does not send to dynamically added iframes after stop()', async () => {
+  it('cancels pending load listener when stopped before iframe finishes loading', async () => {
     coordinator.start();
-    coordinator.stop();
 
     const dynamicIframe = document.createElement('iframe');
     const mockPostMessage = jest.fn();
@@ -112,8 +118,33 @@ describe('CrossOriginIframeCoordinator', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(mockPostMessage).not.toHaveBeenCalled();
+    // Stop before the iframe loads — the pending listener should be removed
+    coordinator.stop();
+
+    // Simulate the child page finishing its load (listener should already be gone)
+    dynamicIframe.dispatchEvent(new Event('load'));
+
+    expect(mockPostMessage).not.toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
     dynamicIframe.remove();
+  });
+
+  it('does not accumulate MutationObservers when start() is called twice', async () => {
+    coordinator.start();
+
+    const dynamicIframe1 = document.createElement('iframe');
+    const mockPm1 = jest.fn();
+    Object.defineProperty(dynamicIframe1, 'contentWindow', { value: { postMessage: mockPm1 }, configurable: true });
+
+    // Second start() should disconnect the first observer before creating a new one
+    coordinator.start();
+
+    document.body.appendChild(dynamicIframe1);
+    await new Promise((r) => setTimeout(r, 0));
+    dynamicIframe1.dispatchEvent(new Event('load'));
+
+    // Only one start signal, not two (from two observers)
+    expect(mockPm1).toHaveBeenCalledTimes(1);
+    dynamicIframe1.remove();
   });
 
   it('handles iframes with no contentWindow gracefully', () => {

--- a/packages/session-replay-browser/test/cross-origin-iframes.test.ts
+++ b/packages/session-replay-browser/test/cross-origin-iframes.test.ts
@@ -149,6 +149,43 @@ describe('CrossOriginIframeCoordinator', () => {
     dynamicIframe1.remove();
   });
 
+  it('sends start signal to iframes nested inside a dynamically added container element', async () => {
+    coordinator.start();
+
+    // Simulate a framework inserting a wrapper div that already contains an iframe
+    const wrapper = document.createElement('div');
+    const nestedIframe = document.createElement('iframe');
+    const mockPostMessage = jest.fn();
+    Object.defineProperty(nestedIframe, 'contentWindow', {
+      value: { postMessage: mockPostMessage },
+      configurable: true,
+    });
+    wrapper.appendChild(nestedIframe);
+    document.body.appendChild(wrapper);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No message yet — waiting for load
+    expect(mockPostMessage).not.toHaveBeenCalled();
+
+    nestedIframe.dispatchEvent(new Event('load'));
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
+    wrapper.remove();
+  });
+
+  it('ignores non-element added nodes such as text nodes', async () => {
+    coordinator.start();
+    const pm1 = (iframe1.contentWindow as any).postMessage as jest.Mock;
+    pm1.mockClear(); // clear the start call from coordinator.start()
+
+    const textNode = document.createTextNode('hello');
+    document.body.appendChild(textNode);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(pm1).not.toHaveBeenCalled();
+    textNode.remove();
+  });
+
   it('handles iframes with no contentWindow gracefully', () => {
     Object.defineProperty(iframe1, 'contentWindow', { value: null, configurable: true });
     expect(() => coordinator.start()).not.toThrow();

--- a/packages/session-replay-browser/test/cross-origin-iframes.test.ts
+++ b/packages/session-replay-browser/test/cross-origin-iframes.test.ts
@@ -1,0 +1,217 @@
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import { CrossOriginIframeCoordinator, isInIframe, listenForParentSignals } from '../src/cross-origin-iframes';
+import { CROSS_ORIGIN_IFRAME_MESSAGE_TYPE } from '../src/constants';
+
+describe('isInIframe', () => {
+  const originalParent = window.parent;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'parent', { value: originalParent, writable: true, configurable: true });
+  });
+
+  it('returns false when window.parent === window (top-level page)', () => {
+    Object.defineProperty(window, 'parent', { value: window, writable: true, configurable: true });
+    expect(isInIframe()).toBe(false);
+  });
+
+  it('returns true when window.parent !== window (inside iframe)', () => {
+    Object.defineProperty(window, 'parent', { value: {} as Window, writable: true, configurable: true });
+    expect(isInIframe()).toBe(true);
+  });
+
+  it('returns true when accessing window.parent throws (sandboxed environment)', () => {
+    Object.defineProperty(window, 'parent', {
+      get() {
+        throw new Error('SecurityError');
+      },
+      configurable: true,
+    });
+    expect(isInIframe()).toBe(true);
+  });
+
+  it('returns false when getGlobalScope() returns null (non-browser environment)', () => {
+    const spy = jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(null as any);
+    expect(isInIframe()).toBe(false);
+    spy.mockRestore();
+  });
+});
+
+describe('CrossOriginIframeCoordinator', () => {
+  let coordinator: CrossOriginIframeCoordinator;
+  let iframe1: HTMLIFrameElement;
+  let iframe2: HTMLIFrameElement;
+
+  beforeEach(() => {
+    coordinator = new CrossOriginIframeCoordinator();
+
+    iframe1 = document.createElement('iframe');
+    iframe2 = document.createElement('iframe');
+    document.body.appendChild(iframe1);
+    document.body.appendChild(iframe2);
+
+    // Mock contentWindow.postMessage on each iframe
+    const mockPostMessage1 = jest.fn();
+    const mockPostMessage2 = jest.fn();
+    Object.defineProperty(iframe1, 'contentWindow', { value: { postMessage: mockPostMessage1 }, configurable: true });
+    Object.defineProperty(iframe2, 'contentWindow', { value: { postMessage: mockPostMessage2 }, configurable: true });
+  });
+
+  afterEach(() => {
+    coordinator.stop();
+    iframe1.remove();
+    iframe2.remove();
+  });
+
+  it('sends start signal to all existing iframes on start()', () => {
+    coordinator.start();
+    const pm1 = (iframe1.contentWindow as any).postMessage as jest.Mock;
+    const pm2 = (iframe2.contentWindow as any).postMessage as jest.Mock;
+    expect(pm1).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
+    expect(pm2).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
+  });
+
+  it('sends start signal to dynamically added iframes', async () => {
+    coordinator.start();
+
+    const dynamicIframe = document.createElement('iframe');
+    const mockPostMessage = jest.fn();
+    Object.defineProperty(dynamicIframe, 'contentWindow', {
+      value: { postMessage: mockPostMessage },
+      configurable: true,
+    });
+    document.body.appendChild(dynamicIframe);
+
+    // MutationObserver callbacks fire asynchronously
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
+    dynamicIframe.remove();
+  });
+
+  it('sends stop signal to all iframes and disconnects observer on stop()', () => {
+    coordinator.start();
+    coordinator.stop();
+
+    const pm1 = (iframe1.contentWindow as any).postMessage as jest.Mock;
+    const pm2 = (iframe2.contentWindow as any).postMessage as jest.Mock;
+    expect(pm1).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' }, '*');
+    expect(pm2).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' }, '*');
+  });
+
+  it('does not send to dynamically added iframes after stop()', async () => {
+    coordinator.start();
+    coordinator.stop();
+
+    const dynamicIframe = document.createElement('iframe');
+    const mockPostMessage = jest.fn();
+    Object.defineProperty(dynamicIframe, 'contentWindow', {
+      value: { postMessage: mockPostMessage },
+      configurable: true,
+    });
+    document.body.appendChild(dynamicIframe);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    dynamicIframe.remove();
+  });
+
+  it('handles iframes with no contentWindow gracefully', () => {
+    Object.defineProperty(iframe1, 'contentWindow', { value: null, configurable: true });
+    expect(() => coordinator.start()).not.toThrow();
+  });
+
+  it('returns early from start() when getGlobalScope() returns null', () => {
+    const spy = jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(null as any);
+    expect(() => coordinator.start()).not.toThrow();
+    const pm1 = (iframe1.contentWindow as any).postMessage as jest.Mock;
+    expect(pm1).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('listenForParentSignals', () => {
+  let cleanup: () => void;
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  function dispatchMessage(source: Window, data: unknown) {
+    const event = new MessageEvent('message', { data, source });
+    window.dispatchEvent(event);
+  }
+
+  it('calls onStart when a start message arrives from window.parent', () => {
+    const onStart = jest.fn();
+    const onStop = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop });
+
+    dispatchMessage(window.parent, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('calls onStop when a stop message arrives from window.parent', () => {
+    const onStart = jest.fn();
+    const onStop = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop });
+
+    dispatchMessage(window.parent, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' });
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages from sources other than window.parent', () => {
+    const onStart = jest.fn();
+    const onStop = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop });
+
+    // Use a source that is explicitly not window.parent (a child iframe, for instance)
+    const foreignSource = {} as Window;
+    dispatchMessage(foreignSource, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages with wrong type', () => {
+    const onStart = jest.fn();
+    const onStop = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop });
+
+    dispatchMessage(window.parent, { type: 'some-other-type', action: 'start' });
+
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages with null data', () => {
+    const onStart = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop: jest.fn() });
+
+    dispatchMessage(window.parent, null);
+
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('removes the event listener after cleanup', () => {
+    const onStart = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop: jest.fn() });
+    cleanup();
+
+    dispatchMessage(window.parent, { type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' });
+
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('returns a no-op cleanup when getGlobalScope() returns null', () => {
+    const spy = jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(null as any);
+    const onStart = jest.fn();
+    cleanup = listenForParentSignals({ onStart, onStop: jest.fn() });
+    expect(() => cleanup()).not.toThrow();
+    expect(onStart).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/session-replay-browser/test/cross-origin-iframes.test.ts
+++ b/packages/session-replay-browser/test/cross-origin-iframes.test.ts
@@ -124,6 +124,8 @@ describe('CrossOriginIframeCoordinator', () => {
     // Simulate the child page finishing its load (listener should already be gone)
     dynamicIframe.dispatchEvent(new Event('load'));
 
+    // stop() sends a stop signal (via sendToAllIframes) but must NOT send a start signal
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'stop' }, '*');
     expect(mockPostMessage).not.toHaveBeenCalledWith({ type: CROSS_ORIGIN_IFRAME_MESSAGE_TYPE, action: 'start' }, '*');
     dynamicIframe.remove();
   });

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4585,6 +4585,50 @@ describe('SessionReplay', () => {
         expect(cancelCallback).toHaveBeenCalled();
       });
 
+      test('onStop before onStart does not throw', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStop } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStop: () => void;
+        };
+        expect(() => onStop()).not.toThrow();
+      });
+
+      test('parent signal listener stays alive across onStop/onStart cycles', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart, onStop } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+          onStop: () => void;
+        };
+        onStart();
+        onStop();
+
+        // Listener must still be alive — a subsequent onStart should work
+        mockRecordFunction.mockClear();
+        onStart();
+        expect(mockRecordFunction).toHaveBeenCalledWith(expect.objectContaining({ recordCrossOriginIframes: true }));
+      });
+
+      test('subsequent onStart cancels previous rrweb recording before starting a new one', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+        const firstCancelCallback = mockRecordFunction.mock.results[0].value as jest.Mock;
+        // Second onStart (e.g. parent session rotated) should cancel the first recording
+        onStart();
+        expect(firstCancelCallback).toHaveBeenCalled();
+      });
+
       test('cleans up parent signal listener on shutdown', async () => {
         const mockCleanup = jest.fn();
         (mockListenForParentSignals as jest.Mock).mockReturnValueOnce(mockCleanup);

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4541,6 +4541,21 @@ describe('SessionReplay', () => {
         );
       });
 
+      test('re-entering child mode cancels the previous parent signal listener', async () => {
+        const firstCleanup = jest.fn();
+        (mockListenForParentSignals as jest.Mock).mockReturnValueOnce(firstCleanup);
+
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        // Record again (e.g. after a session-ID rotation) — should tear down the old listener
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        expect(firstCleanup).toHaveBeenCalled();
+      });
+
       test('starts recording when onStart callback is invoked', async () => {
         await sessionReplay.init(apiKey, crossOriginOptions).promise;
         await sessionReplay.recordEvents();
@@ -4579,6 +4594,18 @@ describe('SessionReplay', () => {
         await jest.runAllTimersAsync();
 
         sessionReplay.shutdown();
+        expect(mockCleanup).toHaveBeenCalled();
+      });
+
+      test('stopRecordingEvents cleans up parent signal listener to prevent stale mode', async () => {
+        const mockCleanup = jest.fn();
+        (mockListenForParentSignals as jest.Mock).mockReturnValueOnce(mockCleanup);
+
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        sessionReplay.stopRecordingEvents();
         expect(mockCleanup).toHaveBeenCalled();
       });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -4596,6 +4596,26 @@ describe('SessionReplay', () => {
         expect(() => onStop()).not.toThrow();
       });
 
+      test('onStop logs warning if cancel callback throws', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart, onStop } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+          onStop: () => void;
+        };
+        onStart();
+        const cancelCallback = mockRecordFunction.mock.results[0].value as jest.Mock;
+        cancelCallback.mockImplementation(() => {
+          throw new Error('cancel failure');
+        });
+        onStop();
+        expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Error occurred while stopping child iframe replay capture:'),
+        );
+      });
+
       test('parent signal listener stays alive across onStop/onStart cycles', async () => {
         await sessionReplay.init(apiKey, crossOriginOptions).promise;
         await sessionReplay.recordEvents();

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -28,6 +28,22 @@ jest.mock(
 );
 import { SessionReplayOptions } from '../src/typings/session-replay';
 
+// Mock cross-origin-iframes so spies work reliably regardless of test ordering
+jest.mock('../src/cross-origin-iframes', () => ({
+  isInIframe: jest.fn().mockReturnValue(false),
+  CrossOriginIframeCoordinator: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+  })),
+  listenForParentSignals: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+import {
+  isInIframe as mockIsInIframe,
+  CrossOriginIframeCoordinator as MockCrossOriginIframeCoordinator,
+  listenForParentSignals as mockListenForParentSignals,
+} from '../src/cross-origin-iframes';
+
 // Mock the URL tracking plugin
 jest.mock('../src/plugins/url-tracking-plugin', () => ({
   createUrlTrackingPlugin: jest.fn().mockImplementation((options: any = {}) => ({
@@ -4433,6 +4449,292 @@ describe('SessionReplay', () => {
           mockOptions.sessionId?.toString() || ''
         } due to matching targeting conditions.`,
       );
+    });
+  });
+
+  describe('cross-origin iframes', () => {
+    const crossOriginOptions: SessionReplayOptions = {
+      ...mockOptions,
+      crossOriginIframes: { enabled: true },
+    };
+
+    // Helper to get the mock coordinator instance created during the last recordEvents() call.
+    // Uses mock.results (not mock.instances) because mockImplementation() return values
+    // are tracked in results, not in instances (instances tracks the `this` context).
+    function getLastCoordinatorInstance() {
+      const ctor = MockCrossOriginIframeCoordinator as jest.Mock;
+      const last = ctor.mock.results[ctor.mock.results.length - 1];
+      return last?.value as { start: jest.Mock; stop: jest.Mock };
+    }
+
+    beforeEach(() => {
+      (mockIsInIframe as jest.Mock).mockReturnValue(false);
+      // jest.resetAllMocks() in the outer afterEach clears mockImplementation, so re-set it here.
+      (MockCrossOriginIframeCoordinator as jest.Mock).mockImplementation(() => ({
+        start: jest.fn(),
+        stop: jest.fn(),
+      }));
+      (mockListenForParentSignals as jest.Mock).mockReturnValue(jest.fn());
+    });
+
+    describe('parent mode', () => {
+      test('passes recordCrossOriginIframes: true to rrweb when enabled', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        expect(mockRecordFunction).toHaveBeenCalledWith(expect.objectContaining({ recordCrossOriginIframes: true }));
+      });
+
+      test('does not pass recordCrossOriginIframes when feature is disabled', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const callArg = mockRecordFunction.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+        expect(callArg?.recordCrossOriginIframes).toBeFalsy();
+      });
+
+      test('stopRecordingEvents stops the coordinator', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const instance = getLastCoordinatorInstance();
+        sessionReplay.stopRecordingEvents();
+        expect(instance.stop).toHaveBeenCalled();
+      });
+
+      test('coordinateChildren: false skips coordinator but still passes flag to rrweb', async () => {
+        await sessionReplay.init(apiKey, {
+          ...mockOptions,
+          crossOriginIframes: { enabled: true, coordinateChildren: false },
+        }).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        expect(mockRecordFunction).toHaveBeenCalledWith(expect.objectContaining({ recordCrossOriginIframes: true }));
+        expect(MockCrossOriginIframeCoordinator).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('child mode', () => {
+      beforeEach(() => {
+        (mockIsInIframe as jest.Mock).mockReturnValue(true);
+      });
+
+      test('does not call rrweb record immediately when in child mode with coordinateChildren: true', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        expect(mockRecordFunction).not.toHaveBeenCalled();
+      });
+
+      test('sets up parent signal listener in child mode', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        expect(mockListenForParentSignals).toHaveBeenCalledWith(
+          expect.objectContaining({ onStart: expect.any(Function), onStop: expect.any(Function) }),
+        );
+      });
+
+      test('starts recording when onStart callback is invoked', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+          onStop: () => void;
+        };
+        onStart();
+
+        expect(mockRecordFunction).toHaveBeenCalledWith(expect.objectContaining({ recordCrossOriginIframes: true }));
+      });
+
+      test('stops recording when onStop callback is invoked', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart, onStop } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+          onStop: () => void;
+        };
+        onStart();
+        const cancelCallback = mockRecordFunction.mock.results[0].value as jest.Mock;
+        onStop();
+        expect(cancelCallback).toHaveBeenCalled();
+      });
+
+      test('cleans up parent signal listener on shutdown', async () => {
+        const mockCleanup = jest.fn();
+        (mockListenForParentSignals as jest.Mock).mockReturnValueOnce(mockCleanup);
+
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        sessionReplay.shutdown();
+        expect(mockCleanup).toHaveBeenCalled();
+      });
+
+      test('coordinateChildren: false records immediately even in iframe context', async () => {
+        await sessionReplay.init(apiKey, {
+          ...mockOptions,
+          crossOriginIframes: { enabled: true, coordinateChildren: false },
+        }).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        expect(mockRecordFunction).toHaveBeenCalledWith(expect.objectContaining({ recordCrossOriginIframes: true }));
+      });
+
+      test('child mode emit callback is a no-op (events forwarded via postMessage by rrweb)', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        const callArgs = mockRecordFunction.mock.calls[0]?.[0] as Record<string, (...args: unknown[]) => unknown>;
+        // The emit callback is a no-op in child mode — just verify it does not throw
+        expect(() => callArgs.emit({ type: 4, data: {}, timestamp: 1 })).not.toThrow();
+      });
+
+      test('mask function URL getters in child mode return currentPageUrl', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        const callArgs = mockRecordFunction.mock.calls[0]?.[0] as Record<string, (...args: unknown[]) => unknown>;
+        // Invoke the URL getter lambdas by calling the mask functions with dummy input
+        if (typeof callArgs?.maskInputFn === 'function') {
+          callArgs.maskInputFn('test', null);
+        }
+        if (typeof callArgs?.maskTextFn === 'function') {
+          callArgs.maskTextFn('test', null);
+        }
+        // No assertion needed — just exercising the lambdas for coverage
+      });
+
+      test('passes omitElementTags into child mode slimDOMOptions', async () => {
+        await sessionReplay.init(apiKey, {
+          ...crossOriginOptions,
+          omitElementTags: { script: true, comment: true },
+        }).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        expect(mockRecordFunction).toHaveBeenCalledWith(
+          expect.objectContaining({ slimDOMOptions: { script: true, comment: true } }),
+        );
+      });
+
+      test('maskAttributeFn in child mode invokes URL getter when key is in maskAttributes', async () => {
+        // Need a config with maskAttributes so the URL getter lambda is actually called
+        await sessionReplay.init(apiKey, {
+          ...crossOriginOptions,
+          privacyConfig: { maskAttributes: ['data-sensitive'] },
+        }).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        const callArgs = mockRecordFunction.mock.calls[0]?.[0] as Record<string, (...args: unknown[]) => unknown>;
+        if (typeof callArgs?.maskAttributeFn === 'function') {
+          callArgs.maskAttributeFn('data-sensitive', 'secret', document.createElement('div'));
+        }
+      });
+
+      test('errorHandler in child mode logs warning for generic errors', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        const callArgs = mockRecordFunction.mock.calls[0]?.[0] as Record<string, (...args: unknown[]) => unknown>;
+        const result = callArgs.errorHandler(new Error('some rrweb error'));
+        expect(result).toBe(true);
+        expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+          'Error while capturing replay (child iframe): ',
+          expect.any(String),
+        );
+      });
+
+      test('errorHandler in child mode re-throws CSSStyleSheet insertRule errors', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        const callArgs = mockRecordFunction.mock.calls[0]?.[0] as Record<string, (...args: unknown[]) => unknown>;
+        const cssError = new Error('insertRule CSSStyleSheet problem');
+        expect(() => callArgs.errorHandler(cssError)).toThrow(cssError);
+      });
+
+      test('errorHandler in child mode re-throws _external_ flagged errors', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+        onStart();
+
+        const callArgs = mockRecordFunction.mock.calls[0]?.[0] as Record<string, (...args: unknown[]) => unknown>;
+        const externalError = Object.assign(new Error('external error'), { _external_: true });
+        expect(() => callArgs.errorHandler(externalError)).toThrow(externalError);
+      });
+
+      test('_recordEventsInChildMode catch block logs warning when recordFunction throws', async () => {
+        await sessionReplay.init(apiKey, crossOriginOptions).promise;
+        await sessionReplay.recordEvents();
+        await jest.runAllTimersAsync();
+
+        const { onStart } = (mockListenForParentSignals as jest.Mock).mock.calls[0][0] as {
+          onStart: () => void;
+        };
+
+        mockRecordFunction.mockImplementationOnce(() => {
+          throw new Error('rrweb init failure');
+        });
+        onStart();
+
+        expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+          'Failed to initialize session replay in child iframe mode:',
+          expect.any(Error),
+        );
+      });
     });
   });
 });

--- a/test-server/session-replay-browser/sr-cross-origin-iframe-child.html
+++ b/test-server/session-replay-browser/sr-cross-origin-iframe-child.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>SR Cross-Origin Iframe Child</title>
+  </head>
+  <body>
+    <div id="child-content">Child iframe unique content</div>
+    <div id="status">loading</div>
+    <script>
+      // Set up the start-signal listener BEFORE the SDK loads so we never miss a message
+      // even if the parent's coordinator fires before the SDK is fully initialized.
+      window.receivedStartSignal = false;
+      window.receivedStopSignal = false;
+      window.addEventListener('message', function (event) {
+        if (event.data && event.data.type === 'amplitude-sr-iframe') {
+          if (event.data.action === 'start') window.receivedStartSignal = true;
+          if (event.data.action === 'stop') window.receivedStopSignal = true;
+        }
+      });
+
+      window.childModeDetected = window.parent !== window;
+    </script>
+    <script type="module">
+      import * as sessionReplay from '@amplitude/session-replay-browser';
+
+      window.sessionReplay = sessionReplay;
+
+      const params = new URLSearchParams(location.search);
+      const sessionId = params.has('sessionId') ? Number(params.get('sessionId')) : Date.now();
+      const deviceId = params.get('deviceId') ?? 'test-device-id';
+
+      void (async () => {
+        try {
+          await sessionReplay.init('d90c5cf09ca2546a1626272906b99a76', {
+            deviceId,
+            sessionId,
+            sampleRate: 1,
+            crossOriginIframes: { enabled: true },
+          }).promise;
+        } catch (err) {
+          document.getElementById('status').textContent = 'error: ' + err.message;
+          window.srError = err.message;
+        }
+
+        window.srReady = true;
+        document.getElementById('status').textContent = 'ready';
+      })();
+    </script>
+  </body>
+</html>

--- a/test-server/session-replay-browser/sr-cross-origin-iframe-parent.html
+++ b/test-server/session-replay-browser/sr-cross-origin-iframe-parent.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>SR Cross-Origin Iframe Parent</title>
+  </head>
+  <body>
+    <div id="parent-content">Parent page content</div>
+    <div id="status">loading</div>
+    <script type="module">
+      import * as sessionReplay from '@amplitude/session-replay-browser';
+
+      window.sessionReplay = sessionReplay;
+
+      const params = new URLSearchParams(location.search);
+      const sessionId = params.has('sessionId') ? Number(params.get('sessionId')) : Date.now();
+      const deviceId = params.get('deviceId') ?? 'test-device-id';
+      const coordinateChildren = params.get('coordinateChildren') !== 'false';
+      // Child URL may be a different origin to test real cross-origin behaviour.
+      // Defaults to the same origin so CI works without a second server.
+      const childSrc = params.get('childSrc') ?? '/session-replay-browser/sr-cross-origin-iframe-child.html';
+
+      void (async () => {
+        try {
+          await sessionReplay.init('d90c5cf09ca2546a1626272906b99a76', {
+            deviceId,
+            sessionId,
+            sampleRate: 1,
+            crossOriginIframes: { enabled: true, coordinateChildren },
+          }).promise;
+        } catch (err) {
+          document.getElementById('status').textContent = 'error: ' + err.message;
+          window.srError = err.message;
+        }
+
+        window.srReady = true;
+        document.getElementById('status').textContent = 'ready';
+
+        // Add the child iframe dynamically so the MutationObserver picks it up
+        // after the coordinator has started. This is the canonical usage pattern.
+        const iframe = document.createElement('iframe');
+        iframe.id = 'child-frame';
+        iframe.src =
+          childSrc +
+          '?sessionId=' +
+          sessionId +
+          '&deviceId=' +
+          deviceId;
+        iframe.style.width = '100%';
+        iframe.style.height = '200px';
+        document.body.appendChild(iframe);
+        window.iframeAdded = true;
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `crossOriginIframes?: CrossOriginIframesConfig` to the `@amplitude/session-replay-browser` init options
- When `enabled: true`, passes `recordCrossOriginIframes` to rrweb so cross-origin child events are relayed to the parent via postMessage
- `CrossOriginIframeCoordinator` (parent side) sends start/stop signals to all current and dynamically-added iframes via MutationObserver
- Child pages auto-detect they are inside an iframe (`isInIframe`) and wait for a start signal from the parent before initialising rrweb recording
- `coordinateChildren: false` opts out of the coordinator (caller manages child lifecycle)

## Changed files

| File | What |
|---|---|
| `src/cross-origin-iframes.ts` | New module: `isInIframe`, `CrossOriginIframeCoordinator`, `listenForParentSignals` |
| `src/session-replay.ts` | Wire coordinator + child-mode listener into record/stop/shutdown lifecycle |
| `src/config/types.ts` | `CrossOriginIframesConfig` interface + field on `SessionReplayLocalConfig` |
| `src/config/local-config.ts` | Copy `crossOriginIframes` from options in constructor |
| `src/constants.ts` | `CROSS_ORIGIN_IFRAME_MESSAGE_TYPE = 'amplitude-sr-iframe'` |
| `src/utils/rrweb.ts` | Add `recordCrossOriginIframes` to `RecordFunction` options type |
| `test/cross-origin-iframes.test.ts` | 17 unit tests for the new module (100% coverage) |
| `test/session-replay.test.ts` | ~20 integration tests for parent/child mode wiring |
| `e2e/cross-origin-iframe.spec.ts` | 5 Playwright e2e tests |
| `test-server/…/sr-cross-origin-iframe-parent.html` | E2e parent page |
| `test-server/…/sr-cross-origin-iframe-child.html` | E2e child page |

## Test plan

- [x] All 809 unit tests pass with 100% statement/branch/function/line coverage
- [x] All 5 Playwright e2e tests pass against the Vite dev server (chromium):
  - Parent initialises without error; snapshot contains parent DOM
  - Coordinator delivers start signal to dynamically-added child iframe
  - Child detects it is inside an iframe (`childModeDetected === true`)
  - `coordinateChildren: false` — child receives no start signal
  - Child page loaded directly (not in iframe) — no error, `childModeDetected === false`
- [x] Pre-existing 230 tests unaffected (feature is behind disabled-by-default flag)
- [x] Verified end-to-end against real Amplitude project: [example replay](https://app.amplitude.com/analytics/lew-amplitude/session-replay/project/635662/search/replay?sessionReplayId=demo-device-5t80j2/1777989690401) showing parent + child iframe events merged into a single session

Closes SR-4094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recording mode coordinated via `postMessage` and `MutationObserver`, changing `recordEvents`/`stopRecordingEvents` lifecycle behavior and rrweb options; bugs here could cause missed recordings, duplicate listeners, or extra runtime overhead when enabled.
> 
> **Overview**
> Adds **opt-in cross-origin `<iframe>` recording** to `@amplitude/session-replay-browser` via new `crossOriginIframes` init options, passing `recordCrossOriginIframes` through to rrweb so child-frame events can be relayed into the parent replay stream.
> 
> Introduces a parent-side coordinator that `postMessage`s start/stop signals to existing and dynamically-added iframes (via `MutationObserver`), and a child-mode flow where iframe pages detect they’re embedded, wait for parent signals, and start/stop rrweb capture without loading parent-specific plugins.
> 
> Updates config/types/constants accordingly, refactors rrweb record option construction for reuse, and adds unit, integration, and Playwright e2e coverage plus test-server HTML fixtures and README documentation for setup, privacy, and limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be7bbed5668143afb1f8663f48fd82827086cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->