### PR TITLE
fix(autocapture): fix stale URL storage for MPAs, also for leave-and-returns

### DIFF
--- a/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
+++ b/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
@@ -130,6 +130,27 @@ export const pageUrlEnrichmentPlugin = ({ internalDomains = [] }: PageUrlEnrichm
         }
         isStorageEnabled = (await sessionStorage?.isEnabled()) ?? false;
 
+        if (sessionStorage && isStorageEnabled) {
+          const referrer = (typeof document !== 'undefined' && document.referrer) || '';
+          const referrerHostname = referrer ? getHostname(referrer) : undefined;
+          const currentHostname = (typeof location !== 'undefined' && location.hostname) || '';
+
+          const arrivedFromDifferentOrigin = !!referrerHostname && referrerHostname !== currentHostname;
+
+          if (arrivedFromDifferentOrigin) {
+            // sessionStorage survives same-tab cross-origin trips (siteA -> external -> siteA),
+            // leaving stale "current" that would wrongly become "previous". document.referrer
+            // is the truthful previous, so overwrite — at the cost of dropping the prior siteA page.
+            const currentURL = getDecodeURI((typeof location !== 'undefined' && location.href) || '');
+            await sessionStorage.set(URL_INFO_STORAGE_KEY, {
+              [CURRENT_PAGE_STORAGE_KEY]: currentURL,
+              [PREVIOUS_PAGE_STORAGE_KEY]: referrer,
+            });
+          } else {
+            await saveURLInfo();
+          }
+        }
+
         globalScope.addEventListener('popstate', saveUrlInfoWrapper);
 
         if (!isProxied) {
@@ -165,19 +186,10 @@ export const pageUrlEnrichmentPlugin = ({ internalDomains = [] }: PageUrlEnrichm
       const locationHREF = getDecodeURI((typeof location !== 'undefined' && location.href) || '');
 
       if (sessionStorage && isStorageEnabled) {
+        // setup() seeds AMP_URL_INFO via saveURLInfo(), and pushState/replaceState/popstate
+        // keep it in sync, so we just read the previous page here.
         const URLInfo = await sessionStorage.get(URL_INFO_STORAGE_KEY);
-        if (!URLInfo?.[CURRENT_PAGE_STORAGE_KEY]) {
-          await sessionStorage.set(URL_INFO_STORAGE_KEY, {
-            [CURRENT_PAGE_STORAGE_KEY]: locationHREF,
-            [PREVIOUS_PAGE_STORAGE_KEY]: document.referrer || '',
-          });
-        }
-
-        const updatedURLInfo = await sessionStorage.get(URL_INFO_STORAGE_KEY);
-        let previousPage = '';
-        if (updatedURLInfo) {
-          previousPage = updatedURLInfo[PREVIOUS_PAGE_STORAGE_KEY] || '';
-        }
+        const previousPage = URLInfo?.[PREVIOUS_PAGE_STORAGE_KEY] || '';
 
         // no need to proceed to add additional properties if the event is one of the default event types to be excluded
         if (EXCLUDED_DEFAULT_EVENT_TYPES.has(event.event_type)) {

--- a/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
+++ b/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
@@ -134,14 +134,23 @@ export const pageUrlEnrichmentPlugin = ({ internalDomains = [] }: PageUrlEnrichm
           const referrer = (typeof document !== 'undefined' && document.referrer) || '';
           const referrerHostname = referrer ? getHostname(referrer) : undefined;
           const currentHostname = (typeof location !== 'undefined' && location.hostname) || '';
+          const currentURL = getDecodeURI((typeof location !== 'undefined' && location.href) || '');
 
-          const arrivedFromDifferentOrigin = !!referrerHostname && referrerHostname !== currentHostname;
+          const existingURLInfo = await sessionStorage.get(URL_INFO_STORAGE_KEY);
+          const storedCurrentURL = existingURLInfo?.[CURRENT_PAGE_STORAGE_KEY] || '';
+
+          // document.referrer is preserved across pushState navigations and full-page
+          // reloads, so a different referrer hostname alone does not prove an external
+          // arrival. Also require the stored "current" to differ from location.href —
+          // that's what distinguishes a genuine new landing in this tab from a refresh
+          // of an already-tracked page (where storage holds the truthful previous).
+          const arrivedFromDifferentOrigin =
+            !!referrerHostname && referrerHostname !== currentHostname && storedCurrentURL !== currentURL;
 
           if (arrivedFromDifferentOrigin) {
             // sessionStorage survives same-tab cross-origin trips (siteA -> external -> siteA),
             // leaving stale "current" that would wrongly become "previous". document.referrer
             // is the truthful previous, so overwrite — at the cost of dropping the prior siteA page.
-            const currentURL = getDecodeURI((typeof location !== 'undefined' && location.href) || '');
             await sessionStorage.set(URL_INFO_STORAGE_KEY, {
               [CURRENT_PAGE_STORAGE_KEY]: currentURL,
               [PREVIOUS_PAGE_STORAGE_KEY]: referrer,

--- a/packages/plugin-page-url-enrichment-browser/test/page-url-enrichment.test.ts
+++ b/packages/plugin-page-url-enrichment-browser/test/page-url-enrichment.test.ts
@@ -621,6 +621,52 @@ describe('pageUrlEnrichmentPlugin', () => {
       await newPlugin.teardown?.();
     });
 
+    test('should keep stored previous page on refresh even when document.referrer is a stale external origin', async () => {
+      // Repro of the SPA-refresh bug: user arrived at /landing from Google,
+      // pushState-navigated to /about, then hit refresh on /about. Browsers
+      // preserve document.referrer (still google.com) across pushState and
+      // full-page reloads, so a referrer-hostname-only check would mistakenly
+      // re-fire the external-origin branch and clobber the truthful internal
+      // previous page (/landing) that pushState had stored.
+      sessionStorage.setItem(
+        URL_INFO_STORAGE_KEY,
+        JSON.stringify({
+          [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/about',
+          [PREVIOUS_PAGE_STORAGE_KEY]: 'https://www.example.com/landing',
+        }),
+      );
+
+      Object.defineProperty(document, 'referrer', {
+        value: 'https://www.google.com/search?q=example',
+        configurable: true,
+      });
+
+      const refreshedUrl = new URL('https://www.example.com/about');
+      mockWindowLocationFromURL(refreshedUrl);
+      mockDocumentTitle('About - Example');
+
+      const newPlugin = pageUrlEnrichmentPlugin();
+      await newPlugin.setup?.(mockConfig, mockAmplitude);
+
+      const urlInfoStr = sessionStorage?.getItem(URL_INFO_STORAGE_KEY) || '';
+      expect(JSON.parse(urlInfoStr)).toStrictEqual({
+        [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/about',
+        [PREVIOUS_PAGE_STORAGE_KEY]: 'https://www.example.com/landing',
+      });
+
+      const event = await newPlugin.execute?.({
+        event_type: 'test_event',
+      });
+
+      expect(event?.event_properties).toMatchObject({
+        '[Amplitude] Page Location': 'https://www.example.com/about',
+        '[Amplitude] Previous Page Location': 'https://www.example.com/landing',
+        '[Amplitude] Previous Page Type': 'internal',
+      });
+
+      await newPlugin.teardown?.();
+    });
+
     test('should fall back to empty previous page when sessionStorage is wiped mid-session', async () => {
       await plugin.setup?.(mockConfig, mockAmplitude);
 

--- a/packages/plugin-page-url-enrichment-browser/test/page-url-enrichment.test.ts
+++ b/packages/plugin-page-url-enrichment-browser/test/page-url-enrichment.test.ts
@@ -121,6 +121,9 @@ describe('pageUrlEnrichmentPlugin', () => {
   afterEach(async () => {
     await plugin.teardown?.();
     window.sessionStorage.setItem('AMP_URL_INFO', '{}');
+    // Reset document.referrer so tests that set it can't leak into later tests;
+    // setup()'s external-origin shortcut depends on this value.
+    Object.defineProperty(document, 'referrer', { value: '', configurable: true });
     jest.restoreAllMocks();
   });
 
@@ -497,32 +500,50 @@ describe('pageUrlEnrichmentPlugin', () => {
       });
     });
 
-    test('should update current page if there is no current info', async () => {
-      await plugin.setup?.(mockConfig, mockAmplitude);
+    test('should shift current to previous on setup when stale storage exists (MPA / full-page reload)', async () => {
+      // Simulate stale sessionStorage left over from the previous page load,
+      // e.g. user clicked an <a href> link triggering a full-page navigation.
+      sessionStorage.setItem(
+        URL_INFO_STORAGE_KEY,
+        JSON.stringify({
+          [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/home',
+          [PREVIOUS_PAGE_STORAGE_KEY]: 'https://google.com/search',
+        }),
+      );
 
-      const firstUrl = new URL('https://www.example.com/about');
-      mockWindowLocationFromURL(firstUrl);
+      // Same-origin referrer simulates a real <a href> click within the site;
+      // the external-origin shortcut in setup() should NOT fire here.
+      Object.defineProperty(document, 'referrer', {
+        value: 'https://www.example.com/home',
+        configurable: true,
+      });
 
-      sessionStorage.clear();
+      // The new page has now booted; location is the new URL.
+      const newUrl = new URL('https://www.example.com/about');
+      mockWindowLocationFromURL(newUrl);
+      mockDocumentTitle('About - Example');
 
-      await plugin.execute?.({
+      const newPlugin = pageUrlEnrichmentPlugin();
+      await newPlugin.setup?.(mockConfig, mockAmplitude);
+
+      const urlInfoStr = sessionStorage?.getItem(URL_INFO_STORAGE_KEY) || '';
+      expect(JSON.parse(urlInfoStr)).toStrictEqual({
+        [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/about',
+        [PREVIOUS_PAGE_STORAGE_KEY]: 'https://www.example.com/home',
+      });
+
+      // The first event after setup should also report the prior page as the previous location.
+      const event = await newPlugin.execute?.({
         event_type: 'test_event',
       });
 
-      const urlInfo = {
-        [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/about',
-        [PREVIOUS_PAGE_STORAGE_KEY]: '',
-      };
+      expect(event?.event_properties).toMatchObject({
+        '[Amplitude] Page Location': 'https://www.example.com/about',
+        '[Amplitude] Previous Page Location': 'https://www.example.com/home',
+        '[Amplitude] Previous Page Type': 'internal',
+      });
 
-      const urlInfoStr = sessionStorage?.getItem(URL_INFO_STORAGE_KEY) || '';
-      expect(JSON.parse(urlInfoStr)).toStrictEqual(urlInfo);
-
-      expect(sessionStorage?.getItem(URL_INFO_STORAGE_KEY)).toStrictEqual(
-        JSON.stringify({
-          [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/about',
-          [PREVIOUS_PAGE_STORAGE_KEY]: '',
-        }),
-      );
+      await newPlugin.teardown?.();
     });
 
     test('should not add properties if they already exist', async () => {
@@ -551,6 +572,72 @@ describe('pageUrlEnrichmentPlugin', () => {
         '[Amplitude] Page Path': '/existingexample',
         '[Amplitude] Page Title': 'Existing Example',
         '[Amplitude] Page URL': 'https://www.existingexample.com/about',
+        '[Amplitude] Previous Page Location': '',
+        '[Amplitude] Previous Page Type': 'direct',
+      });
+    });
+
+    test('should prefer document.referrer over stale storage when arriving from a different origin', async () => {
+      // Simulate the round-trip-away case: user was on /home, left to google.com,
+      // then arrived back on the site (e.g. by clicking a Google search result
+      // pointing at /about). The stored "current" of /home is stale and should NOT
+      // be used as the previous page; document.referrer is the truthful answer.
+      sessionStorage.setItem(
+        URL_INFO_STORAGE_KEY,
+        JSON.stringify({
+          [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/home',
+          [PREVIOUS_PAGE_STORAGE_KEY]: 'https://www.example.com/landing',
+        }),
+      );
+
+      Object.defineProperty(document, 'referrer', {
+        value: 'https://www.google.com/search?q=example',
+        configurable: true,
+      });
+
+      const newUrl = new URL('https://www.example.com/about');
+      mockWindowLocationFromURL(newUrl);
+      mockDocumentTitle('About - Example');
+
+      const newPlugin = pageUrlEnrichmentPlugin();
+      await newPlugin.setup?.(mockConfig, mockAmplitude);
+
+      const urlInfoStr = sessionStorage?.getItem(URL_INFO_STORAGE_KEY) || '';
+      expect(JSON.parse(urlInfoStr)).toStrictEqual({
+        [CURRENT_PAGE_STORAGE_KEY]: 'https://www.example.com/about',
+        [PREVIOUS_PAGE_STORAGE_KEY]: 'https://www.google.com/search?q=example',
+      });
+
+      const event = await newPlugin.execute?.({
+        event_type: 'test_event',
+      });
+
+      expect(event?.event_properties).toMatchObject({
+        '[Amplitude] Page Location': 'https://www.example.com/about',
+        '[Amplitude] Previous Page Location': 'https://www.google.com/search?q=example',
+        '[Amplitude] Previous Page Type': 'external',
+      });
+
+      await newPlugin.teardown?.();
+    });
+
+    test('should fall back to empty previous page when sessionStorage is wiped mid-session', async () => {
+      await plugin.setup?.(mockConfig, mockAmplitude);
+
+      const url = new URL('https://www.example.com/about');
+      mockWindowLocationFromURL(url);
+      mockDocumentTitle('About - Example');
+
+      // Externally wipe AMP_URL_INFO after setup has seeded it. execute() should
+      // gracefully degrade to an empty previous page rather than throw.
+      sessionStorage.removeItem(URL_INFO_STORAGE_KEY);
+
+      const event = await plugin.execute?.({
+        event_type: 'test_event',
+      });
+
+      expect(event?.event_properties).toMatchObject({
+        '[Amplitude] Page Location': 'https://www.example.com/about',
         '[Amplitude] Previous Page Location': '',
         '[Amplitude] Previous Page Type': 'direct',
       });

--- a/test-server/browser-sdk/page-url-enrichment-mpa-a.html
+++ b/test-server/browser-sdk/page-url-enrichment-mpa-a.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/amplitude.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="/helpers/tough-cookie"></script>
+    <title>Page URL Enrichment — MPA repro: Page A</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 24px; max-width: 900px; }
+      h1 { margin-bottom: 4px; }
+      nav a { margin-right: 12px; }
+      .panel { border: 1px solid #ccc; border-radius: 6px; padding: 12px; margin-top: 16px; }
+      .panel h3 { margin: 0 0 8px; font-size: 14px; color: #555; text-transform: uppercase; }
+      pre { background: #f5f5f5; padding: 8px; border-radius: 4px; overflow: auto; margin: 0; }
+      button { margin-right: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>Page A (MPA repro)</h1>
+
+    <nav>
+      <a href="/browser-sdk/page-url-enrichment-mpa-a.html">→ Page A</a>
+      <a href="/browser-sdk/page-url-enrichment-mpa-b.html">→ Page B</a>
+      <a href="/browser-sdk/page-url-enrichment-mpa-c.html">→ Page C</a>
+    </nav>
+
+    <div class="panel">
+      <h3>Live sessionStorage[AMP_URL_INFO]</h3>
+      <pre id="storage"></pre>
+    </div>
+
+    <div class="panel">
+      <h3>Events tracked from this page</h3>
+      <button id="wipe">Wipe AMP_URL_INFO</button>
+      <pre id="events">(none yet — page-view events from autocapture will show here too)</pre>
+    </div>
+
+    <script type="module">
+      import * as amplitude from '@amplitude/analytics-browser';
+
+      const STORAGE_KEY = 'AMP_URL_INFO';
+      const storageEl = document.getElementById('storage');
+      const eventsEl = document.getElementById('events');
+
+      const renderStorage = () => {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        try {
+          storageEl.textContent = raw ? JSON.stringify(JSON.parse(raw), null, 2) : '(empty)';
+        } catch {
+          storageEl.textContent = raw ?? '(empty)';
+        }
+      };
+      renderStorage();
+      setInterval(renderStorage, 250);
+
+      // Inline enrichment plugin so we can see exactly what event properties
+      // each tracked event ends up with — without leaving the page.
+      const inspectorPlugin = {
+        name: 'mpa-repro-inspector',
+        type: 'enrichment',
+        setup: async () => {},
+        execute: async (event) => {
+          const summary = {
+            type: event.event_type,
+            'Page Location': event.event_properties?.['[Amplitude] Page Location'],
+            'Previous Page Location': event.event_properties?.['[Amplitude] Previous Page Location'],
+            'Previous Page Type': event.event_properties?.['[Amplitude] Previous Page Type'],
+          };
+          const line = `[${new Date().toLocaleTimeString()}] ${JSON.stringify(summary, null, 2)}`;
+          eventsEl.textContent =
+            eventsEl.textContent.startsWith('(none')
+              ? line
+              : `${line}\n\n${eventsEl.textContent}`;
+          return event;
+        },
+      };
+
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY,
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
+        {
+          autocapture: {
+            pageViews: true,
+            pageUrlEnrichment: true,
+          },
+        },
+      );
+      amplitude.add(inspectorPlugin);
+
+      document.getElementById('wipe').addEventListener('click', () => {
+        sessionStorage.removeItem(STORAGE_KEY);
+        renderStorage();
+      });
+    </script>
+  </body>
+</html>

--- a/test-server/browser-sdk/page-url-enrichment-mpa-b.html
+++ b/test-server/browser-sdk/page-url-enrichment-mpa-b.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/amplitude.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="/helpers/tough-cookie"></script>
+    <title>Page URL Enrichment — MPA repro: Page B</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 24px; max-width: 900px; }
+      h1 { margin-bottom: 4px; }
+      nav a { margin-right: 12px; }
+      .panel { border: 1px solid #ccc; border-radius: 6px; padding: 12px; margin-top: 16px; }
+      .panel h3 { margin: 0 0 8px; font-size: 14px; color: #555; text-transform: uppercase; }
+      pre { background: #f5f5f5; padding: 8px; border-radius: 4px; overflow: auto; margin: 0; }
+      button { margin-right: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>Page B (MPA repro)</h1>
+
+    <nav>
+      <a href="/browser-sdk/page-url-enrichment-mpa-a.html">→ Page A</a>
+      <a href="/browser-sdk/page-url-enrichment-mpa-b.html">→ Page B</a>
+      <a href="/browser-sdk/page-url-enrichment-mpa-c.html">→ Page C</a>
+    </nav>
+
+    <div class="panel">
+      <h3>Live sessionStorage[AMP_URL_INFO]</h3>
+      <pre id="storage"></pre>
+    </div>
+
+    <div class="panel">
+      <h3>Events tracked from this page</h3>
+      <button id="wipe">Wipe AMP_URL_INFO</button>
+      <pre id="events">(none yet — page-view events from autocapture will show here too)</pre>
+    </div>
+
+    <script type="module">
+      import * as amplitude from '@amplitude/analytics-browser';
+
+      const STORAGE_KEY = 'AMP_URL_INFO';
+      const storageEl = document.getElementById('storage');
+      const eventsEl = document.getElementById('events');
+
+      const renderStorage = () => {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        try {
+          storageEl.textContent = raw ? JSON.stringify(JSON.parse(raw), null, 2) : '(empty)';
+        } catch {
+          storageEl.textContent = raw ?? '(empty)';
+        }
+      };
+      renderStorage();
+      setInterval(renderStorage, 250);
+
+      const inspectorPlugin = {
+        name: 'mpa-repro-inspector',
+        type: 'enrichment',
+        setup: async () => {},
+        execute: async (event) => {
+          const summary = {
+            type: event.event_type,
+            'Page Location': event.event_properties?.['[Amplitude] Page Location'],
+            'Previous Page Location': event.event_properties?.['[Amplitude] Previous Page Location'],
+            'Previous Page Type': event.event_properties?.['[Amplitude] Previous Page Type'],
+          };
+          const line = `[${new Date().toLocaleTimeString()}] ${JSON.stringify(summary, null, 2)}`;
+          eventsEl.textContent =
+            eventsEl.textContent.startsWith('(none')
+              ? line
+              : `${line}\n\n${eventsEl.textContent}`;
+          return event;
+        },
+      };
+
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY,
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
+        {
+          autocapture: {
+            pageViews: true,
+            pageUrlEnrichment: true,
+          },
+        },
+      );
+      amplitude.add(inspectorPlugin);
+
+      document.getElementById('wipe').addEventListener('click', () => {
+        sessionStorage.removeItem(STORAGE_KEY);
+        renderStorage();
+      });
+    </script>
+  </body>
+</html>

--- a/test-server/browser-sdk/page-url-enrichment-mpa-c.html
+++ b/test-server/browser-sdk/page-url-enrichment-mpa-c.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/amplitude.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="/helpers/tough-cookie"></script>
+    <title>Page URL Enrichment — MPA repro: Page C</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 24px; max-width: 900px; }
+      h1 { margin-bottom: 4px; }
+      nav a { margin-right: 12px; }
+      .panel { border: 1px solid #ccc; border-radius: 6px; padding: 12px; margin-top: 16px; }
+      .panel h3 { margin: 0 0 8px; font-size: 14px; color: #555; text-transform: uppercase; }
+      pre { background: #f5f5f5; padding: 8px; border-radius: 4px; overflow: auto; margin: 0; }
+      button { margin-right: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>Page C (MPA repro)</h1>
+
+    <nav>
+      <a href="/browser-sdk/page-url-enrichment-mpa-a.html">→ Page A</a>
+      <a href="/browser-sdk/page-url-enrichment-mpa-b.html">→ Page B</a>
+      <a href="/browser-sdk/page-url-enrichment-mpa-c.html">→ Page C</a>
+    </nav>
+
+    <div class="panel">
+      <h3>Live sessionStorage[AMP_URL_INFO]</h3>
+      <pre id="storage"></pre>
+    </div>
+
+    <div class="panel">
+      <h3>Events tracked from this page</h3>
+      <button id="wipe">Wipe AMP_URL_INFO</button>
+      <pre id="events">(none yet — page-view events from autocapture will show here too)</pre>
+    </div>
+
+    <script type="module">
+      import * as amplitude from '@amplitude/analytics-browser';
+
+      const STORAGE_KEY = 'AMP_URL_INFO';
+      const storageEl = document.getElementById('storage');
+      const eventsEl = document.getElementById('events');
+
+      const renderStorage = () => {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        try {
+          storageEl.textContent = raw ? JSON.stringify(JSON.parse(raw), null, 2) : '(empty)';
+        } catch {
+          storageEl.textContent = raw ?? '(empty)';
+        }
+      };
+      renderStorage();
+      setInterval(renderStorage, 250);
+
+      const inspectorPlugin = {
+        name: 'mpa-repro-inspector',
+        type: 'enrichment',
+        setup: async () => {},
+        execute: async (event) => {
+          const summary = {
+            type: event.event_type,
+            'Page Location': event.event_properties?.['[Amplitude] Page Location'],
+            'Previous Page Location': event.event_properties?.['[Amplitude] Previous Page Location'],
+            'Previous Page Type': event.event_properties?.['[Amplitude] Previous Page Type'],
+          };
+          const line = `[${new Date().toLocaleTimeString()}] ${JSON.stringify(summary, null, 2)}`;
+          eventsEl.textContent =
+            eventsEl.textContent.startsWith('(none')
+              ? line
+              : `${line}\n\n${eventsEl.textContent}`;
+          return event;
+        },
+      };
+
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY,
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'amplitude-typescript test user',
+        {
+          autocapture: {
+            pageViews: true,
+            pageUrlEnrichment: true,
+          },
+        },
+      );
+      amplitude.add(inspectorPlugin);
+
+      document.getElementById('wipe').addEventListener('click', () => {
+        sessionStorage.removeItem(STORAGE_KEY);
+        renderStorage();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Summary
This should address the issue [here](https://amplitude.slack.com/archives/C02E1H87E2C/p1777570969355159).
Adds a couple of pages to the test-server to validate MPA navigation.

Also fix the case for when a user leaves the domain, goes to an external site, and then returns to the same domain.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the enrichment plugin seeds and overwrites `AMP_URL_INFO` on startup, which can affect attribution for all page-view/event tracking. Risk is moderate because it’s a targeted logic change but impacts analytics data correctness across navigation edge cases.
> 
> **Overview**
> Fixes stale `AMP_URL_INFO` handling in the page URL enrichment plugin by seeding storage during `setup()` and adding a cross-origin arrival check that **prefers `document.referrer` over sessionStorage** when returning from another domain, while avoiding clobbering on refresh.
> 
> Simplifies `execute()` to only read the stored previous page (no longer initializes storage there), and expands tests to cover MPA/full reload behavior, leave-and-return flows, refresh-with-stale-referrer, and wiped-storage resiliency. Adds three `test-server` HTML pages to manually reproduce/validate MPA navigation and inspect emitted event properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f8da898657f89337e00ad7ff734133149f667d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->