### PR TITLE
feat(session-replay-react-native): add privacyConfig to plugin config (SDKRN-14)

### DIFF
--- a/packages/session-replay-react-native/src/plugin-session-replay-config.ts
+++ b/packages/session-replay-react-native/src/plugin-session-replay-config.ts
@@ -1,5 +1,7 @@
 import { LogLevel } from '@amplitude/analytics-types';
 
+import type { PrivacyConfig } from './session-replay-config';
+
 /**
  * Configuration for Session Replay React Native Plugin
  */
@@ -28,6 +30,14 @@ export interface SessionReplayPluginConfig {
    * @default true
    */
   autoStart?: boolean;
+
+  /**
+   * Privacy configuration for session replay, including the masking level
+   * applied to sensitive content. When `maskLevel` is omitted it resolves to
+   * `'medium'` at the native boundary.
+   * @default {}
+   */
+  privacyConfig?: PrivacyConfig;
 }
 
 export const getDefaultSessionReplayPluginConfig: () => Required<SessionReplayPluginConfig> = () => {
@@ -36,5 +46,9 @@ export const getDefaultSessionReplayPluginConfig: () => Required<SessionReplayPl
     enableRemoteConfig: true,
     logLevel: LogLevel.Warn,
     autoStart: true,
+    // Intentionally left without a `maskLevel`: the effective default
+    // (`'medium'`) is resolved once at the native boundary by `nativeConfig()`,
+    // mirroring `getDefaultConfig()` in session-replay-config.ts.
+    privacyConfig: {},
   };
 };

--- a/packages/session-replay-react-native/src/plugin-session-replay.ts
+++ b/packages/session-replay-react-native/src/plugin-session-replay.ts
@@ -73,6 +73,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<ReactNativeClient, 
         enableRemoteConfig: this.sessionReplayConfig.enableRemoteConfig,
         logLevel: this.sessionReplayConfig.logLevel,
         autoStart: this.sessionReplayConfig.autoStart,
+        privacyConfig: this.sessionReplayConfig.privacyConfig,
       },
       this.logger,
     );

--- a/packages/session-replay-react-native/test/plugin-session-replay.test.ts
+++ b/packages/session-replay-react-native/test/plugin-session-replay.test.ts
@@ -124,4 +124,20 @@ describe('SessionReplayPlugin Integration', () => {
     const enriched = await plugin.execute(event);
     expect(enriched).toEqual(event); // Should return the same event
   });
+
+  it('threads privacyConfig.maskLevel through to native setup', async () => {
+    const plugin = new SessionReplayPlugin({ privacyConfig: { maskLevel: 'conservative' } });
+    await plugin.setup(minimalConfig, mockReactNativeClient);
+    expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
+      expect.objectContaining({ maskLevel: 'conservative' }),
+    );
+  });
+
+  it('defaults to medium masking when privacyConfig is not provided', async () => {
+    const plugin = new SessionReplayPlugin();
+    await plugin.setup(minimalConfig, mockReactNativeClient);
+    expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
+      expect.objectContaining({ maskLevel: 'medium' }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

First, self-contained slice of **[SDKRN-14](https://linear.app/amplitude/issue/SDKRN-14)** — the epic to eliminate the copy‑paste between the two React Native Session Replay packages by making the **plugin** re‑use the **standalone** package instead of duplicating config types and native modules.

This slice does the one thing the rest of the epic is blocked on: it brings the standalone package's own `SessionReplayPlugin` to **masking parity** with `@amplitude/plugin-session-replay-react-native`. Until the standalone's plugin can carry `privacyConfig`/`maskLevel`, the plugin package can't delegate to it without losing functionality, so this is the natural foundation.

Scoped intentionally narrow: **no publishing, no native source changes, no plugin‑package changes** — so it's safe and easy to review.

## What this changes

`packages/session-replay-react-native/`:

- **`src/plugin-session-replay-config.ts`** — add `privacyConfig?: PrivacyConfig` to `SessionReplayPluginConfig`, reusing the canonical `MaskLevel` / `PrivacyConfig` from `session-replay-config.ts` (no re‑declaration). Default stays `{}` so the effective `'medium'` default is resolved once at the native boundary in `nativeConfig()`, mirroring `getDefaultConfig()`.
- **`src/plugin-session-replay.ts`** — thread `privacyConfig` from the plugin's `setup()` into `privateInit()` so the resolved `maskLevel` reaches the native bridge. Previously the standalone's plugin always defaulted to medium regardless of config.
- **`test/plugin-session-replay.test.ts`** — add tests asserting `privacyConfig.maskLevel` is forwarded to `AMPNativeSessionReplay.setup` and that it defaults to `medium`.

## Why (the duplication)

PR #1771 added `privacyConfig.maskLevel` to **both** RN SR packages because they mirror each other almost line‑for‑line: same `MaskLevel`/`PrivacyConfig`/config shapes, near‑identical iOS Swift / Android Kotlin bridges, and a `SessionReplayPlugin` class in **both** packages. The standalone already exposes a functional API (`init/start/stop/...`) plus its own `SessionReplayPlugin` that delegates to it — functionally what the plugin package should become after consolidation, **except** it was missing the `maskLevel` passthrough. This PR closes that gap.

## Test results

- `tsc -p ./tsconfig.json --noEmit` — passes
- `jest` (standalone package) — **51 passed, 51 total** (8 in the plugin suite, including the 2 new ones)
- `eslint` + `prettier --check` — clean
- `bob build` — CommonJS + ESM targets build; the TS‑defs target only fails locally because `bob` looks for `tsc` under the package's own `node_modules` (hoisted to root in this pnpm workspace) — not a code issue, and CI builds via lerna with hoisting.

## Remaining slices (follow‑up PRs, per SDKRN-14)

This epic has a hard prerequisite that can't land in a code‑only PR, so the rest is intentionally deferred:

1. **Publish the standalone** `@amplitude/session-replay-react-native` at **v0.1.0** (remove `"private": true`, set `publishConfig.access: public`, CHANGELOG). *Hard prerequisite for everything below.*
2. **Plugin depends on the standalone** — add `"@amplitude/session-replay-react-native": "^0.1.0"` as a runtime dep (workspace range locally); re‑export `MaskLevel`, `PrivacyConfig`, `AmpMaskView`, `SessionReplayPlugin`, `SessionReplayPluginConfig` from the standalone; keep a deprecated `SessionReplayConfig = SessionReplayPluginConfig` alias for one release.
3. **Delete the plugin's native sources** (iOS `*.{m,mm,swift}`, Android Kotlin), shrink/remove the plugin podspec to depend transitively on the standalone's pod, drop the plugin gradle module. After this, only `AMPNativeSessionReplay` / `AMPMaskComponentView` ship.
4. **Bridge parity** — reconcile the few bridge deltas (plugin's iOS `teardown` RCT method vs standalone's `invalidate`; positional `setup(...)` vs config‑object `setup(config)`).
5. **Releases + docs** — cut plugin **v0.5.0** (note the transitive native dep + removed `RCTAmpMaskView`/`PluginSessionReplayReactNative` symbols), update CHANGELOGs and CODEOWNERS.
6. **A1 follow‑up (separate ticket)** — promote the plugin to a pure re‑export shim of the standalone's `SessionReplayPlugin`.

## Test plan

- [ ] CI green (lint, typecheck, build, unit tests)
- [ ] Reviewer confirms `maskLevel` reaches native setup for the standalone plugin path
- [ ] No behavior change for existing standalone consumers (default remains `medium`)

Refs SDKRN-14.

Made with [Cursor](https://cursor.com)