### PR TITLE
fix(plugin-page-url-enrichment-browser): stop enriching session_end events

### DIFF
--- a/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
+++ b/packages/plugin-page-url-enrichment-browser/src/page-url-enrichment.ts
@@ -28,10 +28,18 @@ enum PreviousPageType {
   External = 'external', // for different domains
 }
 
+// session_end is generated when a new session starts and is backdated to the end
+// of the previous session. By that point `location` already reflects the first
+// page of the new session, so enriching it would attach the wrong page URL (the
+// next session's landing page) rather than the ended session's last page. Skip it
+// and let the page URL be derived from previous events via a persisted property.
+const SESSION_END_EVENT_TYPE = 'session_end';
+
 export const EXCLUDED_DEFAULT_EVENT_TYPES = new Set<string>([
   SpecialEventType.IDENTIFY,
   SpecialEventType.GROUP_IDENTIFY,
   SpecialEventType.REVENUE,
+  SESSION_END_EVENT_TYPE,
 ]);
 
 export const isPageUrlEnrichmentEnabled = (option: unknown): boolean => {

--- a/packages/plugin-page-url-enrichment-browser/test/page-url-enrichment.test.ts
+++ b/packages/plugin-page-url-enrichment-browser/test/page-url-enrichment.test.ts
@@ -698,6 +698,16 @@ describe('pageUrlEnrichmentPlugin', () => {
 
       expect(excludedEvent?.event_properties).toStrictEqual(undefined);
     });
+
+    test('should not enrich session_end events with page properties', async () => {
+      await plugin.setup?.(mockConfig, mockAmplitude);
+
+      const sessionEndEvent = await plugin.execute?.({
+        event_type: 'session_end',
+      });
+
+      expect(sessionEndEvent?.event_properties).toStrictEqual(undefined);
+    });
   });
 
   describe('teardown', () => {


### PR DESCRIPTION
### Summary

`session_end` events are generated when a *new* session starts, then backdated to the end of the previous session. By the time the page URL enrichment plugin runs, `location` already points at the new session's first page — so End Session events were enriched with the wrong page URL (the next session's landing page) instead of the ended session's last page. This made End Session unreliable as an "exit page" signal.

This adds `session_end` to the plugin's excluded event types so it no longer attaches page properties. The page URL for End Session can instead be derived from previous events via a persisted property at query time.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No