### PR TITLE
fix(release): remove excludeDependents flag from lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,6 @@
       "message": "chore(release): publish",
       "preid": "beta",
       "exact": true,
-      "excludeDependents": true
     }
   },
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"


### PR DESCRIPTION
## Summary

- Removes the `excludeDependents: true` flag from `lerna.json` that was added as a one-time workaround for the GTM hotfix release in PR #1716
- With this flag present, dependent packages (e.g. `plugin-session-replay-browser`) are skipped during normal versioning runs, preventing them from being published to NPM
- Confirmed with Dan Graham that `excludeDependents` is intended for hotfix branches only and should not be on `main`

## Ticket

https://amplitude.atlassian.net/browse/SR-3630

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects release/versioning behavior; main impact is that dependent packages will again be included in normal Lerna version/publish runs.
> 
> **Overview**
> Removes `excludeDependents: true` from `lerna.json` so Lerna’s versioning/publishing on `main` no longer skips dependent packages during release runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfdf8914d281a8ecb5abfb0042488de6ecd31ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->