### PR TITLE
fix(session-replay-browser): suppress IDB transaction-timeout log cascade (SR-4356)

### DIFF
--- a/packages/session-replay-browser/e2e/idb.spec.ts
+++ b/packages/session-replay-browser/e2e/idb.spec.ts
@@ -720,6 +720,77 @@ test.describe('IDB multi-tab and fallback behaviour', () => {
   });
 
   /**
+   * SR-4356 regression guard: when IDB is failing, the SDK must NOT flood
+   * the console with repeated "Failed to store session replay events"
+   * warnings.  Pre-fix, every fire-and-forget addEventToCurrentSequence call
+   * after the wedge opened its own readwrite tx and armed its own 5s
+   * watchdog, so hundreds of warns landed in a single burst (devtools
+   * collapsed them into "429×").  With the tripped flag, only the first
+   * failure logs and subsequent calls short-circuit before opening a tx.
+   *
+   * Strategy: patch IDBObjectStore.prototype.put to throw synchronously on
+   * every call, then generate many rapid events.  Assert that the storage-
+   * failure warn was logged at most once even though many events were
+   * captured.
+   */
+  test('IDB burst suppression: at most one storage-failure warn under sustained failure', async ({ page }) => {
+    await page.addInitScript(() => {
+      let putCallCount = 0;
+      (window as any).__idbPutCalls = () => putCallCount;
+      IDBObjectStore.prototype.put = function () {
+        putCallCount++;
+        throw new DOMException('Simulated IDB put failure', 'QuotaExceededError');
+      } as typeof IDBObjectStore.prototype.put;
+    });
+
+    const { pageErrors, idbWarns } = listenForIdbErrors(page);
+
+    await mockRemoteConfig(page, remoteConfigRecording);
+    await page.route('https://api-sr.amplitude.com/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) }),
+    );
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        logLevel: LOG_LEVEL_DEBUG,
+        storeType: 'idb',
+      }),
+    );
+    await waitForReady(page);
+
+    // Generate enough events to overrun the pre-fix burst threshold.  Mouse
+    // moves trigger rrweb captures at high frequency without needing real
+    // DOM interactions, which is the closest analogue to the customer
+    // scenario (rrweb + console-record + Sentry feedback loop).
+    for (let i = 0; i < 40; i++) {
+      await page.mouse.move(100 + i * 5, 200 + i);
+    }
+    await page.click('#test-button');
+    await page.click('#test-input');
+    await page.click('#test-button');
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => void (window as any).sessionReplay.flush(false));
+    await page.waitForTimeout(500);
+
+    // Sanity check: the put mock actually fired (so we know IDB writes were
+    // attempted and the failure path was exercised).  Without this guard the
+    // warn-count assertion below could pass trivially if the SDK never even
+    // tried to write.
+    const putCalls = await page.evaluate(() => (window as any).__idbPutCalls() as number);
+    expect(putCalls).toBeGreaterThanOrEqual(1);
+
+    // The whole point of SR-4356: even under sustained IDB failure with
+    // many rapid captures, the warn fires exactly once (the first failure
+    // that trips the store).  Pre-fix this would be in the dozens or hundreds.
+    expect(idbWarns.length).toBe(1);
+
+    // No unhandled promise rejections from the in-flight failed txs.
+    expect(pageErrors).toHaveLength(0);
+  });
+
+  /**
    * Hang-protection regression guard: if `indexedDB.open()` never fires
    * `onsuccess`/`onerror` (the documented Chrome-blocked-by-other-tab and
    * "closing" scenarios), the SDK must NOT hang waiting for IDB.  The 2s

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -160,7 +160,14 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   private readonly onPersistentFailure?: () => void;
   private readonly consecutiveFailureThreshold: number;
   private consecutiveFailures = 0;
-  private hasTriggeredFallback = false;
+  // Once tripped, every public write/read method short-circuits without opening
+  // a transaction.  Fire-and-forget callers (events-manager.addEvent) queue
+  // hundreds of operations per second; if IDB is wedged we must prevent each
+  // one from arming its own 5s watchdog (the "429× transaction timed out"
+  // cascade observed in production — see SR-4356).  Tripped flips at the same
+  // moment we decide to call onPersistentFailure, so it also serves as the
+  // re-entrancy guard for that callback.
+  private tripped = false;
 
   constructor(args: InstanceArgs) {
     super(args);
@@ -176,15 +183,31 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   }
 
   private recordFailure() {
+    // Once tripped, the store is permanently dead — there's no point in
+    // tracking further failures (in-flight watchdogs from txs opened before
+    // the trip would otherwise climb the counter unboundedly during a burst).
+    if (this.tripped) return;
     this.consecutiveFailures++;
-    if (!this.hasTriggeredFallback && this.consecutiveFailures >= this.consecutiveFailureThreshold) {
-      this.hasTriggeredFallback = true;
+    if (this.consecutiveFailures >= this.consecutiveFailureThreshold) {
+      this.tripped = true;
       this.onPersistentFailure?.();
     }
   }
 
   private recordSuccess() {
     this.consecutiveFailures = 0;
+  }
+
+  // Centralised failure-log helper.  All five public methods route their
+  // tx.done.catch / outer-catch / watchdog log calls through here so the
+  // tripped guard is defined in exactly one place.  See SR-4356: once the
+  // store is tripped, in-flight transactions opened before the trip can still
+  // fail and would otherwise produce a console burst (the "429× transaction
+  // timed out" cascade).
+  private logFailure(message: string, error?: unknown) {
+    if (!this.tripped) {
+      logIdbError(this.loggerProvider, message, error);
+    }
   }
 
   static async new(
@@ -239,6 +262,21 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   }
 
   getSequencesToSend = async (): Promise<SendingSequencesReturn<number>[] | undefined> => {
+    if (this.tripped) return undefined;
+    return this.readSequencesFromIdb();
+  };
+
+  // Internal recovery-only read used by events-manager.switchToMemoryStore to
+  // attempt one last drain off the IDB handle as part of the fallback path.
+  // Intentionally bypasses the tripped guard: a write-side wedge (e.g.
+  // QuotaExceededError on put) leaves reads healthy, and we want to recover
+  // pending sequences before going to memory-only.  In the truly-wedged case
+  // the per-tx watchdog inside readSequencesFromIdb bounds the exposure.
+  drainForFallback = async (): Promise<SendingSequencesReturn<number>[] | undefined> => {
+    return this.readSequencesFromIdb();
+  };
+
+  private async readSequencesFromIdb(): Promise<SendingSequencesReturn<number>[] | undefined> {
     let errorLogged = false;
     let timedOut = false;
     try {
@@ -250,7 +288,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       // when the outer catch (or the timeout race) already fired for the same abort.
       tx.done.catch((e: unknown) => {
         if (!errorLogged && !timedOut) {
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+          this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
           this.recordFailure();
         }
       });
@@ -262,7 +300,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       const cancelTimeout = armTxDoneTimeout(tx.done, TX_DONE_TIMEOUT_MS, () => {
         if (!errorLogged && !timedOut) {
           timedOut = true;
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: transaction timed out`);
+          this.logFailure(`${STORAGE_FAILURE}: transaction timed out`);
           this.recordFailure();
         }
       });
@@ -289,14 +327,15 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
     } catch (e) {
       if (!timedOut) {
         errorLogged = true;
-        logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+        this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
         this.recordFailure();
       }
     }
     return undefined;
-  };
+  }
 
   storeCurrentSequence = async (sessionId: number) => {
+    if (this.tripped) return undefined;
     let errorLogged = false;
     let timedOut = false;
     try {
@@ -309,7 +348,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       const tx = this.db.transaction([currentSequenceKey, sequencesToSendKey], 'readwrite');
       tx.done.catch((e: unknown) => {
         if (!errorLogged && !timedOut) {
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+          this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
           this.recordFailure();
         }
       });
@@ -317,7 +356,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       const cancelTimeout = armTxDoneTimeout(tx.done, TX_DONE_TIMEOUT_MS, () => {
         if (!errorLogged && !timedOut) {
           timedOut = true;
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: transaction timed out`);
+          this.logFailure(`${STORAGE_FAILURE}: transaction timed out`);
           this.recordFailure();
         }
       });
@@ -362,7 +401,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
     } catch (e) {
       if (!timedOut) {
         errorLogged = true;
-        logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+        this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
         this.recordFailure();
       }
     }
@@ -370,6 +409,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   };
 
   addEventToCurrentSequence = async (sessionId: number, event: string) => {
+    if (this.tripped) return undefined;
     let errorLogged = false;
     let timedOut = false;
     try {
@@ -386,7 +426,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       // (or the timeout) already fired for the same transaction.
       tx.done.catch((e: unknown) => {
         if (!errorLogged && !timedOut) {
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+          this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
           this.recordFailure();
         }
       });
@@ -394,7 +434,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       const cancelTimeout = armTxDoneTimeout(tx.done, TX_DONE_TIMEOUT_MS, () => {
         if (!errorLogged && !timedOut) {
           timedOut = true;
-          logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: transaction timed out`);
+          this.logFailure(`${STORAGE_FAILURE}: transaction timed out`);
           this.recordFailure();
         }
       });
@@ -458,7 +498,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
     } catch (e) {
       if (!timedOut) {
         errorLogged = true;
-        logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+        this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
         this.recordFailure();
       }
     }
@@ -466,6 +506,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
   };
 
   storeSendingEvents = async (sessionId: number, events: Events) => {
+    if (this.tripped) return undefined;
     try {
       const sequenceId = await this.db.put<'sequencesToSend'>(sequencesToSendKey, {
         sessionId: sessionId,
@@ -475,13 +516,14 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       this.recordSuccess();
       return sequenceId;
     } catch (e) {
-      logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+      this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
       this.recordFailure();
     }
     return undefined;
   };
 
   cleanUpSessionEventsStore = async (_sessionId: number, sequenceId?: number) => {
+    if (this.tripped) return;
     if (!sequenceId) {
       return;
     }
@@ -489,7 +531,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       await this.db.delete<'sequencesToSend'>(sequencesToSendKey, sequenceId);
       this.recordSuccess();
     } catch (e) {
-      logIdbError(this.loggerProvider, `${STORAGE_FAILURE}: ${e as string}`, e);
+      this.logFailure(`${STORAGE_FAILURE}: ${e as string}`, e);
       this.recordFailure();
     }
   };

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -61,13 +61,36 @@ export const createEventsManager = async <Type extends EventType>({
     if (!usingIdbStore) return;
     usingIdbStore = false;
     config.loggerProvider.warn('IDB store is experiencing repeated failures; falling back to in-memory event store.');
-    const sequences = lastKnownDeviceId ? await store.getSequencesToSend() : undefined;
+
+    // Swap-first: replace `store` synchronously so any further addEvent /
+    // sendCurrentSequenceEvents calls land on the in-memory store immediately.
+    // The previous implementation awaited getSequencesToSend on the broken IDB
+    // handle BEFORE swapping, which kept new captures gated on the very thing
+    // that was stalling (SR-4356).
+    const idbStore = store;
     store = getMemoryStore();
-    if (sequences && lastKnownDeviceId) {
-      const deviceId = lastKnownDeviceId;
-      sequences.forEach((seq) => {
-        sendEventsList({ sequenceId: seq.sequenceId, events: seq.events, sessionId: seq.sessionId, deviceId });
-      });
+
+    if (!lastKnownDeviceId) return;
+    const deviceId = lastKnownDeviceId;
+
+    // Best-effort recovery drain.  Uses drainForFallback (not the public
+    // getSequencesToSend) so it bypasses the tripped short-circuit and actually
+    // attempts a read off the IDB handle.  A write-side wedge (e.g.
+    // QuotaExceededError on put) often leaves reads healthy, so this can
+    // recover sequences already in sequencesToSend before the failure.  The
+    // per-tx watchdog inside drainForFallback bounds exposure if reads are also
+    // wedged.  The early-return at the top of switchToMemoryStore guarantees
+    // usingIdbStore was true at entry, so idbStore is a SessionReplayEventsIDBStore.
+    try {
+      const sequences = await (idbStore as SessionReplayEventsIDBStore).drainForFallback();
+      if (sequences) {
+        sequences.forEach((seq) => {
+          sendEventsList({ sequenceId: seq.sequenceId, events: seq.events, sessionId: seq.sessionId, deviceId });
+        });
+      }
+    } catch {
+      // Drain failed — IDB is fully wedged.  Accept the loss; new events are
+      // already landing in the memory store.
     }
   };
 

--- a/packages/session-replay-browser/test/events-idb-store-timeout.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store-timeout.test.ts
@@ -405,6 +405,223 @@ describe('IDB timeout / hang protection', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // SR-4356: burst suppression after the store trips
+  // ---------------------------------------------------------------------------
+  describe('burst suppression after trip', () => {
+    test('public methods short-circuit without opening a tx once tripped', async () => {
+      // Set up a working-but-trackable mock so we can observe transaction
+      // counts.  The first call fails and trips the store; subsequent calls
+      // should not call .transaction() / .put() / .delete() at all.
+      let txCalls = 0;
+      let putCalls = 0;
+      let deleteCalls = 0;
+      const okStuckTx = () => ({
+        objectStore: jest.fn().mockReturnValue({
+          // Throw inside the operation so the outer try/catch records a
+          // failure on the very first call.  After that, tripped=true and
+          // public methods must short-circuit.
+          get: jest.fn().mockRejectedValue(new Error('boom')),
+          put: jest.fn().mockRejectedValue(new Error('boom')),
+        }),
+        done: Promise.resolve(),
+      });
+      const mockDB = {
+        transaction: jest.fn().mockImplementation(() => {
+          txCalls++;
+          return okStuckTx();
+        }),
+        put: jest.fn().mockImplementation(() => {
+          putCalls++;
+          return Promise.reject(new Error('boom'));
+        }),
+        delete: jest.fn().mockImplementation(() => {
+          deleteCalls++;
+          return Promise.reject(new Error('boom'));
+        }),
+      } as unknown as EventsIDBStore.SessionReplayDB;
+
+      jest
+        .spyOn(EventsIDBStore, 'createStore')
+        .mockResolvedValue(mockDB as unknown as import('idb').IDBPDatabase<EventsIDBStore.SessionReplayDB>);
+
+      const onPersistentFailure = jest.fn();
+      const store = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: makeLogger(),
+        onPersistentFailure,
+        consecutiveFailureThreshold: 1,
+      });
+      expect(store).toBeDefined();
+
+      // First call fails synchronously inside the try → recordFailure runs →
+      // tripped flips to true and onPersistentFailure fires.
+      await store!.addEventToCurrentSequence(123, mockEvent);
+      expect(onPersistentFailure).toHaveBeenCalledTimes(1);
+      const baselineTxCalls = txCalls;
+
+      // Every subsequent call must short-circuit.  No new tx opened, no put/
+      // delete on the db handle, and crucially no watchdog armed.
+      await store!.addEventToCurrentSequence(123, mockEvent);
+      await store!.getSequencesToSend();
+      await store!.storeCurrentSequence(123);
+      await store!.storeSendingEvents(123, [mockEvent]);
+      await store!.cleanUpSessionEventsStore(123, 1);
+
+      expect(txCalls).toBe(baselineTxCalls);
+      expect(putCalls).toBe(0);
+      expect(deleteCalls).toBe(0);
+      // Callback must not have fired a second time.
+      expect(onPersistentFailure).toHaveBeenCalledTimes(1);
+    });
+
+    test('drainForFallback bypasses tripped and still reads sequences (SR-4356 recovery path)', async () => {
+      // drainForFallback is the one method that MUST NOT honour the tripped
+      // short-circuit — switchToMemoryStore calls it on the already-tripped
+      // store to recover sequences that were persisted before the wedge.
+      // Regression guard: if a future change ever adds `if (this.tripped)
+      // return undefined;` to drainForFallback, this test fails.
+      const seededSequences = [{ sessionId: 7, events: ['evt-a', 'evt-b'], sequenceId: 1 }];
+
+      // Build a mock that:
+      //   (a) makes addEventToCurrentSequence fail, tripping the store,
+      //   (b) lets a subsequent sequencesToSend cursor read succeed.
+      let openCursorIdx = 0;
+      const failingObjectStore = {
+        get: jest.fn().mockRejectedValue(new Error('boom')),
+        put: jest.fn().mockRejectedValue(new Error('boom')),
+      };
+      const readCursor = (
+        idx: number,
+      ): { value: (typeof seededSequences)[number]; key: number; continue: () => Promise<unknown> } | null => {
+        if (idx >= seededSequences.length) return null;
+        const seq = seededSequences[idx];
+        return {
+          value: seq,
+          key: seq.sequenceId,
+          continue: () => Promise.resolve(readCursor(idx + 1)),
+        };
+      };
+      const readingStore = {
+        openCursor: jest.fn().mockImplementation(() => Promise.resolve(readCursor(openCursorIdx++))),
+      };
+      const mockDB = {
+        transaction: jest.fn().mockImplementation((storeName: string | string[]) => {
+          // The failing transaction (used by addEventToCurrentSequence) is over
+          // [currentSequenceKey, sequencesToSendKey]; the read transaction (used
+          // by readSequencesFromIdb) is over 'sequencesToSend' alone.
+          if (Array.isArray(storeName)) {
+            return {
+              objectStore: jest.fn().mockReturnValue(failingObjectStore),
+              done: Promise.resolve(),
+            };
+          }
+          return {
+            store: readingStore,
+            done: Promise.resolve(),
+          };
+        }),
+      } as unknown as EventsIDBStore.SessionReplayDB;
+
+      jest
+        .spyOn(EventsIDBStore, 'createStore')
+        .mockResolvedValue(mockDB as unknown as import('idb').IDBPDatabase<EventsIDBStore.SessionReplayDB>);
+
+      const onPersistentFailure = jest.fn();
+      const store = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: makeLogger(),
+        onPersistentFailure,
+        consecutiveFailureThreshold: 1,
+      });
+      expect(store).toBeDefined();
+
+      // Trip the store via a failing write.
+      await store!.addEventToCurrentSequence(123, mockEvent);
+      expect(onPersistentFailure).toHaveBeenCalledTimes(1);
+
+      // Confirm the public read short-circuits (regression guard for the
+      // other half of the contract).
+      const blocked = await store!.getSequencesToSend();
+      expect(blocked).toBeUndefined();
+
+      // The recovery drain MUST still read the data — this is the whole
+      // point of having a separate method.
+      const recovered = await store!.drainForFallback();
+      expect(recovered).toEqual(seededSequences);
+    });
+
+    test('only the first watchdog logs; later ones in the same burst stay silent', async () => {
+      // Production scenario: hundreds of in-flight readwrite txs all stalling.
+      // Each one armed its own 5s setTimeout BEFORE the store tripped.  When
+      // the burst window arrives, only the first to fire should log — the
+      // rest must stay silent so the console doesn't get the 429× cascade.
+      const txDone = new Promise<void>(() => {
+        // never settles
+      });
+      const stuckOp = new Promise<undefined>(() => {
+        // never resolves
+      });
+
+      const transactionMock = jest.fn().mockReturnValue({
+        objectStore: jest.fn().mockReturnValue({
+          get: jest.fn().mockReturnValue(stuckOp),
+          put: jest.fn().mockReturnValue(stuckOp),
+        }),
+        done: txDone,
+      });
+      const mockDB = {
+        transaction: transactionMock,
+      } as unknown as EventsIDBStore.SessionReplayDB;
+
+      jest
+        .spyOn(EventsIDBStore, 'createStore')
+        .mockResolvedValue(mockDB as unknown as import('idb').IDBPDatabase<EventsIDBStore.SessionReplayDB>);
+
+      const logger = makeLogger();
+      const onPersistentFailure = jest.fn();
+      const store = await SessionReplayEventsIDBStore.new('replay', {
+        apiKey,
+        loggerProvider: logger,
+        onPersistentFailure,
+        consecutiveFailureThreshold: 1,
+      });
+
+      // Queue many in-flight calls before any watchdog fires.  Each is
+      // fire-and-forget (matches events-manager.addEvent behaviour); each
+      // opens its own readwrite tx and arms its own 5s watchdog.
+      const N = 50;
+      for (let i = 0; i < N; i++) {
+        void store!.addEventToCurrentSequence(123, mockEvent);
+      }
+      // Let each call run up to its first await.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(logger.warn).not.toHaveBeenCalled();
+      // Side-channel: prove that all N calls actually opened transactions
+      // (and therefore armed N watchdogs).  Otherwise the warn==1 assertion
+      // below could pass trivially if some bug short-circuited the calls
+      // before they got to arm timers.
+      expect(transactionMock).toHaveBeenCalledTimes(N);
+
+      // Fire the burst.
+      jest.advanceTimersByTime(EventsIDBStore.TX_DONE_TIMEOUT_MS + 100);
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      // Exactly one warn, regardless of how many watchdogs fired.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      const message = (logger.warn.mock.calls[0]?.[0] ?? '') as string;
+      expect(message).toContain('transaction timed out');
+      // The fallback callback also fires exactly once.
+      expect(onPersistentFailure).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // generateUUID fallback: Math.random path when crypto.randomUUID unavailable
   // ---------------------------------------------------------------------------
   describe('generateUUID', () => {

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -37,6 +37,7 @@ describe('createEventsManager', () => {
   const mockIDBStore = {
     storeCurrentSequence: jest.fn(),
     getSequencesToSend: jest.fn(),
+    drainForFallback: jest.fn(),
     cleanUpSessionEventsStore: jest.fn().mockResolvedValue(undefined),
     addEventToCurrentSequence: jest.fn(),
     initialize: jest.fn(),
@@ -611,7 +612,7 @@ describe('createEventsManager', () => {
     });
 
     test('drains and sends pending IDB sequences when falling back', async () => {
-      (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValueOnce([
+      (mockIDBStore.drainForFallback as jest.Mock).mockResolvedValueOnce([
         { events: [mockEventString], sequenceId: 1, sessionId: 123 },
       ]);
       (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockResolvedValue(undefined);
@@ -637,11 +638,11 @@ describe('createEventsManager', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(mockIDBStore.getSequencesToSend).not.toHaveBeenCalled();
+      expect(mockIDBStore.drainForFallback).not.toHaveBeenCalled();
     });
 
     test('new events after fallback go to in-memory store, not IDB', async () => {
-      (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValueOnce([]);
+      (mockIDBStore.drainForFallback as jest.Mock).mockResolvedValueOnce([]);
       (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockResolvedValue(undefined);
 
       const eventsManager = await createEventsManager<'replay'>({ config, type: 'replay', storeType: 'idb' });
@@ -676,7 +677,7 @@ describe('createEventsManager', () => {
     });
 
     test('second switchToMemoryStore call is a no-op (already on memory)', async () => {
-      (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValue([]);
+      (mockIDBStore.drainForFallback as jest.Mock).mockResolvedValue([]);
       (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockResolvedValue(undefined);
 
       const eventsManager = await createEventsManager<'replay'>({ config, type: 'replay', storeType: 'idb' });
@@ -694,6 +695,71 @@ describe('createEventsManager', () => {
 
       // Warning should only be logged once
       expect(mockLoggerProvider.warn).toHaveBeenCalledTimes(1);
+    });
+
+    test('events added during drain go to memory store, not the broken IDB handle (SR-4356)', async () => {
+      // The pre-fix recovery path awaited `store.getSequencesToSend()` on the
+      // broken IDB handle BEFORE swapping `store` to the memory store, so any
+      // addEvent calls in the await window still hit IDB.  The fix swaps
+      // synchronously; this test pins that ordering by holding the drain on a
+      // controllable promise and asserting subsequent addEvents don't touch
+      // the IDB mock.
+      let resolveDrain: (v: never[]) => void = () => undefined;
+      const drainPromise = new Promise<never[]>((resolve) => {
+        resolveDrain = resolve;
+      });
+      (mockIDBStore.drainForFallback as jest.Mock).mockReturnValueOnce(drainPromise);
+      (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockResolvedValue(undefined);
+
+      const eventsManager = await createEventsManager<'replay'>({ config, type: 'replay', storeType: 'idb' });
+      // Establish lastKnownDeviceId so switchToMemoryStore attempts a drain.
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      await Promise.resolve();
+
+      // Reset IDB mock to count post-fallback calls only.
+      (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockClear();
+
+      // Trigger fallback.  switchToMemoryStore must swap synchronously and
+      // then await the drain — which is still pending.
+      capturedOnPersistentFailure?.();
+      // Yield to let the synchronous swap settle.
+      await Promise.resolve();
+
+      // While drain is still in flight, push more events.  These must NOT hit
+      // the IDB mock (proves the swap happened before the await).
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      await Promise.resolve();
+
+      expect(mockIDBStore.addEventToCurrentSequence).not.toHaveBeenCalled();
+
+      // Releasing the drain shouldn't change anything — events are already in memory.
+      resolveDrain([]);
+      await Promise.resolve();
+      expect(mockIDBStore.addEventToCurrentSequence).not.toHaveBeenCalled();
+    });
+
+    test('drain rejection is swallowed and does not block fallback', async () => {
+      // Defence in depth: even if the broken IDB rejects the drain (rather
+      // than returning undefined via the tripped short-circuit), the recovery
+      // path must accept the loss and keep recording in memory.
+      (mockIDBStore.drainForFallback as jest.Mock).mockRejectedValueOnce(new Error('idb is gone'));
+      (mockIDBStore.addEventToCurrentSequence as jest.Mock).mockResolvedValue(undefined);
+
+      const eventsManager = await createEventsManager<'replay'>({ config, type: 'replay', storeType: 'idb' });
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      await Promise.resolve();
+
+      const beforeCalls = (mockIDBStore.addEventToCurrentSequence as jest.Mock).mock.calls.length;
+
+      capturedOnPersistentFailure?.();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Recording continues — new events land on the memory store, not IDB.
+      eventsManager.addEvent({ event: { type: 'replay', data: mockEventString }, sessionId: 123, deviceId: '1a2b3c' });
+      await Promise.resolve();
+      expect((mockIDBStore.addEventToCurrentSequence as jest.Mock).mock.calls.length).toBe(beforeCalls);
     });
   });
 });

--- a/packages/session-replay-browser/test/integration/sampling.test.ts
+++ b/packages/session-replay-browser/test/integration/sampling.test.ts
@@ -180,10 +180,7 @@ describe('module level integration', () => {
         // Wait for async initialize to complete
         await runScheduleTimers();
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
-        const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
-          .results[0].value;
 
-        jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
         expect(sessionRecordingProperties).toMatchObject({
           [DEFAULT_SESSION_REPLAY_PROPERTY]: `1a2b3c/${SESSION_ID_IN_20_SAMPLE}`,
         });
@@ -191,7 +188,15 @@ describe('module level integration', () => {
         const recordArg = mockRecordFunction.mock.calls[0][0] as { emit?: (event: eventWithTime) => void };
         recordArg?.emit?.(mockEvent);
         sessionReplay.sendEvents();
-        await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
+        // Drain pending microtasks + timers so storeCurrentSequence settles on
+        // whichever store is currently active.  Previously this awaited the
+        // IDB-instance spy's first result, but SR-4356 fixes the broken IDB
+        // fallback so that under fake-timer-induced watchdog firings the swap
+        // to the in-memory store actually happens — meaning the IDB instance
+        // may no longer receive storeCurrentSequence calls in this test
+        // environment.  The downstream fetch assertion still validates the
+        // end-to-end recording path.
+        await runScheduleTimers();
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(
           `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&type=replay`,
@@ -241,9 +246,6 @@ describe('module level integration', () => {
         await sessionReplay.init(apiKey, { ...mockOptions, sampleRate: 0.8 }).promise;
         // Wait for async initialize to complete
         await runScheduleTimers();
-        const createEventsIDBStoreInstance = await (SessionReplayIDB.SessionReplayEventsIDBStore.new as jest.Mock).mock
-          .results[0].value;
-        jest.spyOn(createEventsIDBStoreInstance, 'storeCurrentSequence');
         const sessionRecordingProperties = sessionReplay.getSessionReplayProperties();
         expect(sessionRecordingProperties).toMatchObject({
           [DEFAULT_SESSION_REPLAY_PROPERTY]: `1a2b3c/${SESSION_ID_IN_20_SAMPLE}`,
@@ -254,7 +256,11 @@ describe('module level integration', () => {
         const recordArg = mockRecordFunction.mock.calls[0][0] as { emit?: (event: eventWithTime) => void };
         recordArg?.emit?.(mockEvent);
         sessionReplay.sendEvents();
-        await (createEventsIDBStoreInstance.storeCurrentSequence as jest.Mock).mock.results[0].value;
+        // See "should capture" above — drain via runScheduleTimers rather than
+        // spying on the IDB instance's storeCurrentSequence, because SR-4356
+        // means the watchdog-triggered swap may route the call to the memory
+        // store instead.
+        await runScheduleTimers();
         await runScheduleTimers();
         expect(fetch).toHaveBeenLastCalledWith(
           `${SESSION_REPLAY_SERVER_URL}?device_id=1a2b3c&session_id=${SESSION_ID_IN_20_SAMPLE}&type=replay`,


### PR DESCRIPTION
## Summary

- Customer page was seeing hundreds of repeated `Amplitude Logger [Warn]: Failed to store session replay events in IndexedDB: transaction timed out` (devtools collapsed 429×). Self-amplifying loop via rrweb-plugin-console-record + Sentry made it worse.
- Three layered fixes in `packages/session-replay-browser/src/events`:
  1. `tripped` flag on `SessionReplayEventsIDBStore` — public methods short-circuit without opening a tx once tripped, so no more watchdogs are armed
  2. Centralised `logFailure` helper gated on `!tripped` — only the first failure logs; in-flight watchdogs / tx.done rejections stay silent
  3. Swap-first in `switchToMemoryStore` — replace `store` synchronously before the recovery drain. The drain itself uses a new `drainForFallback` that bypasses tripped, preserving recovery on write-side wedges

Linear: [SR-4356](https://linear.app/amplitude/issue/SR-4356/sr-sdk-floods-console-with-transaction-timed-out-warnings-when-idb-is)

## Test plan

- [x] 912 jest tests pass with 100% coverage
- [x] New unit tests cover: short-circuit after trip, log-once across burst, `drainForFallback` bypasses tripped, swap-first ordering, drain rejection swallowed
- [x] New e2e test in `e2e/idb.spec.ts` verifies that under sustained IDB put failure with 40+ rapid events, exactly 1 storage-failure warn is emitted (pre-fix would be dozens)
- [ ] Bugbot pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies session-replay event persistence and mid-session fallback behavior under IndexedDB failure; bugs here could impact event durability or recovery ordering, but changes are gated to failure paths and are heavily test-covered.
> 
> **Overview**
> Prevents session replay from **spamming console warnings** and piling up stalled transactions when IndexedDB becomes unhealthy (SR-4356).
> 
> `SessionReplayEventsIDBStore` now trips a permanent failure flag that makes public read/write methods **short-circuit** (no new transactions/watchdogs) and centralizes storage-failure logging so only the first failure logs; a new `drainForFallback()` bypasses the trip to allow a best-effort final read.
> 
> `switchToMemoryStore` in `events-manager` is reordered to **swap to the in-memory store first**, then attempt the best-effort IDB drain (swallowing drain failures), ensuring new captures aren’t blocked by a wedged IDB handle; unit/integration/e2e tests are updated/added to lock in burst-suppression and swap-first behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4ca24838099cd621851dd8ee18012bef71357a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->