### PR TITLE
fix(ci): add git safe.directory for E2E container

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -79,7 +79,9 @@ jobs:
       - name: Capture E2E HEAD SHA
         id: head-sha
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}


### PR DESCRIPTION
## Problem

The E2E job in `publish-v2.yml` runs inside the `mcr.microsoft.com/playwright` Docker container as a different user than the one that performed `actions/checkout`. Git's dubious-ownership check refuses all git commands, causing `git rev-parse HEAD` to fail silently — the SHA is never written to `$GITHUB_OUTPUT`, leaving `EXPECTED_SHA` empty in the downstream deploy step and causing it to fail.

## Fix

Add a `git config --global --add safe.directory` step before "Capture E2E HEAD SHA" so git trusts the repo directory inside the container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that affects how the E2E job captures the checked-out commit SHA; main risk is misconfiguring git safety and still failing the deploy gating step.
> 
> **Overview**
> Fixes the `publish-v2.yml` E2E job running in a Playwright container by configuring git to trust `$GITHUB_WORKSPACE` via `safe.directory` before running `git rev-parse HEAD`.
> 
> This ensures the `head_sha` output is reliably captured for downstream steps (e.g., the deploy ref-advance check) instead of failing due to git dubious-ownership checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecce34b4ce18fe34307c0bbccb34a39c2f2d4d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->