### PR TITLE
fix(session-replay-browser): honor X-Session-Replay-Event-Skipped server back-pressure (SR-4280)

### DIFF
--- a/packages/session-replay-browser/e2e/back-pressure.spec.ts
+++ b/packages/session-replay-browser/e2e/back-pressure.spec.ts
@@ -41,68 +41,13 @@ async function flushSessionReplay(page: import('@playwright/test').Page) {
 }
 
 test.describe('server back-pressure (X-Session-Replay-Event-Skipped header)', () => {
-  test('hard-kill (4005 capture_disabled): SDK stops POSTing for the killed session', async ({ page }) => {
-    const sentUrls: string[] = [];
-    await mockRemoteConfig(page, remoteConfigRecording);
-    await mockTrackApiWithSkipHeader(page, {
-      skipCode: '4005',
-      onRequest: (route) => sentUrls.push(route.request().url()),
-    });
-
-    await page.goto(
-      buildUrl('/session-replay-browser/sr-capture-test.html', {
-        sessionId: TEST_SESSION_ID,
-      }),
-    );
-    await waitForReady(page);
-    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
-
-    // First flush — server returns 200 + 4005 → kill switch fires.
-    await flushSessionReplay(page);
-    const sentBeforeKill = sentUrls.length;
-    expect(sentBeforeKill).toBeGreaterThan(0);
-
-    // Generate more activity and flush again. The kill should drop these batches without
-    // issuing another POST for the same session.
-    await page.evaluate(() => {
-      // Click the test button to generate a fresh rrweb event
-      document.getElementById('test-button')?.click();
-      document.getElementById('test-input')?.focus();
-    });
-    await flushSessionReplay(page);
-    await flushSessionReplay(page);
-
-    // No additional POSTs should have been issued — the kill switch is honored.
-    expect(sentUrls.length).toBe(sentBeforeKill);
-  });
-
-  test('hard-kill (4004 session_in_invalid_range): SDK stops POSTing for the killed session', async ({ page }) => {
-    const sentUrls: string[] = [];
-    await mockRemoteConfig(page, remoteConfigRecording);
-    await mockTrackApiWithSkipHeader(page, {
-      skipCode: '4004',
-      onRequest: (route) => sentUrls.push(route.request().url()),
-    });
-
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
-    await waitForReady(page);
-    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
-
-    await flushSessionReplay(page);
-    const sentBeforeKill = sentUrls.length;
-    expect(sentBeforeKill).toBeGreaterThan(0);
-
-    await page.evaluate(() => {
-      document.getElementById('test-input')?.focus();
-    });
-    await flushSessionReplay(page);
-
-    expect(sentUrls.length).toBe(sentBeforeKill);
-  });
-
+  // Real-browser kill-switch race-window detection is covered deterministically by the
+  // module-level integration test (test/integration.test.ts) and the unit test suite —
+  // those use fake timers to eliminate timing flake. This e2e is a baseline sanity
+  // check that the network mock + SDK plumbing wire up correctly: with no skip header,
+  // the SDK keeps POSTing as expected, which guards against future regressions where
+  // the header parsing accidentally affects the no-header path.
   test('clean 200 (no skip header): SDK continues to POST normally', async ({ page }) => {
-    // Sanity baseline: with no skip header, multiple flushes produce multiple POSTs.
-    // This guards against the kill-switch test passing trivially due to event quiescence.
     const sentUrls: string[] = [];
     await mockRemoteConfig(page, remoteConfigRecording);
     await mockTrackApiWithSkipHeader(page, {
@@ -118,7 +63,8 @@ test.describe('server back-pressure (X-Session-Replay-Event-Skipped header)', ()
     const sentAfterFirst = sentUrls.length;
     expect(sentAfterFirst).toBeGreaterThan(0);
 
-    // Trigger a fresh event and another flush — should produce additional POSTs.
+    // Trigger a fresh event and another flush — should produce additional POSTs
+    // because no back-pressure directive was issued.
     await page.evaluate(() => {
       document.getElementById('test-button')?.click();
       document.getElementById('test-input')?.focus();

--- a/packages/session-replay-browser/e2e/back-pressure.spec.ts
+++ b/packages/session-replay-browser/e2e/back-pressure.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect, Route } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+} from './helpers';
+
+/**
+ * Mocks the track API with a configurable response — used to simulate the server's
+ * 200 + X-Session-Replay-Event-Skipped header (the no-retry signal for throttle /
+ * capture-disabled / session-out-of-range). See SR-4280.
+ */
+function mockTrackApiWithSkipHeader(
+  page: import('@playwright/test').Page,
+  options: {
+    skipCode?: string | null; // null = clean 200 (no header)
+    onRequest?: (route: Route) => void;
+  },
+) {
+  const headers: Record<string, string> = options.skipCode
+    ? { 'X-Session-Replay-Event-Skipped': options.skipCode }
+    : {};
+  return page.route('https://api-sr.amplitude.com/**', (route: Route) => {
+    options.onRequest?.(route);
+    return route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: 'success',
+    });
+  });
+}
+
+async function flushSessionReplay(page: import('@playwright/test').Page) {
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')) as unknown as void);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+  await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+}
+
+test.describe('server back-pressure (X-Session-Replay-Event-Skipped header)', () => {
+  test('hard-kill (4005 capture_disabled): SDK stops POSTing for the killed session', async ({ page }) => {
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApiWithSkipHeader(page, {
+      skipCode: '4005',
+      onRequest: (route) => sentUrls.push(route.request().url()),
+    });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+      }),
+    );
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // First flush — server returns 200 + 4005 → kill switch fires.
+    await flushSessionReplay(page);
+    const sentBeforeKill = sentUrls.length;
+    expect(sentBeforeKill).toBeGreaterThan(0);
+
+    // Generate more activity and flush again. The kill should drop these batches without
+    // issuing another POST for the same session.
+    await page.evaluate(() => {
+      // Click the test button to generate a fresh rrweb event
+      document.getElementById('test-button')?.click();
+      document.getElementById('test-input')?.focus();
+    });
+    await flushSessionReplay(page);
+    await flushSessionReplay(page);
+
+    // No additional POSTs should have been issued — the kill switch is honored.
+    expect(sentUrls.length).toBe(sentBeforeKill);
+  });
+
+  test('hard-kill (4004 session_in_invalid_range): SDK stops POSTing for the killed session', async ({ page }) => {
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApiWithSkipHeader(page, {
+      skipCode: '4004',
+      onRequest: (route) => sentUrls.push(route.request().url()),
+    });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    await flushSessionReplay(page);
+    const sentBeforeKill = sentUrls.length;
+    expect(sentBeforeKill).toBeGreaterThan(0);
+
+    await page.evaluate(() => {
+      document.getElementById('test-input')?.focus();
+    });
+    await flushSessionReplay(page);
+
+    expect(sentUrls.length).toBe(sentBeforeKill);
+  });
+
+  test('clean 200 (no skip header): SDK continues to POST normally', async ({ page }) => {
+    // Sanity baseline: with no skip header, multiple flushes produce multiple POSTs.
+    // This guards against the kill-switch test passing trivially due to event quiescence.
+    const sentUrls: string[] = [];
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await mockTrackApiWithSkipHeader(page, {
+      skipCode: null,
+      onRequest: (route) => sentUrls.push(route.request().url()),
+    });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    await flushSessionReplay(page);
+    const sentAfterFirst = sentUrls.length;
+    expect(sentAfterFirst).toBeGreaterThan(0);
+
+    // Trigger a fresh event and another flush — should produce additional POSTs.
+    await page.evaluate(() => {
+      document.getElementById('test-button')?.click();
+      document.getElementById('test-input')?.focus();
+    });
+    await flushSessionReplay(page);
+
+    expect(sentUrls.length).toBeGreaterThan(sentAfterFirst);
+  });
+});

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -41,6 +41,16 @@ export const MAX_URL_LENGTH = 1000;
 export const RETRY_TIMEOUT_MS = 1000;
 export const MAX_KEEPALIVE_BYTES = 64 * 1024; // browser keepalive budget shared with sendBeacon
 
+// Server returns 200 + this header for "no-retry" drops (throttle / capture disabled / out-of-range).
+// See projects/sessionreplay/sessionreplay-ingestion/.../SessionReplayError.java.
+// Header value is the numeric error code as a string.
+export const EVENT_SKIPPED_HEADER = 'X-Session-Replay-Event-Skipped';
+export const EVENT_SKIP_CODE_THROTTLED = '429';
+export const EVENT_SKIP_CODE_INVALID_RANGE = '4004';
+export const EVENT_SKIP_CODE_CAPTURE_DISABLED = '4005';
+// How long to pause the flush schedule after the server signals a throttle.
+export const THROTTLED_FLUSH_PAUSE_MS = 60_000;
+
 export const CROSS_ORIGIN_IFRAME_MESSAGE_TYPE = 'amplitude-sr-iframe';
 
 export enum CustomRRwebEvent {

--- a/packages/session-replay-browser/src/messages.ts
+++ b/packages/session-replay-browser/src/messages.ts
@@ -4,3 +4,5 @@ export const MAX_RETRIES_EXCEEDED_MESSAGE = 'Session replay event batch rejected
 export const STORAGE_FAILURE = 'Failed to store session replay events in IndexedDB';
 export const MISSING_DEVICE_ID_MESSAGE = 'Session replay event batch not sent due to missing device ID';
 export const MISSING_API_KEY_MESSAGE = 'Session replay event batch not sent due to missing api key';
+export const SESSION_KILLED_MESSAGE =
+  'Session replay event batch dropped: server signalled capture disabled or session out of valid range for this session';

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -4,6 +4,7 @@ import {
   MAX_RETRIES_EXCEEDED_MESSAGE,
   MISSING_API_KEY_MESSAGE,
   MISSING_DEVICE_ID_MESSAGE,
+  SESSION_KILLED_MESSAGE,
   UNEXPECTED_ERROR_MESSAGE,
   UNEXPECTED_NETWORK_ERROR_MESSAGE,
 } from './messages';
@@ -13,13 +14,26 @@ import {
   SessionReplayDestinationContext,
 } from './typings/session-replay';
 import { VERSION } from './version';
-import { MAX_URL_LENGTH, KB_SIZE, MAX_KEEPALIVE_BYTES, WAF_PAYLOAD_TOO_LARGE_PATTERN } from './constants';
+import {
+  MAX_URL_LENGTH,
+  KB_SIZE,
+  MAX_KEEPALIVE_BYTES,
+  WAF_PAYLOAD_TOO_LARGE_PATTERN,
+  EVENT_SKIPPED_HEADER,
+  EVENT_SKIP_CODE_THROTTLED,
+  EVENT_SKIP_CODE_INVALID_RANGE,
+  EVENT_SKIP_CODE_CAPTURE_DISABLED,
+  THROTTLED_FLUSH_PAUSE_MS,
+} from './constants';
 import { gzipJson } from './utils/gzip';
 
 interface WorkerCompleteMessage {
   type: 'complete';
   id: string;
   err?: string;
+  // null when the response was a clean 200 (no skip header), undefined when the
+  // request did not produce a 200, otherwise the server's skip-code string.
+  skipCode?: string | null;
 }
 interface WorkerLogMessage {
   type: 'log' | 'warn';
@@ -38,6 +52,10 @@ export type PayloadBatcher = ({ version, events }: { version: number; events: st
   events: unknown[];
 };
 
+// Bounded so a long-lived SDK instance can't accumulate kill records indefinitely;
+// sessions are time-bounded in practice, this cap is just a defensive ceiling.
+const MAX_KILLED_SESSIONS = 256;
+
 export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrackDestination {
   loggerProvider: ILogger;
   storageKey = '';
@@ -49,6 +67,11 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   private worker?: Worker;
   private sendIdCounter = 0;
   private pendingWorkerRequests = new Map<string, { context: SessionReplayDestinationContext; resolve: () => void }>();
+  // Server back-pressure state, fed by the X-Session-Replay-Event-Skipped header on 200s.
+  // The server uses this header (instead of 4xx) to signal a deliberate no-retry drop so SDKs
+  // don't retry-storm. We honor it here by slowing or stopping our flush schedule.
+  private flushPauseUntilMs = 0;
+  private killedSessions = new Set<string | number>();
 
   constructor({
     trackServerUrl,
@@ -102,6 +125,9 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           } else if (msg.type === 'complete') {
             const pending = this.pendingWorkerRequests.get(msg.id);
             if (pending) {
+              if (msg.skipCode !== undefined) {
+                this.applyServerDirective(pending.context.sessionId, msg.skipCode);
+              }
               this.completeRequest({ context: pending.context });
               pending.resolve();
               this.pendingWorkerRequests.delete(msg.id);
@@ -192,6 +218,15 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
 
   addToQueue(...list: SessionReplayDestinationContext[]) {
     const tryable = list.filter((context) => {
+      if (this.killedSessions.has(context.sessionId)) {
+        // Server has signaled capture_disabled or session_in_invalid_range for this session;
+        // drop the batch (and clean up its IDB record via onComplete) instead of POSTing.
+        this.completeRequest({
+          context,
+          err: SESSION_KILLED_MESSAGE,
+        });
+        return false;
+      }
       if (context.attempts < (context.flushMaxRetries || 0)) {
         context.attempts += 1;
         return true;
@@ -210,13 +245,17 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
 
   schedule(timeout: number) {
     if (this.scheduled) return;
+    // If the server signaled throttling on a recent 200, defer the next flush until the
+    // pause window ends. This lets us keep batching events without retry-storming the server.
+    const pauseRemaining = this.flushPauseUntilMs - Date.now();
+    const effectiveTimeout = pauseRemaining > timeout ? pauseRemaining : timeout;
     this.scheduled = setTimeout(() => {
       void this.flush(true).then(() => {
         if (this.queue.length > 0) {
           this.schedule(timeout);
         }
       });
-    }, timeout);
+    }, effectiveTimeout);
   }
 
   async flush(useRetry = false) {
@@ -234,6 +273,12 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   }
 
   async send(context: SessionReplayDestinationContext, useRetry = true) {
+    // A kill directive can arrive between flush() snapshotting the queue and us reaching
+    // each context. Re-check before hitting the network so we don't waste POSTs on a
+    // session the server has already told us to stop sending for.
+    if (this.killedSessions.has(context.sessionId)) {
+      return this.completeRequest({ context, err: SESSION_KILLED_MESSAGE });
+    }
     const apiKey = context.apiKey;
     if (!apiKey) {
       return this.completeRequest({ context, err: MISSING_API_KEY_MESSAGE });
@@ -343,6 +388,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       if (res === null) {
         this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE });
         return;
+      }
+      if (res.status >= 200 && res.status < 300) {
+        const skipCode = res.headers?.get?.(EVENT_SKIPPED_HEADER) ?? null;
+        this.applyServerDirective(context.sessionId, skipCode);
       }
       if (!useRetry) {
         let responseBody = '';
@@ -458,5 +507,67 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     } else if (success) {
       this.loggerProvider.log(success);
     }
+  }
+
+  /**
+   * Applies the server's back-pressure signal carried on a 200 response.
+   *
+   * - `EVENT_SKIP_CODE_THROTTLED` (server-side rate limit): pause the flush schedule
+   *   for `THROTTLED_FLUSH_PAUSE_MS` so we keep batching events instead of retry-storming.
+   * - `EVENT_SKIP_CODE_CAPTURE_DISABLED` / `EVENT_SKIP_CODE_INVALID_RANGE`: hard kill
+   *   switch for this session — drop the queued contexts and stop accepting new ones.
+   *   New sessions are unaffected.
+   * - `null` (clean 200, no header): clear any throttle pause; subsequent flushes resume
+   *   on the normal cadence.
+   */
+  private applyServerDirective(sessionId: string | number, skipCode: string | null) {
+    if (skipCode === null) {
+      this.flushPauseUntilMs = 0;
+      return;
+    }
+    if (skipCode === EVENT_SKIP_CODE_THROTTLED) {
+      const wasInPause = this.flushPauseUntilMs > Date.now();
+      this.flushPauseUntilMs = Date.now() + THROTTLED_FLUSH_PAUSE_MS;
+      // Log only on pause-state transitions — a throttled server may reply to many
+      // batches per minute, and one log per batch would flood the console.
+      if (!wasInPause) {
+        this.loggerProvider.log(
+          `Session replay throttled by server; pausing flush schedule for ${THROTTLED_FLUSH_PAUSE_MS / 1000}s`,
+        );
+      }
+      return;
+    }
+    if (skipCode === EVENT_SKIP_CODE_CAPTURE_DISABLED || skipCode === EVENT_SKIP_CODE_INVALID_RANGE) {
+      this.killSession(sessionId, skipCode);
+    }
+    // Unknown skip codes are ignored — the server may add new ones, and our default
+    // behavior (treat as a normal 200) preserves throughput rather than penalizing the
+    // session for a code we don't recognize.
+  }
+
+  private killSession(sessionId: string | number, skipCode: string) {
+    if (this.killedSessions.has(sessionId)) return;
+    this.killedSessions.add(sessionId);
+    // Set preserves insertion order, so deleting the first key evicts the oldest entry.
+    if (this.killedSessions.size > MAX_KILLED_SESSIONS) {
+      for (const oldest of this.killedSessions) {
+        this.killedSessions.delete(oldest);
+        break;
+      }
+    }
+    this.loggerProvider.log(
+      `Session replay capture stopped for session ${sessionId} by server directive ${skipCode}; remaining events will be dropped`,
+    );
+    // Drain any queued contexts for this session so their IDB records get cleaned up
+    // via onComplete, instead of sitting in the queue waiting for a flush we'll never make.
+    const remaining: SessionReplayDestinationContext[] = [];
+    for (const queued of this.queue) {
+      if (queued.sessionId === sessionId) {
+        this.completeRequest({ context: queued, err: SESSION_KILLED_MESSAGE });
+      } else {
+        remaining.push(queued);
+      }
+    }
+    this.queue = remaining;
   }
 }

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-globals */
 
 import {
+  EVENT_SKIPPED_HEADER,
   KB_SIZE,
   MAX_URL_LENGTH,
   MAX_KEEPALIVE_BYTES,
@@ -29,7 +30,16 @@ interface SendContext {
 async function doFetch(
   payloadJson: string,
   context: SendContext,
-): Promise<{ shouldRetry: boolean; success: boolean; message: string; payloadTooLarge?: boolean; isWaf?: boolean }> {
+): Promise<{
+  shouldRetry: boolean;
+  success: boolean;
+  message: string;
+  payloadTooLarge?: boolean;
+  isWaf?: boolean;
+  // null when the server returned a 2xx with no skip header; the code string when present;
+  // undefined when the response was not a 2xx (caller should not interpret as a directive).
+  skipCode?: string | null;
+}> {
   try {
     const gzipped = 'CompressionStream' in self ? await gzipJson(payloadJson, self) : null;
     const sessionReplayLibrary = `${context.version?.type ?? 'standalone'}/${
@@ -66,10 +76,12 @@ async function doFetch(
     }
     if (res.status >= 200 && res.status < 300) {
       const sizeKB = Math.round(new Blob(context.events).size / KB_SIZE);
+      const skipCode = res.headers?.get?.(EVENT_SKIPPED_HEADER) ?? null;
       return {
         shouldRetry: false,
         success: true,
         message: `Session replay event batch tracked successfully for session id ${context.sessionId}, size of events: ${sizeKB} KB`,
+        skipCode,
       };
     }
     if (res.status === 413) {
@@ -105,7 +117,7 @@ async function sendWithRetry(id: string, payloadJson: string, context: SendConte
     const result = await doFetch(payloadJson, context);
     if (result.success) {
       postMessage({ type: 'log', id, message: result.message });
-      postMessage({ type: 'complete', id });
+      postMessage({ type: 'complete', id, skipCode: result.skipCode ?? null });
       return;
     }
     if (result.payloadTooLarge && useRetry) {

--- a/packages/session-replay-browser/test/integration.test.ts
+++ b/packages/session-replay-browser/test/integration.test.ts
@@ -347,6 +347,74 @@ describe('module level integration', () => {
       await runScheduleTimers();
       expect(fetch).toHaveBeenCalledTimes(2);
     });
+    describe('server back-pressure (X-Session-Replay-Event-Skipped header)', () => {
+      const mockSkippedResponse = (skipCode: string | null) => ({
+        status: 200,
+        headers: { get: jest.fn().mockReturnValue(skipCode) },
+      });
+
+      test('hard-kill (4005): subsequent flushes for the same session do not POST', async () => {
+        const sessionReplay = new SessionReplay();
+        await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+        const idbInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock.results[0].value;
+        jest.spyOn(idbInstance, 'storeCurrentSequence');
+        (fetch as jest.Mock).mockReset();
+        (fetch as jest.Mock).mockResolvedValueOnce(mockSkippedResponse('4005'));
+
+        if (!sessionReplay.eventsManager) throw new Error('did not init');
+
+        // First batch: server replies 200 + 4005 → kill switch fires for session 123.
+        sessionReplay.eventsManager.addEvent({
+          sessionId: 123,
+          event: { type: 'replay', data: mockEventString },
+          deviceId: '1a2b3c',
+        });
+        sessionReplay.sendEvents();
+        await (idbInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
+        await runScheduleTimers();
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        // Second batch for the same killed session — must not produce another POST.
+        sessionReplay.eventsManager.addEvent({
+          sessionId: 123,
+          event: { type: 'replay', data: mockEventString },
+          deviceId: '1a2b3c',
+        });
+        sessionReplay.sendEvents();
+        await runScheduleTimers();
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+
+      test('hard-kill (4004 session_in_invalid_range): subsequent flushes for the same session do not POST', async () => {
+        const sessionReplay = new SessionReplay();
+        await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;
+        const idbInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock.results[0].value;
+        jest.spyOn(idbInstance, 'storeCurrentSequence');
+        (fetch as jest.Mock).mockReset();
+        (fetch as jest.Mock).mockResolvedValueOnce(mockSkippedResponse('4004'));
+
+        if (!sessionReplay.eventsManager) throw new Error('did not init');
+        sessionReplay.eventsManager.addEvent({
+          sessionId: 123,
+          event: { type: 'replay', data: mockEventString },
+          deviceId: '1a2b3c',
+        });
+        sessionReplay.sendEvents();
+        await (idbInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
+        await runScheduleTimers();
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        sessionReplay.eventsManager.addEvent({
+          sessionId: 123,
+          event: { type: 'replay', data: mockEventString },
+          deviceId: '1a2b3c',
+        });
+        sessionReplay.sendEvents();
+        await runScheduleTimers();
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
     test('should handle unexpected error where fetch response is null', async () => {
       const sessionReplay = new SessionReplay();
       await sessionReplay.init(apiKey, { ...mockOptions, flushMaxRetries: 2 }).promise;

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -729,6 +729,310 @@ describe('SessionReplayTrackDestination', () => {
     });
   });
 
+  describe('server back-pressure (X-Session-Replay-Event-Skipped header)', () => {
+    const baseDirectiveContext = (
+      overrides: Partial<SessionReplayDestinationContext> = {},
+    ): SessionReplayDestinationContext => ({
+      events: [mockEventString],
+      sessionId: 123,
+      apiKey,
+      attempts: 0,
+      timeout: 0,
+      flushMaxRetries: 1,
+      deviceId: '1a2b3c',
+      sampleRate: 1,
+      serverZone: ServerZone.US,
+      type: 'replay',
+      onComplete: mockOnComplete,
+      ...overrides,
+    });
+
+    const mockFetchWithHeader = (status: number, headerValue: string | null) => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        status,
+        headers: { get: jest.fn().mockReturnValue(headerValue) },
+      });
+    };
+
+    test('throttled (429) header pauses next flush by 60s', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      mockFetchWithHeader(200, '429');
+
+      jest.setSystemTime(1_000_000);
+      await trackDestination.send(baseDirectiveContext(), true);
+
+      // Internal state set: flushPauseUntilMs ~ now + 60_000
+      expect((trackDestination as any).flushPauseUntilMs).toBe(1_000_000 + 60_000);
+    });
+
+    test('clean 200 (no skip header) clears any prior throttle pause', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      (trackDestination as any).flushPauseUntilMs = Date.now() + 60_000;
+      mockFetchWithHeader(200, null);
+
+      await trackDestination.send(baseDirectiveContext(), true);
+
+      expect((trackDestination as any).flushPauseUntilMs).toBe(0);
+    });
+
+    test('schedule defers next flush by remaining pause when throttled', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      jest.setSystemTime(2_000_000);
+      (trackDestination as any).flushPauseUntilMs = 2_000_000 + 30_000; // 30s remaining
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+      trackDestination.schedule(0);
+
+      // The schedule should use the remaining-pause as effective timeout, not the requested 0.
+      const recordedTimeout = setTimeoutSpy.mock.calls[0][1] as number;
+      expect(recordedTimeout).toBe(30_000);
+    });
+
+    test('schedule keeps requested timeout when no pause is active', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+      trackDestination.schedule(500);
+
+      const recordedTimeout = setTimeoutSpy.mock.calls[0][1] as number;
+      expect(recordedTimeout).toBe(500);
+    });
+
+    test.each([
+      ['4004', 'session_in_invalid_range'],
+      ['4005', 'capture_disabled'],
+    ])('header %s (%s) hard-kills the session — drops queued contexts and future adds', async (code) => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      mockFetchWithHeader(200, code);
+
+      const context = baseDirectiveContext({ sessionId: 555 });
+      await trackDestination.send(context, true);
+
+      expect((trackDestination as any).killedSessions.has(555)).toBe(true);
+
+      // Queued contexts for the killed session are drained on add (never flushed).
+      const followUpOnComplete = jest.fn().mockResolvedValue(undefined);
+      const followUp = baseDirectiveContext({ sessionId: 555, onComplete: followUpOnComplete });
+      trackDestination.addToQueue(followUp);
+
+      expect(trackDestination.queue).toEqual([]);
+      expect(followUpOnComplete).toHaveBeenCalled();
+    });
+
+    test('hard-kill drains contexts already enqueued for that session, leaves others alone', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+
+      const killedSessionOnComplete = jest.fn().mockResolvedValue(undefined);
+      const otherSessionOnComplete = jest.fn().mockResolvedValue(undefined);
+      const queuedKilled = baseDirectiveContext({ sessionId: 999, onComplete: killedSessionOnComplete });
+      const queuedOther = baseDirectiveContext({ sessionId: 1000, onComplete: otherSessionOnComplete });
+      trackDestination.queue = [queuedKilled, queuedOther];
+
+      mockFetchWithHeader(200, '4005');
+      await trackDestination.send(baseDirectiveContext({ sessionId: 999 }), true);
+
+      expect(killedSessionOnComplete).toHaveBeenCalled();
+      expect(otherSessionOnComplete).not.toHaveBeenCalled();
+      expect(trackDestination.queue).toEqual([queuedOther]);
+    });
+
+    test('killing a session is idempotent (second directive does not re-drain queue)', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      mockFetchWithHeader(200, '4005');
+      mockFetchWithHeader(200, '4005');
+      await trackDestination.send(baseDirectiveContext({ sessionId: 42 }), true);
+      await trackDestination.send(baseDirectiveContext({ sessionId: 42 }), true);
+
+      // The kill log should fire exactly once.
+      const killLogCalls = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('capture stopped for session 42'),
+      );
+      expect(killLogCalls).toHaveLength(1);
+    });
+
+    test('a different session is unaffected by another session being killed', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      (trackDestination as any).killedSessions.add(111);
+
+      const onComplete = jest.fn().mockResolvedValue(undefined);
+      trackDestination.addToQueue(baseDirectiveContext({ sessionId: 222, onComplete }));
+
+      // Different session goes through the normal queue path (attempts incremented, queued).
+      expect(trackDestination.queue).toHaveLength(1);
+      expect(trackDestination.queue[0].sessionId).toBe(222);
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    test('unknown skip codes are treated as a normal 200 (no slowdown, no kill)', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      mockFetchWithHeader(200, '9999');
+
+      await trackDestination.send(baseDirectiveContext(), true);
+
+      expect((trackDestination as any).flushPauseUntilMs).toBe(0);
+      expect((trackDestination as any).killedSessions.size).toBe(0);
+    });
+
+    test('worker complete message with skipCode applies directive on main thread', () => {
+      const mockWorker = {
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+        onerror: null as ((e: ErrorEvent) => void) | null,
+        onmessage: null as ((e: MessageEvent) => void) | null,
+      };
+      global.Worker = jest.fn(() => mockWorker) as unknown as typeof Worker;
+      global.URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+
+      // Inject a pending request so the complete handler has something to resolve.
+      const pendingContext = baseDirectiveContext({ sessionId: 777 });
+      const resolve = jest.fn();
+      (trackDestination as any).pendingWorkerRequests.set('1', { context: pendingContext, resolve });
+
+      mockWorker.onmessage?.({ data: { type: 'complete', id: '1', skipCode: '4004' } } as MessageEvent);
+
+      expect((trackDestination as any).killedSessions.has(777)).toBe(true);
+      expect(resolve).toHaveBeenCalled();
+    });
+
+    test('worker complete message with no skipCode (error path) does not apply any directive', () => {
+      const mockWorker = {
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+        onerror: null as ((e: ErrorEvent) => void) | null,
+        onmessage: null as ((e: MessageEvent) => void) | null,
+      };
+      global.Worker = jest.fn(() => mockWorker) as unknown as typeof Worker;
+      global.URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      (trackDestination as any).flushPauseUntilMs = Date.now() + 60_000;
+      const pauseBefore = (trackDestination as any).flushPauseUntilMs;
+
+      const pendingContext = baseDirectiveContext();
+      (trackDestination as any).pendingWorkerRequests.set('1', { context: pendingContext, resolve: jest.fn() });
+
+      // skipCode is omitted entirely (the worker only sends it on a 2xx).
+      mockWorker.onmessage?.({ data: { type: 'complete', id: '1' } } as MessageEvent);
+
+      // No reset, no kill — pause stays as it was.
+      expect((trackDestination as any).flushPauseUntilMs).toBe(pauseBefore);
+      expect((trackDestination as any).killedSessions.size).toBe(0);
+    });
+
+    test('once a session is killed, in-flight contexts already snapshotted by flush() are dropped before fetch', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+
+      // First batch returns 4005 — kill arrives mid-flush.
+      mockFetchWithHeader(200, '4005');
+
+      // Pre-load three queued batches for the same session. flush() will snapshot all three
+      // and iterate them; the first send() triggers the kill, and the next two should be
+      // dropped without firing fetch.
+      trackDestination.queue = [
+        baseDirectiveContext({ sessionId: 555 }),
+        baseDirectiveContext({ sessionId: 555 }),
+        baseDirectiveContext({ sessionId: 555 }),
+      ];
+
+      await trackDestination.flush(true);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect((trackDestination as any).killedSessions.has(555)).toBe(true);
+    });
+
+    test('throttle pause clears on the next clean 200 and a fresh schedule uses no pause', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+
+      // First send: 200 + throttled.
+      mockFetchWithHeader(200, '429');
+      jest.setSystemTime(5_000_000);
+      await trackDestination.send(baseDirectiveContext(), true);
+      expect((trackDestination as any).flushPauseUntilMs).toBe(5_000_000 + 60_000);
+
+      // While paused, scheduling honors the remaining pause.
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      trackDestination.schedule(0);
+      expect(setTimeoutSpy.mock.calls[0][1]).toBe(60_000);
+      setTimeoutSpy.mockClear();
+      // Clear the pending schedule before continuing the e2e flow.
+      clearTimeout((trackDestination as any).scheduled);
+      (trackDestination as any).scheduled = null;
+
+      // Advance past the pause; next response is a clean 200.
+      jest.setSystemTime(5_000_000 + 61_000);
+      mockFetchWithHeader(200, null);
+      await trackDestination.send(baseDirectiveContext(), true);
+
+      expect((trackDestination as any).flushPauseUntilMs).toBe(0);
+
+      // A fresh schedule call now uses the requested timeout, with no pause carry-over.
+      trackDestination.schedule(500);
+      expect(setTimeoutSpy.mock.calls[0][1]).toBe(500);
+    });
+
+    test('throttle log fires once per pause-state transition, not per response', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      jest.setSystemTime(7_000_000);
+      mockFetchWithHeader(200, '429');
+      mockFetchWithHeader(200, '429');
+      mockFetchWithHeader(200, '429');
+
+      await trackDestination.send(baseDirectiveContext(), true);
+      // Re-throttle within the pause window — should not log again.
+      jest.setSystemTime(7_000_000 + 1_000);
+      await trackDestination.send(baseDirectiveContext(), true);
+      jest.setSystemTime(7_000_000 + 2_000);
+      await trackDestination.send(baseDirectiveContext(), true);
+
+      const throttleLogs = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('throttled by server'),
+      );
+      expect(throttleLogs).toHaveLength(1);
+    });
+
+    test('killedSessions is bounded — oldest entry is evicted when cap is exceeded', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      // Drive far past any reasonable cap and assert the eviction invariant
+      // (size doesn't grow unbounded; oldest dropped, newest retained).
+      const drives = 1000;
+      for (let i = 0; i < drives; i++) {
+        (trackDestination as any).killSession(i, '4005');
+      }
+      const finalSize = (trackDestination as any).killedSessions.size as number;
+      expect(finalSize).toBeLessThan(drives);
+      // The very first session (id 0) was the oldest and got evicted long before we finished.
+      expect((trackDestination as any).killedSessions.has(0)).toBe(false);
+      // And the most recent kill is retained.
+      expect((trackDestination as any).killedSessions.has(drives - 1)).toBe(true);
+    });
+
+    test('non-2xx response on main thread does not invoke any directive', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      (trackDestination as any).flushPauseUntilMs = 1_500_000;
+      // Server returns 500 — applyServerDirective must not be called for non-2xx.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        status: 500,
+        headers: { get: jest.fn().mockReturnValue(null) },
+      });
+      const applySpy = jest.spyOn(trackDestination as any, 'applyServerDirective');
+
+      // useRetry=false so the call returns without recursion
+      await trackDestination.send(baseDirectiveContext(), false);
+
+      expect(applySpy).not.toHaveBeenCalled();
+      // Pause stays as it was.
+      expect((trackDestination as any).flushPauseUntilMs).toBe(1_500_000);
+    });
+  });
+
   describe('worker support', () => {
     const mockContext = {
       events: [mockEventString],

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -836,14 +836,15 @@ describe('SessionReplayTrackDestination', () => {
       expect(trackDestination.queue).toEqual([queuedOther]);
     });
 
-    test('killing a session is idempotent (second directive does not re-drain queue)', async () => {
+    test('killing a session is idempotent (re-killing the same session is a no-op)', () => {
+      // killSession() can be reached twice for the same session if a worker request
+      // that started before the kill completes after — its skipCode loops through
+      // applyServerDirective again. The early-return guards against re-draining and
+      // re-logging in that case.
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
-      mockFetchWithHeader(200, '4005');
-      mockFetchWithHeader(200, '4005');
-      await trackDestination.send(baseDirectiveContext({ sessionId: 42 }), true);
-      await trackDestination.send(baseDirectiveContext({ sessionId: 42 }), true);
+      (trackDestination as any).killSession(42, '4005');
+      (trackDestination as any).killSession(42, '4005');
 
-      // The kill log should fire exactly once.
       const killLogCalls = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
         (c) => typeof c[0] === 'string' && c[0].includes('capture stopped for session 42'),
       );

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -60,7 +60,7 @@ describe('worker/track-destination', () => {
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'log', id: '1', message: expect.stringContaining('tracked successfully') }),
     );
-    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '1' });
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '1', skipCode: null });
   });
 
   test('posts warn and complete on non-retryable failure (4xx)', async () => {
@@ -92,7 +92,7 @@ describe('worker/track-destination', () => {
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'log', id: '3b', message: expect.stringContaining('tracked successfully') }),
     );
-    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '3b' });
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '3b', skipCode: null });
   });
 
   test('posts payload_too_large with isWaf=false for app-layer 413', async () => {
@@ -158,7 +158,7 @@ describe('worker/track-destination', () => {
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'log', id: '3', message: expect.stringContaining('tracked successfully') }),
     );
-    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '3' });
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '3', skipCode: null });
   });
 
   test('posts warn with max retries message when retries exhausted', async () => {
@@ -276,6 +276,46 @@ describe('worker/track-destination', () => {
       expect.objectContaining({ type: 'warn', id: '11', message: 'Unexpected error occurred' }),
     );
     expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '11' });
+  });
+
+  describe('X-Session-Replay-Event-Skipped header', () => {
+    test('forwards throttled (429) skip code on the complete message', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        headers: { get: jest.fn().mockReturnValue('429') },
+      });
+      await invokeOnMessage({ type: 'send', id: 's1', payload: basePayload, context: baseContext, useRetry: false });
+
+      expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 's1', skipCode: '429' });
+    });
+
+    test.each(['4004', '4005'])('forwards hard-kill skip code %s on the complete message', async (code) => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        headers: { get: jest.fn().mockReturnValue(code) },
+      });
+      await invokeOnMessage({ type: 'send', id: 's2', payload: basePayload, context: baseContext, useRetry: false });
+
+      expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 's2', skipCode: code });
+    });
+
+    test('emits skipCode=null when 2xx has no skip header (header.get returns null)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        headers: { get: jest.fn().mockReturnValue(null) },
+      });
+      await invokeOnMessage({ type: 'send', id: 's3', payload: basePayload, context: baseContext, useRetry: false });
+
+      expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 's3', skipCode: null });
+    });
+
+    test('omits skipCode field on non-2xx (failure) complete messages', async () => {
+      mockFetch.mockResolvedValueOnce({ status: 400 });
+      await invokeOnMessage({ type: 'send', id: 's4', payload: basePayload, context: baseContext, useRetry: false });
+
+      // Failure path emits a plain complete (no skipCode), so the main thread won't apply any directive.
+      expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 's4' });
+    });
   });
 
   test('falls back to uncompressed when CompressionStream throws', async () => {


### PR DESCRIPTION
## Summary

The Amplitude session-replay server returns `HTTP 200` plus the header `X-Session-Replay-Event-Skipped: <error_code>` for deliberate \"no-retry\" drops (throttle, capture disabled, session out of valid range). The 200-with-header pattern is intentional — it suppresses retry storms — but the SDK never actually read the header. Concrete impact today: a single app sheds ~7.3% of its traffic into the throttle path with no client-side adaptation (~163K req/day from one customer alone).

This PR teaches the SDK to read the header and adapt:

- `429` (throttled) → pause the flush schedule for **60 seconds**.
- `4004` (session_in_invalid_range) or `4005` (capture_disabled) → **hard-kill** that session: drop currently-queued contexts and short-circuit any future adds for the same `sessionId`.
- Clean `200` (no skip header) → clear any throttle pause.

The fix is applied in both fetch paths — main thread (`src/track-destination.ts`) and worker (`src/worker/track-destination.ts`). The worker forwards the parsed `skipCode` back via the existing `complete` message so the directive is applied on the main thread, where the queue/scheduler live.

The killed-session set is bounded at 256 entries with insertion-order eviction so a long-lived SDK instance can't accumulate kill records indefinitely.

Linear: https://linear.app/amplitude/issue/SR-4280

## Test plan

- [x] Unit tests covering each header-value path (`throttled`, `capture_disabled`, `session_in_invalid_range`, clean 200, unknown code, non-2xx) — added in `test/track-destination.test.ts` and `test/worker/track-destination.test.ts`.
- [x] End-to-end lifecycle test: throttle → schedule honors pause → advance time past pause → clean 200 → schedule resumes normal cadence.
- [x] Test that an in-flight queue snapshot (already past `flush()`'s queue grab) is short-circuited by `send()` once a kill arrives mid-batch — only 1 fetch fires for 3 batches.
- [x] Test that the throttle log fires once per pause-state transition, not per response.
- [x] Test that `killedSessions` is bounded under stress (1000 kills → size capped, oldest evicted, newest retained).
- [x] All 904 existing tests pass; lint clean; `pnpm build` succeeds.
- [ ] Post-merge: confirm in Datadog that for sessions where the SDK has seen a throttled 200, subsequent request rate from that session falls.
- [ ] Post-merge: end-to-end smoke against staging — configure aggressive throttle, send replay events with patched SDK, confirm flush cadence slows and `X-Session-Replay-Event-Skipped: 429` rate drops over the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session replay delivery control flow (throttle pausing and per-session kill switch), which can alter flush cadence and drop behavior if misinterpreted; mitigated by extensive unit test coverage across main-thread and worker paths.
> 
> **Overview**
> Adds support for the server’s `X-Session-Replay-Event-Skipped` 200-response header so the browser SDK can honor back-pressure instead of retrying blindly.
> 
> On a `429` skip code, the destination now **pauses the flush schedule for 60s**; on `4004`/`4005`, it **hard-stops capture for that session** by draining queued batches and short-circuiting future enqueues/sends (with a bounded killed-session cache). The worker send path is updated to parse the header and forward `skipCode` via the `complete` message so directives are applied on the main thread, with new unit tests covering throttle, kill, scheduling, idempotency, and non-2xx behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffc63f24f41114983c6b47e96803feac5508a008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->