### PR TITLE
fix(analytics-browser): dummy patch to force gtm-snippet update

### DIFF
--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -35,4 +35,5 @@ export { trackVideo, type VideoCaptureOptions } from './video-capture/video-capt
 
 // Export types to maintain backward compatibility with `analytics-types`.
 // In the next major version, only export customer-facing types to reduce the public API surface.
+// (dummy patch analytics-browser to force GTM deploy)
 export * as Types from './types';


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a comment in `packages/analytics-browser/src/index.ts` with no runtime or API behavior changes.
> 
> **Overview**
> Adds a no-op comment in `packages/analytics-browser/src/index.ts` to create a patch release and trigger a GTM snippet deploy/update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f77e9002eeb4a7c00490da56bc0e88c555358342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->