### PR TITLE
fix(analytics-node): export NodeClient and NodeOptions from Types namespace

### DIFF
--- a/packages/analytics-node/src/types.ts
+++ b/packages/analytics-node/src/types.ts
@@ -25,4 +25,6 @@ export {
   Storage,
   TransportType,
   OfflineDisabled,
+  NodeClient,
+  NodeOptions,
 } from '@amplitude/analytics-core';


### PR DESCRIPTION
### Summary

Closes #1758.

The `@amplitude/analytics-node` package's `Types` namespace re-exports a curated list from `@amplitude/analytics-core` but omits `NodeClient` and `NodeOptions`. This is asymmetric with `@amplitude/analytics-browser`'s `Types` namespace, which does re-export the equivalent `BrowserClient`, `BrowserConfig`, and `BrowserOptions`.

As a result, code that references `amplitude.Types.NodeClient` or `amplitude.Types.NodeOptions` silently resolves to `any`. The most visible victim is the Ampli code generator (Runtime `node.js:typescript-ampli-v2`), which emits generated clients of the form:

```ts
import * as amplitude from '@amplitude/analytics-node';

export type NodeClient = amplitude.Types.NodeClient;   // resolves to `any`
export type NodeOptions = amplitude.Types.NodeOptions; // resolves to `any`
```

Those generated files ship with `// @ts-nocheck`, which hides the breakage from the typechecker, so downstream consumers lose type safety with no warning.

This PR adds the two symbols to `packages/analytics-node/src/types.ts`, restoring symmetry with the browser package and making `amplitude.Types.NodeClient` / `amplitude.Types.NodeOptions` resolve to their real types.

### Checklist

- [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
- Does your PR have a breaking change?: no (purely additive type re-export)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands public type re-exports for the Node package and does not change runtime behavior.
>
> **Overview**
> Exports `NodeClient` and `NodeOptions` from `packages/analytics-node/src/types.ts`, making these core Node-specific types available via the analytics-node package's public types surface.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d26ce9a40391e4e3cc4c51b57a8e993598000b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->