### PR TITLE
feat(plugin-session-replay-browser): add flushIntervalConfig passthrough

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -108,6 +108,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         urlChangePollingInterval: this.options.urlChangePollingInterval,
         captureAdoptedStyleSheets: this.options.captureAdoptedStyleSheets,
         crossOriginIframes: this.options.crossOriginIframes,
+        flushIntervalConfig: this.options.flushIntervalConfig,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -11,6 +11,12 @@ import {
  */
 export type CrossOriginIframesConfig = NonNullable<StandaloneSessionReplayOptions['crossOriginIframes']>;
 
+/**
+ * Configuration for rrweb event-split flush cadence.
+ * Extracted from the standalone SDK's SessionReplayOptions.
+ */
+export type FlushIntervalConfig = NonNullable<StandaloneSessionReplayOptions['flushIntervalConfig']>;
+
 export type MaskLevel =
   | 'light' // only mask a subset of inputs that’s deemed sensitive - password, credit card, telephone #, email. These are information we never want to capture.
   | 'medium' // mask all inputs
@@ -182,5 +188,5 @@ export interface SessionReplayOptions {
   /**
    * @see {@link StandaloneSessionReplayOptions.flushIntervalConfig}
    */
-  flushIntervalConfig?: NonNullable<StandaloneSessionReplayOptions['flushIntervalConfig']>;
+  flushIntervalConfig?: FlushIntervalConfig;
 }

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -179,4 +179,8 @@ export interface SessionReplayOptions {
    * @see {@link StandaloneSessionReplayOptions.crossOriginIframes}
    */
   crossOriginIframes?: CrossOriginIframesConfig;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.flushIntervalConfig}
+   */
+  flushIntervalConfig?: NonNullable<StandaloneSessionReplayOptions['flushIntervalConfig']>;
 }

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -150,6 +150,26 @@ describe('SessionReplayPlugin', () => {
       expect(init).toHaveBeenCalledWith('static_key', expect.objectContaining({ storeType: 'idb' }));
     });
 
+    test('should pass flushIntervalConfig through to session replay (undefined when not set)', async () => {
+      const sessionReplay = new SessionReplayPlugin();
+
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
+
+      expect(init).toHaveBeenCalledWith('static_key', expect.objectContaining({ flushIntervalConfig: undefined }));
+    });
+
+    test('should pass flushIntervalConfig through to session replay when provided', async () => {
+      const flushIntervalConfig = { minIntervalMs: 1000, maxIntervalMs: 5000 };
+      const sessionReplay = new SessionReplayPlugin({ flushIntervalConfig });
+
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
+
+      expect(init).toHaveBeenCalledWith(
+        'static_key',
+        expect.objectContaining({ flushIntervalConfig: { minIntervalMs: 1000, maxIntervalMs: 5000 } }),
+      );
+    });
+
     describe('defaultTracking', () => {
       test('should not change defaultTracking when forceSessionTracking is not defined', async () => {
         const sessionReplay = new SessionReplayPlugin();


### PR DESCRIPTION
## Summary

- The standalone `@amplitude/session-replay-browser` SDK shipped `flushIntervalConfig` in #1744 (commit c242dc3) with `minIntervalMs` / `maxIntervalMs` knobs that control rrweb event-split cadence.
- The plugin (`@amplitude/plugin-session-replay-browser`) did not surface this option — its `SessionReplayOptions` type had no `flushIntervalConfig` field, and the value was never forwarded to `sessionReplay.init()`.
- This PR is a straight passthrough: adds the field to the plugin's `SessionReplayOptions` using the same `@see` pattern as the other forwarded options (`privacyConfig`, `performanceConfig`, `crossOriginIframes`, etc.), and includes it in the `srInitOptions` object passed to `init()`.

**No behavior change for existing consumers** — the option is optional and the standalone SDK already has its own defaults and clamping logic (`MIN_FLUSH_INTERVAL_FLOOR_MS`, `MAX_INTERVAL`).

**Downstream motivation**: the `amplitude/javascript` monorepo consumes the plugin, not the standalone SDK. It currently can't tune rrweb send cadence (e.g. to reduce `200 + X-Session-Replay-Event-Skipped` throttling responses on session start) without this passthrough.

## Changes

- `packages/plugin-session-replay-browser/src/typings/session-replay.ts` — adds `flushIntervalConfig?: NonNullable<StandaloneSessionReplayOptions['flushIntervalConfig']>` to `SessionReplayOptions`
- `packages/plugin-session-replay-browser/src/session-replay.ts` — adds `flushIntervalConfig: this.options.flushIntervalConfig` to the `srInitOptions` assignment
- `packages/plugin-session-replay-browser/test/session-replay.test.ts` — adds two tests: passthrough of `undefined` when not set, and forwarding of an explicit `{ minIntervalMs, maxIntervalMs }` value

## Test plan

- [ ] `pnpm --filter @amplitude/plugin-session-replay-browser run test` passes (52 tests, 100% coverage on the two non-integration suites)
- [ ] Integration test suite failure (`browser-sdk-integration.test.ts`) is pre-existing on `main` (missing `@amplitude/analytics-browser` build artifact) and unrelated to this change
- [ ] No new TypeScript errors — `flushIntervalConfig` exists on `SessionReplayOptions` via `Omit<Partial<SessionReplayLocalConfig & SessionIdentifiers>, 'apiKey'>` in the standalone SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a typed, optional config passthrough with tests, and does not change behavior unless consumers set the new option.
> 
> **Overview**
> Adds support for `flushIntervalConfig` in `@amplitude/plugin-session-replay-browser` so consumers can tune rrweb flush cadence.
> 
> The plugin’s `SessionReplayOptions` type now exposes `flushIntervalConfig` (derived from the standalone SDK type) and forwards it into the `srInitOptions` passed to `sessionReplay.init()`, with new unit tests covering both unset and explicitly provided values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de708b6981d705ee3798a37d19e4b8a26b01bdb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->