### PR TITLE
feat(analytics-browser): enable fetch keepalive by default to survive page navigation

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -477,6 +477,7 @@ export const shouldFetchRemoteConfig = (options: BrowserOptions = {}): boolean =
 export const createTransport = (transport?: TransportTypeOrOptions) => {
   const type = typeof transport === 'object' ? transport.type : transport;
   const headers = typeof transport === 'object' ? transport.headers : undefined;
+  const enableKeepalive = typeof transport === 'object' ? transport.enableKeepalive : undefined;
 
   if (type === 'xhr') {
     return new XHRTransport(headers);
@@ -487,7 +488,7 @@ export const createTransport = (transport?: TransportTypeOrOptions) => {
   }
   // Keep a browser-local fetch transport for gzip support.
   // TODO: Merge back to core FetchTransport after React Native supports gzip.
-  return new FetchTransport(headers);
+  return new FetchTransport(headers, enableKeepalive);
 };
 
 export const getTopLevelDomain = async (url?: string, diagnosticsClient?: IDiagnosticsClient) => {

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -8,18 +8,8 @@ import {
   Transport,
 } from '@amplitude/analytics-core';
 
-// keepalive lets a request survive page navigation, but the browser caps the *combined*
-// size of all in-flight keepalive requests in a document at 64 KiB and rejects anything
-// over it (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch). Since that budget
-// is shared (e.g. with session-replay), we gate at half to leave headroom; larger bodies
-// fall back to a plain fetch that won't survive navigation. The headroom also covers using
-// the cheap string length as a rough byte estimate (like the gzip threshold below) instead
-// of measuring exact UTF-8 bytes.
-export const KEEPALIVE_MAX_BODY_SIZE_BYTES = 32 * 1024;
+export const KEEPALIVE_MAX_BODY_SIZE_BYTES = 16 * 1024;
 
-// Temporary browser-specific fetch transport with gzip support.
-// TODO: Merge this implementation back into @amplitude/analytics-core FetchTransport
-// once React Native SDK supports request body gzip.
 export class FetchTransport extends BaseTransport implements Transport {
   private customHeaders: Record<string, string>;
 
@@ -58,8 +48,6 @@ export class FetchTransport extends BaseTransport implements Transport {
       ...headers,
     };
 
-    // Use string length as a rough byte estimate (the compressed path already has an exact
-    // byte count) to avoid allocating a Blob on every request.
     const bodySize = typeof body === 'string' ? body.length : body.byteLength;
 
     const options: RequestInit = {

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -16,10 +16,13 @@ export const KEEPALIVE_MAX_BODY_SIZE_BYTES = 16 * 1024;
 // once React Native SDK supports request body gzip.
 export class FetchTransport extends BaseTransport implements Transport {
   private customHeaders: Record<string, string>;
+  private enableKeepalive: boolean;
 
-  constructor(customHeaders: Record<string, string> = {}) {
+  constructor(customHeaders: Record<string, string> = {}, enableKeepalive?: boolean) {
     super();
     this.customHeaders = customHeaders;
+    // Enabled unless explicitly disabled.
+    this.enableKeepalive = enableKeepalive !== false;
   }
 
   async send(serverUrl: string, payload: Payload, shouldCompressUploadBody = false): Promise<Response | null> {
@@ -58,7 +61,7 @@ export class FetchTransport extends BaseTransport implements Transport {
       headers,
       body,
       method: 'POST',
-      keepalive: bodySize <= KEEPALIVE_MAX_BODY_SIZE_BYTES,
+      keepalive: this.enableKeepalive && bodySize <= KEEPALIVE_MAX_BODY_SIZE_BYTES,
     };
 
     const response = await fetch(serverUrl, options);

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -56,13 +56,11 @@ export class FetchTransport extends BaseTransport implements Transport {
       ...headers,
     };
 
-    const bodyByteLength = typeof body === 'string' ? new Blob([body]).size : body.byteLength;
-
     const options: RequestInit = {
       headers,
       body,
       method: 'POST',
-      keepalive: bodyByteLength <= MAX_KEEPALIVE_BYTES,
+      keepalive: isWithinKeepaliveBudget(body),
     };
 
     const response = await fetch(serverUrl, options);
@@ -75,3 +73,12 @@ export class FetchTransport extends BaseTransport implements Transport {
     }
   }
 }
+
+const isWithinKeepaliveBudget = (body: string | ArrayBuffer): boolean => {
+  if (typeof body !== 'string') {
+    return body.byteLength <= MAX_KEEPALIVE_BYTES;
+  }
+  // UTF-8 byte length is always >= the JS (UTF-16) string length, so a string longer than the
+  // budget is already over it — skip the Blob allocation in that case.
+  return body.length <= MAX_KEEPALIVE_BYTES && new Blob([body]).size <= MAX_KEEPALIVE_BYTES;
+};

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -8,6 +8,20 @@ import {
   Transport,
 } from '@amplitude/analytics-core';
 
+/**
+ * Upper bound on the request body size (in bytes) for which `keepalive` is enabled.
+ *
+ * The Fetch spec caps the *combined* size of all in-flight `keepalive` requests in a
+ * document at 64 KiB; exceeding it makes fetch return a network error rather than
+ * sending the request (see "HTTP-network-or-cache fetch":
+ * https://fetch.spec.whatwg.org/#http-network-or-cache-fetch). That budget is shared
+ * with anything else using keepalive in the same document (e.g. session-replay, the
+ * customer's own beacons), so we gate at half the budget to leave headroom and reduce
+ * the chance of a contention-induced rejection. Larger bodies fall back to a plain
+ * fetch (no size limit) that simply won't survive a page navigation.
+ */
+export const MAX_KEEPALIVE_BYTES = 32 * 1024;
+
 // Temporary browser-specific fetch transport with gzip support.
 // TODO: Merge this implementation back into @amplitude/analytics-core FetchTransport
 // once React Native SDK supports request body gzip.
@@ -49,10 +63,17 @@ export class FetchTransport extends BaseTransport implements Transport {
       ...headers,
     };
 
+    // keepalive lets the request survive page navigation (e.g. a redirect), preventing
+    // the browser from cancelling the in-flight upload. It is gated on body size because
+    // the browser rejects keepalive requests that would exceed the shared 64 KiB budget;
+    // larger bodies fall back to a plain fetch. See MAX_KEEPALIVE_BYTES above.
+    const bodyByteLength = typeof body === 'string' ? new Blob([body]).size : body.byteLength;
+
     const options: RequestInit = {
       headers,
       body,
       method: 'POST',
+      keepalive: bodyByteLength <= MAX_KEEPALIVE_BYTES,
     };
 
     const response = await fetch(serverUrl, options);

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -10,6 +10,9 @@ import {
 
 export const KEEPALIVE_MAX_BODY_SIZE_BYTES = 16 * 1024;
 
+// Temporary browser-specific fetch transport with gzip support.
+// TODO: Merge this implementation back into @amplitude/analytics-core FetchTransport
+// once React Native SDK supports request body gzip.
 export class FetchTransport extends BaseTransport implements Transport {
   private customHeaders: Record<string, string>;
 

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -8,6 +8,7 @@ import {
   Transport,
 } from '@amplitude/analytics-core';
 
+// Conservative 1/4 of the shared 64 KiB keepalive budget. Why 16K: https://github.com/amplitude/Amplitude-TypeScript/pull/1781
 export const KEEPALIVE_MAX_BODY_SIZE_BYTES = 16 * 1024;
 
 // Temporary browser-specific fetch transport with gzip support.

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -8,18 +8,11 @@ import {
   Transport,
 } from '@amplitude/analytics-core';
 
-/**
- * Upper bound on the request body size (in bytes) for which `keepalive` is enabled.
- *
- * The Fetch spec caps the *combined* size of all in-flight `keepalive` requests in a
- * document at 64 KiB; exceeding it makes fetch return a network error rather than
- * sending the request (see "HTTP-network-or-cache fetch":
- * https://fetch.spec.whatwg.org/#http-network-or-cache-fetch). That budget is shared
- * with anything else using keepalive in the same document (e.g. session-replay, the
- * customer's own beacons), so we gate at half the budget to leave headroom and reduce
- * the chance of a contention-induced rejection. Larger bodies fall back to a plain
- * fetch (no size limit) that simply won't survive a page navigation.
- */
+// keepalive lets a request survive page navigation, but the browser caps the *combined*
+// size of all in-flight keepalive requests in a document at 64 KiB and rejects anything
+// over it (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch). Since that budget
+// is shared (e.g. with session-replay), we gate at half to leave headroom; larger bodies
+// fall back to a plain fetch that won't survive navigation.
 export const MAX_KEEPALIVE_BYTES = 32 * 1024;
 
 // Temporary browser-specific fetch transport with gzip support.
@@ -63,10 +56,6 @@ export class FetchTransport extends BaseTransport implements Transport {
       ...headers,
     };
 
-    // keepalive lets the request survive page navigation (e.g. a redirect), preventing
-    // the browser from cancelling the in-flight upload. It is gated on body size because
-    // the browser rejects keepalive requests that would exceed the shared 64 KiB budget;
-    // larger bodies fall back to a plain fetch. See MAX_KEEPALIVE_BYTES above.
     const bodyByteLength = typeof body === 'string' ? new Blob([body]).size : body.byteLength;
 
     const options: RequestInit = {

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -15,7 +15,7 @@ import {
 // fall back to a plain fetch that won't survive navigation. The headroom also covers using
 // the cheap string length as a rough byte estimate (like the gzip threshold below) instead
 // of measuring exact UTF-8 bytes.
-export const MAX_KEEPALIVE_BYTES = 32 * 1024;
+export const KEEPALIVE_MAX_BODY_SIZE_BYTES = 32 * 1024;
 
 // Temporary browser-specific fetch transport with gzip support.
 // TODO: Merge this implementation back into @amplitude/analytics-core FetchTransport
@@ -66,7 +66,7 @@ export class FetchTransport extends BaseTransport implements Transport {
       headers,
       body,
       method: 'POST',
-      keepalive: bodySize <= MAX_KEEPALIVE_BYTES,
+      keepalive: bodySize <= KEEPALIVE_MAX_BODY_SIZE_BYTES,
     };
 
     const response = await fetch(serverUrl, options);

--- a/packages/analytics-browser/src/transports/fetch.ts
+++ b/packages/analytics-browser/src/transports/fetch.ts
@@ -12,7 +12,9 @@ import {
 // size of all in-flight keepalive requests in a document at 64 KiB and rejects anything
 // over it (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch). Since that budget
 // is shared (e.g. with session-replay), we gate at half to leave headroom; larger bodies
-// fall back to a plain fetch that won't survive navigation.
+// fall back to a plain fetch that won't survive navigation. The headroom also covers using
+// the cheap string length as a rough byte estimate (like the gzip threshold below) instead
+// of measuring exact UTF-8 bytes.
 export const MAX_KEEPALIVE_BYTES = 32 * 1024;
 
 // Temporary browser-specific fetch transport with gzip support.
@@ -56,11 +58,15 @@ export class FetchTransport extends BaseTransport implements Transport {
       ...headers,
     };
 
+    // Use string length as a rough byte estimate (the compressed path already has an exact
+    // byte count) to avoid allocating a Blob on every request.
+    const bodySize = typeof body === 'string' ? body.length : body.byteLength;
+
     const options: RequestInit = {
       headers,
       body,
       method: 'POST',
-      keepalive: isWithinKeepaliveBudget(body),
+      keepalive: bodySize <= MAX_KEEPALIVE_BYTES,
     };
 
     const response = await fetch(serverUrl, options);
@@ -73,12 +79,3 @@ export class FetchTransport extends BaseTransport implements Transport {
     }
   }
 }
-
-const isWithinKeepaliveBudget = (body: string | ArrayBuffer): boolean => {
-  if (typeof body !== 'string') {
-    return body.byteLength <= MAX_KEEPALIVE_BYTES;
-  }
-  // UTF-8 byte length is always >= the JS (UTF-16) string length, so a string longer than the
-  // budget is already over it — skip the Blob allocation in that case.
-  return body.length <= MAX_KEEPALIVE_BYTES && new Blob([body]).size <= MAX_KEEPALIVE_BYTES;
-};

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -431,6 +431,16 @@ describe('config', () => {
       expect(transport).toBeInstanceOf(FetchTransport);
       expect(transport).not.toBeInstanceOf(CoreFetchTransport);
     });
+
+    test('should pass enableKeepalive: false through to the fetch transport', async () => {
+      const transport = createTransport({ type: 'fetch', enableKeepalive: false });
+      const fetchMock = jest.fn().mockResolvedValue({ text: () => Promise.resolve('{}') });
+      (global as { fetch?: unknown }).fetch = fetchMock;
+      await transport.send('http://localhost:3000', { api_key: '', events: [] });
+      const [, options] = fetchMock.mock.calls[0];
+      expect(options?.keepalive).toBe(false);
+      delete (global as { fetch?: unknown }).fetch;
+    });
   });
 
   describe('getTopLevelDomain', () => {

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -435,11 +435,15 @@ describe('config', () => {
     test('should pass enableKeepalive: false through to the fetch transport', async () => {
       const transport = createTransport({ type: 'fetch', enableKeepalive: false });
       const fetchMock = jest.fn().mockResolvedValue({ text: () => Promise.resolve('{}') });
+      const originalFetch = global.fetch;
       (global as { fetch?: unknown }).fetch = fetchMock;
-      await transport.send('http://localhost:3000', { api_key: '', events: [] });
-      const [, options] = fetchMock.mock.calls[0];
-      expect(options?.keepalive).toBe(false);
-      delete (global as { fetch?: unknown }).fetch;
+      try {
+        await transport.send('http://localhost:3000', { api_key: '', events: [] });
+        const [, options] = fetchMock.mock.calls[0];
+        expect(options?.keepalive).toBe(false);
+      } finally {
+        global.fetch = originalFetch;
+      }
     });
   });
 

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -162,6 +162,31 @@ describe('fetch transport', () => {
       expect(options?.keepalive).toBe(false);
     });
 
+    test('should disable keepalive when enableKeepalive is false', async () => {
+      const transport = new FetchTransport({}, false);
+      const url = 'http://localhost:3000';
+      const payload = { api_key: '', events: [{ event_type: 'test', device_id: 'test_device_id' }] };
+
+      const fetchSpy = jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response('{}')));
+      await transport.send(url, payload, false);
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(options?.keepalive).toBe(false);
+    });
+
+    test('should enable keepalive when enableKeepalive is undefined or true', async () => {
+      const url = 'http://localhost:3000';
+      const payload = { api_key: '', events: [{ event_type: 'test', device_id: 'test_device_id' }] };
+
+      for (const transport of [new FetchTransport(), new FetchTransport({}, true)]) {
+        const fetchSpy = jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response('{}')));
+        await transport.send(url, payload, false);
+        const [, options] = fetchSpy.mock.calls[0];
+        expect(options?.keepalive).toBe(true);
+        fetchSpy.mockRestore();
+      }
+    });
+
     test('should disable keepalive when the compressed body exceeds the budget', async () => {
       const oversizedCompressed = new ArrayBuffer(KEEPALIVE_MAX_BODY_SIZE_BYTES + 1);
       const isAvailableSpy = jest.spyOn(analyticsCore, 'isCompressionStreamAvailable').mockReturnValue(true);

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -162,6 +162,25 @@ describe('fetch transport', () => {
       expect(options?.keepalive).toBe(false);
     });
 
+    test('should enable keepalive for a body exactly at the budget', async () => {
+      const transport = new FetchTransport();
+      const url = 'http://localhost:3000';
+      // Pad the value so the serialized body length is exactly the cap (the <= boundary).
+      const overhead = JSON.stringify({
+        api_key: '',
+        events: [{ event_type: 'x', event_properties: { value: '' } }],
+      }).length;
+      const value = 'a'.repeat(KEEPALIVE_MAX_BODY_SIZE_BYTES - overhead);
+      const payload = { api_key: '', events: [{ event_type: 'x', event_properties: { value } }] };
+      expect(JSON.stringify(payload).length).toBe(KEEPALIVE_MAX_BODY_SIZE_BYTES);
+
+      const fetchSpy = jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response('{}')));
+      await transport.send(url, payload, false);
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(options?.keepalive).toBe(true);
+    });
+
     test('should disable keepalive when enableKeepalive is false', async () => {
       const transport = new FetchTransport({}, false);
       const url = 'http://localhost:3000';

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -1,7 +1,7 @@
 import { ReadableStream, WritableStream } from 'stream/web';
 import { TextEncoder } from 'util';
 import { MIN_GZIP_UPLOAD_BODY_SIZE_BYTES, Status } from '@amplitude/analytics-core';
-import { FetchTransport } from '../../src/transports/fetch';
+import { FetchTransport, MAX_KEEPALIVE_BYTES } from '../../src/transports/fetch';
 import 'isomorphic-fetch';
 
 if (typeof global.TextEncoder === 'undefined') {
@@ -47,6 +47,7 @@ describe('fetch transport', () => {
         },
         body: JSON.stringify(payload),
         method: 'POST',
+        keepalive: true,
       });
     });
 
@@ -67,6 +68,7 @@ describe('fetch transport', () => {
         },
         body: JSON.stringify(payload),
         method: 'POST',
+        keepalive: true,
       });
       expect(mockCompressionStream).not.toHaveBeenCalled();
 
@@ -129,6 +131,34 @@ describe('fetch transport', () => {
       (global as { Response?: unknown }).Response = OriginalResponse;
       delete (Blob.prototype as unknown as { stream?: () => ReadableStream }).stream;
       delete (global as { CompressionStream?: unknown }).CompressionStream;
+    });
+
+    test('should enable keepalive for bodies at or under the budget', async () => {
+      const transport = new FetchTransport();
+      const url = 'http://localhost:3000';
+      const payload = { api_key: '', events: [{ event_type: 'test', device_id: 'test_device_id' }] };
+
+      const fetchSpy = jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response('{}')));
+      await transport.send(url, payload, false);
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(options?.keepalive).toBe(true);
+    });
+
+    test('should disable keepalive for bodies over the budget', async () => {
+      const transport = new FetchTransport();
+      const url = 'http://localhost:3000';
+      // Build an uncompressed body larger than the keepalive budget.
+      const payload = {
+        api_key: '',
+        events: [{ event_type: 'large', event_properties: { value: 'a'.repeat(MAX_KEEPALIVE_BYTES + 1) } }],
+      };
+
+      const fetchSpy = jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response('{}')));
+      await transport.send(url, payload, false);
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(options?.keepalive).toBe(false);
     });
 
     test('should respect Content-Encoding header when compression is enabled', async () => {

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -2,7 +2,7 @@ import { ReadableStream, WritableStream } from 'stream/web';
 import { TextEncoder } from 'util';
 import * as analyticsCore from '@amplitude/analytics-core';
 import { MIN_GZIP_UPLOAD_BODY_SIZE_BYTES, Status } from '@amplitude/analytics-core';
-import { FetchTransport, MAX_KEEPALIVE_BYTES } from '../../src/transports/fetch';
+import { FetchTransport, KEEPALIVE_MAX_BODY_SIZE_BYTES } from '../../src/transports/fetch';
 import 'isomorphic-fetch';
 
 if (typeof global.TextEncoder === 'undefined') {
@@ -152,7 +152,7 @@ describe('fetch transport', () => {
       const url = 'http://localhost:3000';
       const payload = {
         api_key: '',
-        events: [{ event_type: 'large', event_properties: { value: 'a'.repeat(MAX_KEEPALIVE_BYTES + 1) } }],
+        events: [{ event_type: 'large', event_properties: { value: 'a'.repeat(KEEPALIVE_MAX_BODY_SIZE_BYTES + 1) } }],
       };
 
       const fetchSpy = jest.spyOn(window, 'fetch').mockReturnValueOnce(Promise.resolve(new Response('{}')));
@@ -165,7 +165,7 @@ describe('fetch transport', () => {
     test('should disable keepalive when the compressed body exceeds the budget', async () => {
       // Gate the keepalive flag on the compressed ArrayBuffer size, not the original string.
       // Mock the compression helper directly so the test stays decoupled from its internals.
-      const oversizedCompressed = new ArrayBuffer(MAX_KEEPALIVE_BYTES + 1);
+      const oversizedCompressed = new ArrayBuffer(KEEPALIVE_MAX_BODY_SIZE_BYTES + 1);
       const isAvailableSpy = jest.spyOn(analyticsCore, 'isCompressionStreamAvailable').mockReturnValue(true);
       const compressSpy = jest.spyOn(analyticsCore, 'compressToGzipArrayBuffer').mockResolvedValue(oversizedCompressed);
 

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -127,6 +127,7 @@ describe('fetch transport', () => {
       });
       expect(options?.body).toBeInstanceOf(ArrayBuffer);
       expect(new Uint8Array(options?.body as ArrayBuffer)).toEqual(mockCompressedBytes);
+      expect(options?.keepalive).toBe(true);
 
       (global as { Response?: unknown }).Response = OriginalResponse;
       delete (Blob.prototype as unknown as { stream?: () => ReadableStream }).stream;
@@ -148,7 +149,7 @@ describe('fetch transport', () => {
     test('should disable keepalive for bodies over the budget', async () => {
       const transport = new FetchTransport();
       const url = 'http://localhost:3000';
-      // Build an uncompressed body larger than the keepalive budget.
+      // 'a' is single-byte in UTF-8, so char count equals the byte count the code measures.
       const payload = {
         api_key: '',
         events: [{ event_type: 'large', event_properties: { value: 'a'.repeat(MAX_KEEPALIVE_BYTES + 1) } }],
@@ -159,6 +160,50 @@ describe('fetch transport', () => {
 
       const [, options] = fetchSpy.mock.calls[0];
       expect(options?.keepalive).toBe(false);
+    });
+
+    test('should disable keepalive when the compressed body exceeds the budget', async () => {
+      // Gate the keepalive flag on the compressed ArrayBuffer size, not the original string.
+      const oversizedCompressed = new ArrayBuffer(MAX_KEEPALIVE_BYTES + 1);
+      const OriginalResponse = (global as { Response?: typeof Response }).Response;
+      (global as { Response?: unknown }).Response = jest.fn().mockImplementation(() => ({
+        arrayBuffer: () => Promise.resolve(oversizedCompressed),
+      }));
+      (global as { CompressionStream?: unknown }).CompressionStream = jest.fn().mockImplementation(() => ({
+        readable: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        writable: new WritableStream(),
+      }));
+      Object.defineProperty(Blob.prototype, 'stream', {
+        value: () => new ReadableStream<Uint8Array>(),
+        configurable: true,
+        writable: true,
+      });
+
+      const transport = new FetchTransport();
+      const url = 'http://localhost:3000';
+      const payload = {
+        api_key: '',
+        events: [
+          { event_type: 'large-payload', event_properties: { value: 'a'.repeat(MIN_GZIP_UPLOAD_BODY_SIZE_BYTES) } },
+        ],
+      };
+
+      const fetchSpy = jest
+        .spyOn(window, 'fetch')
+        .mockReturnValueOnce(Promise.resolve({ text: () => Promise.resolve('{}') } as Response));
+      await transport.send(url, payload, true);
+
+      const [, options] = fetchSpy.mock.calls[0];
+      expect(options?.body).toBe(oversizedCompressed);
+      expect(options?.keepalive).toBe(false);
+
+      (global as { Response?: unknown }).Response = OriginalResponse;
+      delete (Blob.prototype as unknown as { stream?: () => ReadableStream }).stream;
+      delete (global as { CompressionStream?: unknown }).CompressionStream;
     });
 
     test('should respect Content-Encoding header when compression is enabled', async () => {

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -163,8 +163,6 @@ describe('fetch transport', () => {
     });
 
     test('should disable keepalive when the compressed body exceeds the budget', async () => {
-      // Gate the keepalive flag on the compressed ArrayBuffer size, not the original string.
-      // Mock the compression helper directly so the test stays decoupled from its internals.
       const oversizedCompressed = new ArrayBuffer(KEEPALIVE_MAX_BODY_SIZE_BYTES + 1);
       const isAvailableSpy = jest.spyOn(analyticsCore, 'isCompressionStreamAvailable').mockReturnValue(true);
       const compressSpy = jest.spyOn(analyticsCore, 'compressToGzipArrayBuffer').mockResolvedValue(oversizedCompressed);

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -1,5 +1,6 @@
 import { ReadableStream, WritableStream } from 'stream/web';
 import { TextEncoder } from 'util';
+import * as analyticsCore from '@amplitude/analytics-core';
 import { MIN_GZIP_UPLOAD_BODY_SIZE_BYTES, Status } from '@amplitude/analytics-core';
 import { FetchTransport, MAX_KEEPALIVE_BYTES } from '../../src/transports/fetch';
 import 'isomorphic-fetch';
@@ -164,24 +165,10 @@ describe('fetch transport', () => {
 
     test('should disable keepalive when the compressed body exceeds the budget', async () => {
       // Gate the keepalive flag on the compressed ArrayBuffer size, not the original string.
+      // Mock the compression helper directly so the test stays decoupled from its internals.
       const oversizedCompressed = new ArrayBuffer(MAX_KEEPALIVE_BYTES + 1);
-      const OriginalResponse = (global as { Response?: typeof Response }).Response;
-      (global as { Response?: unknown }).Response = jest.fn().mockImplementation(() => ({
-        arrayBuffer: () => Promise.resolve(oversizedCompressed),
-      }));
-      (global as { CompressionStream?: unknown }).CompressionStream = jest.fn().mockImplementation(() => ({
-        readable: new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.close();
-          },
-        }),
-        writable: new WritableStream(),
-      }));
-      Object.defineProperty(Blob.prototype, 'stream', {
-        value: () => new ReadableStream<Uint8Array>(),
-        configurable: true,
-        writable: true,
-      });
+      const isAvailableSpy = jest.spyOn(analyticsCore, 'isCompressionStreamAvailable').mockReturnValue(true);
+      const compressSpy = jest.spyOn(analyticsCore, 'compressToGzipArrayBuffer').mockResolvedValue(oversizedCompressed);
 
       const transport = new FetchTransport();
       const url = 'http://localhost:3000';
@@ -201,9 +188,8 @@ describe('fetch transport', () => {
       expect(options?.body).toBe(oversizedCompressed);
       expect(options?.keepalive).toBe(false);
 
-      (global as { Response?: unknown }).Response = OriginalResponse;
-      delete (Blob.prototype as unknown as { stream?: () => ReadableStream }).stream;
-      delete (global as { CompressionStream?: unknown }).CompressionStream;
+      compressSpy.mockRestore();
+      isAvailableSpy.mockRestore();
     });
 
     test('should respect Content-Encoding header when compression is enabled', async () => {

--- a/packages/analytics-browser/test/transport/fetch.test.ts
+++ b/packages/analytics-browser/test/transport/fetch.test.ts
@@ -150,7 +150,6 @@ describe('fetch transport', () => {
     test('should disable keepalive for bodies over the budget', async () => {
       const transport = new FetchTransport();
       const url = 'http://localhost:3000';
-      // 'a' is single-byte in UTF-8, so char count equals the byte count the code measures.
       const payload = {
         api_key: '',
         events: [{ event_type: 'large', event_properties: { value: 'a'.repeat(MAX_KEEPALIVE_BYTES + 1) } }],

--- a/packages/analytics-core/src/types/transport.ts
+++ b/packages/analytics-core/src/types/transport.ts
@@ -10,6 +10,9 @@ export type TransportType = 'xhr' | 'beacon' | 'fetch';
 export interface TransportOptions {
   type?: TransportType;
   headers?: Record<string, string>;
+  // Whether the fetch transport sets `keepalive` so uploads survive page navigation.
+  // Enabled unless explicitly set to false. Has no effect on the xhr/beacon transports.
+  enableKeepalive?: boolean;
 }
 
 export type TransportTypeOrOptions = TransportType | TransportOptions;


### PR DESCRIPTION
## Summary

Linear: [SDKW-14](https://linear.app/amplitude/issue/SDKW-14/investigate-initoptionsmore-causing-gtm-template-upgrade-error-log-in)

This PR adds a new capability to the browser SDK: the default `fetch` transport now sends uploads with **`keepalive: true`**, so in-flight event requests can **complete even when the page is navigating away** (redirects, link clicks, tab close).

Previously, delivering events at navigation time meant opting into `transport: 'beacon'` (`navigator.sendBeacon`). That works, but `sendBeacon` is limited: POST-only, no custom headers, **no gzip** (`Content-Encoding`), no access to the server response, and a hard 64 KiB cap. `fetch` with `keepalive` gives the same "survives navigation" behavior on the **default** transport while keeping everything we already rely on — gzip compression, custom headers, response handling, and the existing retry path. In short, customers no longer have to trade away those features to get navigation-time delivery.

### What changed
- `packages/analytics-browser/src/transports/fetch.ts`
  - New exported constant `KEEPALIVE_MAX_BODY_SIZE_BYTES = 16 * 1024`.
  - Set `keepalive` when the outgoing body is within the cap. Size is measured with `ArrayBuffer.byteLength` for the gzip-compressed body, and the cheap JSON string length as a rough estimate for the uncompressed body (no per-request `Blob`/`TextEncoder` allocation).
- New opt-out: `enableKeepalive?: boolean` on `TransportOptions`. keepalive stays on by default; it is only disabled when explicitly set to `false`. It applies to the `fetch` transport (no effect on `xhr`/`beacon`).
- Tests added/updated for the enabled (small body) and disabled (oversized body) paths, including the compressed-body path and the `enableKeepalive` opt-out.

### Opting out
keepalive is on by default. To disable it (e.g. to avoid competing for the shared keepalive budget):

```js
amplitude.init(API_KEY, { transport: { type: 'fetch', enableKeepalive: false } });
// or at runtime:
amplitude.setTransport({ type: 'fetch', enableKeepalive: false });
```

## Why a 16 KB cap?

`keepalive` comes with a hard, browser-enforced budget, and opting an oversized request into it is **worse** than leaving it off — the browser rejects the request outright instead of sending it. The cap is a graceful fallback: bodies within it get navigation survival; bodies above it send as a normal `fetch` (no size limit, just no survival).

**The limit is normative in the Fetch spec.** WHATWG Fetch Standard, "HTTP-network-or-cache fetch":

> If the sum of `contentLength` and `inflightKeepaliveBytes` is greater than **64 kibibytes**, then return a network error.

Source: https://fetch.spec.whatwg.org/#http-network-or-cache-fetch

Three things drive the 16 KB choice:

1. **It's a network error, not a silent downgrade.** A plain `fetch()` has no body-size limit; the moment you add `keepalive: true`, a body over budget makes the browser **reject the request entirely**. So we only opt a request into keepalive when its body fits.

2. **The 64 KiB budget is *shared*, not per-request.** `inflightKeepaliveBytes` is the combined total of **all** in-flight keepalive requests in the document — our analytics flushes, session-replay uploads (which already use keepalive), and any keepalive/`sendBeacon` traffic from the customer's own code. Headers count toward it too. A cap well below the full budget leaves headroom and reduces contention-induced rejections.

3. **We gate on string length, which can undercount UTF-8 bytes.** To avoid allocating a `Blob`/`TextEncoder` on every send, the uncompressed path uses `body.length` (UTF-16 code units) as a rough proxy for byte size — mirroring the existing gzip threshold (`bodyString.length >= MIN_GZIP_UPLOAD_BODY_SIZE_BYTES`). A code unit expands to at most 3 UTF-8 bytes (a surrogate pair is 2 units → 4 bytes, i.e. 2/unit), so using `64 KiB / 4 = 16 KB` conservatively keeps even a fully multi-byte payload within the real budget.

For reference, Sentry adopted keepalive-by-default and added in-flight queue accounting after early issues with >64 KB requests ([sentry-javascript#7553](https://github.com/getsentry/sentry-javascript/pull/7553), [#2548](https://github.com/getsentry/sentry-javascript/issues/2548)), and `session-replay-browser` already uses keepalive in this repo ([commit fa5f84a](https://github.com/amplitude/Amplitude-TypeScript/commit/fa5f84af9a499e7bc12fbd5a1b8ab06ac89c2271)).

## Real-world payload sizes

In practice, event upload payloads are tiny relative to the 16 KB cap because the body is **gzip-compressed**. Observed request payload size is ~**0.2 KB** whether the batch contains a few events (e.g. 3–4) or many (e.g. 30) — so virtually all real traffic stays well under the cap and benefits from keepalive.

<img width="1300" height="738" alt="Screenshot 2026-05-28 at 10 12 20 PM" src="https://github.com/user-attachments/assets/6cfae3b7-effe-4845-8556-ecfe5511b886" />


## Behavior & blast radius
- Bodies within the cap (effectively all real, gzipped traffic) now survive page navigation.
- Bodies over the cap send exactly as they do today: a plain `fetch` with no size limit, no navigation survival.
- In-session, if a keepalive request is ever rejected on the shared budget, it falls into the destination retry path (`catch` → `handleOtherResponse` → re-schedule), bounded by `flushMaxRetries` — so the outcome is **delay, not loss**.
- Browser coverage: `keepalive` is Baseline *Newly available* (Firefox 133, Nov 2024; Chromium/Safari since ~2019). On browsers without support the option is **silently ignored** — no error, the request just behaves as a normal `fetch`.

## Test plan
- `pnpm --filter @amplitude/analytics-browser test -- test/transport/fetch.test.ts test/config.test.ts` → pass.
  - keepalive enabled for bodies ≤ cap; disabled for oversized uncompressed and oversized compressed bodies.
  - keepalive disabled when `enableKeepalive: false`; enabled when `undefined`/`true`; option wired through `createTransport`.
  - Existing header/gzip assertions updated to include `keepalive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default upload behavior on every browser fetch and interacts with the shared 64 KiB keepalive budget; oversized keepalive requests fail at the network layer, though in-session retries should limit data loss.
> 
> **Overview**
> Browser **`FetchTransport`** now sets **`keepalive: true`** on POST uploads when the outgoing body is within a **32 KiB** cap (`KEEPALIVE_MAX_BODY_SIZE_BYTES`), so typical event batches can finish after redirects or navigation instead of being cancelled.
> 
> Sizing uses **`ArrayBuffer.byteLength`** for gzip bodies and **JSON string length** as a cheap upper bound for uncompressed payloads (no per-request `Blob`). Bodies above the cap omit keepalive and behave like today’s plain `fetch`.
> 
> Tests assert keepalive on small/uncompressed and small/compressed requests, and **`keepalive: false`** for oversized JSON and mocked oversized gzip output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c18000f4e9240bcab9a1d1efa4543efb3ed71fc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

