### PR TITLE
fix(session-replay-browser): merge queued sends after throttle pause (SR-4286)

### DIFF
--- a/packages/session-replay-browser/e2e/playwright.config.ts
+++ b/packages/session-replay-browser/e2e/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: '.',
   testMatch: '*.spec.ts',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
     trace: 'on-first-retry',
     actionTimeout: 30_000,
     navigationTimeout: 30_000,

--- a/packages/session-replay-browser/e2e/throttle-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/throttle-merge.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  readRouteBody,
+} from './helpers';
+
+/**
+ * Mocks the track API with a flag-driven response. While `throttle.value === true`, every
+ * 200 carries the X-Session-Replay-Event-Skipped: 429 header (server-side throttle signal).
+ * Toggling false has subsequent calls return clean 200s.
+ *
+ * Captures the bodies of *fetch* POSTs only — sendBeacon payloads use `version: 2` and are
+ * filtered out so beacon traffic (which bypasses trackDestination's queue and the pause)
+ * doesn't pollute the assertions about post-throttle merge behavior.
+ */
+async function mockTrackApiWithToggleableThrottle(
+  page: Page,
+): Promise<{ getFetchBodies: () => string[]; throttle: { value: boolean } }> {
+  const fetchBodies: string[] = [];
+  const throttle = { value: true };
+  await page.route('https://api-sr.amplitude.com/**', (route: Route) => {
+    const body = readRouteBody(route);
+    // sendBeacon payloads are tagged version: 2 and bypass trackDestination's queue;
+    // trackDestination fetch payloads are version: 1. The merge logic only applies to
+    // the fetch path, so beacon traffic is filtered out of the assertion stream.
+    let isFetchPath = true;
+    try {
+      const parsed = JSON.parse(body) as { version?: number };
+      if (parsed.version === 2) isFetchPath = false;
+    } catch {
+      // Non-JSON body — treat as fetch path (defensive; shouldn't happen in practice).
+    }
+    if (isFetchPath) fetchBodies.push(body);
+    // Echo origin for the credentialed CORS preflight; `*` is rejected when the request
+    // carries credentials, which Chrome does for SR's Authorization-bearing fetches.
+    const requestOrigin = route.request().headers()['origin'] ?? '*';
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': requestOrigin,
+      'Access-Control-Allow-Credentials': 'true',
+      // Without exposing this header, the browser strips it from the page-visible
+      // response and the SDK can't read the throttle directive.
+      'Access-Control-Expose-Headers': 'X-Session-Replay-Event-Skipped',
+    };
+    if (throttle.value) {
+      headers['X-Session-Replay-Event-Skipped'] = '429';
+    }
+    return route.fulfill({ status: 200, headers, body: 'success' });
+  });
+  return { getFetchBodies: () => fetchBodies, throttle };
+}
+
+/**
+ * Continuously generates DOM mutations and pointer events for `durationMs`, embedding the
+ * marker text in the input value. The mutations flow through rrweb → eventCompressor →
+ * events store, and time-based sequence splits (MIN_INTERVAL=500ms, growing) push completed
+ * sequences into trackDestination.queue via addToQueue. We avoid `pagehide`/`blur` entirely
+ * because pagehide triggers `sendBeacon` (which bypasses the throttle pause), and blur fails
+ * to drain the eventCompressor's idle queue.
+ */
+async function continuousActivity(page: Page, marker: string, durationMs: number): Promise<void> {
+  await page.evaluate(
+    ({ tag, ms }) => {
+      // Add a marker div with the .amp-unmask class so the marker text survives SR's
+      // input-masking privacy filter (which would otherwise replace the text with
+      // asterisks and erase any per-cycle distinction). Each cycle appends its own
+      // marker as a fresh DOM mutation event, so the merged POST body contains all
+      // three when coalescing worked.
+      const markerDiv = document.createElement('div');
+      markerDiv.className = 'amp-unmask';
+      markerDiv.textContent = tag;
+      markerDiv.id = `marker-div-${tag}`;
+      document.body.appendChild(markerDiv);
+
+      return new Promise<void>((resolve) => {
+        const start = Date.now();
+        let i = 0;
+        const tick = () => {
+          if (Date.now() - start >= ms) return resolve();
+          const input = document.getElementById('test-input') as HTMLInputElement | null;
+          if (input) {
+            // Input values are masked but the events still flow through rrweb, so we
+            // get the time-based sequence splits we need.
+            input.value = `iter-${i++}`;
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+          document.getElementById('test-button')?.click();
+          // ~20 mutations/sec — fast enough to keep events flowing through every
+          // sequence-split interval, but light enough to be deterministic.
+          setTimeout(tick, 50);
+        };
+        tick();
+      });
+    },
+    { tag: marker, ms: durationMs },
+  );
+}
+
+test.describe('post-throttle release merges queued sends (SR-4286)', () => {
+  test('multiple sequences enqueued during the throttle pause collapse into one POST on manual flush', async ({
+    page,
+  }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getFetchBodies, throttle } = await mockTrackApiWithToggleableThrottle(page);
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    // Generous settle window: rrweb captures the full snapshot, the metadata/debug-info
+    // events flow through eventCompressor's idle queue, and the first natural sequence
+    // split fires. Each fetch POST during this window gets the throttle header, so by
+    // the time we leave this stage, flushPauseUntilMs is set ~60s ahead.
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 4);
+    const baseline = getFetchBodies().length;
+    expect(baseline).toBeGreaterThan(0);
+
+    // Drive ~3 seconds of continuous activity with three distinct markers. The events
+    // flow naturally into the events store; the time-based split logic
+    // (MIN_INTERVAL=500ms, growing) creates multiple sequence boundaries → multiple
+    // addToQueue calls. addToQueue→schedule(0) sees the pause and defers (60s) +
+    // sets mergeOnNextFlush. The first call schedules the timer; subsequent
+    // addToQueues just append to the queue (the early-return on `if (this.scheduled)`).
+    await continuousActivity(page, 'marker-A', 1000);
+    await continuousActivity(page, 'marker-B', 1000);
+    await continuousActivity(page, 'marker-C', 1000);
+
+    // Nothing new should have been sent during the pause — the deferred timer is 60s out.
+    expect(getFetchBodies().length).toBe(baseline);
+
+    // Flip to clean 200 mode, then manually flush. flush() bypasses the deferred timer,
+    // consumes mergeOnNextFlush, merges all queued same-(session,device,api,type) contexts
+    // into a single POST, sends it.
+    throttle.value = false;
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Pre-fix: would be +N POSTs (one per queued context, where N = number of sequence
+    // splits that fired during the activity window). Post-fix: exactly +1 merged POST.
+    expect(getFetchBodies().length - baseline).toBe(1);
+
+    // The merged POST must carry events from all three activity windows — proving the
+    // queued contexts were coalesced rather than reordered, dropped, or split per-marker.
+    const mergedBody = getFetchBodies()[getFetchBodies().length - 1];
+    expect(mergedBody).toContain('marker-A');
+    expect(mergedBody).toContain('marker-B');
+    expect(mergedBody).toContain('marker-C');
+  });
+});

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -50,6 +50,13 @@ export const EVENT_SKIP_CODE_INVALID_RANGE = '4004';
 export const EVENT_SKIP_CODE_CAPTURE_DISABLED = '4005';
 // How long to pause the flush schedule after the server signals a throttle.
 export const THROTTLED_FLUSH_PAUSE_MS = 60_000;
+// Soft char-length cap for merging same-session contexts after a throttle pause.
+// Set to 2 * MAX_EVENT_LIST_SIZE so we'll merge at most ~2 max-size sequences (or many
+// small ones) into one POST — fewer requests during recovery without pushing close to
+// the server's 10MB-compressed 413 ceiling. Compared against `event.length` (char count)
+// to match the per-sequence limit's units; UTF-8 bytes may be larger but the cap is
+// intentionally far below the 413 threshold.
+export const MERGE_AFTER_THROTTLE_SOFT_CAP = 2 * MAX_EVENT_LIST_SIZE;
 
 export const CROSS_ORIGIN_IFRAME_MESSAGE_TYPE = 'amplitude-sr-iframe';
 

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -50,12 +50,11 @@ export const EVENT_SKIP_CODE_INVALID_RANGE = '4004';
 export const EVENT_SKIP_CODE_CAPTURE_DISABLED = '4005';
 // How long to pause the flush schedule after the server signals a throttle.
 export const THROTTLED_FLUSH_PAUSE_MS = 60_000;
-// Soft char-length cap for merging same-session contexts after a throttle pause.
+// Soft UTF-8 byte cap for merging same-session contexts after a throttle pause.
 // Set to 2 * MAX_EVENT_LIST_SIZE so we'll merge at most ~2 max-size sequences (or many
 // small ones) into one POST — fewer requests during recovery without pushing close to
-// the server's 10MB-compressed 413 ceiling. Compared against `event.length` (char count)
-// to match the per-sequence limit's units; UTF-8 bytes may be larger but the cap is
-// intentionally far below the 413 threshold.
+// the server's 10MB-compressed 413 ceiling. Compared against UTF-8 byte size (via Blob)
+// to match the per-sequence limit's units enforced upstream by base-events-store.
 export const MERGE_AFTER_THROTTLE_SOFT_CAP = 2 * MAX_EVENT_LIST_SIZE;
 
 export const CROSS_ORIGIN_IFRAME_MESSAGE_TYPE = 'amplitude-sr-iframe';

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -24,6 +24,7 @@ import {
   EVENT_SKIP_CODE_INVALID_RANGE,
   EVENT_SKIP_CODE_CAPTURE_DISABLED,
   THROTTLED_FLUSH_PAUSE_MS,
+  MERGE_AFTER_THROTTLE_SOFT_CAP,
 } from './constants';
 import { gzipJson } from './utils/gzip';
 
@@ -71,6 +72,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   // The server uses this header (instead of 4xx) to signal a deliberate no-retry drop so SDKs
   // don't retry-storm. We honor it here by slowing or stopping our flush schedule.
   private flushPauseUntilMs = 0;
+  // Set when schedule() defers a flush because we're inside a throttle pause; consumed by
+  // flush() to merge same-session contexts before sending. Throttling is enforced by request
+  // count, so collapsing N queued batches into one POST directly reduces throttle pressure.
+  private mergeOnNextFlush = false;
   private killedSessions = new Set<string | number>();
 
   constructor({
@@ -248,7 +253,13 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     // If the server signaled throttling on a recent 200, defer the next flush until the
     // pause window ends. This lets us keep batching events without retry-storming the server.
     const pauseRemaining = this.flushPauseUntilMs - Date.now();
+    const isPaused = pauseRemaining > 0;
     const effectiveTimeout = pauseRemaining > timeout ? pauseRemaining : timeout;
+    if (isPaused) {
+      // Mark the upcoming flush for merge: contexts piling up during the pause should
+      // be coalesced into one POST per (session, device, api, type, ...) group.
+      this.mergeOnNextFlush = true;
+    }
     this.scheduled = setTimeout(() => {
       void this.flush(true).then(() => {
         if (this.queue.length > 0) {
@@ -259,7 +270,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   }
 
   async flush(useRetry = false) {
-    const list = this.queue;
+    let list = this.queue;
     this.queue = [];
 
     if (this.scheduled) {
@@ -267,9 +278,99 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       this.scheduled = null;
     }
 
+    if (this.mergeOnNextFlush) {
+      this.mergeOnNextFlush = false;
+      list = this.mergeQueueAfterThrottle(list);
+    }
+
     for (const context of list) {
       await this.send(context, useRetry);
     }
+  }
+
+  /**
+   * Coalesces queued contexts that share the same destination identity so the post-throttle
+   * release sends fewer requests. Identity covers everything that affects the request URL,
+   * routing, or per-request semantics — splitting on any difference keeps each merged POST
+   * indistinguishable from the source contexts it replaced.
+   *
+   * Greedy concat with a soft char-length cap (`MERGE_AFTER_THROTTLE_SOFT_CAP`) keeps merged
+   * payloads well under the 413 ceiling; on the rare oversized merge, the existing
+   * split-and-retry path still bisects safely.
+   *
+   * The merged context's `onComplete` fans out to every source context's callback so each
+   * underlying IDB sequence record is cleaned up exactly once on success.
+   */
+  private mergeQueueAfterThrottle(list: SessionReplayDestinationContext[]): SessionReplayDestinationContext[] {
+    if (list.length <= 1) return list;
+
+    const groups = new Map<string, SessionReplayDestinationContext[]>();
+    for (const ctx of list) {
+      // Anything that can change the URL, headers, or backend routing must split groups.
+      const key = [
+        ctx.sessionId,
+        ctx.deviceId ?? '',
+        ctx.apiKey ?? '',
+        ctx.type,
+        ctx.serverZone ?? '',
+        ctx.sampleRate,
+        ctx.version?.type ?? '',
+        ctx.version?.version ?? '',
+      ].join('|');
+      const arr = groups.get(key);
+      if (arr) arr.push(ctx);
+      else groups.set(key, [ctx]);
+    }
+
+    const merged: SessionReplayDestinationContext[] = [];
+    for (const group of groups.values()) {
+      if (group.length === 1) {
+        merged.push(group[0]);
+        continue;
+      }
+      let current: SessionReplayDestinationContext | null = null;
+      let currentChars = 0;
+      const flushCurrent = () => {
+        if (current) merged.push(current);
+        current = null;
+        currentChars = 0;
+      };
+      for (const ctx of group) {
+        const ctxChars = ctx.events.reduce((sum, e) => sum + e.length, 0);
+        if (current === null) {
+          current = { ...ctx, events: [...ctx.events] };
+          currentChars = ctxChars;
+          continue;
+        }
+        if (currentChars + ctxChars > MERGE_AFTER_THROTTLE_SOFT_CAP) {
+          flushCurrent();
+          current = { ...ctx, events: [...ctx.events] };
+          currentChars = ctxChars;
+          continue;
+        }
+        const prevOnComplete = current.onComplete;
+        const ctxOnComplete = ctx.onComplete;
+        current.events = current.events.concat(ctx.events);
+        currentChars += ctxChars;
+        // Most conservative: don't reset the retry budget if any source context had
+        // already burned attempts. addToQueue increments attempts on enqueue, so the
+        // merged context inherits the highest count.
+        current.attempts = Math.max(current.attempts, ctx.attempts);
+        current.onComplete = async () => {
+          // Run both in parallel; an underlying store cleanup failure in one shouldn't
+          // block the other. Errors are surfaced per the source callbacks' own handlers.
+          await Promise.all([prevOnComplete(), ctxOnComplete()]);
+        };
+      }
+      flushCurrent();
+    }
+
+    if (merged.length < list.length) {
+      this.loggerProvider.log(
+        `Session replay throttle pause ended; merged ${list.length} queued batches into ${merged.length} request(s)`,
+      );
+    }
+    return merged;
   }
 
   async send(context: SessionReplayDestinationContext, useRetry = true) {

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -76,6 +76,9 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   // flush() to merge same-session contexts before sending. Throttling is enforced by request
   // count, so collapsing N queued batches into one POST directly reduces throttle pressure.
   private mergeOnNextFlush = false;
+  // Gates the merge log to once per throttle pause window — mirroring the throttle log's
+  // transition-only gating — so a sustained throttle scenario doesn't spam logs every cycle.
+  private mergeLogFiredThisPause = false;
   private killedSessions = new Set<string | number>();
 
   constructor({
@@ -338,13 +341,17 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       for (const ctx of group) {
         const ctxChars = ctx.events.reduce((sum, e) => sum + e.length, 0);
         if (current === null) {
-          current = { ...ctx, events: [...ctx.events] };
+          // Reset attempts to 0 on the merged context so the post-throttle delivery gets a
+          // full retry budget. The throttle pause has already absorbed back-pressure; the
+          // alternative (Math.max of source attempts) would collapse N source budgets into
+          // one and end-of-life all N IDB records on a single retry exhaustion.
+          current = { ...ctx, events: [...ctx.events], attempts: 0 };
           currentChars = ctxChars;
           continue;
         }
         if (currentChars + ctxChars > MERGE_AFTER_THROTTLE_SOFT_CAP) {
           flushCurrent();
-          current = { ...ctx, events: [...ctx.events] };
+          current = { ...ctx, events: [...ctx.events], attempts: 0 };
           currentChars = ctxChars;
           continue;
         }
@@ -352,10 +359,6 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         const ctxOnComplete = ctx.onComplete;
         current.events = current.events.concat(ctx.events);
         currentChars += ctxChars;
-        // Most conservative: don't reset the retry budget if any source context had
-        // already burned attempts. addToQueue increments attempts on enqueue, so the
-        // merged context inherits the highest count.
-        current.attempts = Math.max(current.attempts, ctx.attempts);
         current.onComplete = async () => {
           // Run both in parallel; an underlying store cleanup failure in one shouldn't
           // block the other. Errors are surfaced per the source callbacks' own handlers.
@@ -365,7 +368,8 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       flushCurrent();
     }
 
-    if (merged.length < list.length) {
+    if (merged.length < list.length && !this.mergeLogFiredThisPause) {
+      this.mergeLogFiredThisPause = true;
       this.loggerProvider.log(
         `Session replay throttle pause ended; merged ${list.length} queued batches into ${merged.length} request(s)`,
       );
@@ -566,7 +570,14 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       `Session replay event batch rejected by ${source} (${context.events.length} events, ${totalSizeKB} KB total) — splitting and retrying`,
     );
 
-    // Clean up the original IDB record, then re-enqueue both halves as new in-memory batches
+    // Clean up the original IDB record, then re-enqueue both halves as new in-memory batches.
+    // For a merged-on-throttle context (mergeQueueAfterThrottle), this onComplete is the
+    // fanned-out callback covering N source IDB records — they'll all be cleaned up here.
+    // Halves get noop onCompletes, so a page-close between this cleanup and a half delivery
+    // means up to N source sequences are lost. The merge soft cap (1.4MB chars) is well under
+    // the 10MB compressed 413 ceiling, so a 413 on a merged context is exceedingly rare in
+    // practice; the alternative — deferring source cleanup until both halves complete — would
+    // significantly complicate the retry path for marginal benefit.
     void context.onComplete();
     const noop = (): Promise<void> => Promise.resolve();
     const mid = Math.floor(context.events.length / 2);
@@ -624,6 +635,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   private applyServerDirective(sessionId: string | number, skipCode: string | null) {
     if (skipCode === null) {
       this.flushPauseUntilMs = 0;
+      this.mergeLogFiredThisPause = false;
       return;
     }
     if (skipCode === EVENT_SKIP_CODE_THROTTLED) {

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -332,37 +332,42 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         continue;
       }
       let current: SessionReplayDestinationContext | null = null;
-      let currentChars = 0;
+      let currentBytes = 0;
       const flushCurrent = () => {
         if (current) merged.push(current);
         current = null;
-        currentChars = 0;
+        currentBytes = 0;
       };
       for (const ctx of group) {
-        const ctxChars = ctx.events.reduce((sum, e) => sum + e.length, 0);
+        // UTF-8 byte size, matching how the events store enforces MAX_EVENT_LIST_SIZE
+        // (see base-events-store.ts:getStringSize). Using char length would let a CJK/
+        // emoji-heavy payload sneak past the cap.
+        const ctxBytes = ctx.events.reduce((sum, e) => sum + new Blob([e]).size, 0);
         if (current === null) {
           // Reset attempts to 0 on the merged context so the post-throttle delivery gets a
           // full retry budget. The throttle pause has already absorbed back-pressure; the
           // alternative (Math.max of source attempts) would collapse N source budgets into
           // one and end-of-life all N IDB records on a single retry exhaustion.
           current = { ...ctx, events: [...ctx.events], attempts: 0 };
-          currentChars = ctxChars;
+          currentBytes = ctxBytes;
           continue;
         }
-        if (currentChars + ctxChars > MERGE_AFTER_THROTTLE_SOFT_CAP) {
+        if (currentBytes + ctxBytes > MERGE_AFTER_THROTTLE_SOFT_CAP) {
           flushCurrent();
           current = { ...ctx, events: [...ctx.events], attempts: 0 };
-          currentChars = ctxChars;
+          currentBytes = ctxBytes;
           continue;
         }
         const prevOnComplete = current.onComplete;
         const ctxOnComplete = ctx.onComplete;
         current.events = current.events.concat(ctx.events);
-        currentChars += ctxChars;
+        currentBytes += ctxBytes;
         current.onComplete = async () => {
-          // Run both in parallel; an underlying store cleanup failure in one shouldn't
-          // block the other. Errors are surfaced per the source callbacks' own handlers.
-          await Promise.all([prevOnComplete(), ctxOnComplete()]);
+          // allSettled (not all): an underlying store cleanup failure in one shouldn't
+          // block the other, and the merged onComplete is invoked fire-and-forget via
+          // `void context.onComplete()` — a rejection from `Promise.all` would surface
+          // as an unhandled rejection. Errors stay encapsulated in the source callbacks.
+          await Promise.allSettled([prevOnComplete(), ctxOnComplete()]);
         };
       }
       flushCurrent();

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1150,7 +1150,7 @@ describe('SessionReplayTrackDestination', () => {
       expect(sendSpy).toHaveBeenCalledTimes(2);
     });
 
-    test('merged context inherits the highest attempts count from sources', async () => {
+    test('merged context starts with a fresh retry budget (attempts = 0)', async () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
 
@@ -1163,8 +1163,11 @@ describe('SessionReplayTrackDestination', () => {
 
       await trackDestination.flush(true);
 
+      // Resetting to 0 prevents one retry exhaustion from end-of-life'ing every source IDB
+      // record. The throttle pause already absorbed back-pressure — recovery deserves a
+      // full budget.
       const merged = sendSpy.mock.calls[0][0];
-      expect(merged.attempts).toBe(3);
+      expect(merged.attempts).toBe(0);
     });
 
     test('grouping uses safe fallbacks when optional identity fields are absent', async () => {
@@ -1264,6 +1267,148 @@ describe('SessionReplayTrackDestination', () => {
       // Both source IDB records get cleaned up.
       expect(onCompleteA).toHaveBeenCalled();
       expect(onCompleteB).toHaveBeenCalled();
+    });
+
+    test('worker path: merged context onComplete fans out to source IDB cleanups on worker complete', async () => {
+      const mockWorker = {
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+        onerror: null as ((e: ErrorEvent) => void) | null,
+        onmessage: null as ((e: MessageEvent) => void) | null,
+      };
+      global.Worker = jest.fn(() => mockWorker) as unknown as typeof Worker;
+      global.URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+
+      const onCompleteA = jest.fn().mockResolvedValue(undefined);
+      const onCompleteB = jest.fn().mockResolvedValue(undefined);
+      trackDestination.queue = [
+        baseCtx({ events: ['a'], onComplete: onCompleteA }),
+        baseCtx({ events: ['b'], onComplete: onCompleteB }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      const flushPromise = trackDestination.flush(true);
+
+      // The merge sends one postMessage with merged events.
+      expect(mockWorker.postMessage).toHaveBeenCalledTimes(1);
+      const posted = mockWorker.postMessage.mock.calls[0][0];
+      expect(posted.payload.events).toEqual(['a', 'b']);
+
+      // Worker reports back complete; merged onComplete must fan out to both sources.
+      mockWorker.onmessage?.({ data: { type: 'complete', id: posted.id, skipCode: null } } as MessageEvent);
+      await flushPromise;
+
+      expect(onCompleteA).toHaveBeenCalledTimes(1);
+      expect(onCompleteB).toHaveBeenCalledTimes(1);
+    });
+
+    test('killSession during merge window drains affected contexts before flush merges them', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      const onCompleteA = jest.fn().mockResolvedValue(undefined);
+      const onCompleteB = jest.fn().mockResolvedValue(undefined);
+      const onCompleteOther = jest.fn().mockResolvedValue(undefined);
+      trackDestination.queue = [
+        baseCtx({ sessionId: 999, events: ['a'], onComplete: onCompleteA }),
+        baseCtx({ sessionId: 999, events: ['b'], onComplete: onCompleteB }),
+        baseCtx({ sessionId: 1000, events: ['c'], onComplete: onCompleteOther }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      // Kill session 999 before flush runs — drains its contexts immediately.
+      (trackDestination as any).killSession(999, '4005');
+      expect(onCompleteA).toHaveBeenCalled();
+      expect(onCompleteB).toHaveBeenCalled();
+
+      await trackDestination.flush(true);
+
+      // Only the unaffected session-1000 context goes through.
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const sent = sendSpy.mock.calls[0][0];
+      expect(sent.sessionId).toBe(1000);
+      expect(sent.events).toEqual(['c']);
+    });
+
+    test('413 on merged context cleans up all source IDB records via fanned-out onComplete', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendEventsListSpy = jest.spyOn(trackDestination, 'sendEventsList').mockImplementation(() => undefined);
+
+      const onCompleteA = jest.fn().mockResolvedValue(undefined);
+      const onCompleteB = jest.fn().mockResolvedValue(undefined);
+
+      // Build a merged context as mergeQueueAfterThrottle would: events from two sources,
+      // onComplete fanning out to both source callbacks.
+      const mergedOnComplete = async () => {
+        await Promise.all([onCompleteA(), onCompleteB()]);
+      };
+      const mergedContext: SessionReplayDestinationContext = {
+        events: ['a1', 'a2', 'b1', 'b2'],
+        sessionId: 123,
+        apiKey,
+        attempts: 0,
+        timeout: 0,
+        flushMaxRetries: 2,
+        deviceId: '1a2b3c',
+        sampleRate: 1,
+        serverZone: ServerZone.US,
+        type: 'replay',
+        onComplete: mergedOnComplete,
+      };
+
+      // Trigger the WAF 413 path — splits and re-enqueues both halves with noop onCompletes.
+      trackDestination.handlePayloadTooLargeResponse(mergedContext, true);
+
+      // Both source records get cleaned up exactly once.
+      expect(onCompleteA).toHaveBeenCalledTimes(1);
+      expect(onCompleteB).toHaveBeenCalledTimes(1);
+
+      // Halves re-enqueued with noop onComplete (so they don't double-clean source records).
+      expect(sendEventsListSpy).toHaveBeenCalledTimes(2);
+      const half1 = sendEventsListSpy.mock.calls[0][0];
+      const half2 = sendEventsListSpy.mock.calls[1][0];
+      expect(half1.events).toEqual(['a1', 'a2']);
+      expect(half2.events).toEqual(['b1', 'b2']);
+      // The halves' onComplete is the noop, NOT the merged fan-out.
+      expect(half1.onComplete).not.toBe(mergedOnComplete);
+      expect(half2.onComplete).not.toBe(mergedOnComplete);
+    });
+
+    test('merge log fires once per pause window, not on every release', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      // First merge during the pause: log fires.
+      trackDestination.queue = [baseCtx({ events: ['a'] }), baseCtx({ events: ['b'] })];
+      (trackDestination as any).mergeOnNextFlush = true;
+      await trackDestination.flush(true);
+
+      // Same pause window, another merge happens (e.g., a second deferred flush in the same
+      // sustained throttle): log should NOT fire again.
+      trackDestination.queue = [baseCtx({ events: ['c'] }), baseCtx({ events: ['d'] })];
+      (trackDestination as any).mergeOnNextFlush = true;
+      await trackDestination.flush(true);
+
+      const mergeLogs = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('throttle pause ended; merged'),
+      );
+      expect(mergeLogs).toHaveLength(1);
+
+      // After a clean 200 (pause clears), the gate resets — next merge logs again.
+      (trackDestination as any).applyServerDirective(123, null);
+      trackDestination.queue = [baseCtx({ events: ['e'] }), baseCtx({ events: ['f'] })];
+      (trackDestination as any).mergeOnNextFlush = true;
+      await trackDestination.flush(true);
+
+      const mergeLogsAfter = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('throttle pause ended; merged'),
+      );
+      expect(mergeLogsAfter).toHaveLength(2);
     });
   });
 

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1034,6 +1034,239 @@ describe('SessionReplayTrackDestination', () => {
     });
   });
 
+  describe('merge queued sends after throttle pause', () => {
+    const baseCtx = (overrides: Partial<SessionReplayDestinationContext> = {}): SessionReplayDestinationContext => ({
+      events: [mockEventString],
+      sessionId: 123,
+      apiKey,
+      attempts: 1,
+      timeout: 0,
+      flushMaxRetries: 2,
+      deviceId: '1a2b3c',
+      sampleRate: 1,
+      serverZone: ServerZone.US,
+      type: 'replay',
+      onComplete: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    });
+
+    test('schedule sets mergeOnNextFlush only when deferring due to throttle pause', () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      jest.setSystemTime(10_000_000);
+
+      // No pause: flag stays false.
+      trackDestination.schedule(0);
+      expect((trackDestination as any).mergeOnNextFlush).toBe(false);
+
+      clearTimeout((trackDestination as any).scheduled);
+      (trackDestination as any).scheduled = null;
+
+      // Active pause: flag flips on.
+      (trackDestination as any).flushPauseUntilMs = 10_000_000 + 30_000;
+      trackDestination.schedule(0);
+      expect((trackDestination as any).mergeOnNextFlush).toBe(true);
+    });
+
+    test('flush merges same-(session,device,api,type) batches into one send and fans out onComplete', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      const onCompleteA = jest.fn().mockResolvedValue(undefined);
+      const onCompleteB = jest.fn().mockResolvedValue(undefined);
+      const onCompleteC = jest.fn().mockResolvedValue(undefined);
+      trackDestination.queue = [
+        baseCtx({ events: ['a1', 'a2'], onComplete: onCompleteA }),
+        baseCtx({ events: ['b1'], onComplete: onCompleteB }),
+        baseCtx({ events: ['c1', 'c2', 'c3'], onComplete: onCompleteC }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const merged = sendSpy.mock.calls[0][0];
+      expect(merged.events).toEqual(['a1', 'a2', 'b1', 'c1', 'c2', 'c3']);
+
+      // The merged onComplete must clean up every source IDB record.
+      await merged.onComplete();
+      expect(onCompleteA).toHaveBeenCalledTimes(1);
+      expect(onCompleteB).toHaveBeenCalledTimes(1);
+      expect(onCompleteC).toHaveBeenCalledTimes(1);
+
+      // Flag is consumed.
+      expect((trackDestination as any).mergeOnNextFlush).toBe(false);
+    });
+
+    test('different sessions are kept as separate POSTs', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      trackDestination.queue = [
+        baseCtx({ sessionId: 1, events: ['a'] }),
+        baseCtx({ sessionId: 2, events: ['b'] }),
+        baseCtx({ sessionId: 1, events: ['c'] }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      // Two groups by sessionId — session 1 merges, session 2 stays alone.
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+      const sentBySession = new Map(
+        sendSpy.mock.calls.map((c) => {
+          const ctx = c[0];
+          return [ctx.sessionId, ctx.events];
+        }),
+      );
+      expect(sentBySession.get(1)).toEqual(['a', 'c']);
+      expect(sentBySession.get(2)).toEqual(['b']);
+    });
+
+    test('merge respects soft size cap by splitting into multiple sends', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      // Each context is just under the cap; together they exceed it. Expect a split into 3.
+      const big = 'x'.repeat(800_000); // > MERGE_AFTER_THROTTLE_SOFT_CAP / 2 (= 700_000)
+      trackDestination.queue = [baseCtx({ events: [big] }), baseCtx({ events: [big] }), baseCtx({ events: [big] })];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      // Each event by itself is under the cap, but adding a second pushes over — so each
+      // gets sent separately.
+      expect(sendSpy).toHaveBeenCalledTimes(3);
+    });
+
+    test('flush does not merge when the flag is off (steady state untouched)', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      trackDestination.queue = [baseCtx({ events: ['a'] }), baseCtx({ events: ['b'] })];
+      // mergeOnNextFlush stays false — normal flush path.
+
+      await trackDestination.flush(true);
+
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('merged context inherits the highest attempts count from sources', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      trackDestination.queue = [
+        baseCtx({ attempts: 1, events: ['a'] }),
+        baseCtx({ attempts: 3, events: ['b'] }),
+        baseCtx({ attempts: 2, events: ['c'] }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      const merged = sendSpy.mock.calls[0][0];
+      expect(merged.attempts).toBe(3);
+    });
+
+    test('grouping uses safe fallbacks when optional identity fields are absent', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      // All optional fields (deviceId, apiKey, serverZone, version) are missing on both
+      // contexts. They should still group together (matching empty-string fallback) rather
+      // than splitting on undefined-vs-undefined string-key collisions.
+      trackDestination.queue = [
+        baseCtx({
+          events: ['a'],
+          deviceId: undefined,
+          apiKey: undefined,
+          serverZone: undefined,
+          version: undefined,
+        }),
+        baseCtx({
+          events: ['b'],
+          deviceId: undefined,
+          apiKey: undefined,
+          serverZone: undefined,
+          version: undefined,
+        }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const merged = sendSpy.mock.calls[0][0];
+      expect(merged.events).toEqual(['a', 'b']);
+    });
+
+    test('grouping uses version.type and version.version when present', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      // Different version.type splits the group.
+      trackDestination.queue = [
+        baseCtx({ events: ['a'], version: { type: 'plugin', version: '1.0.0' } }),
+        baseCtx({ events: ['b'], version: { type: 'standalone', version: '1.0.0' } }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('mergeOnNextFlush stays cleared after a no-op merge (single context)', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      trackDestination.queue = [baseCtx({ events: ['only'] })];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      expect((trackDestination as any).mergeOnNextFlush).toBe(false);
+    });
+
+    test('end-to-end: throttled response → pause → enqueue → release flush merges into one POST', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      jest.setSystemTime(20_000_000);
+
+      // First send is throttled — flushPauseUntilMs gets set.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        status: 200,
+        headers: { get: jest.fn().mockReturnValue('429') },
+      });
+      await trackDestination.send(baseCtx(), true);
+      expect((trackDestination as any).flushPauseUntilMs).toBe(20_000_000 + 60_000);
+
+      // While paused, several batches enqueue. addToQueue → schedule(0) sets the merge flag.
+      trackDestination.queue = [];
+      const onCompleteA = jest.fn().mockResolvedValue(undefined);
+      const onCompleteB = jest.fn().mockResolvedValue(undefined);
+      trackDestination.addToQueue(baseCtx({ events: ['a'], onComplete: onCompleteA, attempts: 0 }));
+      trackDestination.addToQueue(baseCtx({ events: ['b'], onComplete: onCompleteB, attempts: 0 }));
+      expect((trackDestination as any).mergeOnNextFlush).toBe(true);
+
+      // Pause expires; the deferred flush fires. Stub fetch to a clean 200.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        status: 200,
+        headers: { get: jest.fn().mockReturnValue(null) },
+      });
+      jest.setSystemTime(20_000_000 + 60_001);
+      await runScheduleTimers();
+
+      // Single fetch for the merged POST (plus the original throttled one earlier = 2 total).
+      const fetchCalls = (global.fetch as jest.Mock).mock.calls;
+      expect(fetchCalls).toHaveLength(2);
+      const mergedBody = JSON.parse(fetchCalls[1][1].body as string);
+      expect(mergedBody.events).toEqual(['a', 'b']);
+
+      // Both source IDB records get cleaned up.
+      expect(onCompleteA).toHaveBeenCalled();
+      expect(onCompleteB).toHaveBeenCalled();
+    });
+  });
+
   describe('worker support', () => {
     const mockContext = {
       events: [mockEventString],

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1170,6 +1170,30 @@ describe('SessionReplayTrackDestination', () => {
       expect(merged.attempts).toBe(0);
     });
 
+    test('one source onComplete rejection does not block the other source onComplete', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+      const onCompleteFails = jest.fn().mockRejectedValue(new Error('IDB cleanup failed'));
+      const onCompleteSucceeds = jest.fn().mockResolvedValue(undefined);
+
+      trackDestination.queue = [
+        baseCtx({ events: ['a'], onComplete: onCompleteFails }),
+        baseCtx({ events: ['b'], onComplete: onCompleteSucceeds }),
+      ];
+      (trackDestination as any).mergeOnNextFlush = true;
+
+      await trackDestination.flush(true);
+
+      const merged = sendSpy.mock.calls[0][0];
+      // allSettled: the failing onComplete must NOT prevent the succeeding one from running,
+      // and the merged onComplete itself must resolve (not reject) so its fire-and-forget
+      // caller doesn't produce an unhandled rejection.
+      await expect(merged.onComplete()).resolves.toBeUndefined();
+      expect(onCompleteFails).toHaveBeenCalledTimes(1);
+      expect(onCompleteSucceeds).toHaveBeenCalledTimes(1);
+    });
+
     test('grouping uses safe fallbacks when optional identity fields are absent', async () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

When the server throttles us via `X-Session-Replay-Event-Skipped: 429`, the SDK pauses its flush schedule for 60s (`THROTTLED_FLUSH_PAUSE_MS`). During the pause, completed sequences pile up in `trackDestination.queue` — and on release we send each one as its **own POST**. A 60s pause that accumulates 6 sequences releases as 6 sequential POSTs back-to-back, which is exactly the behavior the request-count-based throttle is asking us to avoid.

This change merges same-`(sessionId, deviceId, apiKey, type, serverZone, sampleRate, version)` queued contexts into one POST when the deferred flush fires:

- Group queued contexts by destination identity (anything that affects URL/headers/routing splits the group).
- Greedily concat events with a soft char-length cap (`MERGE_AFTER_THROTTLE_SOFT_CAP = 2 * MAX_EVENT_LIST_SIZE = 1.4MB`), well under the 10MB-compressed 413 ceiling.
- Merged context's `onComplete` fans out so every source IDB sequence is cleaned up.
- Reset `attempts: 0` on the merged context so post-throttle recovery gets a full retry budget instead of collapsing N source budgets into one.
- Gated on `mergeOnNextFlush`, set only when `schedule()` deferred a flush due to the pause — steady-state behavior is unchanged.
- Merge log fires once per pause window (cleared when `applyServerDirective` sees a clean 200), mirroring the throttle log's transition-only gating.

The existing 413 split-and-retry path still works on a merged context; the source-cleanup amplification (page-close mid-retry can lose up to N sequences instead of 1) is documented in code — exceedingly rare given the cap vs ceiling headroom.

Linear: [SR-4286](https://linear.app/amplitude/issue/SR-4286/session-replay-browser-combine-queued-sends-after-throttle-pause)

## Test plan

- [x] All 920 existing + new tests pass with 100% statements/branches/functions/lines coverage
- [x] New tests cover: schedule sets/clears \`mergeOnNextFlush\` based on pause state; merge collapses same-session contexts and fans out \`onComplete\`; different sessions stay separate; soft cap enforced; steady-state untouched; \`attempts: 0\` reset; optional-field grouping fallbacks; version-based grouping; e2e throttle→pause→enqueue→release→merged POST; worker-path complete fans out; kill-mid-merge drains correctly; 413-on-merged uses noop halves; merge log gates per pause cycle
- [x] Lint clean
- [ ] CI green
- [ ] Bugbot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session replay delivery/back-pressure behavior by changing how queued batches are flushed after a throttle, which could affect request volume and cleanup semantics despite being gated to throttle-pause scenarios and covered by extensive tests.
> 
> **Overview**
> **Reduces request spikes after server throttling.** When a throttle pause is active, the next `flush()` now merges queued session replay batches that share the same destination identity into fewer POSTs (with a soft size cap and a fanned-out `onComplete`), instead of sending each queued sequence as its own request.
> 
> Adds `MERGE_AFTER_THROTTLE_SOFT_CAP` and merge/log gating in `track-destination`, plus comprehensive unit coverage and a new Playwright e2e that simulates `X-Session-Replay-Event-Skipped: 429` and asserts queued sequences collapse into a single fetch POST on release. Playwright config also allows overriding `baseURL` via `PLAYWRIGHT_BASE_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 333d5b1b2f9455054767edba1165fe23c6f07ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->