### PR TITLE
chore(session-replay-browser): scrub customer name from privacy e2e test (SR-4452)

### DIFF
--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -639,10 +639,10 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     expect(isMaskedText(getTextContent(plainEl!))).toBe(true);
   });
 
-  // Repro for GoFundMe customer report (Slack C0AJHTHCB96 / 2026-05-12):
+  // Repro for customer report (Slack C0AJHTHCB96 / 2026-05-12):
   // defaultMaskLevel: conservative + a urlMaskLevels rule routing the page to 'light'.
   // Under the light URL rule, plain <p> body text on the matched page is visible.
-  test('urlMaskLevels light rule leaves plain body text visible (GFM repro)', async ({ page }) => {
+  test('urlMaskLevels light rule leaves plain body text visible', async ({ page }) => {
     await mockRemoteConfig(
       page,
       remoteConfigWithPrivacy({


### PR DESCRIPTION
## Summary
- Remove a customer name from a comment and a test title in `packages/session-replay-browser/e2e/privacy.spec.ts`.
- Internal Slack channel ID retained for traceability; test behaviour is unchanged.
- `packages/plugin-session-replay-browser` had no occurrences.

Linear: [SR-4452](https://linear.app/amplitude/issue/SR-4452)

## Test plan
- [ ] Targeted privacy e2e spec still passes — only the test name changed, no logic touched.
- [ ] Repo grep confirms no remaining occurrences in `session-replay-browser` / `plugin-session-replay-browser` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates an e2e test comment and test name to remove a customer reference; runtime behavior and assertions are unchanged.
> 
> **Overview**
> Removes a customer-specific reference from the `privacy.spec.ts` e2e test by updating an in-file comment and the associated test title, while retaining the Slack channel ID for internal traceability.
> 
> No test logic or masking behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b43eb765c9349241b3c4c0d7118a58fa7e59bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->