### PR TITLE
chore: allow hotfix/* branches

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -23,18 +23,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch protection
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event.inputs.releaseType }}" == "dry-run" ]; then
+          if [ "$RELEASE_TYPE" = "dry-run" ]; then
             echo "✅ Branch check skipped: dry-run mode allows any branch"
-            echo "Current branch: ${{ github.ref_name }}"
+            echo "Current branch: $REF_NAME"
             exit 0
           fi
-          if [ "${{ github.ref_name }}" != "main" && "${{ github.ref_name }}" != "hotfix/*" ]; then
-            echo "❌ This workflow can only be triggered from the main branch."
-            echo "Current branch: ${{ github.ref_name }}"
-            exit 1
-          fi
-          echo "✅ Branch check passed: workflow is running from main"
+          case "$REF_NAME" in
+            main|hotfix/*)
+              echo "✅ Branch check passed: workflow is running from allowed branch ($REF_NAME)"
+              ;;
+            *)
+              echo "❌ This workflow can only be triggered from main or hotfix/* branches."
+              echo "Current branch: $REF_NAME"
+              exit 1
+              ;;
+          esac
 
       - name: ${{ github.actor }} permission check to do a release
         uses: 'lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f'

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -29,7 +29,7 @@ jobs:
             echo "Current branch: ${{ github.ref_name }}"
             exit 0
           fi
-          if [ "${{ github.ref_name }}" != "main" ]; then
+          if [ "${{ github.ref_name }}" != "main" && "${{ github.ref_name }}" != "hotfix/*" ]; then
             echo "❌ This workflow can only be triggered from the main branch."
             echo "Current branch: ${{ github.ref_name }}"
             exit 1


### PR DESCRIPTION
### Summary

Fixes https://github.com/amplitude/Amplitude-TypeScript/actions/runs/25331507501/job/74266183394

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the GitHub Actions branch-allowlist logic for the publish workflow, expanding it from `main` to `main` and `hotfix/*`.
> 
> **Overview**
> Updates `.github/workflows/publish-v2.yml` branch protection in the `authorize` job to allow workflow dispatches from `main` **or** `hotfix/*` branches (with `dry-run` still bypassing the check).
> 
> Refactors the shell check to use `RELEASE_TYPE`/`REF_NAME` env vars and a `case` statement for clearer allow/deny messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866e26bdbc3cbdb5a4479173cf485bb7c3f61d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->