### PR TITLE
chore(session-replay-react-native): require AmplitudeSessionReplay >=0.11.1

### DIFF
--- a/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
+++ b/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.9.5'
+  s.dependency 'AmplitudeSessionReplay', '>=0.11.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
+++ b/packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.11.0'
+  s.dependency 'AmplitudeSessionReplay', '>=0.11.1'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
+++ b/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.9.5'
+  s.dependency 'AmplitudeSessionReplay', '>=0.11.0'
   s.dependency 'AmplitudeCore', '>=1.4.2'
 
   # This code is to support RN prior to 0.71.0. Should be removed when we drop support for RN < 0.71.0.

--- a/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
+++ b/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.11.0'
+  s.dependency 'AmplitudeSessionReplay', '>=0.11.1'
   s.dependency 'AmplitudeCore', '>=1.4.2'
 
   # This code is to support RN prior to 0.71.0. Should be removed when we drop support for RN < 0.71.0.


### PR DESCRIPTION
## Summary

Bumps the `AmplitudeSessionReplay` CocoaPods dependency lower bound from `>=0.9.5` to `>=0.11.0` in the React Native Session Replay plugin and standalone podspecs:

- `packages/plugin-session-replay-react-native/amplitude-plugin-session-replay-react-native.podspec`
- `packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec`

## Rationale

This pulls in `AmplitudeSessionReplay` 0.11.0, which adds conservative-masking support for React Native text on iOS. Raising the lower bound ensures the React Native SDK resolves a version that includes this fix.

## Notes for consumers

Existing projects should run `pod update` to move onto `AmplitudeSessionReplay` 0.11.0.

## Test plan

- [ ] `pod install` resolves `AmplitudeSessionReplay >= 0.11.0` in the React Native example apps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor bump only in podspecs; low risk aside from possible pod resolution or build breakage if apps pin older AmplitudeSessionReplay.
> 
> **Overview**
> Raises the **AmplitudeSessionReplay** CocoaPods minimum from `>=0.9.5` to `>=0.11.1` in both React Native Session Replay podspecs (`amplitude-plugin-session-replay-react-native` and `AmplitudeSessionReplayReactNative`).
> 
> That forces iOS builds to resolve a native session replay release that includes **conservative masking for React Native text**. Consumers need to run **`pod update`** (or equivalent) so their lockfiles pick up the newer pod.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ca0fb000f1bbb6f0d59f09cc32da8fe3e78646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->