### PR TITLE
test(gtm-snippet): decompress gzipped request bodies in e2e (#1707)

### DIFF
--- a/packages/gtm-snippet/e2e/gtm-snippet.spec.ts
+++ b/packages/gtm-snippet/e2e/gtm-snippet.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { parseRequestBody } from './helpers';
 
 test.describe('GTM Snippet Page', () => {
   let requests: any[] = [];
@@ -8,9 +9,8 @@ test.describe('GTM Snippet Page', () => {
     // Intercept Amplitude API calls
     await page.route('https://api2.amplitude.com/2/httpapi', async (route) => {
       const request = route.request();
-      const postData = request.postData();
-      if (postData) {
-        const data = JSON.parse(postData);
+      const data = parseRequestBody(request);
+      if (data) {
         requests.push(data);
       }
       await route.continue();

--- a/packages/gtm-snippet/e2e/helpers.ts
+++ b/packages/gtm-snippet/e2e/helpers.ts
@@ -1,0 +1,21 @@
+import { gunzipSync } from 'zlib';
+import type { Request } from '@playwright/test';
+
+/**
+ * Parse request body as JSON. Decompresses gzip when Content-Encoding: gzip is set.
+ * Uses postDataBuffer() for gzip so we get raw bytes; uses postData() for plain JSON.
+ */
+export function parseRequestBody(request: Request): Record<string, unknown> | undefined {
+  const contentEncoding = request.headers()['content-encoding'];
+
+  if (contentEncoding === 'gzip') {
+    const buffer = request.postDataBuffer();
+    if (!buffer || buffer.length === 0) return undefined;
+    const bodyStr = gunzipSync(buffer).toString('utf8');
+    return JSON.parse(bodyStr) as Record<string, unknown>;
+  }
+
+  const postData = request.postData();
+  if (!postData) return undefined;
+  return JSON.parse(postData) as Record<string, unknown>;
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Playwright e2e test utilities and only affect how intercepted request bodies are parsed.
> 
> **Overview**
> Updates the GTM snippet Playwright e2e test to correctly capture Amplitude `/2/httpapi` payloads when they are sent with `Content-Encoding: gzip`.
> 
> Introduces a small `parseRequestBody` helper that uses `postDataBuffer()` + `gunzipSync` for gzipped bodies and falls back to `postData()` for plain JSON, and wires the test to use this helper when recording intercepted requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 389cc743b0c2278cb25bb0ed67848b4cb19b512f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->