### PR TITLE
chore: add a bootstrapping script to publish single package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,14 +83,12 @@ As soon as your changes are approved, a team member will merge your PR to main a
 Because the workflow uses Trusted Publishing, a new package can't be published from the publish workflow on the first try. 
 
 To publish a package for the first time (administrators only):
-1. run `pnpm install` from the route
-2. navigate to the root of the new package
-3. run `pnpm build`
-4. run `pnpm publish` (requires admin credentials with 2FA)
-5. navigate to the NPM homepage of the new package
-6. open "Settings" and configure it to use Trusted Publishing
-7. copy the same configuration used in [analytics browser](https://www.npmjs.com/package/@amplitude/analytics-browser/access). **case sensitive**
-8. now that it's in NPM and Trusted Publishing is enabled, this package can now be published from workflows
+1. run `pnpm install` from the root
+2. run `bash scripts/publish/bootstrap-npm-package.sh` and enter the full npm package name (e.g. `@amplitude/my-new-package`). The script publishes an empty package (package.json only); `npm publish` will prompt for your 2FA code.
+3. navigate to the NPM homepage of the new package
+4. open "Settings" and configure it to use Trusted Publishing
+5. copy the same configuration used in [analytics browser](https://www.npmjs.com/package/@amplitude/analytics-browser/access). **case sensitive**
+6. now that it's in NPM and Trusted Publishing is enabled, this package can now be published from workflows
 
 #### Recovering a partial `publish-v2` workflow run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Because the workflow uses Trusted Publishing, a new package can't be published f
 
 To publish a package for the first time (administrators only):
 1. run `pnpm install` from the root
-2. run `bash scripts/publish/bootstrap-npm-package.sh` and enter the full npm package name (e.g. `@amplitude/my-new-package`). The script publishes an empty package (package.json only); `npm publish` will prompt for your 2FA code.
+2. run `pnpm deploy:publish:bootstrap` and enter the full npm package name (e.g. `@amplitude/my-new-package`) when prompted. The script publishes an empty package (package.json only); this requires you to be logged into an NPM admin account with 2FA enabled.
 3. navigate to the NPM homepage of the new package
 4. open "Settings" and configure it to use Trusted Publishing
 5. copy the same configuration used in [analytics browser](https://www.npmjs.com/package/@amplitude/analytics-browser/access). **case sensitive**

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deploy:publish": "pnpm -r --filter \"./packages/**\" publish --no-git-checks",
     "deploy:publish:dry-run": "DRY_RUN=true pnpm -r --filter \"./packages/**\" publish --dry-run --no-git-checks",
     "deploy:pack": "DRY_RUN=true pnpm -r --filter \"./packages/**\" pack",
+    "deploy:publish:bootstrap": "sh ./scripts/publish/bootstrap-npm-package.sh",
     "dev": "concurrently \"pnpm run watch\" \"vite dev --open\"",
     "dev:ssh": "pnpm run setup-dev-ssh && export SSH=true && pnpm run dev",
     "docs": "typedoc",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deploy:publish": "pnpm -r --filter \"./packages/**\" publish --no-git-checks",
     "deploy:publish:dry-run": "DRY_RUN=true pnpm -r --filter \"./packages/**\" publish --dry-run --no-git-checks",
     "deploy:pack": "DRY_RUN=true pnpm -r --filter \"./packages/**\" pack",
-    "deploy:publish:bootstrap": "sh ./scripts/publish/bootstrap-npm-package.sh",
+    "deploy:publish:bootstrap": "bash ./scripts/publish/bootstrap-npm-package.sh",
     "dev": "concurrently \"pnpm run watch\" \"vite dev --open\"",
     "dev:ssh": "pnpm run setup-dev-ssh && export SSH=true && pnpm run dev",
     "docs": "typedoc",

--- a/scripts/publish/bootstrap-npm-package.sh
+++ b/scripts/publish/bootstrap-npm-package.sh
@@ -9,7 +9,7 @@
 #
 # Prerequisites:
 #   - npm login (admin account with publish + 2FA)
-#   - package name must not already exist on npm (or you intend to overwrite)
+#   - package name must not already exist on npm
 #
 # Usage:
 #   bash scripts/publish/bootstrap-npm-package.sh

--- a/scripts/publish/bootstrap-npm-package.sh
+++ b/scripts/publish/bootstrap-npm-package.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Bootstrap a new @amplitude package on npm for Trusted Publishing.
+#
+# GitHub Actions cannot publish a package that does not exist on npm yet.
+# This script publishes a one-time empty package (package.json only) using
+# your npm account and 2FA. After that, configure Trusted Publishing on npm
+# and use the normal publish workflows for real releases.
+#
+# Prerequisites:
+#   - npm login (admin account with publish + 2FA)
+#   - package name must not already exist on npm (or you intend to overwrite)
+#
+# Usage:
+#   bash scripts/publish/bootstrap-npm-package.sh
+
+set -euo pipefail
+
+cleanup() {
+  if [ -n "${WORK_DIR:-}" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+echo "Bootstrap npm package for Trusted Publishing"
+echo "----------------------------------------------"
+echo ""
+echo "This publishes an empty package (package.json only) so the name"
+echo "exists on npm before enabling Trusted Publishing in package settings."
+echo ""
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "❌ npm is required but was not found in PATH."
+  exit 1
+fi
+
+if ! npm whoami >/dev/null 2>&1; then
+  echo "❌ Not logged in to npm. Run: npm login"
+  exit 1
+fi
+
+echo "Logged in to npm as: $(npm whoami)"
+echo ""
+
+read -r -p "Package name to publish (e.g. @amplitude/my-new-package): " PACKAGE_NAME
+PACKAGE_NAME="$(echo "$PACKAGE_NAME" | xargs)"
+if [ -z "$PACKAGE_NAME" ]; then
+  echo "❌ Package name is required."
+  exit 1
+fi
+
+read -r -p "Initial version [0.0.1]: " PACKAGE_VERSION
+PACKAGE_VERSION="${PACKAGE_VERSION:-0.0.1}"
+PACKAGE_VERSION="$(echo "$PACKAGE_VERSION" | xargs)"
+if [ -z "$PACKAGE_VERSION" ]; then
+  echo "❌ Version is required."
+  exit 1
+fi
+
+if npm view "$PACKAGE_NAME" version >/dev/null 2>&1; then
+  EXISTING_VERSION="$(npm view "$PACKAGE_NAME" version)"
+  echo ""
+  echo "❌ $PACKAGE_NAME already exists on npm (latest: $EXISTING_VERSION)."
+  echo "   Trusted Publishing bootstrap is only for packages that are not on npm yet."
+  exit 1
+fi
+
+echo ""
+echo "Will publish:"
+echo "  name:    $PACKAGE_NAME"
+echo "  version: $PACKAGE_VERSION"
+echo "  files:   package.json only"
+echo ""
+read -r -p "Publish to npm? [y/N] " CONFIRM_PUBLISH
+if [[ ! "$CONFIRM_PUBLISH" =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/amplitude-npm-bootstrap.XXXXXX")"
+
+cat > "$WORK_DIR/package.json" <<EOF
+{
+  "name": "$PACKAGE_NAME",
+  "version": "$PACKAGE_VERSION",
+  "description": "Bootstrap placeholder for Trusted Publishing setup. Do not use.",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}
+EOF
+
+echo ""
+echo "Publishing from $WORK_DIR ..."
+echo "npm will prompt for your 2FA one-time password when required."
+echo ""
+
+(
+  cd "$WORK_DIR"
+  # Run outside the monorepo so workspace settings do not affect publish.
+  npm publish --access=public --tag alpha
+)
+
+echo ""
+echo "✅ Published $PACKAGE_NAME@$PACKAGE_VERSION"
+echo ""
+echo "Next steps:"
+echo "  1. Open https://www.npmjs.com/package/${PACKAGE_NAME}/access"
+echo "  2. Configure Trusted Publishing (match @amplitude/analytics-browser settings)"
+echo "  3. Publish real versions from GitHub Actions or the normal release workflow"
+echo ""


### PR DESCRIPTION
### Summary

Add a script that, when invoked, publishes an NPM package for the first time. Done locally and requires 2FA.

Example of a successfully bootstrapped script: https://www.npmjs.com/package/dang-bootstrap-example/access


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a local, opt-in helper script and docs for first-time npm package bootstrapping; no runtime/library code or CI publish flow is modified.
> 
> **Overview**
> Adds a new `deploy:publish:bootstrap` script (`scripts/publish/bootstrap-npm-package.sh`) that interactively publishes a one-time *empty* npm package (package.json only) to reserve the name and enable Trusted Publishing.
> 
> Updates `CONTRIBUTING.md` to replace the manual first-publish steps with the new bootstrap command and follow-up Trusted Publishing configuration instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd86ea267389fc37531d640497c159f7334a023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->