### PR TITLE
feat(session-replay-browser): add flushIntervalConfig to tune rrweb event-split cadence

### DIFF
--- a/packages/session-replay-browser/e2e/flush-interval-config.spec.ts
+++ b/packages/session-replay-browser/e2e/flush-interval-config.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+} from './helpers';
+
+/**
+ * Mocks the track API so we can confirm the SDK actually delivers events
+ * through the full real-browser pipeline.
+ */
+async function captureTrackRequestUrls(page: Page): Promise<{ getUrls: () => string[] }> {
+  const urls: string[] = [];
+  await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+    urls.push(route.request().url());
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  return { getUrls: () => urls };
+}
+
+async function flushAndSettle(page: Page) {
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+  await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+}
+
+test.describe('flushIntervalConfig', () => {
+  // The unit + integration tests in test/ exhaustively cover the validator and the
+  // value-propagation through createEventsManager (including the first-split regression
+  // bugbot caught). These e2e tests are the last-mile guard that a real browser, going
+  // through the full SDK init path with Vite + worker compression + rrweb, accepts the
+  // option without surfacing init errors and still emits events end-to-end.
+
+  test('initializes cleanly with custom min/max and delivers events on explicit flush', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getUrls } = await captureTrackRequestUrls(page);
+
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        flushMinIntervalMs: 5000,
+        flushMaxIntervalMs: 30_000,
+      }),
+    );
+    await waitForReady(page);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    const initError = await page.evaluate(() => (window as any).srError as string | undefined);
+    expect(initError).toBeUndefined();
+
+    await page.evaluate(() => {
+      document.getElementById('test-button')?.click();
+    });
+    await flushAndSettle(page);
+
+    expect(getUrls().length).toBeGreaterThan(0);
+    const sdkErrors = consoleErrors.filter((e) => /session.replay|amplitude/i.test(e));
+    expect(sdkErrors).toEqual([]);
+  });
+
+  test('Infinity maxIntervalMs is accepted and the SDK initializes cleanly', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getUrls } = await captureTrackRequestUrls(page);
+
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        flushMinIntervalMs: 5000,
+        flushMaxIntervalMs: 'Infinity',
+      }),
+    );
+    await waitForReady(page);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    const initError = await page.evaluate(() => (window as any).srError as string | undefined);
+    expect(initError).toBeUndefined();
+
+    await flushAndSettle(page);
+
+    // Recording is functional even with an unbounded upper interval.
+    expect(getUrls().length).toBeGreaterThan(0);
+    const sdkErrors = consoleErrors.filter((e) => /session.replay|amplitude/i.test(e));
+    expect(sdkErrors).toEqual([]);
+  });
+
+  test('sub-floor minIntervalMs is clamped without aborting init', async ({ page }) => {
+    // Validator clamps to the 100ms floor and emits a warn; init must still succeed.
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await captureTrackRequestUrls(page);
+
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        flushMinIntervalMs: 0,
+      }),
+    );
+    await waitForReady(page);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    const initError = await page.evaluate(() => (window as any).srError as string | undefined);
+    expect(initError).toBeUndefined();
+    const sdkErrors = consoleErrors.filter((e) => /session.replay|amplitude/i.test(e));
+    expect(sdkErrors).toEqual([]);
+  });
+});

--- a/packages/session-replay-browser/e2e/playwright.config.ts
+++ b/packages/session-replay-browser/e2e/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: '.',
   testMatch: '*.spec.ts',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
     trace: 'on-first-retry',
     actionTimeout: 30_000,
     navigationTimeout: 30_000,

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_SAMPLE_RATE,
   DEFAULT_SERVER_ZONE,
   DEFAULT_URL_CHANGE_POLLING_INTERVAL,
+  MAX_INTERVAL,
+  MIN_INTERVAL,
   UNMASK_TEXT_CLASS,
 } from '../constants';
 import { SessionReplayOptions, StoreType } from '../typings/session-replay';
@@ -141,15 +143,33 @@ function sanitizeFlushIntervalConfig(raw: FlushIntervalConfig, loggerProvider: I
       sanitized.maxIntervalMs = raw.maxIntervalMs;
     }
   }
-  if (
-    sanitized.minIntervalMs !== undefined &&
-    sanitized.maxIntervalMs !== undefined &&
-    sanitized.maxIntervalMs < sanitized.minIntervalMs
-  ) {
-    loggerProvider.warn(
-      `flushIntervalConfig.maxIntervalMs (${sanitized.maxIntervalMs}) is less than minIntervalMs (${sanitized.minIntervalMs}); raising max to match min.`,
-    );
-    sanitized.maxIntervalMs = sanitized.minIntervalMs;
+  // Cross-validate against the SDK's effective defaults so that a partial config (only one of
+  // {minIntervalMs, maxIntervalMs}) doesn't get silently clamped by the unspecified default.
+  // Concrete failure mode without this: customer sets only `minIntervalMs: 30_000`, the store's
+  // `maxInterval` falls back to `MAX_INTERVAL = 10_000`, and `shouldSplitEventsList` then
+  // caps the effective interval at 10s — silently negating the customer's tune-up.
+  // The user-supplied value always wins; we fill in the other side to match.
+  if (sanitized.minIntervalMs !== undefined || sanitized.maxIntervalMs !== undefined) {
+    const effectiveMin = sanitized.minIntervalMs ?? MIN_INTERVAL;
+    const effectiveMax = sanitized.maxIntervalMs ?? MAX_INTERVAL;
+    if (effectiveMax < effectiveMin) {
+      if (sanitized.maxIntervalMs === undefined) {
+        loggerProvider.warn(
+          `flushIntervalConfig.minIntervalMs (${effectiveMin}) exceeds the default maxIntervalMs (${MAX_INTERVAL}); raising max to match min.`,
+        );
+        sanitized.maxIntervalMs = effectiveMin;
+      } else if (sanitized.minIntervalMs === undefined) {
+        loggerProvider.warn(
+          `flushIntervalConfig.maxIntervalMs (${effectiveMax}) is below the default minIntervalMs (${MIN_INTERVAL}); lowering min to match max.`,
+        );
+        sanitized.minIntervalMs = effectiveMax;
+      } else {
+        loggerProvider.warn(
+          `flushIntervalConfig.maxIntervalMs (${sanitized.maxIntervalMs}) is less than minIntervalMs (${sanitized.minIntervalMs}); raising max to match min.`,
+        );
+        sanitized.maxIntervalMs = sanitized.minIntervalMs;
+      }
+    }
   }
   return sanitized;
 }

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -1,4 +1,4 @@
-import { Config, Logger, FetchTransport, LogLevel } from '@amplitude/analytics-core';
+import { Config, ILogger, Logger, FetchTransport, LogLevel } from '@amplitude/analytics-core';
 import {
   DEFAULT_PERFORMANCE_CONFIG,
   DEFAULT_SAMPLE_RATE,
@@ -10,6 +10,7 @@ import { SessionReplayOptions, StoreType } from '../typings/session-replay';
 import {
   SessionReplayLocalConfig as ISessionReplayLocalConfig,
   CrossOriginIframesConfig,
+  FlushIntervalConfig,
   InteractionConfig,
   PrivacyConfig,
   SessionReplayPerformanceConfig,
@@ -45,6 +46,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   captureAdoptedStyleSheets?: boolean;
   crossOriginIframes?: CrossOriginIframesConfig;
   fullSnapshotIntervalMs?: number;
+  flushIntervalConfig?: FlushIntervalConfig;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -106,5 +108,48 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     if (options.crossOriginIframes) {
       this.crossOriginIframes = options.crossOriginIframes;
     }
+    if (options.flushIntervalConfig) {
+      this.flushIntervalConfig = sanitizeFlushIntervalConfig(options.flushIntervalConfig, this.loggerProvider);
+    }
   }
+}
+
+// 100ms floor avoids degenerate configs (0/negative) that would split on every event.
+// Customers wanting fewer requests should be raising the value, not lowering it; the floor
+// is just a defensive guard against typos and unsigned-int rollovers.
+const MIN_FLUSH_INTERVAL_FLOOR_MS = 100;
+
+function sanitizeFlushIntervalConfig(raw: FlushIntervalConfig, loggerProvider: ILogger): FlushIntervalConfig {
+  const sanitized: FlushIntervalConfig = {};
+  if (raw.minIntervalMs !== undefined) {
+    if (!Number.isFinite(raw.minIntervalMs) || raw.minIntervalMs < MIN_FLUSH_INTERVAL_FLOOR_MS) {
+      loggerProvider.warn(
+        `flushIntervalConfig.minIntervalMs ${raw.minIntervalMs} is below floor ${MIN_FLUSH_INTERVAL_FLOOR_MS}ms; clamping.`,
+      );
+      sanitized.minIntervalMs = MIN_FLUSH_INTERVAL_FLOOR_MS;
+    } else {
+      sanitized.minIntervalMs = raw.minIntervalMs;
+    }
+  }
+  if (raw.maxIntervalMs !== undefined) {
+    if (!Number.isFinite(raw.maxIntervalMs) || raw.maxIntervalMs < MIN_FLUSH_INTERVAL_FLOOR_MS) {
+      loggerProvider.warn(
+        `flushIntervalConfig.maxIntervalMs ${raw.maxIntervalMs} is below floor ${MIN_FLUSH_INTERVAL_FLOOR_MS}ms; clamping.`,
+      );
+      sanitized.maxIntervalMs = MIN_FLUSH_INTERVAL_FLOOR_MS;
+    } else {
+      sanitized.maxIntervalMs = raw.maxIntervalMs;
+    }
+  }
+  if (
+    sanitized.minIntervalMs !== undefined &&
+    sanitized.maxIntervalMs !== undefined &&
+    sanitized.maxIntervalMs < sanitized.minIntervalMs
+  ) {
+    loggerProvider.warn(
+      `flushIntervalConfig.maxIntervalMs (${sanitized.maxIntervalMs}) is less than minIntervalMs (${sanitized.minIntervalMs}); raising max to match min.`,
+    );
+    sanitized.maxIntervalMs = sanitized.minIntervalMs;
+  }
+  return sanitized;
 }

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -134,7 +134,10 @@ function sanitizeFlushIntervalConfig(raw: FlushIntervalConfig, loggerProvider: I
     }
   }
   if (raw.maxIntervalMs !== undefined) {
-    if (!Number.isFinite(raw.maxIntervalMs) || raw.maxIntervalMs < MIN_FLUSH_INTERVAL_FLOOR_MS) {
+    // Unlike min, `Infinity` is a meaningful value here: it means "no upper bound on interval
+    // growth" (Math.min(Infinity, x) === x in BaseEventsStore.shouldSplitEventsList). Reject
+    // only NaN and sub-floor values; pass Infinity through.
+    if (Number.isNaN(raw.maxIntervalMs) || raw.maxIntervalMs < MIN_FLUSH_INTERVAL_FLOOR_MS) {
       loggerProvider.warn(
         `flushIntervalConfig.maxIntervalMs ${raw.maxIntervalMs} is below floor ${MIN_FLUSH_INTERVAL_FLOOR_MS}ms; clamping.`,
       );

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -236,6 +236,34 @@ export interface SessionReplayLocalConfig extends IConfig {
   crossOriginIframes?: CrossOriginIframesConfig;
   /** Interval in ms at which the SDK takes a full DOM snapshot. Disabled by default — periodic snapshots are expensive. Recommended value: 300000 (5 min). */
   fullSnapshotIntervalMs?: number;
+  /**
+   * Controls how often the SDK splits buffered rrweb events into a sequence and dispatches
+   * the resulting batch to the server. The interval starts at `minIntervalMs` and grows by
+   * `minIntervalMs` after each split, capped at `maxIntervalMs`. Lowering values increases
+   * replay availability latency improvements at the cost of more requests; raising them
+   * reduces request volume (and 200+`X-Session-Replay-Event-Skipped` throttling responses)
+   * at the cost of slightly delayed replay availability.
+   *
+   * Defaults: `{ minIntervalMs: 500, maxIntervalMs: 10_000 }`. Tune up if the server is
+   * back-pressuring the SDK on session start.
+   */
+  flushIntervalConfig?: FlushIntervalConfig;
+}
+
+export interface FlushIntervalConfig {
+  /**
+   * Lower bound on the rrweb event-split interval in milliseconds. Also the increment
+   * added to the interval after each split. Must be > 0; values are clamped to a 100ms floor.
+   *
+   * @defaultValue 500
+   */
+  minIntervalMs?: number;
+  /**
+   * Upper bound on the rrweb event-split interval in milliseconds. Must be >= `minIntervalMs`.
+   *
+   * @defaultValue 10000
+   */
+  maxIntervalMs?: number;
 }
 
 export interface SessionReplayJoinedConfig extends SessionReplayLocalConfig {

--- a/packages/session-replay-browser/src/events/base-events-store.ts
+++ b/packages/session-replay-browser/src/events/base-events-store.ts
@@ -14,7 +14,11 @@ export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
   private minInterval = MIN_INTERVAL;
   private maxInterval = MAX_INTERVAL;
   private maxPersistedEventsSize = MAX_EVENT_LIST_SIZE;
-  private interval = this.minInterval;
+  // Assigned in the constructor after `minInterval` is overridden by `args`. Class-field
+  // initializers run before the constructor body, so initializing here would freeze
+  // `interval` at the class-field default (500ms) — defeating any caller-supplied minInterval
+  // for the very first split.
+  private interval!: number;
   private _timeAtLastSplit = Date.now(); // Initialize this so we have a point of comparison when events are recorded
 
   public get timeAtLastSplit() {
@@ -26,6 +30,7 @@ export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
     this.minInterval = args.minInterval ?? this.minInterval;
     this.maxInterval = args.maxInterval ?? this.maxInterval;
     this.maxPersistedEventsSize = args.maxPersistedEventsSize ?? this.maxPersistedEventsSize;
+    this.interval = this.minInterval;
   }
 
   abstract addEventToCurrentSequence(

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -250,6 +250,8 @@ export class SessionReplay implements AmplitudeSessionReplay {
       rrwebEventManager = await createEventsManager<'replay'>({
         config: this.config,
         type: 'replay',
+        minInterval: this.config.flushIntervalConfig?.minIntervalMs,
+        maxInterval: this.config.flushIntervalConfig?.maxIntervalMs,
         storeType,
         trackDestinationWorkerScript,
       });

--- a/packages/session-replay-browser/test/base-events-store.test.ts
+++ b/packages/session-replay-browser/test/base-events-store.test.ts
@@ -85,4 +85,34 @@ describe('BaseEventsStore', () => {
     expect(store.shouldSplitEventsList(['test'], 'test')).toBe(true);
     return;
   });
+
+  describe('first-split interval honors caller-supplied minInterval', () => {
+    // Regression: class-field initializer `private interval = this.minInterval` ran before
+    // the constructor body, so `interval` froze at the class-field default (500ms) regardless
+    // of `args.minInterval`. The fix moves that assignment into the constructor body.
+    test('does not split before minInterval has elapsed', async () => {
+      jest.useFakeTimers().setSystemTime(Date.now());
+      const store = new InMemoryEventsStore({
+        loggerProvider: mockLoggerProvider,
+        minInterval: 5_000,
+        maxInterval: 30_000,
+      });
+      await store.addEventToCurrentSequence(1, 'a');
+      // Advance past the class-field default (500ms) but well under the configured 5s min.
+      jest.advanceTimersByTime(1_000);
+      expect(store.shouldSplitEventsList(['a'], 'b')).toBe(false);
+    });
+
+    test('splits once minInterval has elapsed', async () => {
+      jest.useFakeTimers().setSystemTime(Date.now());
+      const store = new InMemoryEventsStore({
+        loggerProvider: mockLoggerProvider,
+        minInterval: 5_000,
+        maxInterval: 30_000,
+      });
+      await store.addEventToCurrentSequence(1, 'a');
+      jest.advanceTimersByTime(5_001);
+      expect(store.shouldSplitEventsList(['a'], 'b')).toBe(true);
+    });
+  });
 });

--- a/packages/session-replay-browser/test/config/local-config.test.ts
+++ b/packages/session-replay-browser/test/config/local-config.test.ts
@@ -40,14 +40,30 @@ describe('SessionReplayLocalConfig', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('minIntervalMs'));
     });
 
-    test('clamps non-finite values (NaN, Infinity) to the floor', () => {
+    test('clamps non-finite minIntervalMs (NaN, Infinity) to the floor', () => {
       const config = new SessionReplayLocalConfig('static_key', {
         loggerProvider: logger,
-        flushIntervalConfig: { minIntervalMs: NaN, maxIntervalMs: Infinity },
+        flushIntervalConfig: { minIntervalMs: NaN },
       });
       expect(config.flushIntervalConfig?.minIntervalMs).toBe(100);
-      expect(config.flushIntervalConfig?.maxIntervalMs).toBe(100);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('minIntervalMs'));
+    });
+
+    test('preserves Infinity for maxIntervalMs as "no upper bound"', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: 5000, maxIntervalMs: Infinity },
+      });
+      expect(config.flushIntervalConfig?.maxIntervalMs).toBe(Infinity);
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('maxIntervalMs'));
+    });
+
+    test('clamps NaN maxIntervalMs to the floor', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { maxIntervalMs: NaN },
+      });
+      expect(config.flushIntervalConfig?.maxIntervalMs).toBe(100);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('maxIntervalMs'));
     });
 

--- a/packages/session-replay-browser/test/config/local-config.test.ts
+++ b/packages/session-replay-browser/test/config/local-config.test.ts
@@ -60,7 +60,7 @@ describe('SessionReplayLocalConfig', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('less than minIntervalMs'));
     });
 
-    test('accepts only minIntervalMs without maxIntervalMs', () => {
+    test('accepts only minIntervalMs without maxIntervalMs when below default max', () => {
       const config = new SessionReplayLocalConfig('static_key', {
         loggerProvider: logger,
         flushIntervalConfig: { minIntervalMs: 3000 },
@@ -68,12 +68,30 @@ describe('SessionReplayLocalConfig', () => {
       expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 3000 });
     });
 
-    test('accepts only maxIntervalMs without minIntervalMs', () => {
+    test('accepts only maxIntervalMs without minIntervalMs when above default min', () => {
       const config = new SessionReplayLocalConfig('static_key', {
         loggerProvider: logger,
         flushIntervalConfig: { maxIntervalMs: 30_000 },
       });
       expect(config.flushIntervalConfig).toEqual({ maxIntervalMs: 30_000 });
+    });
+
+    test('raises max to match user min when only minIntervalMs is set above the default max', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: 30_000 },
+      });
+      expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 30_000, maxIntervalMs: 30_000 });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('exceeds the default maxIntervalMs'));
+    });
+
+    test('lowers min to match user max when only maxIntervalMs is set below the default min', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { maxIntervalMs: 200 },
+      });
+      expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 200, maxIntervalMs: 200 });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('below the default minIntervalMs'));
     });
   });
 });

--- a/packages/session-replay-browser/test/config/local-config.test.ts
+++ b/packages/session-replay-browser/test/config/local-config.test.ts
@@ -1,0 +1,79 @@
+import { ILogger, Logger } from '@amplitude/analytics-core';
+import { SessionReplayLocalConfig } from '../../src/config/local-config';
+
+describe('SessionReplayLocalConfig', () => {
+  describe('flushIntervalConfig', () => {
+    let warnSpy: jest.SpyInstance;
+    let logger: ILogger;
+
+    beforeEach(() => {
+      logger = new Logger();
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {
+        /* swallow */
+      });
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test('is undefined when option is omitted', () => {
+      const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
+      expect(config.flushIntervalConfig).toBeUndefined();
+    });
+
+    test('passes through custom min/max when both are valid', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: 2000, maxIntervalMs: 30_000 },
+      });
+      expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 2000, maxIntervalMs: 30_000 });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('clamps minIntervalMs below the 100ms floor and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: 0 },
+      });
+      expect(config.flushIntervalConfig?.minIntervalMs).toBe(100);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('minIntervalMs'));
+    });
+
+    test('clamps non-finite values (NaN, Infinity) to the floor', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: NaN, maxIntervalMs: Infinity },
+      });
+      expect(config.flushIntervalConfig?.minIntervalMs).toBe(100);
+      expect(config.flushIntervalConfig?.maxIntervalMs).toBe(100);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('minIntervalMs'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('maxIntervalMs'));
+    });
+
+    test('raises max to match min when caller inverts them', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: 5000, maxIntervalMs: 1000 },
+      });
+      expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 5000, maxIntervalMs: 5000 });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('less than minIntervalMs'));
+    });
+
+    test('accepts only minIntervalMs without maxIntervalMs', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { minIntervalMs: 3000 },
+      });
+      expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 3000 });
+    });
+
+    test('accepts only maxIntervalMs without minIntervalMs', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        flushIntervalConfig: { maxIntervalMs: 30_000 },
+      });
+      expect(config.flushIntervalConfig).toEqual({ maxIntervalMs: 30_000 });
+    });
+  });
+});

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -465,6 +465,25 @@ describe('SessionReplay', () => {
       expect(sessionReplay.loggerProvider).toBeDefined();
     });
 
+    test('forwards flushIntervalConfig to the replay events manager', async () => {
+      const createEventsManagerSpy = jest.spyOn(SessionReplayEventsManager, 'createEventsManager');
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        flushIntervalConfig: { minIntervalMs: 2500, maxIntervalMs: 30_000 },
+      }).promise;
+      const replayCall = createEventsManagerSpy.mock.calls.find(([args]) => args.type === 'replay');
+      expect(replayCall).toBeDefined();
+      expect(replayCall?.[0]).toEqual(expect.objectContaining({ minInterval: 2500, maxInterval: 30_000 }));
+    });
+
+    test('omits flush interval values when flushIntervalConfig is not set', async () => {
+      const createEventsManagerSpy = jest.spyOn(SessionReplayEventsManager, 'createEventsManager');
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const replayCall = createEventsManagerSpy.mock.calls.find(([args]) => args.type === 'replay');
+      expect(replayCall?.[0].minInterval).toBeUndefined();
+      expect(replayCall?.[0].maxInterval).toBeUndefined();
+    });
+
     test('should invoke page leave listeners', async () => {
       const invokeEventMap = new Map<string, any>();
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({

--- a/test-server/session-replay-browser/sr-capture-test.html
+++ b/test-server/session-replay-browser/sr-capture-test.html
@@ -23,6 +23,21 @@
       const useWebWorker = params.get('useWebWorker') === 'true';
       const mergeMutations = params.get('mergeMutations') === 'true';
       const storeType = params.get('storeType') ?? undefined;
+      const parseIntervalMs = (raw) => {
+        if (raw === null) return undefined;
+        if (raw === 'Infinity') return Infinity;
+        const n = Number(raw);
+        return Number.isNaN(n) ? undefined : n;
+      };
+      const flushMinIntervalMs = parseIntervalMs(params.get('flushMinIntervalMs'));
+      const flushMaxIntervalMs = parseIntervalMs(params.get('flushMaxIntervalMs'));
+      const flushIntervalConfig =
+        flushMinIntervalMs !== undefined || flushMaxIntervalMs !== undefined
+          ? {
+              ...(flushMinIntervalMs !== undefined ? { minIntervalMs: flushMinIntervalMs } : {}),
+              ...(flushMaxIntervalMs !== undefined ? { maxIntervalMs: flushMaxIntervalMs } : {}),
+            }
+          : undefined;
 
       void (async () => {
         try {
@@ -35,6 +50,7 @@
             useWebWorker,
             performanceConfig: { enabled: true, mergeMutations },
             ...(storeType ? { storeType } : {}),
+            ...(flushIntervalConfig ? { flushIntervalConfig } : {}),
           }).promise;
         } catch (err) {
           document.getElementById('status').textContent = 'error: ' + err.message;


### PR DESCRIPTION
## Summary

Adds `flushIntervalConfig: { minIntervalMs, maxIntervalMs }` to `SessionReplayLocalConfig` so customers (or specific deployments) can raise the rrweb event-split cadence without waiting on an SDK upgrade.

## Context

Even after SR-4280 landed (honoring `X-Session-Replay-Event-Skipped` server back-pressure), we're still seeing significant 200+throttle traffic on v1.30.2. Walking the splitting logic (`BaseEventsStore.shouldSplitEventsList`) explains why:

- The interval starts at `MIN_INTERVAL = 500ms` and grows by 500ms after each split, capped at `MAX_INTERVAL = 10s`.
- A busy session fires roughly **10 batches in the first 30 seconds** before settling at 6/min — comparable to 1.5 minutes of steady-state traffic packed into the first half-minute.
- All of that happens **before** the first server response can arrive, so SR-4280's `flushPauseUntilMs` doesn't dampen the upfront burst. The throttle pause only affects the *next* schedule, not in-flight or already-queued contexts.
- `flushPauseUntilMs` and `killedSessions` are in-memory and per-instance, so every fresh page load / SDK init repeats the burst from scratch.

This PR doesn't touch the defaults — it just exposes the knob. We can roll out higher values for specific high-volume customers (or recommend tuning for self-hosted standalone integrations) without shipping a behavior change to everyone.

## What's in here

- `flushIntervalConfig?: FlushIntervalConfig` on `SessionReplayLocalConfig`, with `minIntervalMs` and `maxIntervalMs` fields (both optional).
- Validation in `SessionReplayLocalConfig` — clamps non-finite or sub-100ms values, raises `max` to match `min` if a caller inverts them, warns via the configured logger.
- Wires the values into `createEventsManager('replay')` (the `interaction` manager already had its own `INTERACTION_MIN_INTERVAL` plumbing).
- New `test/config/local-config.test.ts` covering defaults, custom values, clamping, and inversion.
- New tests in `session-replay.test.ts` verifying the values flow into `createEventsManager`.

## Test plan

- [x] `pnpm --filter @amplitude/session-replay-browser build` — clean
- [x] `npx jest --testPathIgnorePatterns=e2e` — 915/915 pass, 100% coverage
- [x] `pnpm lint:eslint` / `pnpm lint:prettier` — clean (warnings are pre-existing, unrelated files)
- [ ] Try a higher `minIntervalMs` (e.g., 3000ms) on a heavy-traffic test page and confirm the early-burst request count drops as expected

## Follow-ups (not in this PR)

- Bumping default `MIN_INTERVAL` once we have data on customer impact of the new knob.
- Persisting `flushPauseUntilMs` / `killedSessions` to localStorage keyed by API key, so cold starts honor the server's last directive instead of re-discovering it.
- Exposing this via remote config so backend ops can dial cadence per-org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new customer-facing tuning for replay flush cadence and fixes a timing initialization regression that affects when the first event split occurs, which can change request patterns in production. Changes are guarded behind optional config but touch core event batching/splitting behavior.
> 
> **Overview**
> Adds `flushIntervalConfig` (`minIntervalMs`/`maxIntervalMs`) to `SessionReplayLocalConfig` to let callers tune rrweb event-split/flush cadence, including sanitization (100ms floor, `Infinity` support for max, and min/max cross-validation with warnings).
> 
> Wires the config through `SessionReplay` into `createEventsManager('replay')`, and fixes `BaseEventsStore` so the **first split interval** correctly honors caller-supplied `minInterval` (not the class-field default).
> 
> Adds unit/integration coverage for the validator and forwarding behavior, plus Playwright e2e tests and a configurable Playwright `baseURL`; updates the SR capture test page to accept interval params via querystring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce43e660901e1d4795a7c3bc6eff70fe269157d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->