### PR TITLE
feat(session-replay): enforce min_session_duration_ms from remote config

### DIFF
--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -139,6 +139,10 @@ export class SessionReplayJoinedConfigGenerator {
       if (Object.prototype.hasOwnProperty.call(samplingConfig, 'sample_rate')) {
         config.sampleRate = samplingConfig.sample_rate;
       }
+
+      if (Object.prototype.hasOwnProperty.call(samplingConfig, 'min_session_duration_ms')) {
+        config.minSessionDurationMs = samplingConfig.min_session_duration_ms;
+      }
     } else {
       // If config API response was valid (ie 200), but no config returned, assume that
       // customer has not yet set up config, and use sample rate from SDK options,

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -141,7 +141,7 @@ export class SessionReplayJoinedConfigGenerator {
       }
 
       if (Object.prototype.hasOwnProperty.call(samplingConfig, 'min_session_duration_ms')) {
-        config.minSessionDurationMs = samplingConfig.min_session_duration_ms;
+        config.minSessionDurationMs = this.sanitizeMinSessionDurationMs(samplingConfig.min_session_duration_ms);
       }
     } else {
       // If config API response was valid (ie 200), but no config returned, assume that
@@ -234,7 +234,42 @@ export class SessionReplayJoinedConfigGenerator {
       remoteConfig: sessionReplayRemoteConfig,
     };
   }
+
+  /**
+   * Defensive bounds for the remote-supplied min_session_duration_ms. A misconfigured
+   * value (e.g. 30_000_000) would silently suppress every replay until the config is
+   * pushed again, so we clamp to a sane ceiling and warn on out-of-range inputs.
+   * Returns undefined for clearly invalid values so the gate falls back to disabled
+   * rather than carrying a NaN through downstream comparisons.
+   */
+  private sanitizeMinSessionDurationMs(raw: unknown): number | undefined {
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+      this.localConfig.loggerProvider.warn(
+        `min_session_duration_ms remote value is not a finite number (got ${String(raw)}); ignoring.`,
+      );
+      return undefined;
+    }
+    if (raw < 0) {
+      this.localConfig.loggerProvider.warn(`min_session_duration_ms remote value is negative (${raw}); ignoring.`);
+      return undefined;
+    }
+    if (raw > MAX_MIN_SESSION_DURATION_MS) {
+      this.localConfig.loggerProvider.warn(
+        `min_session_duration_ms remote value ${raw} exceeds ${MAX_MIN_SESSION_DURATION_MS}ms ceiling; clamping.`,
+      );
+      return MAX_MIN_SESSION_DURATION_MS;
+    }
+    return raw;
+  }
 }
+
+/**
+ * Upper bound for the remote-configured replay min duration. 60 seconds is well above
+ * any reasonable bounce threshold; values higher than this are almost certainly typos
+ * (e.g. seconds confused for milliseconds, or an extra zero) and would otherwise
+ * suppress every replay until the config is corrected.
+ */
+export const MAX_MIN_SESSION_DURATION_MS = 60_000;
 
 export const createSessionReplayJoinedConfigGenerator = async (apiKey: string, options: SessionReplayOptions) => {
   const localConfig = new SessionReplayLocalConfig(apiKey, options);

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -5,6 +5,7 @@ import { TargetingFlag } from '@amplitude/targeting';
 export interface SamplingConfig {
   sample_rate: number;
   capture_enabled: boolean;
+  min_session_duration_ms?: number;
 }
 
 export interface InteractionConfig {
@@ -228,6 +229,7 @@ export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {
   interactionConfig?: InteractionConfig;
   loggingConfig?: LoggingConfig;
   targetingConfig?: TargetingConfig;
+  minSessionDurationMs?: number;
 }
 
 export interface SessionReplayConfigs {

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -35,4 +35,14 @@ export enum CustomRRwebEvent {
   FETCH_REQUEST = 'fetch-request',
   METADATA = 'metadata',
   TARGETING_DECISION = 'targeting-decision',
+  /**
+   * Emitted once per session, on the first send that passes the min_session_duration_ms
+   * gate. Captures how many sends were suppressed before passing and the elapsed time
+   * spent below the threshold. Lets backend ingestion diff intended replay count vs
+   * actual ingestion so on-call can spot start-time-tracking regressions.
+   *
+   * Sessions that bounce before crossing the threshold never emit this event by design
+   * (the whole payload is suppressed); their absence is the signal.
+   */
+  REPLAY_GATE_DECISION = 'replay-gate-decision',
 }

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -17,6 +17,11 @@ export type EventsManagerWithBeacon<Type extends EventType> = AmplitudeSessionRe
    * Used to populate a sendBeacon payload when the page is unloading.
    */
   getBeaconEvents(): string[];
+  /**
+   * Drops all pending beacon events. Used when the session is decided to be below
+   * the min duration threshold so its events don't leak into a later session's beacon.
+   */
+  dropPendingBeaconEvents(): void;
   trackDestination: SessionReplayTrackDestination;
 };
 
@@ -219,8 +224,13 @@ export const createEventsManager = async <Type extends EventType>({
           if (!canSend) {
             // The split atomically moved events to sequencesToSend; without cleanup
             // they would be unconditionally replayed on next page load via
-            // sendStoredEvents, bypassing the min session duration gate.
-            void store.cleanUpSessionEventsStore(sequenceToSend.sessionId, sequenceToSend.sequenceId);
+            // sendStoredEvents, bypassing the min session duration gate. The split
+            // batch must also be dropped from the beacon buffer so it isn't sent
+            // via sendBeacon on page unload (potentially attributed to a later session).
+            store.cleanUpSessionEventsStore(sequenceToSend.sessionId, sequenceToSend.sequenceId).catch((e) => {
+              config.loggerProvider.warn('Failed to clean up dropped session replay sequence:', e);
+            });
+            advanceBeaconWindow(absIdx);
             return;
           }
           // Events before absIdx belong to the split batch being sent; advance window.
@@ -244,12 +254,17 @@ export const createEventsManager = async <Type extends EventType>({
 
   const getBeaconEvents = (): string[] => [...beaconBuffer];
 
+  const dropPendingBeaconEvents = () => {
+    advanceBeaconWindow(beaconWindowStart + beaconBuffer.length);
+  };
+
   return {
     sendCurrentSequenceEvents,
     addEvent,
     sendStoredEvents,
     flush,
     getBeaconEvents,
+    dropPendingBeaconEvents,
     trackDestination,
   };
 };

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -133,9 +133,6 @@ export const createEventsManager = async <Type extends EventType>({
         });
     }
 
-    if (shouldSend && !shouldSend()) {
-      return;
-    }
     trackDestination.sendEventsList({
       events: events,
       sessionId: sessionId,
@@ -155,6 +152,11 @@ export const createEventsManager = async <Type extends EventType>({
 
   const sendCurrentSequenceEvents = ({ sessionId, deviceId }: { sessionId: number; deviceId: string }) => {
     lastKnownDeviceId = deviceId;
+    // Evaluate shouldSend synchronously before the async store read. asyncSetSessionId
+    // updates sessionStartTime immediately after calling sendEvents(), so by the time
+    // storeCurrentSequence resolves the start time would reflect the new session and
+    // the elapsed check would compute ~0ms, silently dropping the previous session's events.
+    if (shouldSend && !shouldSend()) return;
     // Snapshot the absolute end-index before the async store read so that any events
     // pushed after this point are NOT considered sent and remain in the beacon buffer.
     const snapshotAbsIdx = beaconWindowStart + beaconBuffer.length;
@@ -209,6 +211,7 @@ export const createEventsManager = async <Type extends EventType>({
       .addEventToCurrentSequence(sessionId, event.data)
       .then((sequenceToSend) => {
         if (sequenceToSend) {
+          if (shouldSend && !shouldSend()) return;
           // Events before absIdx belong to the split batch being sent; advance window.
           advanceBeaconWindow(absIdx);
           sendEventsList({

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -28,6 +28,7 @@ export const createEventsManager = async <Type extends EventType>({
   payloadBatcher,
   storeType,
   trackDestinationWorkerScript,
+  shouldSend,
 }: {
   config: SessionReplayJoinedConfig;
   type: Type;
@@ -36,6 +37,7 @@ export const createEventsManager = async <Type extends EventType>({
   payloadBatcher?: PayloadBatcher;
   storeType: StoreType;
   trackDestinationWorkerScript?: string;
+  shouldSend?: () => boolean;
 }): Promise<EventsManagerWithBeacon<Type>> => {
   const trackDestination = new SessionReplayTrackDestination({
     ...config,
@@ -131,6 +133,9 @@ export const createEventsManager = async <Type extends EventType>({
         });
     }
 
+    if (shouldSend && !shouldSend()) {
+      return;
+    }
     trackDestination.sendEventsList({
       events: events,
       sessionId: sessionId,

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -216,7 +216,13 @@ export const createEventsManager = async <Type extends EventType>({
       .addEventToCurrentSequence(sessionId, event.data)
       .then((sequenceToSend) => {
         if (sequenceToSend) {
-          if (!canSend) return;
+          if (!canSend) {
+            // The split atomically moved events to sequencesToSend; without cleanup
+            // they would be unconditionally replayed on next page load via
+            // sendStoredEvents, bypassing the min session duration gate.
+            void store.cleanUpSessionEventsStore(sequenceToSend.sessionId, sequenceToSend.sequenceId);
+            return;
+          }
           // Events before absIdx belong to the split batch being sent; advance window.
           advanceBeaconWindow(absIdx);
           sendEventsList({

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -202,6 +202,11 @@ export const createEventsManager = async <Type extends EventType>({
     deviceId: string;
   }) => {
     lastKnownDeviceId = deviceId;
+    // Capture shouldSend synchronously before the async store write, for the same
+    // reason as sendCurrentSequenceEvents: asyncSetSessionId updates sessionStartTime
+    // synchronously, so evaluating inside the .then() would use the new session's
+    // start time and compute ~0ms elapsed, silently dropping a valid batch.
+    const canSend = !shouldSend || shouldSend();
     // Record the absolute index of this event in the beacon buffer before the async
     // store operation. If a batch split occurs, we advance the window up to (but not
     // including) this event so that it starts the next pending window.
@@ -211,7 +216,7 @@ export const createEventsManager = async <Type extends EventType>({
       .addEventToCurrentSequence(sessionId, event.data)
       .then((sequenceToSend) => {
         if (sequenceToSend) {
-          if (shouldSend && !shouldSend()) return;
+          if (!canSend) return;
           // Events before absIdx belong to the split batch being sent; advance window.
           advanceBeaconWindow(absIdx);
           sendEventsList({

--- a/packages/session-replay-browser/src/replay-start-time-store.ts
+++ b/packages/session-replay-browser/src/replay-start-time-store.ts
@@ -1,0 +1,122 @@
+import { getGlobalScope, ILogger } from '@amplitude/analytics-core';
+
+/**
+ * Persists the wall-clock time at which a session's replay first began capturing,
+ * keyed by sessionId. The persisted value drives the `min_session_duration_ms` gate:
+ * we measure elapsed *replay* time, not just current page-load time, so a session that
+ * is paused and resumed (or that crosses a page navigation) is still gated correctly.
+ *
+ * All storage access is wrapped in try/catch — when localStorage is unavailable (Safari
+ * private mode, quota exceeded, sandboxed iframe) callers fall back to `Date.now()` so
+ * the gate degrades gracefully instead of throwing.
+ */
+
+const KEY_PREFIX = 'AMP_SR_START_';
+const APIKEY_FINGERPRINT_LEN = 10;
+
+/**
+ * TTL beyond which a stored start time is treated as stale and pruned on next init.
+ * 24 hours covers the longest realistic single-session duration in Amplitude (default
+ * inactivity timeout is 30 minutes; some configs extend sessions across resumes).
+ */
+export const REPLAY_START_TIME_TTL_MS = 24 * 60 * 60 * 1000;
+
+const buildKeyPrefix = (apiKey: string) => `${KEY_PREFIX}${apiKey.substring(0, APIKEY_FINGERPRINT_LEN)}_`;
+const buildKey = (apiKey: string, sessionId: string | number) => `${buildKeyPrefix(apiKey)}${sessionId}`;
+
+const getLocalStorage = (): Storage | undefined => {
+  try {
+    const scope = getGlobalScope() as { localStorage?: Storage } | undefined;
+    return scope?.localStorage;
+  } catch {
+    // Accessing localStorage can throw in some sandboxed contexts.
+    return undefined;
+  }
+};
+
+/**
+ * Returns the persisted replay start time for this sessionId if one exists and is fresh,
+ * otherwise writes `now` and returns it. Returns undefined only if storage is unavailable
+ * — callers should fall back to a transient `Date.now()` in that case.
+ */
+export const getOrInitReplayStartTime = (
+  apiKey: string,
+  sessionId: string | number,
+  now: number,
+  logger?: ILogger,
+): number | undefined => {
+  const storage = getLocalStorage();
+  if (!storage) return undefined;
+  const key = buildKey(apiKey, sessionId);
+  try {
+    const raw = storage.getItem(key);
+    if (raw !== null) {
+      const parsed = Number(raw);
+      // Treat NaN, non-finite, future-dated, and stale entries as missing.
+      if (Number.isFinite(parsed) && parsed > 0 && parsed <= now && now - parsed < REPLAY_START_TIME_TTL_MS) {
+        return parsed;
+      }
+    }
+    storage.setItem(key, String(now));
+    return now;
+  } catch (e) {
+    logger?.debug(`Failed to read/write replay start time from storage: ${String(e)}`);
+    return undefined;
+  }
+};
+
+export const setReplayStartTime = (
+  apiKey: string,
+  sessionId: string | number,
+  startTime: number,
+  logger?: ILogger,
+): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(buildKey(apiKey, sessionId), String(startTime));
+  } catch (e) {
+    logger?.debug(`Failed to write replay start time to storage: ${String(e)}`);
+  }
+};
+
+export const removeReplayStartTime = (apiKey: string, sessionId: string | number, logger?: ILogger): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(buildKey(apiKey, sessionId));
+  } catch (e) {
+    logger?.debug(`Failed to remove replay start time from storage: ${String(e)}`);
+  }
+};
+
+/**
+ * Drops stored start times older than {@link REPLAY_START_TIME_TTL_MS}. Cheap best-effort
+ * sweep called on init — keeps localStorage from accumulating dead entries when sessions
+ * end without a clean transition (browser close, crash). Scoped to this API key's keys
+ * so multi-tenant pages don't churn through each other's entries.
+ */
+export const pruneStaleReplayStartTimes = (apiKey: string, now: number, logger?: ILogger): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  const prefix = buildKeyPrefix(apiKey);
+  try {
+    // Collect first; localStorage indices shift as we remove.
+    const stale: string[] = [];
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i);
+      if (!key || !key.startsWith(prefix)) continue;
+      const raw = storage.getItem(key);
+      if (raw === null) continue;
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0 || now - parsed >= REPLAY_START_TIME_TTL_MS) {
+        stale.push(key);
+      }
+    }
+    for (const key of stale) {
+      storage.removeItem(key);
+    }
+  } catch (e) {
+    logger?.debug(`Failed to prune stale replay start times: ${String(e)}`);
+  }
+};

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -98,6 +98,13 @@ export class SessionReplay implements AmplitudeSessionReplay {
   pageLeaveFns: PageLeaveFn[] = [];
   sessionStartTime: number | undefined;
   rrwebEventManager: EventsManagerWithBeacon<'replay'> | undefined;
+  /**
+   * Count of sendEvents() calls suppressed by the min-session-duration gate for the
+   * current session. Drives the REPLAY_GATE_DECISION rrweb event on first send-after-pass.
+   */
+  private suppressedSendCount = 0;
+  /** True once REPLAY_GATE_DECISION has been emitted for the current session. */
+  private hasEmittedGateDecision = false;
   private scrollHook?: scrollCallback;
   private clickHandler?: ClickHandler;
   private networkObservers?: NetworkObservers;
@@ -407,6 +414,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
       deviceId: deviceIdForReplayId,
     });
     this.sessionStartTime = Date.now();
+    this.suppressedSendCount = 0;
+    this.hasEmittedGateDecision = false;
     // Persist new session's start time so a page reload mid-session resumes the gate.
     // Also drop the previous session's entry — the localStorage cleanup deliberately
     // happens here (and via TTL prune on init) rather than after a successful send:
@@ -613,7 +622,25 @@ export class SessionReplay implements AmplitudeSessionReplay {
         // Drop pending beacon events so this below-threshold session's data
         // can't leak into a later session's beacon flush on page unload.
         this.rrwebEventManager?.dropPendingBeaconEvents();
+        this.suppressedSendCount++;
         return;
+      }
+      // On the first send-after-pass for the session, emit a custom rrweb event so the
+      // payload itself carries the gate verdict. Lets backend ingestion diff intended
+      // vs actual replay counts to spot start-time-tracking regressions.
+      if (!this.hasEmittedGateDecision && this.config?.minSessionDurationMs !== undefined) {
+        this.hasEmittedGateDecision = true;
+        const elapsedMs = this.sessionStartTime !== undefined ? Date.now() - this.sessionStartTime : undefined;
+        void this.addCustomRRWebEvent(
+          CustomRRwebEvent.REPLAY_GATE_DECISION,
+          {
+            sessionId: sessionIdToSend,
+            suppressedSendCount: this.suppressedSendCount,
+            elapsedMs,
+            minSessionDurationMs: this.config.minSessionDurationMs,
+          },
+          false,
+        );
       }
       this.eventsManager.sendCurrentSequenceEvents({ sessionId: sessionIdToSend, deviceId });
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -190,6 +190,24 @@ export class SessionReplay implements AmplitudeSessionReplay {
     };
   }
 
+  /**
+   * Single source of truth for the min_session_duration_ms gate. Returns true when the
+   * current session has not yet reached the configured threshold (and we have both a
+   * configured value and a recorded start time). Returns false when there's no
+   * threshold, no recorded start time, or the threshold has been met — i.e. it
+   * answers "should this batch be suppressed?".
+   *
+   * Centralizing the check means future changes (clock-skew tolerance, switching to
+   * performance.now(), etc.) are one-line edits.
+   */
+  private isBelowMinSessionDuration(): boolean {
+    const minSessionDurationMs = this.config?.minSessionDurationMs;
+    if (minSessionDurationMs === undefined || this.sessionStartTime === undefined) {
+      return false;
+    }
+    return Date.now() - this.sessionStartTime < minSessionDurationMs;
+  }
+
   private getCurrentPageForTargeting(): SessionReplayTargetingInput['page'] {
     const currentUrl = getGlobalScope()?.location?.href;
     return currentUrl != null ? { url: currentUrl } : undefined;
@@ -266,12 +284,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         type: 'replay',
         storeType,
         trackDestinationWorkerScript,
-        shouldSend: () => {
-          const { minSessionDurationMs } = this.config ?? {};
-          if (minSessionDurationMs === undefined || this.sessionStartTime === undefined) return true;
-          const elapsed = Date.now() - this.sessionStartTime;
-          return elapsed >= minSessionDurationMs;
-        },
+        shouldSend: () => !this.isBelowMinSessionDuration(),
       });
       this.rrwebEventManager = rrwebEventManager;
       managers.push({ name: 'replay', manager: rrwebEventManager });
@@ -323,10 +336,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         if (!events.length) return;
         const deviceId = this.getDeviceId();
         if (!deviceId) return;
-        const { minSessionDurationMs } = this.config;
-        if (minSessionDurationMs !== undefined && this.sessionStartTime !== undefined) {
-          if (Date.now() - this.sessionStartTime < minSessionDurationMs) return;
-        }
+        if (this.isBelowMinSessionDuration()) return;
         rrwebEventManager.trackDestination.sendBeacon({
           events,
           sessionId: this.identifiers.sessionId,
@@ -586,18 +596,18 @@ export class SessionReplay implements AmplitudeSessionReplay {
     const sessionIdToSend = sessionId || this.identifiers?.sessionId;
     const deviceId = this.getDeviceId();
     if (this.eventsManager && sessionIdToSend && deviceId) {
-      if (this.config?.minSessionDurationMs !== undefined && this.sessionStartTime !== undefined) {
-        const sessionDuration = Date.now() - this.sessionStartTime;
-        const willSend = sessionDuration >= this.config.minSessionDurationMs;
-        if (!willSend) {
-          this.loggerProvider.log(
-            `Session ${sessionIdToSend} not sent: duration ${sessionDuration}ms is below minimum ${this.config.minSessionDurationMs}ms.`,
-          );
-          // Drop pending beacon events so this below-threshold session's data
-          // can't leak into a later session's beacon flush on page unload.
-          this.rrwebEventManager?.dropPendingBeaconEvents();
-          return;
-        }
+      if (this.isBelowMinSessionDuration()) {
+        // Safe to dereference: isBelowMinSessionDuration() only returns true when both
+        // this.config and this.sessionStartTime are defined.
+        const startTime = this.sessionStartTime as number;
+        const minMs = (this.config as SessionReplayJoinedConfig).minSessionDurationMs as number;
+        this.loggerProvider.log(
+          `Session ${sessionIdToSend} not sent: duration ${Date.now() - startTime}ms is below minimum ${minMs}ms.`,
+        );
+        // Drop pending beacon events so this below-threshold session's data
+        // can't leak into a later session's beacon flush on page unload.
+        this.rrwebEventManager?.dropPendingBeaconEvents();
+        return;
       }
       this.eventsManager.sendCurrentSequenceEvents({ sessionId: sessionIdToSend, deviceId });
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -1027,6 +1027,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
   }
 
   async flush(useRetry = false) {
+    // Intentionally not gated on min_session_duration_ms. flush() forwards payloads
+    // already queued in trackDestination, and every code path that queues into it —
+    // sendCurrentSequenceEvents, addEvent's batch-split path, sendStoredEvents reading
+    // sequencesToSend from IDB — has already passed the gate at the time of queuing.
+    // A duplicate gate here would be unreachable.
     return this.eventsManager?.flush(useRetry);
   }
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -93,7 +93,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
   private lastTargetingParams?: SessionReplayTargetingInput;
   private lastShouldRecordDecision?: boolean;
 
-  // Visible for testing only
+  // Visible for testing only — the next three fields are intentionally public so
+  // tests can stub/inspect page-leave behavior and the min-session-duration gate.
   pageLeaveFns: PageLeaveFn[] = [];
   sessionStartTime: number | undefined;
   rrwebEventManager: EventsManagerWithBeacon<'replay'> | undefined;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -639,7 +639,18 @@ export class SessionReplay implements AmplitudeSessionReplay {
       // On the first send-after-pass for the session, emit a custom rrweb event so the
       // payload itself carries the gate verdict. Lets backend ingestion diff intended
       // vs actual replay counts to spot start-time-tracking regressions.
-      if (!this.hasEmittedGateDecision && this.config?.minSessionDurationMs !== undefined) {
+      //
+      // Gate on recording being active too: addCustomRRWebEvent is a no-op when
+      // recordCancelCallback/recordFunction aren't set yet (e.g. a blur-listener-fired
+      // sendEvents reaches us before _recordEvents() activates on a reloaded long-lived
+      // session). Tripping hasEmittedGateDecision unconditionally would lose the signal
+      // for that session's first real send.
+      if (
+        !this.hasEmittedGateDecision &&
+        this.config?.minSessionDurationMs !== undefined &&
+        this.recordCancelCallback &&
+        this.recordFunction
+      ) {
         this.hasEmittedGateDecision = true;
         const elapsedMs = this.sessionStartTime !== undefined ? Date.now() - this.sessionStartTime : undefined;
         void this.addCustomRRWebEvent(

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -328,6 +328,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
     // Register beacon fallback for page exit. sendBeacon survives page unload
     // and delivers any incremental events that haven't been flushed via fetch yet.
+    //
+    // Known cross-session race: if asyncSetSessionId fired and its async
+    // storeCurrentSequence hasn't resolved before unload, the beacon buffer can still
+    // hold previous-session events. The gate below reads the *new* session's
+    // sessionStartTime, so legitimately-sendable old-session events get suppressed.
+    // Follow-up: track start time per buffered batch instead of globally.
     this.pageLeaveFns = [
       ...this.pageLeaveFns,
       () => {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -307,6 +307,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
         if (!events.length) return;
         const deviceId = this.getDeviceId();
         if (!deviceId) return;
+        const { minSessionDurationMs } = this.config;
+        if (minSessionDurationMs !== undefined && this.sessionStartTime !== undefined) {
+          if (Date.now() - this.sessionStartTime < minSessionDurationMs) return;
+        }
         rrwebEventManager.trackDestination.sendBeacon({
           events,
           sessionId: this.identifiers.sessionId,

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -90,6 +90,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
   // Visible for testing only
   pageLeaveFns: PageLeaveFn[] = [];
   sessionStartTime: number | undefined;
+  rrwebEventManager: EventsManagerWithBeacon<'replay'> | undefined;
   private scrollHook?: scrollCallback;
   private clickHandler?: ClickHandler;
   private networkObservers?: NetworkObservers;
@@ -258,6 +259,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
           return elapsed >= minSessionDurationMs;
         },
       });
+      this.rrwebEventManager = rrwebEventManager;
       managers.push({ name: 'replay', manager: rrwebEventManager });
     } catch (error) {
       const typedError = error as Error;
@@ -566,6 +568,9 @@ export class SessionReplay implements AmplitudeSessionReplay {
           this.loggerProvider.log(
             `Session ${sessionIdToSend} not sent: duration ${sessionDuration}ms is below minimum ${this.config.minSessionDurationMs}ms.`,
           );
+          // Drop pending beacon events so this below-threshold session's data
+          // can't leak into a later session's beacon flush on page unload.
+          this.rrwebEventManager?.dropPendingBeaconEvents();
           return;
         }
       }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -93,8 +93,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
   private lastTargetingParams?: SessionReplayTargetingInput;
   private lastShouldRecordDecision?: boolean;
 
-  // Visible for testing only — the next three fields are intentionally public so
-  // tests can stub/inspect page-leave behavior and the min-session-duration gate.
+  // Public on purpose. `pageLeaveFns` is iterated by `pageLeaveListener`,
+  // `rrwebEventManager` is dereferenced in `asyncSetSessionId` to drop the beacon buffer
+  // at a session boundary, and `sessionStartTime` drives `isBelowMinSessionDuration()`.
+  // Tests also stub/inspect these — privatizing them would break both production callers
+  // and the gate's test coverage.
   pageLeaveFns: PageLeaveFn[] = [];
   sessionStartTime: number | undefined;
   rrwebEventManager: EventsManagerWithBeacon<'replay'> | undefined;

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -408,6 +408,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.sendEvents(previousSessionId);
     }
 
+    // Drop any beacon-buffered events from the previous session BEFORE installing the
+    // new identifiers / start time. Otherwise the page-leave beacon path could attribute
+    // old-session events to the new session id, and the gate (using the new start time)
+    // would compute the wrong elapsed duration.
+    this.rrwebEventManager?.dropPendingBeaconEvents();
+
     const deviceIdForReplayId = deviceId || this.getDeviceId();
     this.identifiers = new SessionIdentifiers({
       sessionId: sessionId,
@@ -619,9 +625,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
         this.loggerProvider.log(
           `Session ${sessionIdToSend} not sent: duration ${Date.now() - startTime}ms is below minimum ${minMs}ms.`,
         );
-        // Drop pending beacon events so this below-threshold session's data
-        // can't leak into a later session's beacon flush on page unload.
-        this.rrwebEventManager?.dropPendingBeaconEvents();
+        // We deliberately do NOT clear the beacon buffer here. Blur/visibility-change
+        // can call sendEvents() mid-session; if the session later crosses the threshold
+        // those buffered events are legitimately sendable via beacon on page exit.
+        // Cross-session leak is prevented in asyncSetSessionId, which drops the buffer
+        // at the session transition. The page-leave path also gates independently.
         this.suppressedSendCount++;
         return;
       }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -429,7 +429,10 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // re-suppress already-eligible sessions.
     if (this.config?.apiKey) {
       setReplayStartTime(this.config.apiKey, sessionId, this.sessionStartTime, this.loggerProvider);
-      if (previousSessionId !== undefined) {
+      // Only clear the prior entry when the id actually changed. A caller that passes the
+      // current sessionId redundantly would otherwise have its just-written entry deleted
+      // here, restarting the gate clock from Date.now() on the next page reload.
+      if (previousSessionId !== undefined && previousSessionId !== sessionId) {
         removeReplayStartTime(this.config.apiKey, previousSessionId, this.loggerProvider);
       }
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -89,6 +89,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   // Visible for testing only
   pageLeaveFns: PageLeaveFn[] = [];
+  sessionStartTime: number | undefined;
   private scrollHook?: scrollCallback;
   private clickHandler?: ClickHandler;
   private networkObservers?: NetworkObservers;
@@ -361,6 +362,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
       sessionId: sessionId,
       deviceId: deviceIdForReplayId,
     });
+    this.sessionStartTime = Date.now();
 
     // If there is no previous session id, SDK is being initialized for the first time,
     // and config was just fetched in initialization, so no need to fetch it a second time
@@ -544,10 +546,18 @@ export class SessionReplay implements AmplitudeSessionReplay {
   sendEvents(sessionId?: string | number) {
     const sessionIdToSend = sessionId || this.identifiers?.sessionId;
     const deviceId = this.getDeviceId();
-    this.eventsManager &&
-      sessionIdToSend &&
-      deviceId &&
+    if (this.eventsManager && sessionIdToSend && deviceId) {
+      if (this.config?.minSessionDurationMs !== undefined && this.sessionStartTime !== undefined) {
+        const sessionDuration = Date.now() - this.sessionStartTime;
+        if (sessionDuration < this.config.minSessionDurationMs) {
+          this.loggerProvider.log(
+            `Session ${sessionIdToSend} not sent: duration ${sessionDuration}ms is below minimum ${this.config.minSessionDurationMs}ms.`,
+          );
+          return;
+        }
+      }
       this.eventsManager.sendCurrentSequenceEvents({ sessionId: sessionIdToSend, deviceId });
+    }
   }
 
   async initialize(shouldSendStoredEvents = false) {

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -52,6 +52,12 @@ import { clickBatcher, ClickHandler, clickNonBatcher } from './hooks/click';
 import { ScrollWatcher } from './hooks/scroll';
 import { SessionIdentifiers } from './identifiers';
 import { SafeLoggerProvider } from './logger';
+import {
+  getOrInitReplayStartTime,
+  pruneStaleReplayStartTimes,
+  removeReplayStartTime,
+  setReplayStartTime,
+} from './replay-start-time-store';
 import { evaluateTargetingAndStore } from './targeting/targeting-manager';
 import {
   AmplitudeSessionReplay,
@@ -198,8 +204,15 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.loggerProvider.enable(options.logLevel as LogLevel);
     this.currentPageUrl = getCurrentUrl();
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
-    // Use the session ID itself as the start time if it's a numeric timestamp, otherwise Date.now()
-    this.sessionStartTime = typeof options.sessionId === 'number' ? options.sessionId : Date.now();
+    // Persist replay start time per sessionId so the min_session_duration_ms gate
+    // measures replay duration (survives page reloads within a session) rather than
+    // page-load duration. Storage failures fall back to a transient Date.now().
+    const now = Date.now();
+    pruneStaleReplayStartTimes(apiKey, now, this.loggerProvider);
+    this.sessionStartTime =
+      options.sessionId !== undefined
+        ? getOrInitReplayStartTime(apiKey, options.sessionId, now, this.loggerProvider) ?? now
+        : now;
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     const { joinedConfig, localConfig, remoteConfig } = await this.joinedConfigGenerator.generateJoinedConfig();
     this.config = joinedConfig;
@@ -377,6 +390,17 @@ export class SessionReplay implements AmplitudeSessionReplay {
       deviceId: deviceIdForReplayId,
     });
     this.sessionStartTime = Date.now();
+    // Persist new session's start time so a page reload mid-session resumes the gate.
+    // Also drop the previous session's entry — the localStorage cleanup deliberately
+    // happens here (and via TTL prune on init) rather than after a successful send:
+    // mid-session reloads would otherwise re-init the start time to Date.now() and
+    // re-suppress already-eligible sessions.
+    if (this.config?.apiKey) {
+      setReplayStartTime(this.config.apiKey, sessionId, this.sessionStartTime, this.loggerProvider);
+      if (previousSessionId !== undefined) {
+        removeReplayStartTime(this.config.apiKey, previousSessionId, this.loggerProvider);
+      }
+    }
 
     // If there is no previous session id, SDK is being initialized for the first time,
     // and config was just fetched in initialization, so no need to fetch it a second time

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -411,32 +411,36 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.sendEvents(previousSessionId);
     }
 
+    const isSessionChange = previousSessionId !== sessionId;
+
     // Drop any beacon-buffered events from the previous session BEFORE installing the
     // new identifiers / start time. Otherwise the page-leave beacon path could attribute
     // old-session events to the new session id, and the gate (using the new start time)
-    // would compute the wrong elapsed duration.
-    this.rrwebEventManager?.dropPendingBeaconEvents();
+    // would compute the wrong elapsed duration. Skip on a redundant same-sessionId call —
+    // the buffer belongs to the *continuing* session and should ship via beacon as normal.
+    if (isSessionChange) {
+      this.rrwebEventManager?.dropPendingBeaconEvents();
+    }
 
     const deviceIdForReplayId = deviceId || this.getDeviceId();
     this.identifiers = new SessionIdentifiers({
       sessionId: sessionId,
       deviceId: deviceIdForReplayId,
     });
-    this.sessionStartTime = Date.now();
-    this.suppressedSendCount = 0;
-    this.hasEmittedGateDecision = false;
-    // Persist new session's start time so a page reload mid-session resumes the gate.
-    // Also drop the previous session's entry — the localStorage cleanup deliberately
-    // happens here (and via TTL prune on init) rather than after a successful send:
-    // mid-session reloads would otherwise re-init the start time to Date.now() and
-    // re-suppress already-eligible sessions.
-    if (this.config?.apiKey) {
-      setReplayStartTime(this.config.apiKey, sessionId, this.sessionStartTime, this.loggerProvider);
-      // Only clear the prior entry when the id actually changed. A caller that passes the
-      // current sessionId redundantly would otherwise have its just-written entry deleted
-      // here, restarting the gate clock from Date.now() on the next page reload.
-      if (previousSessionId !== undefined && previousSessionId !== sessionId) {
-        removeReplayStartTime(this.config.apiKey, previousSessionId, this.loggerProvider);
+
+    // Gate state and persisted start time only get reset on an actual session boundary.
+    // A redundant setSessionId(currentId) call would otherwise overwrite both the in-memory
+    // and stored start time with a fresh Date.now() — restarting the gate clock for what is
+    // supposed to be a continuing session.
+    if (isSessionChange) {
+      this.sessionStartTime = Date.now();
+      this.suppressedSendCount = 0;
+      this.hasEmittedGateDecision = false;
+      if (this.config?.apiKey) {
+        setReplayStartTime(this.config.apiKey, sessionId, this.sessionStartTime, this.loggerProvider);
+        if (previousSessionId !== undefined) {
+          removeReplayStartTime(this.config.apiKey, previousSessionId, this.loggerProvider);
+        }
       }
     }
 

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -197,6 +197,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.loggerProvider.enable(options.logLevel as LogLevel);
     this.currentPageUrl = getCurrentUrl();
     this.identifiers = new SessionIdentifiers({ sessionId: options.sessionId, deviceId: options.deviceId });
+    // Use the session ID itself as the start time if it's a numeric timestamp, otherwise Date.now()
+    this.sessionStartTime = typeof options.sessionId === 'number' ? options.sessionId : Date.now();
     this.joinedConfigGenerator = await createSessionReplayJoinedConfigGenerator(apiKey, options);
     const { joinedConfig, localConfig, remoteConfig } = await this.joinedConfigGenerator.generateJoinedConfig();
     this.config = joinedConfig;
@@ -249,6 +251,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
         type: 'replay',
         storeType,
         trackDestinationWorkerScript,
+        shouldSend: () => {
+          const { minSessionDurationMs } = this.config ?? {};
+          if (minSessionDurationMs === undefined || this.sessionStartTime === undefined) return true;
+          const elapsed = Date.now() - this.sessionStartTime;
+          return elapsed >= minSessionDurationMs;
+        },
       });
       managers.push({ name: 'replay', manager: rrwebEventManager });
     } catch (error) {
@@ -549,7 +557,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
     if (this.eventsManager && sessionIdToSend && deviceId) {
       if (this.config?.minSessionDurationMs !== undefined && this.sessionStartTime !== undefined) {
         const sessionDuration = Date.now() - this.sessionStartTime;
-        if (sessionDuration < this.config.minSessionDurationMs) {
+        const willSend = sessionDuration >= this.config.minSessionDurationMs;
+        if (!willSend) {
           this.loggerProvider.log(
             `Session ${sessionIdToSend} not sent: duration ${sessionDuration}ms is below minimum ${this.config.minSessionDurationMs}ms.`,
           );

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -177,6 +177,13 @@ describe('SessionReplayJoinedConfigGenerator', () => {
           captureEnabled: false,
         });
       });
+      test('should use min_session_duration_ms from API', async () => {
+        mockRemoteConfig = {
+          sr_sampling_config: { ...samplingConfig, min_session_duration_ms: 3000 },
+        };
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+        expect(config.minSessionDurationMs).toBe(3000);
+      });
       test('should set captureEnabled to true if no values returned from API', async () => {
         mockRemoteConfig = {
           sr_sampling_config: {} as any,

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -184,6 +184,44 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
         expect(config.minSessionDurationMs).toBe(3000);
       });
+      test('should clamp min_session_duration_ms above ceiling and warn', async () => {
+        mockRemoteConfig = {
+          sr_sampling_config: { ...samplingConfig, min_session_duration_ms: 30_000_000 },
+        };
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+        expect(config.minSessionDurationMs).toBe(60_000);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLocalConfig.loggerProvider.warn).toHaveBeenCalledWith(
+          expect.stringContaining('exceeds 60000ms ceiling; clamping'),
+        );
+      });
+      test('should drop negative min_session_duration_ms and warn', async () => {
+        mockRemoteConfig = {
+          sr_sampling_config: { ...samplingConfig, min_session_duration_ms: -100 },
+        };
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+        expect(config.minSessionDurationMs).toBeUndefined();
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLocalConfig.loggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('is negative'));
+      });
+      test('should drop non-finite min_session_duration_ms and warn', async () => {
+        mockRemoteConfig = {
+          sr_sampling_config: { ...samplingConfig, min_session_duration_ms: 'not-a-number' as unknown as number },
+        };
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+        expect(config.minSessionDurationMs).toBeUndefined();
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLocalConfig.loggerProvider.warn).toHaveBeenCalledWith(
+          expect.stringContaining('not a finite number'),
+        );
+      });
+      test('should drop NaN min_session_duration_ms and warn', async () => {
+        mockRemoteConfig = {
+          sr_sampling_config: { ...samplingConfig, min_session_duration_ms: NaN },
+        };
+        const { joinedConfig: config } = await joinedConfigGenerator.generateJoinedConfig();
+        expect(config.minSessionDurationMs).toBeUndefined();
+      });
       test('should set captureEnabled to true if no values returned from API', async () => {
         mockRemoteConfig = {
           sr_sampling_config: {} as any,

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -378,13 +378,19 @@ describe('createEventsManager', () => {
     test('should block sendEventsList in addEvent when shouldSend returns false', async () => {
       const mockAddEventPromise = Promise.resolve({ events: [mockEventString], sequenceId: 1, sessionId: 123 });
       (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockReturnValue(mockAddEventPromise);
+      let shouldSendCallCount = 0;
       const eventsManager = await createEventsManager<'replay'>({
         config,
         type: 'replay',
         storeType: 'idb',
-        shouldSend: () => false,
+        shouldSend: () => {
+          shouldSendCallCount++;
+          return false;
+        },
       });
       eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      // shouldSend must be evaluated synchronously (before the async store resolves).
+      expect(shouldSendCallCount).toBe(1);
       jest.runAllTimers();
       return mockAddEventPromise
         .catch(() => {

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -399,6 +399,9 @@ describe('createEventsManager', () => {
         .finally(() => {
           const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
           expect(trackDestinationInstance.sendEventsList).not.toHaveBeenCalled();
+          // Split events were atomically moved to sequencesToSend by the store; if we don't
+          // clean them up they'd be unconditionally replayed via sendStoredEvents on next load.
+          expect(mockIDBStore.cleanUpSessionEventsStore).toHaveBeenCalledWith(123, 1);
         });
     });
 

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -406,15 +406,12 @@ describe('createEventsManager', () => {
         shouldSend: () => false,
       });
       eventsManager.sendCurrentSequenceEvents({ sessionId: 123, deviceId: '1a2b3c' });
+      // shouldSend is evaluated synchronously — storeCurrentSequence must not be called at all.
+      expect(mockIDBStore.storeCurrentSequence).not.toHaveBeenCalled();
       jest.runAllTimers();
-      return mockStoreEventPromise
-        .catch(() => {
-          // ignore
-        })
-        .finally(() => {
-          const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
-          expect(trackDestinationInstance.sendEventsList).not.toHaveBeenCalled();
-        });
+      await mockStoreEventPromise;
+      const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+      expect(trackDestinationInstance.sendEventsList).not.toHaveBeenCalled();
     });
 
     test('should allow sendEventsList when shouldSend returns true', async () => {

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -402,7 +402,31 @@ describe('createEventsManager', () => {
           // Split events were atomically moved to sequencesToSend by the store; if we don't
           // clean them up they'd be unconditionally replayed via sendStoredEvents on next load.
           expect(mockIDBStore.cleanUpSessionEventsStore).toHaveBeenCalledWith(123, 1);
+          // The split batch must also be removed from the beacon buffer so it can't be
+          // sent via sendBeacon on page unload (potentially attributed to a later session).
+          expect(eventsManager.getBeaconEvents()).toEqual([mockEventString]);
         });
+    });
+
+    test('should log warning when cleanUpSessionEventsStore rejects on canSend=false split', async () => {
+      const mockAddEventPromise = Promise.resolve({ events: [mockEventString], sequenceId: 1, sessionId: 123 });
+      (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockReturnValue(mockAddEventPromise);
+      (mockIDBStore.cleanUpSessionEventsStore as jest.Mock).mockRejectedValueOnce(new Error('idb gone'));
+      const eventsManager = await createEventsManager<'replay'>({
+        config,
+        type: 'replay',
+        storeType: 'idb',
+        shouldSend: () => false,
+      });
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      // Let the addEvent .then() chain and the cleanUp .catch() chain both settle.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        'Failed to clean up dropped session replay sequence:',
+        expect.any(Error),
+      );
     });
 
     test('should block sendEventsList in sendCurrentSequenceEvents when shouldSend returns false', async () => {
@@ -553,6 +577,27 @@ describe('createEventsManager', () => {
       const snapshot = eventsManager.getBeaconEvents();
       snapshot.push('extra');
       expect(eventsManager.getBeaconEvents()).toHaveLength(1);
+    });
+  });
+
+  describe('dropPendingBeaconEvents', () => {
+    test('should clear the buffer and not affect later events added under a new session', async () => {
+      const eventsManager = await createEventsManager({
+        config,
+        type: 'replay',
+        storeType: 'memory',
+      });
+      const oldEvent = JSON.stringify({ type: 3, timestamp: 1 });
+      const newEvent = JSON.stringify({ type: 3, timestamp: 2 });
+      eventsManager.addEvent({ event: { type: 'replay', data: oldEvent }, sessionId: 1, deviceId: '1a2b3c' });
+      expect(eventsManager.getBeaconEvents()).toEqual([oldEvent]);
+
+      eventsManager.dropPendingBeaconEvents();
+      expect(eventsManager.getBeaconEvents()).toEqual([]);
+
+      // Subsequent events from a new session must accumulate cleanly without the dropped events.
+      eventsManager.addEvent({ event: { type: 'replay', data: newEvent }, sessionId: 2, deviceId: '1a2b3c' });
+      expect(eventsManager.getBeaconEvents()).toEqual([newEvent]);
     });
   });
 

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -374,6 +374,71 @@ describe('createEventsManager', () => {
     });
   });
 
+  describe('shouldSend callback', () => {
+    test('should block sendEventsList in addEvent when shouldSend returns false', async () => {
+      const mockAddEventPromise = Promise.resolve({ events: [mockEventString], sequenceId: 1, sessionId: 123 });
+      (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockReturnValue(mockAddEventPromise);
+      const eventsManager = await createEventsManager<'replay'>({
+        config,
+        type: 'replay',
+        storeType: 'idb',
+        shouldSend: () => false,
+      });
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      jest.runAllTimers();
+      return mockAddEventPromise
+        .catch(() => {
+          // ignore
+        })
+        .finally(() => {
+          const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+          expect(trackDestinationInstance.sendEventsList).not.toHaveBeenCalled();
+        });
+    });
+
+    test('should block sendEventsList in sendCurrentSequenceEvents when shouldSend returns false', async () => {
+      const mockStoreEventPromise = Promise.resolve({ events: [mockEventString], sequenceId: 1, sessionId: 123 });
+      (mockIDBStore.storeCurrentSequence as jest.Mock).mockReturnValue(mockStoreEventPromise);
+      const eventsManager = await createEventsManager<'replay'>({
+        config,
+        type: 'replay',
+        storeType: 'idb',
+        shouldSend: () => false,
+      });
+      eventsManager.sendCurrentSequenceEvents({ sessionId: 123, deviceId: '1a2b3c' });
+      jest.runAllTimers();
+      return mockStoreEventPromise
+        .catch(() => {
+          // ignore
+        })
+        .finally(() => {
+          const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+          expect(trackDestinationInstance.sendEventsList).not.toHaveBeenCalled();
+        });
+    });
+
+    test('should allow sendEventsList when shouldSend returns true', async () => {
+      const mockAddEventPromise = Promise.resolve({ events: [mockEventString], sequenceId: 1, sessionId: 123 });
+      (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockReturnValue(mockAddEventPromise);
+      const eventsManager = await createEventsManager<'replay'>({
+        config,
+        type: 'replay',
+        storeType: 'idb',
+        shouldSend: () => true,
+      });
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      jest.runAllTimers();
+      return mockAddEventPromise
+        .catch(() => {
+          // ignore
+        })
+        .finally(() => {
+          const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+          expect(trackDestinationInstance.sendEventsList).toHaveBeenCalledTimes(1);
+        });
+    });
+  });
+
   describe('flush', () => {
     test('should call track destination flush with useRetry as true', async () => {
       const eventsManager = await createEventsManager<'replay'>({

--- a/packages/session-replay-browser/test/replay-start-time-store.test.ts
+++ b/packages/session-replay-browser/test/replay-start-time-store.test.ts
@@ -1,0 +1,329 @@
+import {
+  getOrInitReplayStartTime,
+  pruneStaleReplayStartTimes,
+  REPLAY_START_TIME_TTL_MS,
+  removeReplayStartTime,
+  setReplayStartTime,
+} from '../src/replay-start-time-store';
+
+describe('replay-start-time-store', () => {
+  const apiKey = 'test_api_key_12345';
+  const prefix = `AMP_SR_START_${apiKey.substring(0, 10)}_`;
+  const logger = {
+    log: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    enable: jest.fn(),
+    disable: jest.fn(),
+  };
+
+  /**
+   * jsdom's localStorage methods live on Storage.prototype and aren't own properties,
+   * so `jest.spyOn(localStorage, 'getItem')` doesn't bind. Patching the prototype
+   * directly is the reliable way to inject failure modes — callers must restore.
+   */
+  const overrideStorageMethod = <K extends 'getItem' | 'setItem' | 'removeItem' | 'key'>(
+    name: K,
+    impl: Storage[K],
+  ): (() => void) => {
+    const proto = Object.getPrototypeOf(globalThis.localStorage) as Storage;
+    const original = proto[name];
+    proto[name] = impl;
+    return () => {
+      proto[name] = original;
+    };
+  };
+
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('getOrInitReplayStartTime', () => {
+    test('writes now when no entry exists and returns it', () => {
+      const now = 1_700_000_000_000;
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', now, logger);
+      expect(result).toBe(now);
+      expect(globalThis.localStorage.getItem(`${prefix}sess1`)).toBe(String(now));
+    });
+
+    test('returns existing fresh entry without overwriting', () => {
+      const earlier = 1_700_000_000_000;
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(earlier));
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', earlier + 60_000, logger);
+      expect(result).toBe(earlier);
+      expect(globalThis.localStorage.getItem(`${prefix}sess1`)).toBe(String(earlier));
+    });
+
+    test('treats NaN entries as missing and overwrites', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, 'NaN');
+      const now = 1_700_000_000_000;
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', now, logger);
+      expect(result).toBe(now);
+    });
+
+    test('treats non-finite entries as missing and overwrites', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, 'Infinity');
+      const now = 1_700_000_000_000;
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', now, logger);
+      expect(result).toBe(now);
+    });
+
+    test('treats future-dated entries as missing and overwrites', () => {
+      const now = 1_700_000_000_000;
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(now + 60_000));
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', now, logger);
+      expect(result).toBe(now);
+    });
+
+    test('treats zero/negative entries as missing and overwrites', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, '0');
+      const now = 1_700_000_000_000;
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', now, logger);
+      expect(result).toBe(now);
+    });
+
+    test('treats stale entries as missing and overwrites', () => {
+      const stale = 1_000_000_000_000;
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(stale));
+      const result = getOrInitReplayStartTime(apiKey, 'sess1', stale + REPLAY_START_TIME_TTL_MS + 1, logger);
+      expect(result).toBe(stale + REPLAY_START_TIME_TTL_MS + 1);
+    });
+
+    test('returns undefined and logs when storage throws', () => {
+      const restore = overrideStorageMethod('getItem', () => {
+        throw new Error('boom');
+      });
+      try {
+        const result = getOrInitReplayStartTime(apiKey, 'sess1', 1_700_000_000_000, logger);
+        expect(result).toBeUndefined();
+        expect(logger.debug).toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    test('returns undefined when globalThis.localStorage is unavailable', () => {
+      const orig = globalThis.localStorage;
+      Object.defineProperty(globalThis, 'localStorage', { value: undefined, configurable: true });
+      try {
+        const result = getOrInitReplayStartTime(apiKey, 'sess1', 1_700_000_000_000, logger);
+        expect(result).toBeUndefined();
+      } finally {
+        Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true });
+      }
+    });
+
+    test('returns undefined when accessing globalThis.localStorage throws', () => {
+      const orig = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+      Object.defineProperty(globalThis, 'localStorage', {
+        get() {
+          throw new Error('blocked');
+        },
+        configurable: true,
+      });
+      try {
+        const result = getOrInitReplayStartTime(apiKey, 'sess1', 1_700_000_000_000, logger);
+        expect(result).toBeUndefined();
+      } finally {
+        if (orig) Object.defineProperty(globalThis, 'localStorage', orig);
+      }
+    });
+
+    test('works without logger', () => {
+      const restore = overrideStorageMethod('getItem', () => {
+        throw new Error('boom');
+      });
+      try {
+        const result = getOrInitReplayStartTime(apiKey, 'sess1', 1_700_000_000_000);
+        expect(result).toBeUndefined();
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('setReplayStartTime', () => {
+    test('writes the start time to storage', () => {
+      setReplayStartTime(apiKey, 'sess1', 1_700_000_000_000, logger);
+      expect(globalThis.localStorage.getItem(`${prefix}sess1`)).toBe('1700000000000');
+    });
+
+    test('swallows and logs storage errors', () => {
+      const restore = overrideStorageMethod('setItem', () => {
+        throw new Error('quota');
+      });
+      try {
+        expect(() => setReplayStartTime(apiKey, 'sess1', 1_700_000_000_000, logger)).not.toThrow();
+        expect(logger.debug).toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    test('no-op when storage is unavailable', () => {
+      const orig = globalThis.localStorage;
+      Object.defineProperty(globalThis, 'localStorage', { value: undefined, configurable: true });
+      try {
+        expect(() => setReplayStartTime(apiKey, 'sess1', 1_700_000_000_000, logger)).not.toThrow();
+      } finally {
+        Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true });
+      }
+    });
+
+    test('swallows storage errors without a logger', () => {
+      const restore = overrideStorageMethod('setItem', () => {
+        throw new Error('quota');
+      });
+      try {
+        expect(() => setReplayStartTime(apiKey, 'sess1', 1_700_000_000_000)).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('removeReplayStartTime', () => {
+    test('removes the entry', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, '12345');
+      removeReplayStartTime(apiKey, 'sess1', logger);
+      expect(globalThis.localStorage.getItem(`${prefix}sess1`)).toBeNull();
+    });
+
+    test('swallows and logs storage errors', () => {
+      const restore = overrideStorageMethod('removeItem', () => {
+        throw new Error('blocked');
+      });
+      try {
+        expect(() => removeReplayStartTime(apiKey, 'sess1', logger)).not.toThrow();
+        expect(logger.debug).toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    test('swallows storage errors without a logger', () => {
+      const restore = overrideStorageMethod('removeItem', () => {
+        throw new Error('blocked');
+      });
+      try {
+        expect(() => removeReplayStartTime(apiKey, 'sess1')).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+
+    test('no-op when storage is unavailable', () => {
+      const orig = globalThis.localStorage;
+      Object.defineProperty(globalThis, 'localStorage', { value: undefined, configurable: true });
+      try {
+        expect(() => removeReplayStartTime(apiKey, 'sess1', logger)).not.toThrow();
+      } finally {
+        Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true });
+      }
+    });
+  });
+
+  describe('pruneStaleReplayStartTimes', () => {
+    test('removes entries older than TTL but keeps fresh ones', () => {
+      const now = 1_700_000_000_000;
+      const fresh = now - 1_000;
+      const stale = now - REPLAY_START_TIME_TTL_MS - 1;
+      globalThis.localStorage.setItem(`${prefix}fresh`, String(fresh));
+      globalThis.localStorage.setItem(`${prefix}stale`, String(stale));
+      // An entry from a different api key should not be touched.
+      globalThis.localStorage.setItem(`AMP_SR_START_other_apik_stale`, String(stale));
+
+      pruneStaleReplayStartTimes(apiKey, now, logger);
+
+      expect(globalThis.localStorage.getItem(`${prefix}fresh`)).toBe(String(fresh));
+      expect(globalThis.localStorage.getItem(`${prefix}stale`)).toBeNull();
+      expect(globalThis.localStorage.getItem(`AMP_SR_START_other_apik_stale`)).toBe(String(stale));
+    });
+
+    test('removes entries with non-finite or non-positive values', () => {
+      globalThis.localStorage.setItem(`${prefix}bad1`, 'not-a-number');
+      globalThis.localStorage.setItem(`${prefix}bad2`, '-1');
+      pruneStaleReplayStartTimes(apiKey, 1_700_000_000_000, logger);
+      expect(globalThis.localStorage.getItem(`${prefix}bad1`)).toBeNull();
+      expect(globalThis.localStorage.getItem(`${prefix}bad2`)).toBeNull();
+    });
+
+    test('ignores keys that do not match the prefix', () => {
+      globalThis.localStorage.setItem('OTHER_KEY', 'whatever');
+      pruneStaleReplayStartTimes(apiKey, 1_700_000_000_000, logger);
+      expect(globalThis.localStorage.getItem('OTHER_KEY')).toBe('whatever');
+    });
+
+    test('skips iteration entries where key() returns null', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(Date.now()));
+      const proto = Object.getPrototypeOf(globalThis.localStorage) as Storage;
+      const origKey = proto.key.bind(proto);
+      let calls = 0;
+      const restore = overrideStorageMethod('key', (idx: number) => {
+        calls++;
+        if (calls === 1) return null;
+        return origKey(idx);
+      });
+      try {
+        expect(() => pruneStaleReplayStartTimes(apiKey, Date.now(), logger)).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+
+    test('skips entries where getItem returns null mid-iteration', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(Date.now()));
+      const proto = Object.getPrototypeOf(globalThis.localStorage) as Storage;
+      const origGet = proto.getItem.bind(proto);
+      let callCount = 0;
+      const restore = overrideStorageMethod('getItem', (k: string) => {
+        callCount++;
+        if (callCount === 1) return null;
+        return origGet(k);
+      });
+      try {
+        expect(() => pruneStaleReplayStartTimes(apiKey, Date.now(), logger)).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+
+    test('swallows and logs errors during iteration', () => {
+      // Seed an entry so the loop actually enters and reaches storage.key().
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(Date.now()));
+      const restore = overrideStorageMethod('key', () => {
+        throw new Error('boom');
+      });
+      try {
+        expect(() => pruneStaleReplayStartTimes(apiKey, 1_700_000_000_000, logger)).not.toThrow();
+        expect(logger.debug).toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    test('no-op when storage is unavailable', () => {
+      const orig = globalThis.localStorage;
+      Object.defineProperty(globalThis, 'localStorage', { value: undefined, configurable: true });
+      try {
+        expect(() => pruneStaleReplayStartTimes(apiKey, 1_700_000_000_000, logger)).not.toThrow();
+      } finally {
+        Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true });
+      }
+    });
+
+    test('swallows iteration errors without a logger', () => {
+      globalThis.localStorage.setItem(`${prefix}sess1`, String(Date.now()));
+      const restore = overrideStorageMethod('key', () => {
+        throw new Error('boom');
+      });
+      try {
+        expect(() => pruneStaleReplayStartTimes(apiKey, 1_700_000_000_000)).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+  });
+});

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1421,6 +1421,22 @@ describe('SessionReplay', () => {
       expect(newStart).toBe(sessionReplay.sessionStartTime);
     });
 
+    test('does not delete its own start-time entry when sessionId is unchanged', async () => {
+      globalThis.localStorage.clear();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const key = `AMP_SR_START_${apiKey.substring(0, 10)}_123`;
+      const beforeStart = Number(globalThis.localStorage.getItem(key));
+      expect(beforeStart).toBeGreaterThan(0);
+
+      // Caller passes the current sessionId redundantly — must not leave storage empty.
+      await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c');
+
+      const afterStart = Number(globalThis.localStorage.getItem(key));
+      expect(afterStart).toBeGreaterThan(0);
+      // The freshly-written entry should match the new sessionStartTime.
+      expect(afterStart).toBe(sessionReplay.sessionStartTime);
+    });
+
     test('drops previous-session beacon buffer on session transition', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
       if (!sessionReplay.rrwebEventManager) throw new Error('init');

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1972,6 +1972,29 @@ describe('SessionReplay', () => {
       sessionReplay.sendEvents();
       expect(sendEventsMock).not.toHaveBeenCalled();
     });
+    test('it should send if minSessionDurationMs is set but sessionStartTime is undefined', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      const sendEventsMock = jest.fn();
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = sendEventsMock;
+      sessionReplay.config.minSessionDurationMs = 5000;
+      sessionReplay.sessionStartTime = undefined;
+      sessionReplay.sendEvents();
+      expect(sendEventsMock).toHaveBeenCalled();
+    });
+    test('it should send if config is undefined', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager) {
+        throw new Error('Did not call init');
+      }
+      const sendEventsMock = jest.fn();
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = sendEventsMock;
+      sessionReplay.config = undefined;
+      sessionReplay.sendEvents();
+      expect(sendEventsMock).toHaveBeenCalled();
+    });
     test('it should send if session duration meets minSessionDurationMs', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
       if (!sessionReplay.eventsManager || !sessionReplay.config) {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1872,6 +1872,42 @@ describe('SessionReplay', () => {
       }).not.toThrow();
     });
 
+    test('should not call sendBeacon if session duration is below minSessionDurationMs', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) throw new Error('No eventsManager or config');
+      sessionReplay.config.minSessionDurationMs = 5000;
+      sessionReplay.sessionStartTime = Date.now() - 1000;
+      const mockSendBeacon = jest.fn().mockReturnValue(true);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
+        navigator: { sendBeacon: mockSendBeacon },
+      } as unknown as typeof globalThis);
+      sessionReplay.eventsManager.addEvent({
+        sessionId: 123,
+        event: { type: 'replay', data: 'x' },
+        deviceId: '1a2b3c',
+      });
+      triggerBeacon(sessionReplay);
+      expect(mockSendBeacon).not.toHaveBeenCalled();
+    });
+
+    test('should call sendBeacon if session duration meets minSessionDurationMs', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) throw new Error('No eventsManager or config');
+      sessionReplay.config.minSessionDurationMs = 1000;
+      sessionReplay.sessionStartTime = Date.now() - 5000;
+      const mockSendBeacon = jest.fn().mockReturnValue(true);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
+        navigator: { sendBeacon: mockSendBeacon },
+      } as unknown as typeof globalThis);
+      sessionReplay.eventsManager.addEvent({
+        sessionId: 123,
+        event: { type: 'replay', data: 'x' },
+        deviceId: '1a2b3c',
+      });
+      triggerBeacon(sessionReplay);
+      expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+    });
+
     test('should not call sendBeacon if rrwebEventManager failed to initialize', async () => {
       // When createEventsManager throws for the 'replay' type, rrwebEventManager stays
       // undefined in the pageLeaveFns closure — the beacon fn should handle this gracefully.

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1455,6 +1455,9 @@ describe('SessionReplay', () => {
       if (!sessionReplay.eventsManager || !sessionReplay.config) throw new Error('init');
       sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
       const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      // Recording must be active for the gate-decision emission to fire.
+      sessionReplay.recordCancelCallback = jest.fn();
+      (sessionReplay as any).recordFunction = { addCustomEvent: jest.fn() };
       sessionReplay.config.minSessionDurationMs = 1000;
       sessionReplay.sessionStartTime = Date.now() - 5000;
 
@@ -2174,6 +2177,10 @@ describe('SessionReplay', () => {
       }
       sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
       const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      // Recording must be active for the gate-decision event to fire; addCustomRRWebEvent
+      // is a no-op when recordCancelCallback / recordFunction are unset.
+      sessionReplay.recordCancelCallback = jest.fn();
+      (sessionReplay as any).recordFunction = { addCustomEvent: jest.fn() };
       sessionReplay.config.minSessionDurationMs = 5000;
 
       // First call: below threshold, suppressed.
@@ -2209,9 +2216,36 @@ describe('SessionReplay', () => {
       }
       sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
       const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.recordCancelCallback = jest.fn();
+      (sessionReplay as any).recordFunction = { addCustomEvent: jest.fn() };
       sessionReplay.config.minSessionDurationMs = undefined;
       sessionReplay.sendEvents();
       expect(addCustomSpy).not.toHaveBeenCalled();
+    });
+    test('does not emit or trip the gate-decision flag when recording is inactive', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
+      const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.config.minSessionDurationMs = 5000;
+      sessionReplay.sessionStartTime = Date.now() - 6000;
+      // Recording not started yet — emission is a no-op so the flag must NOT trip.
+      sessionReplay.recordCancelCallback = null;
+      (sessionReplay as any).recordFunction = null;
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).not.toHaveBeenCalled();
+
+      // Once recording activates, the next send should emit.
+      sessionReplay.recordCancelCallback = jest.fn();
+      (sessionReplay as any).recordFunction = { addCustomEvent: jest.fn() };
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).toHaveBeenCalledWith(
+        'replay-gate-decision',
+        expect.objectContaining({ sessionId: 123 }),
+        false,
+      );
     });
     test('emits elapsedMs as undefined when sessionStartTime is missing at first send-after-pass', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
@@ -2220,6 +2254,8 @@ describe('SessionReplay', () => {
       }
       sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
       const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.recordCancelCallback = jest.fn();
+      (sessionReplay as any).recordFunction = { addCustomEvent: jest.fn() };
       sessionReplay.config.minSessionDurationMs = 5000;
       // sessionStartTime undefined makes isBelowMinSessionDuration() return false, so the
       // pass-path fires but elapsedMs can't be computed.

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -116,6 +116,9 @@ describe('SessionReplay', () => {
       href: 'http://localhost',
     },
     indexedDB: new IDBFactory(),
+    // jsdom provides a working localStorage; expose it so the replay-start-time-store
+    // (which reads through getGlobalScope) sees a real storage in tests.
+    localStorage: globalThis.localStorage,
     navigator: {
       storage: {
         estimate: () => {
@@ -260,20 +263,82 @@ describe('SessionReplay', () => {
       });
     }
   });
-  describe('init', () => {
-    test('should set sessionStartTime from numeric sessionId', async () => {
-      await sessionReplay.init(apiKey, mockOptions).promise;
-      expect(sessionReplay.sessionStartTime).toBe(123);
+  describe('init: sessionStartTime persistence', () => {
+    beforeEach(() => {
+      globalThis.localStorage.clear();
     });
 
-    test('should set sessionStartTime to Date.now() when sessionId is not a number', async () => {
+    test('fresh init writes Date.now() and reads it back', async () => {
+      const before = Date.now();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const after = Date.now();
+      expect(sessionReplay.sessionStartTime).toBeGreaterThanOrEqual(before);
+      expect(sessionReplay.sessionStartTime).toBeLessThanOrEqual(after);
+      const stored = globalThis.localStorage.getItem(`AMP_SR_START_${apiKey.substring(0, 10)}_123`);
+      expect(Number(stored)).toBe(sessionReplay.sessionStartTime);
+    });
+
+    test('second init for same sessionId recovers stored value', async () => {
+      // Seed storage to simulate a prior init having written the start time.
+      const original = Date.now() - 60_000;
+      globalThis.localStorage.setItem(`AMP_SR_START_${apiKey.substring(0, 10)}_123`, String(original));
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      expect(sessionReplay.sessionStartTime).toBe(original);
+    });
+
+    test('corrupt stored value falls back to Date.now() and overwrites', async () => {
+      globalThis.localStorage.setItem(`AMP_SR_START_${apiKey.substring(0, 10)}_123`, 'not-a-number');
+      const before = Date.now();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const after = Date.now();
+      expect(sessionReplay.sessionStartTime).toBeGreaterThanOrEqual(before);
+      expect(sessionReplay.sessionStartTime).toBeLessThanOrEqual(after);
+      const stored = Number(globalThis.localStorage.getItem(`AMP_SR_START_${apiKey.substring(0, 10)}_123`));
+      expect(stored).toBe(sessionReplay.sessionStartTime);
+    });
+
+    test('TTL prune drops stale entries on init', async () => {
+      const staleKey = `AMP_SR_START_${apiKey.substring(0, 10)}_999`;
+      // 25 hours ago, beyond REPLAY_START_TIME_TTL_MS (24h).
+      globalThis.localStorage.setItem(staleKey, String(Date.now() - 25 * 60 * 60 * 1000));
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      expect(globalThis.localStorage.getItem(staleKey)).toBeNull();
+    });
+
+    test('falls back to Date.now() when localStorage access throws', async () => {
+      // jsdom's localStorage methods live on Storage.prototype, not as own properties,
+      // so jest.spyOn doesn't bind — patch the prototype directly.
+      const proto = Object.getPrototypeOf(globalThis.localStorage) as Storage;
+      const origGet = proto.getItem;
+      const origSet = proto.setItem;
+      proto.getItem = () => {
+        throw new Error('storage disabled');
+      };
+      proto.setItem = () => {
+        throw new Error('storage disabled');
+      };
+      try {
+        const before = Date.now();
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        const after = Date.now();
+        expect(sessionReplay.sessionStartTime).toBeGreaterThanOrEqual(before);
+        expect(sessionReplay.sessionStartTime).toBeLessThanOrEqual(after);
+      } finally {
+        proto.getItem = origGet;
+        proto.setItem = origSet;
+      }
+    });
+
+    test('uses Date.now() when sessionId is undefined', async () => {
       const before = Date.now();
       await sessionReplay.init(apiKey, { ...mockOptions, sessionId: undefined }).promise;
       const after = Date.now();
       expect(sessionReplay.sessionStartTime).toBeGreaterThanOrEqual(before);
       expect(sessionReplay.sessionStartTime).toBeLessThanOrEqual(after);
     });
+  });
 
+  describe('init', () => {
     test('should pass current page to evaluateTargetingAndCapture during init', async () => {
       const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
       await sessionReplay.init(apiKey, mockOptions).promise;
@@ -1340,6 +1405,20 @@ describe('SessionReplay', () => {
           }
         ).latestUrlChangeTargetingEvaluationId,
       ).toBe(2);
+    });
+
+    test('writes new session start time and removes previous session entry', async () => {
+      globalThis.localStorage.clear();
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const prevKey = `AMP_SR_START_${apiKey.substring(0, 10)}_123`;
+      const nextKey = `AMP_SR_START_${apiKey.substring(0, 10)}_456`;
+      expect(globalThis.localStorage.getItem(prevKey)).not.toBeNull();
+
+      await (sessionReplay as any).asyncSetSessionId(456, '9l8m7n');
+
+      expect(globalThis.localStorage.getItem(prevKey)).toBeNull();
+      const newStart = Number(globalThis.localStorage.getItem(nextKey));
+      expect(newStart).toBe(sessionReplay.sessionStartTime);
     });
   });
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1421,6 +1421,19 @@ describe('SessionReplay', () => {
       expect(newStart).toBe(sessionReplay.sessionStartTime);
     });
 
+    test('drops previous-session beacon buffer on session transition', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.rrwebEventManager) throw new Error('init');
+      const dropBeaconMock = jest.fn();
+      sessionReplay.rrwebEventManager.dropPendingBeaconEvents = dropBeaconMock;
+
+      await (sessionReplay as any).asyncSetSessionId(456, '9l8m7n');
+
+      // Prevents the page-leave beacon path from misattributing previous-session
+      // events to the new session id.
+      expect(dropBeaconMock).toHaveBeenCalledTimes(1);
+    });
+
     test('resets per-session gate-decision state on session change', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
       if (!sessionReplay.eventsManager || !sessionReplay.config) throw new Error('init');
@@ -2082,10 +2095,12 @@ describe('SessionReplay', () => {
       sessionReplay.sessionStartTime = Date.now() - 1000;
       sessionReplay.sendEvents();
       expect(sendEventsMock).not.toHaveBeenCalled();
-      // Pending beacon events must be dropped so they can't leak into a later session.
-      expect(dropBeaconMock).toHaveBeenCalledTimes(1);
+      // Beacon buffer is intentionally preserved here: a later send-after-pass within
+      // the same session may legitimately deliver these events via beacon on page exit.
+      // Cross-session leak is prevented in asyncSetSessionId instead.
+      expect(dropBeaconMock).not.toHaveBeenCalled();
     });
-    test('it should not throw on below-threshold drop when rrwebEventManager is undefined', async () => {
+    test('it should not throw on below-threshold sendEvents when rrwebEventManager is undefined', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
       if (!sessionReplay.eventsManager || !sessionReplay.config) {
         throw new Error('Did not call init');

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1421,20 +1421,43 @@ describe('SessionReplay', () => {
       expect(newStart).toBe(sessionReplay.sessionStartTime);
     });
 
-    test('does not delete its own start-time entry when sessionId is unchanged', async () => {
+    test('preserves stored and in-memory start time when sessionId is unchanged', async () => {
       globalThis.localStorage.clear();
       await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.config) throw new Error('init');
       const key = `AMP_SR_START_${apiKey.substring(0, 10)}_123`;
-      const beforeStart = Number(globalThis.localStorage.getItem(key));
-      expect(beforeStart).toBeGreaterThan(0);
+      // Pin a known start time so a regression (overwrite to Date.now()) is visible
+      // regardless of how Date.now() advances during the asyncSetSessionId call.
+      const pinned = 1_700_000_000_000;
+      sessionReplay.sessionStartTime = pinned;
+      globalThis.localStorage.setItem(key, String(pinned));
+      // Trip gate-decision state so we can assert it survives.
+      (sessionReplay as any).hasEmittedGateDecision = true;
+      (sessionReplay as any).suppressedSendCount = 7;
 
-      // Caller passes the current sessionId redundantly — must not leave storage empty.
+      // Caller passes the current sessionId redundantly — must NOT restart the gate clock.
       await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c');
 
-      const afterStart = Number(globalThis.localStorage.getItem(key));
-      expect(afterStart).toBeGreaterThan(0);
-      // The freshly-written entry should match the new sessionStartTime.
-      expect(afterStart).toBe(sessionReplay.sessionStartTime);
+      expect(Number(globalThis.localStorage.getItem(key))).toBe(pinned);
+      expect(sessionReplay.sessionStartTime).toBe(pinned);
+      // Per-session gate state must also be preserved.
+      expect((sessionReplay as any).hasEmittedGateDecision).toBe(true);
+      expect((sessionReplay as any).suppressedSendCount).toBe(7);
+    });
+
+    test('drops previous-session beacon buffer ONLY on real session change', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.rrwebEventManager) throw new Error('init');
+      const dropBeaconMock = jest.fn();
+      sessionReplay.rrwebEventManager.dropPendingBeaconEvents = dropBeaconMock;
+
+      // Redundant same-id call: buffer must NOT be dropped (it belongs to the continuing session).
+      await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c');
+      expect(dropBeaconMock).not.toHaveBeenCalled();
+
+      // Real change: buffer MUST be dropped.
+      await (sessionReplay as any).asyncSetSessionId(456, '9l8m7n');
+      expect(dropBeaconMock).toHaveBeenCalledTimes(1);
     });
 
     test('drops previous-session beacon buffer on session transition', async () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -261,6 +261,19 @@ describe('SessionReplay', () => {
     }
   });
   describe('init', () => {
+    test('should set sessionStartTime from numeric sessionId', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      expect(sessionReplay.sessionStartTime).toBe(123);
+    });
+
+    test('should set sessionStartTime to Date.now() when sessionId is not a number', async () => {
+      const before = Date.now();
+      await sessionReplay.init(apiKey, { ...mockOptions, sessionId: undefined }).promise;
+      const after = Date.now();
+      expect(sessionReplay.sessionStartTime).toBeGreaterThanOrEqual(before);
+      expect(sessionReplay.sessionStartTime).toBeLessThanOrEqual(after);
+    });
+
     test('should pass current page to evaluateTargetingAndCapture during init', async () => {
       const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
       await sessionReplay.init(apiKey, mockOptions).promise;

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1911,6 +1911,33 @@ describe('SessionReplay', () => {
       sessionReplay.sendEvents();
       expect(sendEventsMock).not.toHaveBeenCalled();
     });
+    test('it should not send if session duration is below minSessionDurationMs', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      const sendEventsMock = jest.fn();
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = sendEventsMock;
+      sessionReplay.config.minSessionDurationMs = 5000;
+      sessionReplay.sessionStartTime = Date.now() - 1000;
+      sessionReplay.sendEvents();
+      expect(sendEventsMock).not.toHaveBeenCalled();
+    });
+    test('it should send if session duration meets minSessionDurationMs', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      const sendEventsMock = jest.fn();
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = sendEventsMock;
+      sessionReplay.config.minSessionDurationMs = 1000;
+      sessionReplay.sessionStartTime = Date.now() - 5000;
+      sessionReplay.sendEvents();
+      expect(sendEventsMock).toHaveBeenCalledWith({
+        sessionId: 123,
+        deviceId: '1a2b3c',
+      });
+    });
   });
   describe('stopRecordingEvents', () => {
     test('it should catch errors as warnings', async () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1420,6 +1420,36 @@ describe('SessionReplay', () => {
       const newStart = Number(globalThis.localStorage.getItem(nextKey));
       expect(newStart).toBe(sessionReplay.sessionStartTime);
     });
+
+    test('resets per-session gate-decision state on session change', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) throw new Error('init');
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
+      const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.config.minSessionDurationMs = 1000;
+      sessionReplay.sessionStartTime = Date.now() - 5000;
+
+      // First send for session A emits gate-decision and trips hasEmittedGateDecision.
+      sessionReplay.sendEvents();
+      const sessionAGateCall = addCustomSpy.mock.calls.find((c) => c[0] === 'replay-gate-decision');
+      expect(sessionAGateCall).toBeDefined();
+      expect(sessionAGateCall?.[1]).toEqual(expect.objectContaining({ sessionId: 123 }));
+
+      await (sessionReplay as any).asyncSetSessionId(456, '9l8m7n');
+      // asyncSetSessionId regenerates the joined config; restore the threshold so the new
+      // session is gated identically to the prior one.
+      if (sessionReplay.config) sessionReplay.config.minSessionDurationMs = 1000;
+      // Drop calls from the session-id transition itself (debug-info / targeting-decision)
+      // so we can assert specifically that the next sendEvents re-emits gate-decision.
+      addCustomSpy.mockClear();
+      sessionReplay.sessionStartTime = Date.now() - 5000;
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).toHaveBeenCalledWith(
+        'replay-gate-decision',
+        expect.objectContaining({ sessionId: 456, suppressedSendCount: 0 }),
+        false,
+      );
+    });
   });
 
   describe('getSessionId', () => {
@@ -2105,6 +2135,70 @@ describe('SessionReplay', () => {
         sessionId: 123,
         deviceId: '1a2b3c',
       });
+    });
+    test('emits REPLAY_GATE_DECISION on first send-after-pass with suppressed count', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
+      const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.config.minSessionDurationMs = 5000;
+
+      // First call: below threshold, suppressed.
+      sessionReplay.sessionStartTime = Date.now() - 1000;
+      sessionReplay.sendEvents();
+      // Second call: still below threshold, suppressed.
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).not.toHaveBeenCalled();
+
+      // Third call: now above threshold — emits gate-decision event with the two prior suppressions.
+      sessionReplay.sessionStartTime = Date.now() - 6000;
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).toHaveBeenCalledWith(
+        'replay-gate-decision',
+        expect.objectContaining({
+          sessionId: 123,
+          suppressedSendCount: 2,
+          minSessionDurationMs: 5000,
+          elapsedMs: expect.any(Number),
+        }),
+        false,
+      );
+
+      // Fourth call: subsequent send doesn't re-emit (once per session).
+      addCustomSpy.mockClear();
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).not.toHaveBeenCalled();
+    });
+    test('does not emit REPLAY_GATE_DECISION when minSessionDurationMs is unset', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
+      const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.config.minSessionDurationMs = undefined;
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).not.toHaveBeenCalled();
+    });
+    test('emits elapsedMs as undefined when sessionStartTime is missing at first send-after-pass', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config) {
+        throw new Error('Did not call init');
+      }
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = jest.fn();
+      const addCustomSpy = jest.spyOn(sessionReplay, 'addCustomRRWebEvent').mockResolvedValue(undefined);
+      sessionReplay.config.minSessionDurationMs = 5000;
+      // sessionStartTime undefined makes isBelowMinSessionDuration() return false, so the
+      // pass-path fires but elapsedMs can't be computed.
+      sessionReplay.sessionStartTime = undefined;
+      sessionReplay.sendEvents();
+      expect(addCustomSpy).toHaveBeenCalledWith(
+        'replay-gate-decision',
+        expect.objectContaining({ elapsedMs: undefined }),
+        false,
+      );
     });
   });
   describe('stopRecordingEvents', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1962,14 +1962,31 @@ describe('SessionReplay', () => {
     });
     test('it should not send if session duration is below minSessionDurationMs', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.eventsManager || !sessionReplay.config || !sessionReplay.rrwebEventManager) {
+        throw new Error('Did not call init');
+      }
+      const sendEventsMock = jest.fn();
+      const dropBeaconMock = jest.fn();
+      sessionReplay.eventsManager.sendCurrentSequenceEvents = sendEventsMock;
+      sessionReplay.rrwebEventManager.dropPendingBeaconEvents = dropBeaconMock;
+      sessionReplay.config.minSessionDurationMs = 5000;
+      sessionReplay.sessionStartTime = Date.now() - 1000;
+      sessionReplay.sendEvents();
+      expect(sendEventsMock).not.toHaveBeenCalled();
+      // Pending beacon events must be dropped so they can't leak into a later session.
+      expect(dropBeaconMock).toHaveBeenCalledTimes(1);
+    });
+    test('it should not throw on below-threshold drop when rrwebEventManager is undefined', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
       if (!sessionReplay.eventsManager || !sessionReplay.config) {
         throw new Error('Did not call init');
       }
       const sendEventsMock = jest.fn();
       sessionReplay.eventsManager.sendCurrentSequenceEvents = sendEventsMock;
+      sessionReplay.rrwebEventManager = undefined;
       sessionReplay.config.minSessionDurationMs = 5000;
       sessionReplay.sessionStartTime = Date.now() - 1000;
-      sessionReplay.sendEvents();
+      expect(() => sessionReplay.sendEvents()).not.toThrow();
       expect(sendEventsMock).not.toHaveBeenCalled();
     });
     test('it should send if minSessionDurationMs is set but sessionStartTime is undefined', async () => {


### PR DESCRIPTION
## Summary

- Adds `min_session_duration_ms` field to `SamplingConfig` type (parsed from `sr_sampling_config` in remote config)
- Adds `minSessionDurationMs` field to `SessionReplayJoinedConfig`
- Tracks `sessionStartTime` when a new session ID is set in `asyncSetSessionId`
- In `sendEvents`, checks elapsed time against `minSessionDurationMs` before forwarding events — sessions shorter than the threshold are dropped with a log message
- Adds two unit tests covering the below-threshold (suppressed) and at/above-threshold (sent) cases

## Linear

[SR-3858](https://linear.app/amplitude/issue/SR-3858)

## Test plan

- [ ] `it should not send if session duration is below minSessionDurationMs` — mock a 1 s elapsed session with a 5 s threshold; verify `sendCurrentSequenceEvents` is not called
- [ ] `it should send if session duration meets minSessionDurationMs` — mock a 5 s elapsed session with a 1 s threshold; verify `sendCurrentSequenceEvents` is called with correct args
- [ ] Existing `sendEvents` tests still pass (no regression to the no-threshold path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new remote-config-driven gate that can suppress replay delivery and alters session boundary/flush behavior; mistakes could drop or misattribute replay data despite added clamps and tests.
> 
> **Overview**
> Adds support for remote `sr_sampling_config.min_session_duration_ms`, exposing it as `joinedConfig.minSessionDurationMs` with defensive validation/clamping (60s ceiling) and warnings.
> 
> Enforces this threshold across replay delivery paths: `SessionReplay.sendEvents()` and page-exit `sendBeacon` now suppress sends until the session has run long enough, track suppressed send attempts, and emit a one-time `CustomRRwebEvent.REPLAY_GATE_DECISION` on the first send-after-pass.
> 
> Persists per-session replay start time in `localStorage` (with TTL pruning) so the gate survives reloads/navigation, and hardens session transitions by dropping prior-session beacon buffers and resetting gate state only on real session changes. `createEventsManager` also gains a synchronous `shouldSend` hook plus `dropPendingBeaconEvents` to prevent gated sequences from leaking via IDB/beacon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660aa6bc38e7a87ca8de9cc68beda68baf28022b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->