### PR TITLE
fix(analytics-browser): dummy commit to force analytics-browser upgrade

### DIFF
--- a/packages/analytics-browser/src/index.ts
+++ b/packages/analytics-browser/src/index.ts
@@ -35,4 +35,5 @@ export { trackVideo, type VideoCaptureOptions } from './video-capture/video-capt
 
 // Export types to maintain backward compatibility with `analytics-types`.
 // In the next major version, only export customer-facing types to reduce the public API surface.
+// (dummy comment to trigger an analytics-browser release)
 export * as Types from './types';


### PR DESCRIPTION
### Summary

Doing this so that it will publish analytics-browser to CDN and will include G&S fixes from: https://github.com/amplitude/Amplitude-TypeScript/pull/1778

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no logic, configuration, or public API impact.
> 
> **Overview**
> Adds a **dummy comment** in `packages/analytics-browser/src/index.ts` next to the existing types export note. There is **no runtime or API change**—only documentation-style text meant to bump the package version.
> 
> The intent is to **publish a new `@amplitude/analytics-browser` release** (including CDN) so it picks up **G&S fixes** already merged elsewhere (see PR #1778), without shipping new browser SDK behavior in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77109d1f3636037d83a6f22f7e451e5692b20c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->