### PR TITLE
fix(session-replay-browser): drop empty batches at the store layer (SR-4284)

### DIFF
--- a/packages/session-replay-browser/e2e/size-limits.spec.ts
+++ b/packages/session-replay-browser/e2e/size-limits.spec.ts
@@ -9,7 +9,7 @@ import {
   waitForReady,
   readRouteBody,
 } from './helpers';
-import { MAX_SINGLE_EVENT_SIZE } from '../src/constants';
+import { MAX_EVENT_LIST_SIZE, MAX_SINGLE_EVENT_SIZE } from '../src/constants';
 
 // Just over the byte cap so the next full snapshot is guaranteed oversized.
 // Derived from the constant so the test stays in sync if the threshold is bumped.
@@ -200,5 +200,106 @@ test.describe('WAF 413 bisect-retry', () => {
     // produces at most one tracking call. Allow a small slack for an unrelated follow-up
     // flush during the wait, but flag a regression that re-enables bisect on app-layer 413s.
     expect(callCount).toBeLessThanOrEqual(2);
+  });
+});
+
+// ─── Empty-batch leak (SR-4284) ───────────────────────────────────────────────
+
+test.describe('empty batch leak (SR-4284)', () => {
+  // A single rrweb event between MAX_EVENT_LIST_SIZE (700 KB) and MAX_SINGLE_EVENT_SIZE
+  // (9 MB) passes the per-event capture-time guard but, when it lands in
+  // addEventToCurrentSequence with an empty buffer, drives shouldSplitEventsList's
+  // size-constraint branch true on a zero-event buffer. Pre-fix the split path
+  // finalized that empty buffer into sequencesToSend, leaving an events:[] row that
+  // older SDKs would later POST as an empty body (the root cause of the ~416/24h
+  // "Empty request body" 400s on the uploader). Post-fix we expect no empty-body
+  // POSTs and no empty rows to ever be persisted in IDB.
+
+  // 2× the list cap: comfortably under the per-event cap. The rrweb full snapshot
+  // serializing this attribute will be > 700 KB but << 9 MB, so it bypasses the
+  // capture-time drop and exercises the SR-4284 store-layer path.
+  const MID_SIZE_ATTR_LENGTH = MAX_EVENT_LIST_SIZE * 2;
+
+  async function injectMidSizeNode(page: import('@playwright/test').Page): Promise<void> {
+    await page.evaluate((len) => {
+      const div = document.createElement('div');
+      div.setAttribute('data-mid', 'x'.repeat(len));
+      document.body.appendChild(div);
+    }, MID_SIZE_ATTR_LENGTH);
+  }
+
+  test('mid-sized event into a drained slot fires the store-layer guard and posts no empty body', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    // Capture every POST body so we can assert no empty-body POST went to the wire.
+    const rawBodies: string[] = [];
+    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+      rawBodies.push(readRouteBody(route));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+
+    // Capture console.warn output. The SR-4284 store-layer guards emit a sampled
+    // (1-in-100, first hit deterministic) warn whose presence proves the guards
+    // actually fired — without this signal, the test would also pass when only the
+    // upstream events-manager guard catches the empty (the older, weaker protection).
+    const warnings: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning') warnings.push(msg.text());
+    });
+
+    // logLevel=2 (Warn) so the SDK's loggerProvider.warn calls reach the console.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        logLevel: 2,
+      }),
+    );
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Drain the current-sequence slot so it exists with events:[] (the precondition
+    // for the SR-4284 root cause). blur → events-manager.sendCurrentSequenceEvents →
+    // store.storeCurrentSequence → IDB current-sequence row reset to {events:[], tabId}.
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Now mutate the DOM with a > 700 KB attribute. rrweb emits an incremental
+    // mutation event that, serialized, exceeds MAX_EVENT_LIST_SIZE. It lands in
+    // addEventToCurrentSequence on a slot that already exists with events:[] —
+    // shouldSplitEventsList's size-constraint branch fires on a zero-event buffer.
+    // Pre-fix this would have written events:[] into sequencesToSend; post-fix the
+    // store-layer guard catches it and emits the SR-4284 sampled warn.
+    await injectMidSizeNode(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 4);
+
+    // Drain again so the held mid-size event (parked in the slot by the post-fix
+    // "skip empty write, just claim slot" path) is promoted and sent. This is the
+    // post-fix behaviour: events aren't lost, just deferred to the next drain.
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 2);
+
+    // Assertion 1: the SR-4284 store-layer addEventToCurrentSequence guard fired.
+    // This is the strongest signal that the bug pathway was actually exercised AND
+    // caught at the store layer — not just the events-manager fallback cleanup.
+    expect(
+      warnings.some((w) => w.includes('Filtered empty session replay sequence at addEventToCurrentSequence')),
+    ).toBe(true);
+
+    // Assertion 2: no POST body had an empty events array.
+    expect(rawBodies.length).toBeGreaterThan(0);
+    for (const body of rawBodies) {
+      const events = decodeEvents(body);
+      expect(events.length).toBeGreaterThan(0);
+    }
+
+    // Assertion 3: the mid-size event still reached the wire. Without the fix, the
+    // empty row would have been written first and the real event held in the slot;
+    // with the fix, the real event still gets delivered on the next flush.
+    const allEvents = rawBodies.flatMap(decodeEvents);
+    const hasMidSizeEvent = rawBodies.some((b) => b.length > MAX_EVENT_LIST_SIZE);
+    expect(hasMidSizeEvent).toBe(true);
+    expect(allEvents.length).toBeGreaterThan(0);
   });
 });

--- a/packages/session-replay-browser/e2e/size-limits.spec.ts
+++ b/packages/session-replay-browser/e2e/size-limits.spec.ts
@@ -238,20 +238,22 @@ test.describe('empty batch leak (SR-4284)', () => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
     });
 
-    // Capture console.warn output. The SR-4284 store-layer guards emit a sampled
-    // (1-in-100, first hit deterministic) warn whose presence proves the guards
-    // actually fired — without this signal, the test would also pass when only the
-    // upstream events-manager guard catches the empty (the older, weaker protection).
-    const warnings: string[] = [];
+    // Capture console.log output. The SR-4284 store-layer guards emit a sampled
+    // (1-in-100, first hit deterministic) debug message whose presence proves the
+    // guards actually fired — without this signal, the test would also pass when
+    // only the upstream events-manager guard catches the empty (the older, weaker
+    // protection). The SDK's logger routes debug() to console.log (see Logger),
+    // so we capture 'log' type messages and filter for the [Debug] prefix.
+    const debugMessages: string[] = [];
     page.on('console', (msg) => {
-      if (msg.type() === 'warning') warnings.push(msg.text());
+      if (msg.type() === 'log' && msg.text().includes('[Debug]')) debugMessages.push(msg.text());
     });
 
-    // logLevel=2 (Warn) so the SDK's loggerProvider.warn calls reach the console.
+    // logLevel=4 (Debug) so the SDK's loggerProvider.debug calls reach the console.
     await page.goto(
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
-        logLevel: 2,
+        logLevel: 4,
       }),
     );
     await waitForReady(page);
@@ -284,7 +286,7 @@ test.describe('empty batch leak (SR-4284)', () => {
     // This is the strongest signal that the bug pathway was actually exercised AND
     // caught at the store layer — not just the events-manager fallback cleanup.
     expect(
-      warnings.some((w) => w.includes('Filtered empty session replay sequence at addEventToCurrentSequence')),
+      debugMessages.some((m) => m.includes('Filtered empty session replay sequence at addEventToCurrentSequence')),
     ).toBe(true);
 
     // Assertion 2: no POST body had an empty events array.

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -161,6 +161,17 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   private readonly consecutiveFailureThreshold: number;
   private consecutiveFailures = 0;
   private hasTriggeredFallback = false;
+  private emptyFilteredCount = 0;
+
+  // Sampled (1 in 100) warn so we can observe whether the store-layer guards are
+  // catching empty-batch cases that would otherwise hit the empty-body 400 path on
+  // the server. Per-store-instance counter (rather than Math.random) keeps the first
+  // hit deterministic for tests and dev consoles.
+  private maybeWarnEmptyFiltered(source: string) {
+    if (this.emptyFilteredCount++ % 100 === 0) {
+      this.loggerProvider.warn(`Filtered empty session replay sequence at ${source} (idb store)`);
+    }
+  }
 
   constructor(args: InstanceArgs) {
     super(args);
@@ -269,17 +280,25 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       let cursor = await tx.store.openCursor();
       while (cursor) {
         const { sessionId, events } = cursor.value;
-        // Return all completed sequences regardless of tabId.  Filtering by tab
-        // would cause event loss on page reload: a new store instance gets a
-        // fresh in-memory UUID and would never see sequences written by the
-        // previous instance.  Completed sequences are safe to flush by any
-        // tab/instance; the server deduplicates, and cleanUpSessionEventsStore
-        // on an already-deleted key is a no-op.
-        sequences.push({
-          events,
-          sequenceId: cursor.key,
-          sessionId,
-        });
+        // Skip empty persisted records. These can come from older SDK builds that
+        // wrote zero-event sequences via addEventToCurrentSequence's split path
+        // (when a single oversized event triggered a split with empty buffer);
+        // flushing them produces empty-body POSTs the server rejects with 400.
+        if (events.length === 0) {
+          this.maybeWarnEmptyFiltered('getSequencesToSend');
+        } else {
+          // Return all completed sequences regardless of tabId.  Filtering by tab
+          // would cause event loss on page reload: a new store instance gets a
+          // fresh in-memory UUID and would never see sequences written by the
+          // previous instance.  Completed sequences are safe to flush by any
+          // tab/instance; the server deduplicates, and cleanUpSessionEventsStore
+          // on an already-deleted key is a no-op.
+          sequences.push({
+            events,
+            sequenceId: cursor.key,
+            sessionId,
+          });
+        }
         cursor = await cursor.continue();
       }
 
@@ -333,8 +352,10 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
         return undefined;
       }
 
-      // Skip empty sequences — no point writing a zero-event row to sequencesToSend.
+      // Skip empty sequences — no point writing a zero-event row to sequencesToSend
+      // (would later POST as an empty body and 400 on the server).
       if (currentSequenceData.events.length === 0) {
+        this.maybeWarnEmptyFiltered('storeCurrentSequence');
         cancelTimeout();
         return undefined;
       }
@@ -441,6 +462,19 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       // Split path: reset sessionCurrentSequence and write the old events to
       // sequencesToSend atomically within the same transaction.
       const eventsToSend = ownedSequence.events;
+
+      // shouldSplitEventsList can return true with an empty buffer when a single
+      // incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB) — the size-constraint
+      // branch fires regardless of current length. Don't write a zero-event row to
+      // sequencesToSend (which would later POST as an empty body, the SR-4284 root
+      // cause); just claim the slot for the new event without finalizing anything.
+      if (eventsToSend.length === 0) {
+        await tx.objectStore(currentSequenceKey).put({ sessionId, events: [event], tabId: this.tabId });
+        this.recordSuccess();
+        cancelTimeout();
+        return undefined;
+      }
+
       await tx.objectStore(currentSequenceKey).put({ sessionId, events: [event], tabId: this.tabId });
       const sequenceId = await tx.objectStore(sequencesToSendKey).put({
         sessionId,

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -254,7 +254,11 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
     let timedOut = false;
     try {
       const sequences: SendingSequencesReturn<number>[] = [];
-      const tx = this.db.transaction('sequencesToSend');
+      // readwrite mode so we can prune stale empty rows in-place. Without that,
+      // older-SDK-persisted events:[] rows sit in IDB indefinitely and re-fire the
+      // sampled warn on every flush cycle, creating Datadog noise indistinguishable
+      // from active bug occurrences.
+      const tx = this.db.transaction('sequencesToSend', 'readwrite');
       // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
       // cursor traversal completes) are always handled without blocking the return path.
       // The errorLogged / timedOut flags prevent double-logging and double-recording
@@ -284,8 +288,12 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
         // wrote zero-event sequences via addEventToCurrentSequence's split path
         // (when a single oversized event triggered a split with empty buffer);
         // flushing them produces empty-body POSTs the server rejects with 400.
+        // Delete them in-place so they don't re-fire the sampled warn on every
+        // subsequent flush — by construction (this fix) we never write empty rows
+        // anymore, so any empty row is unambiguously stale.
         if (events.length === 0) {
           this.maybeWarnEmptyFiltered('getSequencesToSend');
+          await cursor.delete();
         } else {
           // Return all completed sequences regardless of tabId.  Filtering by tab
           // would cause event loss on page reload: a new store instance gets a

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -163,13 +163,14 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   private hasTriggeredFallback = false;
   private emptyFilteredCount = 0;
 
-  // Sampled (1 in 100) warn so we can observe whether the store-layer guards are
-  // catching empty-batch cases that would otherwise hit the empty-body 400 path on
-  // the server. Per-store-instance counter (rather than Math.random) keeps the first
-  // hit deterministic for tests and dev consoles.
-  private maybeWarnEmptyFiltered(source: string) {
+  // Sampled (1 in 100) debug log so we can observe whether the store-layer guards
+  // are catching empty-batch cases that would otherwise hit the empty-body 400 path
+  // on the server. Logged at debug, not warn — this is operational telemetry for
+  // post-deploy verification, not a customer-actionable warning. Per-store-instance
+  // counter (rather than Math.random) keeps the first hit deterministic for tests.
+  private maybeLogEmptyFiltered(source: string) {
     if (this.emptyFilteredCount++ % 100 === 0) {
-      this.loggerProvider.warn(`Filtered empty session replay sequence at ${source} (idb store)`);
+      this.loggerProvider.debug(`Filtered empty session replay sequence at ${source} (idb store)`);
     }
   }
 
@@ -256,7 +257,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       const sequences: SendingSequencesReturn<number>[] = [];
       // readwrite mode so we can prune stale empty rows in-place. Without that,
       // older-SDK-persisted events:[] rows sit in IDB indefinitely and re-fire the
-      // sampled warn on every flush cycle, creating Datadog noise indistinguishable
+      // sampled log on every flush cycle, creating Datadog noise indistinguishable
       // from active bug occurrences.
       const tx = this.db.transaction('sequencesToSend', 'readwrite');
       // Attach a catch handler immediately so tx.done rejections (e.g. AbortError after
@@ -288,11 +289,11 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
         // wrote zero-event sequences via addEventToCurrentSequence's split path
         // (when a single oversized event triggered a split with empty buffer);
         // flushing them produces empty-body POSTs the server rejects with 400.
-        // Delete them in-place so they don't re-fire the sampled warn on every
+        // Delete them in-place so they don't re-fire the sampled log on every
         // subsequent flush — by construction (this fix) we never write empty rows
         // anymore, so any empty row is unambiguously stale.
         if (events.length === 0) {
-          this.maybeWarnEmptyFiltered('getSequencesToSend');
+          this.maybeLogEmptyFiltered('getSequencesToSend');
           await cursor.delete();
         } else {
           // Return all completed sequences regardless of tabId.  Filtering by tab
@@ -363,7 +364,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       // Skip empty sequences — no point writing a zero-event row to sequencesToSend
       // (would later POST as an empty body and 400 on the server).
       if (currentSequenceData.events.length === 0) {
-        this.maybeWarnEmptyFiltered('storeCurrentSequence');
+        this.maybeLogEmptyFiltered('storeCurrentSequence');
         cancelTimeout();
         return undefined;
       }
@@ -480,7 +481,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       // Datadog can confirm the new SDK is actually preventing the bug at its source
       // (vs. only seeing leftover-state hits at the get/storeCurrentSequence layers).
       if (eventsToSend.length === 0) {
-        this.maybeWarnEmptyFiltered('addEventToCurrentSequence');
+        this.maybeLogEmptyFiltered('addEventToCurrentSequence');
         await tx.objectStore(currentSequenceKey).put({ sessionId, events: [event], tabId: this.tabId });
         this.recordSuccess();
         cancelTimeout();

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -468,7 +468,11 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       // branch fires regardless of current length. Don't write a zero-event row to
       // sequencesToSend (which would later POST as an empty body, the SR-4284 root
       // cause); just claim the slot for the new event without finalizing anything.
+      // This is the *primary* root-cause filter site: warn here so post-deploy
+      // Datadog can confirm the new SDK is actually preventing the bug at its source
+      // (vs. only seeing leftover-state hits at the get/storeCurrentSequence layers).
       if (eventsToSend.length === 0) {
+        this.maybeWarnEmptyFiltered('addEventToCurrentSequence');
         await tx.objectStore(currentSequenceKey).put({ sessionId, events: [event], tabId: this.tabId });
         this.recordSuccess();
         cancelTimeout();

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -33,7 +33,13 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     const result: SendingSequencesReturn<number>[] = [];
     for (const [sequenceId, { sessionId, events }] of Object.entries(this.finalizedSequences)) {
       if (events.length === 0) {
+        // Prune in-place for consistency with the IDB store: by construction we
+        // never write empty sequences anymore, so any empty entry is unambiguously
+        // stale residue. Without the delete, every subsequent getSequencesToSend
+        // would re-iterate the empty entry and re-fire the sampled warn, producing
+        // repeated noise that's indistinguishable from active bug occurrences.
         this.maybeWarnEmptyFiltered('getSequencesToSend');
+        delete this.finalizedSequences[Number(sequenceId)];
         continue;
       }
       result.push({ sequenceId: Number(sequenceId), sessionId, events });

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -43,7 +43,13 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
 
   async storeCurrentSequence(sessionId: string | number): Promise<SendingSequencesReturn<number> | undefined> {
     const buffered = this.sequences[sessionId];
-    if (!buffered || buffered.length === 0) {
+    if (!buffered) {
+      return undefined;
+    }
+    if (buffered.length === 0) {
+      // Slot exists but is empty (e.g. drained by a prior storeCurrentSequence then
+      // re-flushed before any new event landed). Don't finalize a zero-event row.
+      this.maybeWarnEmptyFiltered('storeCurrentSequence');
       return undefined;
     }
     return this.addSequence(sessionId);
@@ -58,13 +64,18 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     }
 
     let sequenceReturn: SendingSequencesReturn<number> | undefined;
-    // Only finalize a split batch when there's something to send. shouldSplitEventsList
-    // can return true with an empty buffer when a single incoming event is larger than
-    // MAX_EVENT_LIST_SIZE (700 KB) — the size-constraint branch fires regardless of
-    // current length. Without this guard we'd finalize an empty sequence that the
-    // network layer would later POST as an empty body (the SR-4284 root cause).
-    if (this.sequences[sessionId].length > 0 && this.shouldSplitEventsList(this.sequences[sessionId], event)) {
-      sequenceReturn = this.addSequence(sessionId);
+    // shouldSplitEventsList can return true with an empty buffer when a single
+    // incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB) — the size-constraint
+    // branch fires regardless of current length. Don't finalize a zero-event sequence
+    // (the SR-4284 root cause); just hold the incoming event in the buffer.
+    // shouldSplitEventsList's time-elapsed branch only fires when events.length > 0
+    // (see base-events-store.ts), so calling it on an empty buffer has no side effects.
+    if (this.shouldSplitEventsList(this.sequences[sessionId], event)) {
+      if (this.sequences[sessionId].length === 0) {
+        this.maybeWarnEmptyFiltered('addEventToCurrentSequence');
+      } else {
+        sequenceReturn = this.addSequence(sessionId);
+      }
     }
 
     this.sequences[sessionId].push(event);

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -19,13 +19,14 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     return { sequenceId, events, sessionId };
   }
 
-  // Sampled (1 in 100) warn so we can observe whether the store-layer guards are
-  // actually catching cases that would otherwise hit the empty-body 400 path on the
-  // server. Per-store-instance counter rather than Math.random keeps the first hit
-  // deterministic for tests and visible in dev consoles.
-  private maybeWarnEmptyFiltered(source: string) {
+  // Sampled (1 in 100) debug log so we can observe whether the store-layer guards
+  // are actually catching cases that would otherwise hit the empty-body 400 path on
+  // the server. Logged at debug, not warn — this is operational telemetry for
+  // post-deploy verification, not a customer-actionable warning. Per-store-instance
+  // counter rather than Math.random keeps the first hit deterministic for tests.
+  private maybeLogEmptyFiltered(source: string) {
     if (this.emptyFilteredCount++ % 100 === 0) {
-      this.loggerProvider.warn(`Filtered empty session replay sequence at ${source} (in-memory store)`);
+      this.loggerProvider.debug(`Filtered empty session replay sequence at ${source} (in-memory store)`);
     }
   }
 
@@ -36,9 +37,9 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
         // Prune in-place for consistency with the IDB store: by construction we
         // never write empty sequences anymore, so any empty entry is unambiguously
         // stale residue. Without the delete, every subsequent getSequencesToSend
-        // would re-iterate the empty entry and re-fire the sampled warn, producing
+        // would re-iterate the empty entry and re-fire the sampled log, producing
         // repeated noise that's indistinguishable from active bug occurrences.
-        this.maybeWarnEmptyFiltered('getSequencesToSend');
+        this.maybeLogEmptyFiltered('getSequencesToSend');
         delete this.finalizedSequences[Number(sequenceId)];
         continue;
       }
@@ -55,7 +56,7 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     if (buffered.length === 0) {
       // Slot exists but is empty (e.g. drained by a prior storeCurrentSequence then
       // re-flushed before any new event landed). Don't finalize a zero-event row.
-      this.maybeWarnEmptyFiltered('storeCurrentSequence');
+      this.maybeLogEmptyFiltered('storeCurrentSequence');
       return undefined;
     }
     return this.addSequence(sessionId);
@@ -78,7 +79,7 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     // (see base-events-store.ts), so calling it on an empty buffer has no side effects.
     if (this.shouldSplitEventsList(this.sequences[sessionId], event)) {
       if (this.sequences[sessionId].length === 0) {
-        this.maybeWarnEmptyFiltered('addEventToCurrentSequence');
+        this.maybeLogEmptyFiltered('addEventToCurrentSequence');
       } else {
         sequenceReturn = this.addSequence(sessionId);
       }

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -5,6 +5,7 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
   private finalizedSequences: Record<number, { sessionId: string | number; events: string[] }> = {};
   private sequences: Record<string | number, string[]> = {};
   private sequenceId = 0;
+  private emptyFilteredCount = 0;
 
   private resetCurrentSequence(sessionId: string | number) {
     this.sequences[sessionId] = [];
@@ -18,16 +19,31 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     return { sequenceId, events, sessionId };
   }
 
+  // Sampled (1 in 100) warn so we can observe whether the store-layer guards are
+  // actually catching cases that would otherwise hit the empty-body 400 path on the
+  // server. Per-store-instance counter rather than Math.random keeps the first hit
+  // deterministic for tests and visible in dev consoles.
+  private maybeWarnEmptyFiltered(source: string) {
+    if (this.emptyFilteredCount++ % 100 === 0) {
+      this.loggerProvider.warn(`Filtered empty session replay sequence at ${source} (in-memory store)`);
+    }
+  }
+
   async getSequencesToSend(): Promise<SendingSequencesReturn<number>[] | undefined> {
-    return Object.entries(this.finalizedSequences).map(([sequenceId, { sessionId, events }]) => ({
-      sequenceId: Number(sequenceId),
-      sessionId,
-      events,
-    }));
+    const result: SendingSequencesReturn<number>[] = [];
+    for (const [sequenceId, { sessionId, events }] of Object.entries(this.finalizedSequences)) {
+      if (events.length === 0) {
+        this.maybeWarnEmptyFiltered('getSequencesToSend');
+        continue;
+      }
+      result.push({ sequenceId: Number(sequenceId), sessionId, events });
+    }
+    return result;
   }
 
   async storeCurrentSequence(sessionId: string | number): Promise<SendingSequencesReturn<number> | undefined> {
-    if (!this.sequences[sessionId]) {
+    const buffered = this.sequences[sessionId];
+    if (!buffered || buffered.length === 0) {
       return undefined;
     }
     return this.addSequence(sessionId);
@@ -42,7 +58,12 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
     }
 
     let sequenceReturn: SendingSequencesReturn<number> | undefined;
-    if (this.shouldSplitEventsList(this.sequences[sessionId], event)) {
+    // Only finalize a split batch when there's something to send. shouldSplitEventsList
+    // can return true with an empty buffer when a single incoming event is larger than
+    // MAX_EVENT_LIST_SIZE (700 KB) — the size-constraint branch fires regardless of
+    // current length. Without this guard we'd finalize an empty sequence that the
+    // network layer would later POST as an empty body (the SR-4284 root cause).
+    if (this.sequences[sessionId].length > 0 && this.shouldSplitEventsList(this.sequences[sessionId], event)) {
       sequenceReturn = this.addSequence(sessionId);
     }
 

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -384,6 +384,15 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       };
 
       const serverUrl = `${getServerUrl(context.serverZone, this.trackServerUrl)}?${urlParams.toString()}`;
+      // Final defensive guard: never POST a zero-event payload. Upper layers (events-manager
+      // oversize filter, send()'s post-batcher check, store-layer filters) should already
+      // have caught this — but SR-4284 fleet logs show ~416 empty-body 400s/24h slipping
+      // through somehow, so a cheap belt-and-braces check immediately before fetch prevents
+      // any future regression from re-introducing the same server rejection.
+      if (payload.events.length === 0) {
+        this.completeRequest({ context });
+        return;
+      }
       const res = await fetch(serverUrl, options);
       if (res === null) {
         this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE });

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -89,6 +89,26 @@ describe('SessionReplayEventsIDBStore', () => {
         },
       ]);
     });
+    // SR-4284: IDB drain on init can encounter sequencesToSend rows with events:[]
+    // that older SDK builds persisted (e.g. via the addEventToCurrentSequence
+    // split-with-empty-buffer path before the SR-4284 fix). Those rows must be
+    // filtered out so the network layer never POSTs an empty body.
+    test('filters out empty sequences (stale records persisted by older SDK builds)', async () => {
+      const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      await eventsStorage?.storeSendingEvents(123, []);
+      await eventsStorage?.storeSendingEvents(456, [mockEventString]);
+      await eventsStorage?.storeSendingEvents(789, []);
+
+      const unsentSequences = await eventsStorage?.getSequencesToSend();
+      expect(unsentSequences).toEqual([{ sessionId: 456, sequenceId: 2, events: [mockEventString] }]);
+      // Sampled warn (1-of-100, first hit deterministic) should fire when filter triggers.
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered empty session replay sequence'),
+      );
+    });
     test('should handle undefined store', async () => {
       mockStoreForError();
       const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
@@ -176,6 +196,28 @@ describe('SessionReplayEventsIDBStore', () => {
 
       expect(sequenceData).toBeUndefined();
     });
+    // SR-4284: a current-sequence record with events:[] should NOT be promoted to
+    // sequencesToSend (would POST as an empty body and 400 on the server).
+    test('returns undefined when current-sequence record exists with zero events', async () => {
+      const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+
+      // Seed a session row, then split it so the current-sequence slot is reset
+      // to events:[] but still owned by this tab.
+      eventsStorage!.shouldSplitEventsList = jest.fn().mockReturnValue(false);
+      await eventsStorage?.addEventToCurrentSequence(123, mockEventString);
+      await eventsStorage?.storeCurrentSequence(123);
+      // After storeCurrentSequence the current-sequence slot for 123 is { events: [], tabId }.
+
+      const sequenceData = await eventsStorage?.storeCurrentSequence(123);
+      expect(sequenceData).toBeUndefined();
+      // Sampled warn (1-of-100, deterministic on first hit) should have fired.
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered empty session replay sequence'),
+      );
+    });
     test('should catch errors', async () => {
       mockStoreForError();
       const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
@@ -243,6 +285,42 @@ describe('SessionReplayEventsIDBStore', () => {
       expect(eventsToSend).toEqual({ sessionId: 123, events: [mockEventString], sequenceId: 1 });
       const allSessionCurrentSequence = await eventsStorage?.getCurrentSequenceEvents(123);
       expect(allSessionCurrentSequence).toEqual([{ events: [mockEventString2], sessionId: 123 }]);
+    });
+
+    // SR-4284: shouldSplitEventsList can return true with an empty buffer when a
+    // single incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB) — the size
+    // branch fires regardless of current length. The split path must NOT write a
+    // zero-event row to sequencesToSend; just claim the slot for the incoming event.
+    test('does not write empty sequencesToSend row when split fires on empty buffer', async () => {
+      const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: mockLoggerProvider,
+      });
+      // Set up the precondition: an existing current-sequence row owned by this tab
+      // with events:[]. addEventToCurrentSequence's first-time path (no record) won't
+      // exercise the split branch — we need an existing empty slot.
+      eventsStorage!.shouldSplitEventsList = jest.fn().mockReturnValue(false);
+      await eventsStorage?.addEventToCurrentSequence(123, mockEventString);
+      await eventsStorage?.storeCurrentSequence(123);
+      // Slot is now { events: [], tabId } and sequencesToSend has 1 row (sequenceId=1).
+
+      // Now flip shouldSplit to true and add a new event — the split path will run
+      // with eventsToSend=[]. Without the SR-4284 fix this writes an empty row.
+      eventsStorage!.shouldSplitEventsList = jest.fn().mockReturnValue(true);
+      const result = await eventsStorage?.addEventToCurrentSequence(123, mockEventString2);
+
+      // No completed sequence returned (nothing was finalized).
+      expect(result).toBeUndefined();
+      // The incoming event is held in the current-sequence slot for next time.
+      const allSessionCurrentSequence = await eventsStorage?.getCurrentSequenceEvents(123);
+      expect(allSessionCurrentSequence).toEqual([{ events: [mockEventString2], sessionId: 123 }]);
+      // Inspect raw DB directly — the getSequencesToSend filter would mask a buggy
+      // empty write, so we open a cursor and count rows ourselves.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rawDb = (eventsStorage as any).db as IDBPDatabase<SessionReplayDB>;
+      const allRows = await rawDb.getAll('sequencesToSend');
+      expect(allRows).toHaveLength(1);
+      expect(allRows[0].events).toEqual([mockEventString]);
     });
 
     test('should split the events list at max size and send', async () => {

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -321,6 +321,11 @@ describe('SessionReplayEventsIDBStore', () => {
       const allRows = await rawDb.getAll('sequencesToSend');
       expect(allRows).toHaveLength(1);
       expect(allRows[0].events).toEqual([mockEventString]);
+      // Sampled warn fires at the root-cause filter site so post-deploy Datadog can
+      // confirm the new SDK is preventing the bug at its source.
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered empty session replay sequence at addEventToCurrentSequence'),
+      );
     });
 
     test('should split the events list at max size and send', async () => {

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -93,7 +93,7 @@ describe('SessionReplayEventsIDBStore', () => {
     // that older SDK builds persisted (e.g. via the addEventToCurrentSequence
     // split-with-empty-buffer path before the SR-4284 fix). Those rows must be
     // filtered out so the network layer never POSTs an empty body.
-    test('filters out empty sequences (stale records persisted by older SDK builds)', async () => {
+    test('filters out and deletes empty sequences (stale records persisted by older SDK builds)', async () => {
       const eventsStorage = await SessionReplayEventsIDBStore.new('replay', {
         apiKey,
         loggerProvider: mockLoggerProvider,
@@ -108,6 +108,20 @@ describe('SessionReplayEventsIDBStore', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence'),
       );
+
+      // The empty rows should have been pruned in-place — a second call must
+      // see them gone and not re-fire the sampled warn (otherwise older-SDK
+      // residue produces Datadog noise indefinitely across page reloads).
+      (mockLoggerProvider.warn as jest.Mock).mockClear();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rawDb = (eventsStorage as any).db as IDBPDatabase<SessionReplayDB>;
+      const allRows = await rawDb.getAll('sequencesToSend');
+      expect(allRows).toHaveLength(1);
+      expect(allRows[0].events).toEqual([mockEventString]);
+
+      const second = await eventsStorage?.getSequencesToSend();
+      expect(second).toEqual([{ sessionId: 456, sequenceId: 2, events: [mockEventString] }]);
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
     });
     test('should handle undefined store', async () => {
       mockStoreForError();

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -105,14 +105,14 @@ describe('SessionReplayEventsIDBStore', () => {
       const unsentSequences = await eventsStorage?.getSequencesToSend();
       expect(unsentSequences).toEqual([{ sessionId: 456, sequenceId: 2, events: [mockEventString] }]);
       // Sampled warn (1-of-100, first hit deterministic) should fire when filter triggers.
-      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence'),
       );
 
       // The empty rows should have been pruned in-place — a second call must
       // see them gone and not re-fire the sampled warn (otherwise older-SDK
       // residue produces Datadog noise indefinitely across page reloads).
-      (mockLoggerProvider.warn as jest.Mock).mockClear();
+      (mockLoggerProvider.debug as jest.Mock).mockClear();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const rawDb = (eventsStorage as any).db as IDBPDatabase<SessionReplayDB>;
       const allRows = await rawDb.getAll('sequencesToSend');
@@ -121,7 +121,7 @@ describe('SessionReplayEventsIDBStore', () => {
 
       const second = await eventsStorage?.getSequencesToSend();
       expect(second).toEqual([{ sessionId: 456, sequenceId: 2, events: [mockEventString] }]);
-      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
+      expect(mockLoggerProvider.debug).not.toHaveBeenCalled();
     });
     test('should handle undefined store', async () => {
       mockStoreForError();
@@ -228,7 +228,7 @@ describe('SessionReplayEventsIDBStore', () => {
       const sequenceData = await eventsStorage?.storeCurrentSequence(123);
       expect(sequenceData).toBeUndefined();
       // Sampled warn (1-of-100, deterministic on first hit) should have fired.
-      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence'),
       );
     });
@@ -337,7 +337,7 @@ describe('SessionReplayEventsIDBStore', () => {
       expect(allRows[0].events).toEqual([mockEventString]);
       // Sampled warn fires at the root-cause filter site so post-deploy Datadog can
       // confirm the new SDK is preventing the bug at its source.
-      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence at addEventToCurrentSequence'),
       );
     });

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -66,11 +66,11 @@ describe('InMemoryEventsStore', () => {
       // Now buffer for sessionId is [] (touched, empty). Reset the warn spy so we
       // only see calls from the next operation.
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      (mockLoggerProvider.warn as jest.Mock).mockClear();
+      (mockLoggerProvider.debug as jest.Mock).mockClear();
 
       expect(await store.storeCurrentSequence(sessionId)).toBeUndefined();
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence at storeCurrentSequence'),
       );
     });
@@ -107,7 +107,7 @@ describe('InMemoryEventsStore', () => {
       expect(sequences).toHaveLength(1);
       expect(sequences[0].events).toStrictEqual(['real']);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence'),
       );
 
@@ -115,11 +115,11 @@ describe('InMemoryEventsStore', () => {
       // and not re-fire the sampled warn, otherwise old residue produces noise
       // indefinitely on every flush cycle.
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      (mockLoggerProvider.warn as jest.Mock).mockClear();
+      (mockLoggerProvider.debug as jest.Mock).mockClear();
       const second = (await store.getSequencesToSend())!;
       expect(second).toHaveLength(1);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
+      expect(mockLoggerProvider.debug).not.toHaveBeenCalled();
     });
   });
 
@@ -131,7 +131,7 @@ describe('InMemoryEventsStore', () => {
     // empty body and 400s on the server.
     test('does not finalize a zero-event sequence when buffer is empty', async () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      (mockLoggerProvider.warn as jest.Mock).mockClear();
+      (mockLoggerProvider.debug as jest.Mock).mockClear();
       store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
       const result = await store.addEventToCurrentSequence(sessionId, 'huge-event');
       expect(result).toBeUndefined();
@@ -139,7 +139,7 @@ describe('InMemoryEventsStore', () => {
       // Sampled warn fires at the root-cause filter site so post-deploy Datadog can
       // confirm the new SDK is preventing the bug at its source.
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+      expect(mockLoggerProvider.debug).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence at addEventToCurrentSequence'),
       );
     });

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -55,6 +55,21 @@ describe('InMemoryEventsStore', () => {
       expect(events).toStrictEqual(['test']);
       expect(sequenceSessionId).toStrictEqual(sessionId);
     });
+
+    // SR-4284: storeCurrentSequence on a session with a touched-but-empty buffer
+    // (e.g. addEventToCurrentSequence then a flush draining the buffer) should NOT
+    // finalize a zero-event sequence — that's the empty-body 400 root cause.
+    test('returns undefined when buffer exists but is empty', async () => {
+      // Touch the buffer so this.sequences[sessionId] exists, then drain it via split.
+      store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
+      await store.addEventToCurrentSequence(sessionId, 'first');
+      // After the split a second event creates a finalized sequence and resets buffer.
+      await store.addEventToCurrentSequence(sessionId, 'second');
+      // Pop the buffered 'second' event by finalizing once — leaves the slot empty but defined.
+      await store.storeCurrentSequence(sessionId);
+      // Now buffer for sessionId is [] (touched, empty).
+      expect(await store.storeCurrentSequence(sessionId)).toBeUndefined();
+    });
   });
 
   describe('getSequencesToSend', () => {
@@ -72,6 +87,39 @@ describe('InMemoryEventsStore', () => {
       expect(sequenceId).toBe(0);
       expect(events).toStrictEqual(['test']);
       expect(sequenceSessionId).toStrictEqual(sessionId);
+    });
+
+    // SR-4284: empty finalized sequences (e.g. drained from a previous SDK build via
+    // storeSendingEvents, or from a future regression) must not be returned to the
+    // network layer — they would POST as empty bodies and 400 on the server.
+    test('filters out empty finalized sequences', async () => {
+      // storeSendingEvents accepts any events array, including the [] case that older
+      // SDK builds could emit via the split-with-empty-buffer path.
+      await store.storeSendingEvents(sessionId, []);
+      await store.storeSendingEvents(sessionId, ['real']);
+      await store.storeSendingEvents(sessionId, []);
+
+      const sequences = (await store.getSequencesToSend())!;
+      expect(sequences).toHaveLength(1);
+      expect(sequences[0].events).toStrictEqual(['real']);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered empty session replay sequence'),
+      );
+    });
+  });
+
+  describe('addEventToCurrentSequence empty-buffer split guard (SR-4284)', () => {
+    // Repro for the SR-4284 root cause: shouldSplitEventsList can return true even when
+    // the current buffer is empty, because the size-constraint branch fires when a
+    // single incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB). Without the
+    // guard, addSequence would finalize a zero-event sequence that later POSTs as an
+    // empty body and 400s on the server.
+    test('does not finalize a zero-event sequence when buffer is empty', async () => {
+      store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
+      const result = await store.addEventToCurrentSequence(sessionId, 'huge-event');
+      expect(result).toBeUndefined();
+      expect(await store.getSequencesToSend()).toStrictEqual([]);
     });
   });
 

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -59,16 +59,20 @@ describe('InMemoryEventsStore', () => {
     // SR-4284: storeCurrentSequence on a session with a touched-but-empty buffer
     // (e.g. addEventToCurrentSequence then a flush draining the buffer) should NOT
     // finalize a zero-event sequence — that's the empty-body 400 root cause.
-    test('returns undefined when buffer exists but is empty', async () => {
-      // Touch the buffer so this.sequences[sessionId] exists, then drain it via split.
-      store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
+    test('returns undefined and warns when buffer exists but is empty', async () => {
+      // Touch the buffer with a single event, then drain it via storeCurrentSequence.
       await store.addEventToCurrentSequence(sessionId, 'first');
-      // After the split a second event creates a finalized sequence and resets buffer.
-      await store.addEventToCurrentSequence(sessionId, 'second');
-      // Pop the buffered 'second' event by finalizing once — leaves the slot empty but defined.
       await store.storeCurrentSequence(sessionId);
-      // Now buffer for sessionId is [] (touched, empty).
+      // Now buffer for sessionId is [] (touched, empty). Reset the warn spy so we
+      // only see calls from the next operation.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      (mockLoggerProvider.warn as jest.Mock).mockClear();
+
       expect(await store.storeCurrentSequence(sessionId)).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered empty session replay sequence at storeCurrentSequence'),
+      );
     });
   });
 
@@ -116,10 +120,18 @@ describe('InMemoryEventsStore', () => {
     // guard, addSequence would finalize a zero-event sequence that later POSTs as an
     // empty body and 400s on the server.
     test('does not finalize a zero-event sequence when buffer is empty', async () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      (mockLoggerProvider.warn as jest.Mock).mockClear();
       store.shouldSplitEventsList = jest.fn().mockReturnValue(true);
       const result = await store.addEventToCurrentSequence(sessionId, 'huge-event');
       expect(result).toBeUndefined();
       expect(await store.getSequencesToSend()).toStrictEqual([]);
+      // Sampled warn fires at the root-cause filter site so post-deploy Datadog can
+      // confirm the new SDK is preventing the bug at its source.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered empty session replay sequence at addEventToCurrentSequence'),
+      );
     });
   });
 

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -96,7 +96,7 @@ describe('InMemoryEventsStore', () => {
     // SR-4284: empty finalized sequences (e.g. drained from a previous SDK build via
     // storeSendingEvents, or from a future regression) must not be returned to the
     // network layer — they would POST as empty bodies and 400 on the server.
-    test('filters out empty finalized sequences', async () => {
+    test('filters out and prunes empty finalized sequences', async () => {
       // storeSendingEvents accepts any events array, including the [] case that older
       // SDK builds could emit via the split-with-empty-buffer path.
       await store.storeSendingEvents(sessionId, []);
@@ -110,6 +110,16 @@ describe('InMemoryEventsStore', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
         expect.stringContaining('Filtered empty session replay sequence'),
       );
+
+      // Empty entries should have been pruned — a second call must see them gone
+      // and not re-fire the sampled warn, otherwise old residue produces noise
+      // indefinitely on every flush cycle.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      (mockLoggerProvider.warn as jest.Mock).mockClear();
+      const second = (await store.getSequencesToSend())!;
+      expect(second).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -274,6 +274,31 @@ describe('SessionReplayTrackDestination', () => {
       await trackDestination.send(context);
       expect(fetch).not.toHaveBeenCalled();
     });
+    // SR-4284: defensive belt-and-braces guard immediately before fetch. The send()
+    // post-batcher check at the top is the primary line of defense, but a payloadBatcher
+    // that strips events to zero AFTER that check (or any future regression) must still
+    // not produce an empty-body POST. We invoke sendOnMainThread directly with an empty
+    // payload to exercise the literal pre-fetch guard rather than the upstream check.
+    test('pre-fetch guard skips fetch when payload events array is empty', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const context: SessionReplayDestinationContext = {
+        events: [mockEventString],
+        sessionId: 123,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 1,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        type: 'replay',
+        apiKey,
+        onComplete: mockOnComplete,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (trackDestination as any).sendOnMainThread(apiKey, '1a2b3c', context, { version: 1, events: [] }, false);
+      expect(fetch).not.toHaveBeenCalled();
+      expect(mockOnComplete).toHaveBeenCalled();
+    });
     test('should not send anything if api key not set', async () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       trackDestination.loggerProvider = mockLoggerProvider;


### PR DESCRIPTION
## Summary

Fixes [SR-4284](https://linear.app/amplitude/issue/SR-4284). `SessionReplayServletV2` is rejecting ~416 POSTs/24h with `Empty request body` (HTTP 400) across the fleet. The SDK is `fetch()`-ing with a body containing zero events. Volume is small but it spans many SDK versions.

## Root cause

`shouldSplitEventsList` returns `true` via the size-constraint branch whenever a single incoming event exceeds `MAX_EVENT_LIST_SIZE` (700 KB), **regardless of the current buffer length**. When `addEventToCurrentSequence` runs that branch with an empty buffer, the split path finalizes a zero-event sequence into `sequencesToSend`. That row is later flushed and POSTed as an empty body.

## Changes

Store-layer hardening for both `InMemoryEventsStore` and `SessionReplayEventsIDBStore`:

- **`addEventToCurrentSequence` split path** — skips finalize when buffer is empty. *Primary root-cause fix.*
- **`storeCurrentSequence`** — returns `undefined` when nothing's buffered (memory store was missing the length check; idb store already guarded but now logs).
- **`getSequencesToSend`** — filters out `events: []` rows. Catches stale persisted records from older SDK builds during IDB drain on init.
- **Sampled (1-in-100) `loggerProvider.warn`** at every filter site — so post-deploy Datadog can confirm the guards are catching real cases.

Defensive `if (!events.length) return` in `track-destination.ts` immediately before `fetch(...)` — cheap belt-and-braces against any future regression.

## Test plan

- [x] `pnpm test` — 913 passing, 100% coverage maintained
- [x] `pnpm lint` — clean (only pre-existing warnings)
- [x] Tests cover all four filter sites (split-with-empty, storeCurrentSequence-on-empty, getSequencesToSend filter, pre-fetch guard) for both store backends
- [ ] After merge + rollout: re-query Datadog `service:session-replay-uploader "Empty request body"` and confirm volume drops materially

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session replay persistence and send paths (IDB/memory stores and final `fetch`), so regressions could affect delivery or flushing behavior, though changes are narrowly scoped to filtering empty sequences with added tests.
> 
> **Overview**
> Prevents session replay from ever persisting or POSTing **empty event batches** (fix for SR-4284).
> 
> Adds store-layer guards in both `SessionReplayEventsIDBStore` and `InMemoryEventsStore` to avoid finalizing `events: []` on split/flush, and to filter+prune any previously persisted empty sequences during `getSequencesToSend` (with sampled debug logging for verification).
> 
> Adds a final pre-`fetch` defensive check in `track-destination.ts` to skip sending if the payload’s `events` array is empty, and expands unit + e2e coverage to reproduce the drained-slot/oversize split scenario and assert no empty-body requests are made.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7047131056fe2db5917bf92a818fdda8997fec58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->