### PR TITLE
fix(analytics-browser): guard snippet bootstrap against undefined _iq and _q

### DIFF
--- a/packages/analytics-browser/src/gtm-snippet-index.ts
+++ b/packages/analytics-browser/src/gtm-snippet-index.ts
@@ -32,7 +32,7 @@ import { runQueuedFunctions } from './utils/snippet-helper';
     GlobalScope.amplitudeGTM._q = [];
     runQueuedFunctions(amplitudeGTM, queue);
 
-    const instanceNames = Object.keys(GlobalScope.amplitudeGTM._iq) || [];
+    const instanceNames = Object.keys(GlobalScope.amplitudeGTM._iq || {});
     for (let i = 0; i < instanceNames.length; i++) {
       const instanceName = instanceNames[i];
       const instance = Object.assign(GlobalScope.amplitudeGTM._iq[instanceName], createNamedInstance(instanceName));

--- a/packages/analytics-browser/src/gtm-snippet-index.ts
+++ b/packages/analytics-browser/src/gtm-snippet-index.ts
@@ -27,12 +27,20 @@ import { runQueuedFunctions } from './utils/snippet-helper';
     createInstance: createNamedInstance,
   });
 
+  // Normalize proxy queues so a pre-existing global with `invoked = true` but
+  // missing `_q` / `_iq` doesn't crash either this bootstrap or downstream
+  // GTM wrapper code that reads `amplitudeGTM._iq[name]` directly.
+  GlobalScope.amplitudeGTM._q = GlobalScope.amplitudeGTM._q || [];
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  GlobalScope.amplitudeGTM._iq = GlobalScope.amplitudeGTM._iq || {};
+
   if (GlobalScope.amplitudeGTM.invoked) {
     const queue = GlobalScope.amplitudeGTM._q;
     GlobalScope.amplitudeGTM._q = [];
     runQueuedFunctions(amplitudeGTM, queue);
 
-    const instanceNames = Object.keys(GlobalScope.amplitudeGTM._iq || {});
+    const instanceNames = Object.keys(GlobalScope.amplitudeGTM._iq);
     for (let i = 0; i < instanceNames.length; i++) {
       const instanceName = instanceNames[i];
       const instance = Object.assign(GlobalScope.amplitudeGTM._iq[instanceName], createNamedInstance(instanceName));

--- a/packages/analytics-browser/src/snippet-index.ts
+++ b/packages/analytics-browser/src/snippet-index.ts
@@ -49,7 +49,7 @@ function resolveCurrentScriptUrl(): string | undefined {
     GlobalScope.amplitude._q = [];
     runQueuedFunctions(amplitude, queue);
 
-    const instanceNames = Object.keys(GlobalScope.amplitude._iq) || [];
+    const instanceNames = Object.keys(GlobalScope.amplitude._iq || {});
     for (let i = 0; i < instanceNames.length; i++) {
       const instanceName = instanceNames[i];
       const instance = Object.assign(GlobalScope.amplitude._iq[instanceName], createNamedInstance(instanceName));

--- a/packages/analytics-browser/src/snippet-index.ts
+++ b/packages/analytics-browser/src/snippet-index.ts
@@ -44,12 +44,20 @@ function resolveCurrentScriptUrl(): string | undefined {
     createInstance: createNamedInstance,
   });
 
+  // Normalize proxy queues so a pre-existing global with `invoked = true` but
+  // missing `_q` / `_iq` doesn't crash either this bootstrap or downstream
+  // code (e.g. GTM wrappers that read `amplitude._iq[name]` directly).
+  GlobalScope.amplitude._q = GlobalScope.amplitude._q || [];
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  GlobalScope.amplitude._iq = GlobalScope.amplitude._iq || {};
+
   if (GlobalScope.amplitude.invoked) {
     const queue = GlobalScope.amplitude._q;
     GlobalScope.amplitude._q = [];
     runQueuedFunctions(amplitude, queue);
 
-    const instanceNames = Object.keys(GlobalScope.amplitude._iq || {});
+    const instanceNames = Object.keys(GlobalScope.amplitude._iq);
     for (let i = 0; i < instanceNames.length; i++) {
       const instanceName = instanceNames[i];
       const instance = Object.assign(GlobalScope.amplitude._iq[instanceName], createNamedInstance(instanceName));

--- a/packages/analytics-browser/src/utils/snippet-helper.ts
+++ b/packages/analytics-browser/src/utils/snippet-helper.ts
@@ -17,7 +17,7 @@ interface InstanceProxy {
  * Applies the proxied functions on the proxied amplitude snippet to an instance of the real object.
  * @ignore
  */
-export const runQueuedFunctions = (instance: object, queue: QueueProxy) => {
+export const runQueuedFunctions = (instance: object, queue: QueueProxy | undefined) => {
   convertProxyObjectToRealObject(instance, queue);
 };
 
@@ -25,7 +25,7 @@ export const runQueuedFunctions = (instance: object, queue: QueueProxy) => {
  * Applies the proxied functions on the proxied object to an instance of the real object.
  * Used to convert proxied Identify and Revenue objects.
  */
-export const convertProxyObjectToRealObject = <T>(instance: T, queue: QueueProxy): T => {
+export const convertProxyObjectToRealObject = <T>(instance: T, queue: QueueProxy | undefined): T => {
   if (!queue) {
     return instance;
   }

--- a/packages/analytics-browser/src/utils/snippet-helper.ts
+++ b/packages/analytics-browser/src/utils/snippet-helper.ts
@@ -26,6 +26,9 @@ export const runQueuedFunctions = (instance: object, queue: QueueProxy) => {
  * Used to convert proxied Identify and Revenue objects.
  */
 export const convertProxyObjectToRealObject = <T>(instance: T, queue: QueueProxy): T => {
+  if (!queue) {
+    return instance;
+  }
   for (let i = 0; i < queue.length; i++) {
     const { name, args, resolve } = queue[i];
     const fn = instance && instance[name as keyof T];

--- a/packages/analytics-browser/test/utils/snippet-helper.test.ts
+++ b/packages/analytics-browser/test/utils/snippet-helper.test.ts
@@ -50,12 +50,7 @@ describe('snippet-helper', () => {
 
     test('should return instance when queue is undefined', () => {
       const instance = { init: jest.fn() };
-      expect(
-        SnippetHelper.convertProxyObjectToRealObject(
-          instance,
-          undefined as unknown as Parameters<typeof SnippetHelper.convertProxyObjectToRealObject>[1],
-        ),
-      ).toBe(instance);
+      expect(SnippetHelper.convertProxyObjectToRealObject(instance, undefined)).toBe(instance);
       expect(instance.init).not.toHaveBeenCalled();
     });
   });

--- a/packages/analytics-browser/test/utils/snippet-helper.test.ts
+++ b/packages/analytics-browser/test/utils/snippet-helper.test.ts
@@ -47,5 +47,16 @@ describe('snippet-helper', () => {
       expect(SnippetHelper.convertProxyObjectToRealObject(instance, queue)).toBe(instance);
       expect(resolve).toHaveBeenCalledTimes(1);
     });
+
+    test('should return instance when queue is undefined', () => {
+      const instance = { init: jest.fn() };
+      expect(
+        SnippetHelper.convertProxyObjectToRealObject(
+          instance,
+          undefined as unknown as Parameters<typeof SnippetHelper.convertProxyObjectToRealObject>[1],
+        ),
+      ).toBe(instance);
+      expect(instance.init).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Two `TypeError`s in the snippet bootstrap. Combined: **7,612 of 15,226 real SDK uncaught errors (~50%) over 7 days**, surfaced via the [SDK Diagnostics – Browser SDK dashboard](https://p.datadoghq.com/sb/b06b5541a-da514652ca1ab503d6ea57fedeb6a6fe).

## What's going wrong

When the bundle starts up it checks `window.amplitude.invoked` to decide "the snippet ran, the queues `_q` and `_iq` are ready — drain them." But `invoked = true` can be set without `_q` / `_iq` ever existing. When that happens, the bootstrap crashes.

**This isn't really a snippet template bug — the template always seeds both queues.** The bundle just trusts the global state too much. Most likely sources of the bad state:

1. **Browser extensions / tracking blockers / in-app webview wrappers** that stub `window.amplitude = { invoked: true, track: noop }` to neuter analytics. They don't know `_iq` is supposed to exist. Matches the heavy skew toward Instagram / Mobile Safari in-app browsers in the logs.
2. **Two Amplitude integrations on the same page** — e.g. an older internal wrapper that sets `invoked: true` and `_q` but predates `_iq`, plus a newer `<script src=...>` bundle loaded directly. The wrapper wins the global.

Fix: have the bootstrap normalize `_q` and `_iq` itself instead of trusting them.

## The bugs

### 1. `Object.keys(amplitude._iq)` at [snippet-index.ts:52](https://github.com/amplitude/Amplitude-TypeScript/blob/%40amplitude%2Fanalytics-browser%402.39.0/packages/analytics-browser/src/snippet-index.ts#L52) — 6,167 events / 7d

`Object.keys(_iq) || []` doesn't help: `Object.keys(undefined)` throws *before* `||` is ever evaluated.

[Datadog logs](https://app.datadoghq.com/logs?live=false&query=service%3Asdk-diagnostics+%22SDK+Diagnostic+Event%22+sdk.error.uncaught+%22snippet-index.ts%3A52%22&storage=flex_tier&stream_sort=desc)

```json
{
  "event_name": "sdk.error.uncaught",
  "app_id": "<redacted>",
  "sdk_tags": {
    "library": "amplitude-ts-sdk-script/2.39.0",
    "os_name": "Mobile Safari",
    "device_model": "iOS"
  },
  "event_properties": {
    "error_name": "TypeError",
    "message": "TypeError: undefined is not an object (evaluating 'Object.keys(e.amplitude._iq)')",
    "stack_unminified": [
      "at GlobalScope (packages/analytics-browser/src/snippet-index.ts:52:38)"
    ]
  }
}
```

### 2. `queue.length` at [snippet-helper.ts:29](https://github.com/amplitude/Amplitude-TypeScript/blob/%40amplitude%2Fanalytics-browser%402.39.0/packages/analytics-browser/src/utils/snippet-helper.ts#L29) — 1,445 events / 7d

When iterating named instances, `instance._q` can be `undefined` for the same reason. `convertProxyObjectToRealObject` now returns early when `queue` is falsy.

[Datadog logs](https://app.datadoghq.com/logs?live=false&query=service%3Asdk-diagnostics+%22SDK+Diagnostic+Event%22+sdk.error.uncaught+%22snippet-helper.ts%3A29%22&storage=flex_tier&stream_sort=desc)

```json
{
  "event_name": "sdk.error.uncaught",
  "app_id": "<redacted>",
  "sdk_tags": {
    "library": "amplitude-ts-sdk-script/2.39.0",
    "os_name": "Instagram",
    "device_model": "Android"
  },
  "event_properties": {
    "error_name": "TypeError",
    "message": "Cannot read properties of undefined (reading 'length')",
    "stack_unminified": [
      "at length (packages/analytics-browser/src/utils/snippet-helper.ts:29:28)",
      "at convertProxyObjectToRealObject (packages/analytics-browser/src/utils/snippet-helper.ts:21:2)",
      "at runQueuedFunctions (packages/analytics-browser/src/snippet-index.ts:58:6)"
    ]
  }
}
```

## Customer impact

Each crash surfaces an uncaught `TypeError` in the customer's browser console and any RUM / error-monitoring they run. The main `amplitude` object IS set up before the crash, so direct `amplitude.track(...)` calls after the snippet still work — but pre-load queued events on named instances are lost. After the fix, bootstrap completes cleanly.

## Changes

- [`snippet-index.ts`](packages/analytics-browser/src/snippet-index.ts) / [`gtm-snippet-index.ts`](packages/analytics-browser/src/gtm-snippet-index.ts) — normalize `_q` and `_iq` on the global right after `Object.assign`.
- [`snippet-helper.ts`](packages/analytics-browser/src/utils/snippet-helper.ts) — return early when `queue` is falsy; widen the parameter type to `QueueProxy | undefined`.
- [`snippet-helper.test.ts`](packages/analytics-browser/test/utils/snippet-helper.test.ts) — regression test for the undefined-queue case.

## Test plan

- [x] `pnpm --filter @amplitude/analytics-browser test` — 493 pass (was 492, +1 new test)
- [x] `pnpm --filter @amplitude/analytics-browser lint` — clean (pre-existing warnings only)
- [ ] Monitor dashboard after release to confirm the volume drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)