### PR TITLE
fix(plugin-session-replay-browser): forward crossOriginIframes to underlying SDK

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -107,6 +107,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         enableUrlChangePolling: this.options.enableUrlChangePolling,
         urlChangePollingInterval: this.options.urlChangePollingInterval,
         captureAdoptedStyleSheets: this.options.captureAdoptedStyleSheets,
+        crossOriginIframes: this.options.crossOriginIframes,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -5,6 +5,12 @@ import {
   type SessionReplayOptions as StandaloneSessionReplayOptions, // used for documentation
 } from '@amplitude/session-replay-browser';
 
+/**
+ * Configuration for cross-origin iframe support.
+ * Extracted from the standalone SDK's SessionReplayOptions.
+ */
+export type CrossOriginIframesConfig = NonNullable<StandaloneSessionReplayOptions['crossOriginIframes']>;
+
 export type MaskLevel =
   | 'light' // only mask a subset of inputs that’s deemed sensitive - password, credit card, telephone #, email. These are information we never want to capture.
   | 'medium' // mask all inputs
@@ -169,4 +175,8 @@ export interface SessionReplayOptions {
    * @see {@link StandaloneSessionReplayOptions.captureAdoptedStyleSheets}
    */
   captureAdoptedStyleSheets?: boolean;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.crossOriginIframes}
+   */
+  crossOriginIframes?: CrossOriginIframesConfig;
 }

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -395,6 +395,19 @@ describe('SessionReplayPlugin', () => {
         }),
       );
     });
+
+    test('should forward crossOriginIframes to session-replay SDK', async () => {
+      const crossOriginIframes = { enabled: true, coordinateChildren: false };
+      const sessionReplay = new SessionReplayPlugin({ crossOriginIframes });
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
+
+      expect(init).toHaveBeenCalledTimes(1);
+      expect(init.mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          crossOriginIframes,
+        }),
+      );
+    });
   });
 
   describe('onSessionIdChanged', () => {


### PR DESCRIPTION
## Context

Cross-origin iframe support (`crossOriginIframes: { enabled, coordinateChildren }`) was added to the standalone `@amplitude/session-replay-browser` SDK — it starts a `CrossOriginIframeCoordinator` that postMessages start/stop signals to child iframes. However, the plugin wrapper (`@amplitude/plugin-session-replay-browser`) never exposed or forwarded this config, making the feature completely inaccessible to plugin users.

This gap surfaced while preparing a bug bash for cross-origin iframe support; it was documented in the bash spreadsheet's "Plugin Forwarding" tab.

## Change

Two fixes in the plugin package only (standalone SDK untouched):

- **Type gap**: Added `CrossOriginIframesConfig` (derived from the standalone SDK's `SessionReplayOptions` via `NonNullable<StandaloneSessionReplayOptions['crossOriginIframes']>`) and a `crossOriginIframes?: CrossOriginIframesConfig` field to the plugin's `SessionReplayOptions` interface in `src/typings/session-replay.ts`. Without this, plugin users get a TypeScript error when they try to pass the option.

- **Forwarding gap**: Added `crossOriginIframes: this.options.crossOriginIframes` to the `srInitOptions` builder in `setup()` in `src/session-replay.ts`. Without this, the value was silently dropped before reaching `sessionReplay.init()` even if a user worked around the type gap.

## Test plan

- [x] Unit test added: `"should forward crossOriginIframes to session-replay SDK"` — instantiates the plugin with `crossOriginIframes: { enabled: true, coordinateChildren: false }`, calls `setup()`, and asserts `sessionReplay.init` is called with the matching object via `expect.objectContaining`
- [x] Full test suite passes with 100% coverage (Statements: 100%, Branches: 100%, Functions: 100%, Lines: 100%)
- [x] Build passes (`pnpm --filter @amplitude/plugin-session-replay-browser... build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, additive option wiring/type change that only affects users who opt into `crossOriginIframes`, plus a unit test to guard the forwarding behavior.
> 
> **Overview**
> Adds first-class support for configuring **cross-origin iframe replay** via the plugin by introducing a typed `crossOriginIframes` option (derived from the standalone SDK types).
> 
> Updates plugin initialization to forward `crossOriginIframes` into the underlying `sessionReplay.init()` options, and adds a unit test asserting the option is passed through unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75da993b77ab42c7c3275d2424a6f87a68bc3f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->