### PR TITLE
feat(session-replay): add fetch keepalive to reduce 499 errors on page navigation

### DIFF
--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -28,6 +28,7 @@ export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 3; // 3 days
 export const KB_SIZE = 1024;
 export const MAX_URL_LENGTH = 1000;
 export const RETRY_TIMEOUT_MS = 1000;
+export const MAX_KEEPALIVE_BYTES = 64 * 1024; // browser keepalive budget shared with sendBeacon
 
 export enum CustomRRwebEvent {
   GET_SR_PROPS = 'get-sr-props',

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -13,7 +13,7 @@ import {
   SessionReplayDestinationContext,
 } from './typings/session-replay';
 import { VERSION } from './version';
-import { MAX_URL_LENGTH, KB_SIZE } from './constants';
+import { MAX_URL_LENGTH, KB_SIZE, MAX_KEEPALIVE_BYTES } from './constants';
 import { gzipJson } from './utils/gzip';
 
 interface WorkerCompleteMessage {
@@ -306,6 +306,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       const globalScope = getGlobalScope();
       const gzipped =
         globalScope && 'CompressionStream' in globalScope ? await gzipJson(payloadJson, globalScope) : null;
+      const payloadSize = gzipped ? gzipped.byteLength : new Blob([payloadJson]).size;
       const options: RequestInit = {
         headers: {
           'Content-Type': 'application/json',
@@ -320,6 +321,9 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         },
         body: (gzipped ?? payloadJson) as BodyInit,
         method: 'POST',
+        // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
+        // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
+        keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
       };
 
       const serverUrl = `${getServerUrl(context.serverZone, this.trackServerUrl)}?${urlParams.toString()}`;

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-globals */
 
-import { KB_SIZE, MAX_URL_LENGTH, RETRY_TIMEOUT_MS } from '../constants';
+import { KB_SIZE, MAX_URL_LENGTH, MAX_KEEPALIVE_BYTES, RETRY_TIMEOUT_MS } from '../constants';
 import { MAX_RETRIES_EXCEEDED_MESSAGE, UNEXPECTED_ERROR_MESSAGE, UNEXPECTED_NETWORK_ERROR_MESSAGE } from '../messages';
 import { gzipJson } from '../utils/gzip';
 import { getServerUrl } from '../utils/server-url';
@@ -46,7 +46,15 @@ async function doFetch(
       'X-Sampling-Hash-Alg': 'xxhash32',
       ...(gzipped ? { 'Content-Encoding': 'gzip' } : {}),
     };
-    const res = await fetch(serverUrl, { method: 'POST', headers, body: (gzipped ?? payloadJson) as BodyInit });
+    const payloadSize = gzipped ? gzipped.byteLength : new Blob([payloadJson]).size;
+    const res = await fetch(serverUrl, {
+      method: 'POST',
+      headers,
+      body: (gzipped ?? payloadJson) as BodyInit,
+      // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
+      // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
+      keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
+    });
     if (res === null) {
       return { shouldRetry: false, success: false, message: UNEXPECTED_ERROR_MESSAGE };
     }

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -354,6 +354,7 @@ describe('SessionReplayTrackDestination', () => {
             'X-Client-Version': VERSION,
           },
           method: 'POST',
+          keepalive: true,
         },
       );
     });
@@ -392,6 +393,7 @@ describe('SessionReplayTrackDestination', () => {
             'X-Client-Version': VERSION,
           },
           method: 'POST',
+          keepalive: true,
         },
       );
     });
@@ -482,6 +484,50 @@ describe('SessionReplayTrackDestination', () => {
 
       await trackDestination.send(context, false);
       expect(addToQueue).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('keepalive', () => {
+    test('sets keepalive true for small payloads', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context: SessionReplayDestinationContext = {
+        events: [mockEventString],
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        type: 'replay',
+        onComplete: mockOnComplete,
+      };
+      await trackDestination.send(context);
+      const options = (fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(options.keepalive).toBe(true);
+    });
+
+    test('sets keepalive false when uncompressed payload exceeds 64 KB', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      // ~66 KB of event data
+      const bigEvent = 'x'.repeat(66 * 1024);
+      const context: SessionReplayDestinationContext = {
+        events: [bigEvent],
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        type: 'replay',
+        onComplete: mockOnComplete,
+      };
+      await trackDestination.send(context);
+      const options = (fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(options.keepalive).toBe(false);
     });
   });
 

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -55,6 +55,7 @@ describe('worker/track-destination', () => {
     expect(url).toContain('type=replay');
     expect((options.headers as Record<string, string>)['Authorization']).toBe('Bearer test-api-key');
     expect(options.method).toBe('POST');
+    expect(options.keepalive).toBe(true);
 
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'log', id: '1', message: expect.stringContaining('tracked successfully') }),


### PR DESCRIPTION
## Summary

- Adds `keepalive: true` to all session replay `fetch` calls (main-thread and worker paths) so the browser keeps requests alive through page navigation, directly preventing 499 (Client Closed Request) errors
- Only enables keepalive when payload ≤ 64 KB to respect the browser's shared keepalive budget; larger payloads fall back to existing retry logic
- Adds `MAX_KEEPALIVE_BYTES = 64 * 1024` constant and two new unit tests covering the size-threshold behaviour

Closes [SR-4123](https://linear.app/amplitude/issue/SR-4123/featsession-replay-add-fetch-keepalive-to-reduce-499-errors-on-page)

## Context

499 is NGINX's status for "client closed request". It fires when the browser cancels an in-flight fetch during navigation or tab close. Retry logic cannot recover from this because the page context is gone. The Fetch `keepalive` option ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#keepalive)) is the web-standard solution — same guarantee as `sendBeacon` but with full HTTP control. The existing `sendBeacon`-on-pagehide path remains unchanged; `keepalive` fills the gap for requests already in-flight at the time of navigation.

## Test plan

- [ ] Existing unit tests pass (`npx jest --testPathPattern="track-destination"`)
- [ ] New `keepalive` describe block covers: small payload → `keepalive: true`, oversized payload → `keepalive: false`
- [ ] Manual: open a page with session replay, trigger a recording, navigate away mid-flush — verify no 499s in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes network request behavior for all session-replay uploads (main thread and worker), which could affect delivery reliability in browsers with strict keepalive limits.
> 
> **Overview**
> **Session replay upload requests now use Fetch `keepalive` when possible** to reduce 499 (client-closed) errors during page navigation.
> 
> Adds `MAX_KEEPALIVE_BYTES` (64 KB) and sets `keepalive: true` only when the (gzipped or raw) payload is at/below this threshold in both the main-thread and worker `fetch` paths, with updated unit tests to assert the new `keepalive` behavior and size cutoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe511852210768a1c4e8bcae5cc1fd71b937a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->