### PR TITLE
fix(analytics-react-native): use workspace:* for analytics-core dep

### DIFF
--- a/packages/analytics-react-native/package.json
+++ b/packages/analytics-react-native/package.json
@@ -58,7 +58,7 @@
     "url": "https://github.com/amplitude/Amplitude-TypeScript/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-core": "2.48.1",
+    "@amplitude/analytics-core": "workspace:*",
     "@amplitude/ua-parser-js": "^0.7.31",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "tslib": "^2.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,8 +347,8 @@ importers:
   packages/analytics-react-native:
     dependencies:
       '@amplitude/analytics-core':
-        specifier: 2.48.1
-        version: 2.48.1
+        specifier: workspace:*
+        version: link:../analytics-core
       '@amplitude/ua-parser-js':
         specifier: ^0.7.31
         version: 0.7.33
@@ -1114,9 +1114,6 @@ packages:
 
   '@amplitude/analytics-connector@1.6.4':
     resolution: {integrity: sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==}
-
-  '@amplitude/analytics-core@2.48.1':
-    resolution: {integrity: sha512-6ltecomnZc9z1AUE59orcoLYii0gPoVBBoI4qoMGXw2lsxFh35zx32LPrXO3ezFkTE71CS44AzwaBFsSxQWRuw==}
 
   '@amplitude/analytics-types@1.4.0':
     resolution: {integrity: sha512-RiMPHBqdrJ8ktTqG+Wzj2htnN/PCG9jGZG0SXtTFnWwVvcAJYbYm55/nrP1TTyrx1OlLhvF2VG3lVUP/xGAU8w==}
@@ -9948,14 +9945,6 @@ packages:
 snapshots:
 
   '@amplitude/analytics-connector@1.6.4': {}
-
-  '@amplitude/analytics-core@2.48.1':
-    dependencies:
-      '@amplitude/analytics-connector': 1.6.4
-      '@types/zen-observable': 0.8.3
-      safe-json-stringify: 1.2.0
-      tslib: 2.8.1
-      zen-observable: 0.10.0
 
   '@amplitude/analytics-types@1.4.0': {}
 


### PR DESCRIPTION
## Summary

Unblocks the publish pipeline. The 5/20 release attempt from main failed at lerna's post-bump `pnpm install --lockfile-only` step:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @amplitude/analytics-core@2.48.2
This error happened while installing a direct dependency of packages/analytics-react-native
```

## Root cause

`packages/analytics-react-native/package.json` was the only package in the repo using a literal version pin (`"@amplitude/analytics-core": "2.48.1"`) instead of `workspace:*`. Two unrelated changes converged to trip this:

- [`27d4ddd1`](https://github.com/amplitude/Amplitude-TypeScript/commit/27d4ddd1) (#1747, 5/13) bumped the pin from `2.41.5` to `2.48.1`, making it match the *current* analytics-core version. That's the condition under which lerna's update-dependents logic rewrites the pin on the next bump.
- [`516719a2`](https://github.com/amplitude/Amplitude-TypeScript/commit/516719a2) (#1750, 5/15) — `fix(analytics-browser): bump background capture version` — actually modified `packages/analytics-core/src/messenger/constants.ts`. The `fix:` conventional commit + analytics-core file path qualifies analytics-core for a `2.48.1 → 2.48.2` patch bump.

In the failing run, lerna bumped analytics-core to `2.48.2`, rewrote analytics-react-native's pin to `"2.48.2"`, then `pnpm install --lockfile-only` 404'd against the registry because `2.48.2` hadn't been published yet (chicken-and-egg).

## Fix

Switch the literal pin to `workspace:*`, matching every other package in the repo. pnpm rewrites `workspace:*` to the exact published version at publish time, so the published tarball still pins `analytics-core` to a single version (no caret) — the original "no auto-upgrade" intent from #1596 is preserved for consumers.

## Test plan

- [x] `pnpm install --lockfile-only` cleanly resolves to `link:../analytics-core` (lockfile diff included)
- [ ] CI green
- [ ] After merge: re-run publish-v2.yml on main, expect lerna version to bump analytics-core to 2.48.2 and the lockfile step to succeed (workspace link resolves locally, no registry round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes dependency resolution for `@amplitude/analytics-react-native` to link `@amplitude/analytics-core` from the workspace, avoiding registry version pinning issues during releases.
> 
> **Overview**
> Switches `@amplitude/analytics-react-native` to depend on `@amplitude/analytics-core` via `workspace:*` instead of a hard-pinned version.
> 
> Updates `pnpm-lock.yaml` accordingly (workspace `link:../analytics-core`) and drops the now-unused lockfile entry/snapshot for the previously pinned `@amplitude/analytics-core@2.48.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba32cc19ad4fa3813a680d15c041145fb746570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->