### PR TITLE
ci: revert allowing hotfix/* in authorize

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -28,25 +28,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch protection
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "$RELEASE_TYPE" = "dry-run" ]; then
+          if [ "${{ github.event.inputs.releaseType }}" == "dry-run" ]; then
             echo "✅ Branch check skipped: dry-run mode allows any branch"
-            echo "Current branch: $REF_NAME"
+            echo "Current branch: ${{ github.ref_name }}"
             exit 0
           fi
-          case "$REF_NAME" in
-            main|hotfix/*)
-              echo "✅ Branch check passed: workflow is running from allowed branch ($REF_NAME)"
-              ;;
-            *)
-              echo "❌ This workflow can only be triggered from main or hotfix/* branches."
-              echo "Current branch: $REF_NAME"
-              exit 1
-              ;;
-          esac
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "❌ This workflow can only be triggered from the main branch."
+            echo "Current branch: ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "✅ Branch check passed: workflow is running from main"
 
       - name: ${{ github.actor }} permission check to do a release
         uses: 'lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f'


### PR DESCRIPTION
Reverts amplitude/Amplitude-TypeScript#1717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release workflow gating and removes `hotfix/*` support in the initial authorization step, which could block intended release runs from hotfix branches. Impact is limited to CI/CD behavior but affects the publishing path.
> 
> **Overview**
> Tightens `publish-v2.yml` authorization branch protection by **removing `hotfix/*` support** and requiring the workflow to be triggered from `main` (except for `dry-run`, which still allows any branch).
> 
> Also simplifies the branch-check step by inlining GitHub context variables instead of passing them via step `env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0cec2072f36dfa3b7814d29beaef28f90e248a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->