### PR TITLE
fix(analytics-core): coerce non-string apiKey in remote config localStorage key

### DIFF
--- a/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
+++ b/packages/analytics-core/src/remote-config/remote-config-localstorage.ts
@@ -6,7 +6,8 @@ export class RemoteConfigLocalStorage implements RemoteConfigStorage {
   private readonly logger: ILogger;
 
   constructor(apiKey: string, logger: ILogger) {
-    this.key = `AMP_remote_config_${apiKey.substring(0, 10)}`;
+    const apiKeyString = typeof apiKey === 'string' ? apiKey : '';
+    this.key = `AMP_remote_config_${apiKeyString.substring(0, 10)}`;
     this.logger = logger;
   }
 

--- a/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts
@@ -123,4 +123,15 @@ describe('RemoteConfigLocalStorage', () => {
       jest.restoreAllMocks();
     });
   });
+
+  describe('constructor', () => {
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a number', 12345],
+      ['an object', { apiKey: 'oops' }],
+    ])('should not throw when apiKey is %s', (_label, badApiKey) => {
+      expect(() => new RemoteConfigLocalStorage(badApiKey as unknown as string, logger)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When a caller passes a non-string `apiKey` to `amplitude.init` (undefined, null, a number, etc), `RemoteConfigLocalStorage`'s constructor calls `apiKey.substring(0, 10)` and crashes with `TypeError: e.substring is not a function`. Because the constructor runs inside an async `_init`, the failure surfaces as an **unhandled promise rejection** in the customer's app, then aborts the rest of SDK init.

Volume: **399 events / 7d** on the [SDK Diagnostics – Browser SDK dashboard](https://p.datadoghq.com/sb/b06b5541a-da514652ca1ab503d6ea57fedeb6a6fe).

[Example logs](https://app.datadoghq.com/logs?live=false&query=service%3Asdk-diagnostics+%22SDK+Diagnostic+Event%22+sdk.error.uncaught+%22remote-config-localstorage.ts%22&storage=flex_tier&stream_sort=desc)

## What the customer sees

- An uncaught `TypeError: e.substring is not a function` in their browser console and any RUM/error-monitoring they run
- `amplitude.init(...)` rejects; subsequent `amplitude.track(...)` calls never get a real client and quietly do nothing (or queue forever)

## Fix

Coerce non-string `apiKey` to an empty string when building the localStorage key. The downstream remote-config fetch will still fail (because the apiKey is genuinely invalid), but in a structured way — logged as a 4xx with `isLastFetchInvalidApiKey = true` — instead of throwing a confusing TypeError that aborts the rest of init.

- [`packages/analytics-core/src/remote-config/remote-config-localstorage.ts:9`](packages/analytics-core/src/remote-config/remote-config-localstorage.ts#L9) — guard `apiKey.substring(...)` against non-string input.
- [`packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts`](packages/analytics-core/test/remote-config/remote-config-localstorage.test.ts) — regression coverage for `undefined`, `null`, number, and object inputs.

## Test plan

- [x] `pnpm --filter @amplitude/analytics-core test` — 797 pass, 100% coverage maintained
- [x] `pnpm --filter @amplitude/analytics-core lint` — clean (pre-existing warnings only)
- [ ] Monitor dashboard after release for drop in `remote-config-localstorage.ts:9` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)