### PR TITLE
fix(analytics-browser): bump background capture version

### DIFF
--- a/packages/analytics-core/src/messenger/constants.ts
+++ b/packages/analytics-core/src/messenger/constants.ts
@@ -9,5 +9,4 @@ export const AMPLITUDE_ORIGINS_MAP: Record<string, string> = {
 };
 
 // Background capture script URL (shared between autocapture and session-replay)
-export const AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL =
-  'https://cdn.amplitude.com/libs/background-capture-1.0.0-alpha.3.js.gz';
+export const AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL = 'https://cdn.amplitude.com/libs/background-capture-1.0.1.js.gz';


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk constant change, but it alters which remote `background-capture` bundle is loaded at runtime for autocapture/session-replay flows.
> 
> **Overview**
> Updates `AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL` to point to `background-capture-1.0.1.js.gz` (from `1.0.0-alpha.3`), changing the default remote script loaded by `enableBackgroundCapture` for autocapture/session-replay background capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ba97c89ee2fda88a9e6762d908357e12057a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->