### PR TITLE
ci(publish-v2): fail if ref advanced since e2e checkout (#1708)

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -56,6 +56,8 @@ jobs:
     needs: [authorize]
     container:
       image: mcr.microsoft.com/playwright:v1.55.0
+    outputs:
+      head_sha: ${{ steps.head-sha.outputs.sha }}
 
     steps:
       - name: Check out git repository
@@ -63,6 +65,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch || github.ref_name }}
+
+      - name: Capture E2E HEAD SHA
+        id: head-sha
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests
         uses: ./.github/actions/e2e-test
@@ -110,6 +117,13 @@ jobs:
         uses: ./.github/actions/build-and-test
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Verify ref has not advanced since e2e checkout
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        env:
+          EXPECTED_SHA: ${{ needs.e2e.outputs.head_sha }}
+          REF: ${{ github.event.inputs.branch || github.ref_name }}
+        run: bash scripts/publish/check-ref-not-advanced.sh
 
       # Only create release version when using from-git (default behavior)
       # from-package mode uses existing package.json versions and doesn't need git tags

--- a/scripts/publish/check-ref-not-advanced.sh
+++ b/scripts/publish/check-ref-not-advanced.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Guard against the race where a PR merges to the publish ref between
+# the e2e job's checkout and the lerna version push. If the ref has
+# advanced past the SHA E2E ran against, the chore(release): publish
+# commit would land on top of code this run never tested in E2E, making
+# the git history misleading. Re-dispatch is the right recovery — it
+# re-runs E2E against the new HEAD.
+#
+# Required env vars:
+#   EXPECTED_SHA - the SHA the ref is expected to still be at
+#                  (typically the e2e job's HEAD after checkout)
+#   REF          - the branch name to compare against (e.g. main)
+
+set -euo pipefail
+
+if [ -z "${EXPECTED_SHA:-}" ] || [ -z "${REF:-}" ]; then
+  echo "❌ EXPECTED_SHA and REF must be set in the environment."
+  exit 1
+fi
+
+# Validate REF as a branch name to prevent it being interpreted as a git
+# flag (e.g. a value starting with '-') or a tag with the same short name.
+if ! git check-ref-format --branch "$REF" >/dev/null 2>&1; then
+  echo "❌ REF is not a valid branch name: $REF"
+  exit 1
+fi
+
+# Read the current remote SHA directly. A plain `git fetch <refspec>`
+# without an explicit destination is not guaranteed to update
+# refs/remotes/origin/$REF, so reading the remote-tracking ref afterwards
+# can return a stale SHA and defeat the guard. Capture the command's
+# exit status explicitly so transient/auth failures surface a
+# diagnosable error rather than just a bare non-zero exit from set -e.
+# stderr is left to flow to the runner log so git's own error message
+# (auth failure, network error, etc.) is visible above our own.
+if ! LS_OUTPUT=$(git ls-remote origin "refs/heads/$REF"); then
+  echo "❌ git ls-remote failed for origin refs/heads/$REF (see error above)"
+  exit 1
+fi
+
+REMOTE_SHA=$(echo "$LS_OUTPUT" | awk '{print $1}')
+
+if [ -z "$REMOTE_SHA" ]; then
+  echo "❌ Could not resolve remote SHA for refs/heads/$REF on origin"
+  exit 1
+fi
+
+if [ "$REMOTE_SHA" != "$EXPECTED_SHA" ]; then
+  echo "❌ $REF has advanced since this run's E2E checkout."
+  echo "   Expected SHA: $EXPECTED_SHA"
+  echo "   Current $REF: $REMOTE_SHA"
+  echo ""
+  echo "A commit landed on $REF while this workflow was running. The"
+  echo "chore(release): publish commit would appear after it in history,"
+  echo "falsely implying the new commit was tested by this run's E2E."
+  echo ""
+  echo "Re-dispatch this workflow to include the new commits and re-run E2E."
+  exit 1
+fi
+
+echo "✅ $REF is still at expected SHA: $EXPECTED_SHA"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it can cause publish workflows to fail more often if the target branch advances during a run or if `git ls-remote` intermittently errors.
> 
> **Overview**
> Adds a publish workflow guard to prevent releasing from an untested commit.
> 
> `publish-v2.yml` now captures the checked-out HEAD SHA during the `e2e` job and, before running `lerna version` in `deploy`, verifies the target branch ref still points to that SHA.
> 
> Introduces `scripts/publish/check-ref-not-advanced.sh`, which validates the branch name and uses `git ls-remote` to fail the run with a clear message when the ref has advanced (or when the remote lookup fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6836393b5ec89b918423f50a673799cf6803cc9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->