### PR TITLE
feat(analytics-react-native): offline mode via native connectivity checker (SDKRN-5)

### DIFF
--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -10,6 +10,8 @@ function HomeScreen({ navigation }) {
   return (
     <View style={styles.container}>
       <Text>Home Screen</Text>
+      <Button title="Online test" onPress={() => track('RN Expo Online Test')} />
+      <Button title="Offline test" onPress={() => track('RN Expo Offline Test')} />
       <Button title="Go to Settings" onPress={() => navigation.navigate('Settings')} />
     </View>
   );
@@ -29,7 +31,9 @@ export default function App() {
     (async () => {
         // AMPLITUDE_API_KEY is inlined at bundle time (see babel.config.js).
         await init(process.env.AMPLITUDE_API_KEY || 'YOUR_API_KEY', 'react-native-user-id', {
-          logLevel: Types.LogLevel.Error,
+          // Debug so offline-mode log lines ("Skipping flush while offline.",
+          // flush/upload) are visible when manually testing connectivity.
+          logLevel: Types.LogLevel.Debug,
           // autocapture: { } // <-- todo
         }).promise;
         track('expo-app/react-native/test-event');

--- a/examples/react-native/expo-app/metro.config.js
+++ b/examples/react-native/expo-app/metro.config.js
@@ -16,10 +16,32 @@ config.watchFolders = [
   path.join(packagesRoot, 'plugin-page-view-tracking-browser'),
 ];
 config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
-// `packages/analytics-react-native` pins its own react-native devDep; force the app's copy.
-config.resolver.extraNodeModules = {
+
+// Force a SINGLE copy of react-native / react for the whole bundle.
+//
+// `packages/analytics-react-native` pins its own `react-native` devDep (0.70.6),
+// so Metro resolves the workspace-linked SDK's `react-native` imports to that
+// NESTED copy — a second react-native in the bundle alongside the app's 0.71.x.
+// A duplicate react-native means a duplicate `RCTDeviceEventEmitter` singleton:
+// the native bridge emits connectivity events on the APP's emitter, but the SDK's
+// `NativeEventEmitter` listener is registered on the duplicate's emitter, so the
+// SDK never receives `AmplitudeNetworkConnectivityChanged` events and offline mode
+// only ever sees the initial seed (never live changes). `extraNodeModules` is just
+// a resolution *fallback* and doesn't override the nested copy, so redirect
+// explicitly via `resolveRequest`.
+const forcedSingletons = {
   'react-native': path.resolve(projectRoot, 'node_modules/react-native'),
   react: path.resolve(projectRoot, 'node_modules/react'),
+};
+config.resolver.extraNodeModules = forcedSingletons;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  for (const [name, dir] of Object.entries(forcedSingletons)) {
+    if (moduleName === name || moduleName.startsWith(name + '/')) {
+      const target = path.join(dir, moduleName.slice(name.length));
+      return context.resolveRequest(context, target, platform);
+    }
+  }
+  return context.resolveRequest(context, moduleName, platform);
 };
 
 module.exports = config;

--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -66,6 +66,14 @@ android {
     targetCompatibility JavaVersion.VERSION_1_8
   }
 
+  testOptions {
+    unitTests {
+      // Robolectric needs the merged Android resources/manifest on the test classpath.
+      includeAndroidResources = true
+      returnDefaultValues = true
+    }
+  }
+
 }
 
 repositories {
@@ -81,6 +89,15 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+  // Unit tests for the framework-free connectivity logic (ConnectivityChecker).
+  // Robolectric provides the android.net.* stubs so we can mock ConnectivityManager
+  // without a device; see src/test/.../ConnectivityCheckerTest.kt.
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.robolectric:robolectric:4.10.3"
+  // mockk 1.13.3 is the last release built against Kotlin 1.7; newer mockk drags in
+  // kotlin-stdlib 1.9.x which the example app's 1.7 Kotlin compiler can't read.
+  testImplementation "io.mockk:mockk:1.13.3"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/packages/analytics-react-native/android/src/main/AndroidManifest.xml
+++ b/packages/analytics-react-native/android/src/main/AndroidManifest.xml
@@ -1,3 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.amplitude.reactnative">
+    <!-- Required by AmplitudeReactNativeConnectivityModule to observe network
+         connectivity for offline mode. Auto-merges into the host app manifest. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/packages/analytics-react-native/android/src/main/AndroidManifestNew.xml
+++ b/packages/analytics-react-native/android/src/main/AndroidManifestNew.xml
@@ -1,2 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required by AmplitudeReactNativeConnectivityModule to observe network
+         connectivity for offline mode. Auto-merges into the host app manifest. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
@@ -1,11 +1,5 @@
 package com.amplitude.reactnative
 
-import android.content.Context
-import android.net.ConnectivityManager
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
-import android.os.Build
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -24,33 +18,29 @@ private const val CONNECTIVITY_EVENT_NAME = "AmplitudeNetworkConnectivityChanged
  * request/response [AmplitudeReactNativeModule] so its callback lifecycle stays
  * isolated.
  *
- * Connectivity is monitored with [ConnectivityManager]. `registerDefaultNetworkCallback`
- * is API 24+, while `minSdkVersion` is 21, so we fall back to
- * `registerNetworkCallback(NetworkRequest, callback)` on API 21–23.
+ * The Android networking logic lives in the framework-free [ConnectivityChecker]
+ * (so it can be unit-tested without React Native on the classpath); this module
+ * is the thin React bridge around it — it seeds JS via [getNetworkConnectivityStatus]
+ * and forwards connectivity changes as [CONNECTIVITY_EVENT_NAME] events.
  */
 @ReactModule(name = CONNECTIVITY_MODULE_NAME)
 class AmplitudeReactNativeConnectivityModule(
     private val reactContext: ReactApplicationContext
 ) : ReactContextBaseJavaModule(reactContext) {
 
-    private val connectivityManager: ConnectivityManager?
-        get() = reactContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-
-    private var networkCallback: ConnectivityManager.NetworkCallback? = null
-
-    // Last known connectivity state, used to seed JS and to dedupe.
-    @Volatile
-    private var isConnected = true
+    private val connectivityChecker = ConnectivityChecker(reactContext) { connected ->
+        emitConnectivityChange(connected)
+    }
 
     override fun getName(): String {
         return CONNECTIVITY_MODULE_NAME
     }
 
     // Required so `NativeEventEmitter` doesn't warn on the JS side. The actual
-    // registration is lazy (see [registerNetworkCallback]).
+    // registration is lazy (see [ConnectivityChecker.start]).
     @ReactMethod
     fun addListener(eventName: String) {
-        registerNetworkCallback()
+        connectivityChecker.start()
     }
 
     @ReactMethod
@@ -66,69 +56,7 @@ class AmplitudeReactNativeConnectivityModule(
      */
     @ReactMethod
     fun getNetworkConnectivityStatus(promise: Promise) {
-        promise.resolve(Arguments.createMap().apply { putBoolean("isConnected", currentConnectivity()) })
-    }
-
-    @Synchronized
-    private fun registerNetworkCallback() {
-        if (networkCallback != null) {
-            return
-        }
-        val manager = connectivityManager ?: return
-
-        // Seed the current state so we don't wait for the first change to know
-        // whether we're online.
-        isConnected = currentConnectivity()
-
-        val callback = object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                handleConnectivityChange(true)
-            }
-
-            override fun onLost(network: Network) {
-                handleConnectivityChange(false)
-            }
-
-            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
-                handleConnectivityChange(hasInternetCapability(capabilities))
-            }
-        }
-
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                manager.registerDefaultNetworkCallback(callback)
-            } else {
-                val request = NetworkRequest.Builder()
-                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                    .build()
-                manager.registerNetworkCallback(request, callback)
-            }
-            networkCallback = callback
-        } catch (e: SecurityException) {
-            // Some devices throw if ACCESS_NETWORK_STATE is missing; leave the
-            // callback unregistered and rely on the seeded state.
-        }
-    }
-
-    @Synchronized
-    private fun unregisterNetworkCallback() {
-        val callback = networkCallback ?: return
-        try {
-            connectivityManager?.unregisterNetworkCallback(callback)
-        } catch (e: IllegalArgumentException) {
-            // Callback was not registered; ignore.
-        }
-        networkCallback = null
-    }
-
-    private fun handleConnectivityChange(connected: Boolean) {
-        // Dedupe repeated same-state callbacks (e.g. onCapabilitiesChanged firing
-        // multiple times) so JS doesn't flush-storm.
-        if (isConnected == connected) {
-            return
-        }
-        isConnected = connected
-        emitConnectivityChange(connected)
+        promise.resolve(Arguments.createMap().apply { putBoolean("isConnected", connectivityChecker.currentConnectivity()) })
     }
 
     private fun emitConnectivityChange(connected: Boolean) {
@@ -141,39 +69,14 @@ class AmplitudeReactNativeConnectivityModule(
             .emit(CONNECTIVITY_EVENT_NAME, params)
     }
 
-    private fun currentConnectivity(): Boolean {
-        val manager = connectivityManager ?: return true
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val network = manager.activeNetwork ?: return false
-            val capabilities = manager.getNetworkCapabilities(network) ?: return false
-            hasInternetCapability(capabilities)
-        } else {
-            @Suppress("DEPRECATION")
-            manager.activeNetworkInfo?.isConnected ?: false
-        }
-    }
-
-    // NET_CAPABILITY_VALIDATED was added in API 23 (M); on API 21-22 it is never
-    // reported, so requiring it there would make the device read as permanently
-    // offline. Gate the validation requirement behind M and require only
-    // INTERNET on 21-22.
-    private fun hasInternetCapability(capabilities: NetworkCapabilities): Boolean {
-        val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            hasInternet && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-        } else {
-            hasInternet
-        }
-    }
-
     override fun invalidate() {
-        unregisterNetworkCallback()
+        connectivityChecker.stop()
         super.invalidate()
     }
 
     @Deprecated("Deprecated in Java")
     override fun onCatalystInstanceDestroy() {
-        unregisterNetworkCallback()
+        connectivityChecker.stop()
         @Suppress("DEPRECATION")
         super.onCatalystInstanceDestroy()
     }

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
@@ -90,10 +90,7 @@ class AmplitudeReactNativeConnectivityModule(
             }
 
             override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
-                handleConnectivityChange(
-                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-                        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-                )
+                handleConnectivityChange(hasInternetCapability(capabilities))
             }
         }
 
@@ -149,11 +146,23 @@ class AmplitudeReactNativeConnectivityModule(
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val network = manager.activeNetwork ?: return false
             val capabilities = manager.getNetworkCapabilities(network) ?: return false
-            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-                capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            hasInternetCapability(capabilities)
         } else {
             @Suppress("DEPRECATION")
             manager.activeNetworkInfo?.isConnected ?: false
+        }
+    }
+
+    // NET_CAPABILITY_VALIDATED was added in API 23 (M); on API 21-22 it is never
+    // reported, so requiring it there would make the device read as permanently
+    // offline. Gate the validation requirement behind M and require only
+    // INTERNET on 21-22.
+    private fun hasInternetCapability(capabilities: NetworkCapabilities): Boolean {
+        val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            hasInternet && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        } else {
+            hasInternet
         }
     }
 

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
@@ -1,0 +1,171 @@
+package com.amplitude.reactnative
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.modules.core.DeviceEventManagerModule
+
+const val CONNECTIVITY_MODULE_NAME = "AmplitudeReactNativeConnectivity"
+private const val CONNECTIVITY_EVENT_NAME = "AmplitudeNetworkConnectivityChanged"
+
+/**
+ * Connectivity-only native module bridged back to JS as
+ * [CONNECTIVITY_MODULE_NAME]. It is intentionally separate from the
+ * request/response [AmplitudeReactNativeModule] so its callback lifecycle stays
+ * isolated.
+ *
+ * Connectivity is monitored with [ConnectivityManager]. `registerDefaultNetworkCallback`
+ * is API 24+, while `minSdkVersion` is 21, so we fall back to
+ * `registerNetworkCallback(NetworkRequest, callback)` on API 21–23.
+ */
+@ReactModule(name = CONNECTIVITY_MODULE_NAME)
+class AmplitudeReactNativeConnectivityModule(
+    private val reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+
+    private val connectivityManager: ConnectivityManager?
+        get() = reactContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    // Last known connectivity state, used to seed JS and to dedupe.
+    @Volatile
+    private var isConnected = true
+
+    override fun getName(): String {
+        return CONNECTIVITY_MODULE_NAME
+    }
+
+    // Required so `NativeEventEmitter` doesn't warn on the JS side. The actual
+    // registration is lazy (see [registerNetworkCallback]).
+    @ReactMethod
+    fun addListener(eventName: String) {
+        registerNetworkCallback()
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+        // No-op: we keep the single callback registered for the lifetime of the
+        // module and unregister it in invalidate()/onCatalystInstanceDestroy().
+    }
+
+    /**
+     * Returns the current connectivity state. The network callback only fires on
+     * subsequent changes, so JS reads this once on setup to seed the initial
+     * `offline` value.
+     */
+    @ReactMethod
+    fun getNetworkConnectivityStatus(promise: Promise) {
+        promise.resolve(Arguments.createMap().apply { putBoolean("isConnected", currentConnectivity()) })
+    }
+
+    @Synchronized
+    private fun registerNetworkCallback() {
+        if (networkCallback != null) {
+            return
+        }
+        val manager = connectivityManager ?: return
+
+        // Seed the current state so we don't wait for the first change to know
+        // whether we're online.
+        isConnected = currentConnectivity()
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                handleConnectivityChange(true)
+            }
+
+            override fun onLost(network: Network) {
+                handleConnectivityChange(false)
+            }
+
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                handleConnectivityChange(
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                )
+            }
+        }
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                manager.registerDefaultNetworkCallback(callback)
+            } else {
+                val request = NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+                manager.registerNetworkCallback(request, callback)
+            }
+            networkCallback = callback
+        } catch (e: SecurityException) {
+            // Some devices throw if ACCESS_NETWORK_STATE is missing; leave the
+            // callback unregistered and rely on the seeded state.
+        }
+    }
+
+    @Synchronized
+    private fun unregisterNetworkCallback() {
+        val callback = networkCallback ?: return
+        try {
+            connectivityManager?.unregisterNetworkCallback(callback)
+        } catch (e: IllegalArgumentException) {
+            // Callback was not registered; ignore.
+        }
+        networkCallback = null
+    }
+
+    private fun handleConnectivityChange(connected: Boolean) {
+        // Dedupe repeated same-state callbacks (e.g. onCapabilitiesChanged firing
+        // multiple times) so JS doesn't flush-storm.
+        if (isConnected == connected) {
+            return
+        }
+        isConnected = connected
+        emitConnectivityChange(connected)
+    }
+
+    private fun emitConnectivityChange(connected: Boolean) {
+        if (!reactContext.hasActiveCatalystInstance()) {
+            return
+        }
+        val params: WritableMap = Arguments.createMap().apply { putBoolean("isConnected", connected) }
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit(CONNECTIVITY_EVENT_NAME, params)
+    }
+
+    private fun currentConnectivity(): Boolean {
+        val manager = connectivityManager ?: return true
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = manager.activeNetwork ?: return false
+            val capabilities = manager.getNetworkCapabilities(network) ?: return false
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        } else {
+            @Suppress("DEPRECATION")
+            manager.activeNetworkInfo?.isConnected ?: false
+        }
+    }
+
+    override fun invalidate() {
+        unregisterNetworkCallback()
+        super.invalidate()
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onCatalystInstanceDestroy() {
+        unregisterNetworkCallback()
+        @Suppress("DEPRECATION")
+        super.onCatalystInstanceDestroy()
+    }
+}

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativePackage.java
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativePackage.java
@@ -17,6 +17,7 @@ public class AmplitudeReactNativePackage implements ReactPackage {
     public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new AmplitudeReactNativeModule(reactContext));
+        modules.add(new AmplitudeReactNativeConnectivityModule(reactContext));
         return modules;
     }
 

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/ConnectivityChecker.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/ConnectivityChecker.kt
@@ -1,0 +1,128 @@
+package com.amplitude.reactnative
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+
+/**
+ * Framework-free connectivity logic extracted from
+ * [AmplitudeReactNativeConnectivityModule] so it can be unit-tested with
+ * Robolectric without React Native on the classpath. The module owns the React
+ * bridge (promise resolution + event emission); this class owns everything that
+ * only depends on the Android networking APIs.
+ *
+ * Connectivity is monitored with [ConnectivityManager]. `registerDefaultNetworkCallback`
+ * is API 24+, while `minSdkVersion` is 21, so we fall back to
+ * `registerNetworkCallback(NetworkRequest, callback)` on API 21–23.
+ *
+ * @param onConnectivityChanged invoked (off the registration thread) whenever the
+ *   connectivity state actually changes — repeated same-state callbacks are deduped.
+ */
+internal class ConnectivityChecker(
+    private val context: Context,
+    private val onConnectivityChanged: (Boolean) -> Unit,
+) {
+    private val connectivityManager: ConnectivityManager?
+        get() = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    // Last known connectivity state, used to seed JS and to dedupe.
+    @Volatile
+    internal var isConnected = true
+        private set
+
+    /**
+     * Lazily registers the network callback. Idempotent: a second call while a
+     * callback is already registered is a no-op.
+     */
+    @Synchronized
+    fun start() {
+        if (networkCallback != null) {
+            return
+        }
+        val manager = connectivityManager ?: return
+
+        // Seed the current state so we don't wait for the first change to know
+        // whether we're online.
+        isConnected = currentConnectivity()
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                handleConnectivityChange(true)
+            }
+
+            override fun onLost(network: Network) {
+                handleConnectivityChange(false)
+            }
+
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                handleConnectivityChange(hasInternetCapability(capabilities))
+            }
+        }
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                manager.registerDefaultNetworkCallback(callback)
+            } else {
+                val request = NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+                manager.registerNetworkCallback(request, callback)
+            }
+            networkCallback = callback
+        } catch (e: SecurityException) {
+            // Some devices throw if ACCESS_NETWORK_STATE is missing; leave the
+            // callback unregistered and rely on the seeded state.
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        val callback = networkCallback ?: return
+        try {
+            connectivityManager?.unregisterNetworkCallback(callback)
+        } catch (e: IllegalArgumentException) {
+            // Callback was not registered; ignore.
+        }
+        networkCallback = null
+    }
+
+    private fun handleConnectivityChange(connected: Boolean) {
+        // Dedupe repeated same-state callbacks (e.g. onCapabilitiesChanged firing
+        // multiple times) so JS doesn't flush-storm.
+        if (isConnected == connected) {
+            return
+        }
+        isConnected = connected
+        onConnectivityChanged(connected)
+    }
+
+    fun currentConnectivity(): Boolean {
+        val manager = connectivityManager ?: return true
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = manager.activeNetwork ?: return false
+            val capabilities = manager.getNetworkCapabilities(network) ?: return false
+            hasInternetCapability(capabilities)
+        } else {
+            @Suppress("DEPRECATION")
+            manager.activeNetworkInfo?.isConnected ?: false
+        }
+    }
+
+    // NET_CAPABILITY_VALIDATED was added in API 23 (M); on API 21-22 it is never
+    // reported, so requiring it there would make the device read as permanently
+    // offline. Gate the validation requirement behind M and require only
+    // INTERNET on 21-22.
+    internal fun hasInternetCapability(capabilities: NetworkCapabilities): Boolean {
+        val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            hasInternet && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        } else {
+            hasInternet
+        }
+    }
+}

--- a/packages/analytics-react-native/android/src/test/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModuleTest.kt
+++ b/packages/analytics-react-native/android/src/test/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModuleTest.kt
@@ -1,0 +1,135 @@
+package com.amplitude.reactnative
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Thin-bridge tests for [AmplitudeReactNativeConnectivityModule] — the React
+ * glue that the framework-free [ConnectivityChecker] (covered separately in
+ * [ConnectivityCheckerTest]) delegates from. Covers the two behaviors that need
+ * the React surface: [AmplitudeReactNativeConnectivityModule.getNetworkConnectivityStatus]
+ * resolving a promise, and the `hasActiveCatalystInstance()` emit guard.
+ *
+ * `Arguments.createMap()` is static-mocked to a [JavaOnlyMap] (the pure-Java
+ * WritableMap) since the native map factory isn't installed in unit tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.N])
+class AmplitudeReactNativeConnectivityModuleTest {
+    private val reactContext: ReactApplicationContext = mockk(relaxed = true)
+    private val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+    private val emitter: RCTDeviceEventEmitter = mockk(relaxed = true)
+    private val network: Network = mockk()
+    private lateinit var module: AmplitudeReactNativeConnectivityModule
+
+    @Before
+    fun setUp() {
+        mockkStatic(Arguments::class)
+        every { Arguments.createMap() } answers { JavaOnlyMap() }
+        every { reactContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        every { reactContext.getJSModule(RCTDeviceEventEmitter::class.java) } returns emitter
+        module = AmplitudeReactNativeConnectivityModule(reactContext)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Arguments::class)
+    }
+
+    private fun caps(internet: Boolean, validated: Boolean): NetworkCapabilities =
+        mockk {
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns internet
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns validated
+        }
+
+    @Test
+    fun `getNetworkConnectivityStatus resolves isConnected true when connected`() {
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns caps(internet = true, validated = true)
+        val promise = mockk<Promise>(relaxed = true)
+        val resultSlot = slot<WritableMap>()
+
+        module.getNetworkConnectivityStatus(promise)
+
+        verify { promise.resolve(capture(resultSlot)) }
+        assertTrue(resultSlot.captured.getBoolean("isConnected"))
+    }
+
+    @Test
+    fun `getNetworkConnectivityStatus resolves isConnected false when disconnected`() {
+        every { connectivityManager.activeNetwork } returns null
+        val promise = mockk<Promise>(relaxed = true)
+        val resultSlot = slot<WritableMap>()
+
+        module.getNetworkConnectivityStatus(promise)
+
+        verify { promise.resolve(capture(resultSlot)) }
+        assertFalse(resultSlot.captured.getBoolean("isConnected"))
+    }
+
+    @Test
+    fun `emits connectivity change event when catalyst instance is active`() {
+        every { reactContext.hasActiveCatalystInstance() } returns true
+        every { connectivityManager.activeNetwork } returns null // seed disconnected
+        val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } returns Unit
+
+        module.addListener("AmplitudeNetworkConnectivityChanged")
+        callbackSlot.captured.onAvailable(network) // false -> true: should emit
+
+        val payloadSlot = slot<WritableMap>()
+        verify(exactly = 1) { emitter.emit("AmplitudeNetworkConnectivityChanged", capture(payloadSlot)) }
+        assertTrue(payloadSlot.captured.getBoolean("isConnected"))
+    }
+
+    @Test
+    fun `removeListeners is a no-op and does not unregister the callback`() {
+        every { connectivityManager.activeNetwork } returns null // seed disconnected
+        every { connectivityManager.registerDefaultNetworkCallback(any()) } returns Unit
+        module.addListener("AmplitudeNetworkConnectivityChanged")
+
+        module.removeListeners(1)
+
+        verify(exactly = 0) { connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>()) }
+    }
+
+    // Backlog #5: the emit is dropped when the bridge is inactive, but the
+    // checker's deduped state has already advanced — so JS can desync until a
+    // different transition. This documents the current drop behavior.
+    @Test
+    fun `drops connectivity emit when catalyst instance is inactive (documents desync #5)`() {
+        every { reactContext.hasActiveCatalystInstance() } returns false
+        every { connectivityManager.activeNetwork } returns null // seed disconnected
+        val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } returns Unit
+
+        module.addListener("AmplitudeNetworkConnectivityChanged")
+        callbackSlot.captured.onAvailable(network) // state advances, but emit is dropped
+
+        verify(exactly = 0) { reactContext.getJSModule(RCTDeviceEventEmitter::class.java) }
+        verify(exactly = 0) { emitter.emit(any(), any()) }
+    }
+}

--- a/packages/analytics-react-native/android/src/test/java/com/amplitude/reactnative/ConnectivityCheckerTest.kt
+++ b/packages/analytics-react-native/android/src/test/java/com/amplitude/reactnative/ConnectivityCheckerTest.kt
@@ -1,0 +1,319 @@
+package com.amplitude.reactnative
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import android.net.NetworkRequest
+import android.os.Build
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric/JUnit4 + mockk tests for [ConnectivityChecker] — the framework-free
+ * connectivity logic the JS `offline-integration.test.ts` mocks out. Mirrors the
+ * pattern in Amplitude-Kotlin's `AndroidNetworkConnectivityCheckerTest`:
+ * Robolectric runner + per-API-level `@Config(sdk = [...])`, mocking
+ * [ConnectivityManager]/[NetworkCapabilities]/[Network] with mockk.
+ *
+ * The default API level for the class is M (23, the API >= 23 path); individual
+ * tests override it with `@Config(sdk = [...])`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.M])
+class ConnectivityCheckerTest {
+    private val context: Context = mockk()
+    private val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+    private val network: Network = mockk()
+
+    // Connectivity changes delivered to the listener, in order.
+    private val changes = mutableListOf<Boolean>()
+    private lateinit var checker: ConnectivityChecker
+
+    @Before
+    fun setUp() {
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        checker = ConnectivityChecker(context) { connected -> changes.add(connected) }
+    }
+
+    private fun capabilities(internet: Boolean, validated: Boolean): NetworkCapabilities =
+        mockk {
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns internet
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns validated
+        }
+
+    /** Seed `currentConnectivity() == false` on API 23+ so `start()` seeds `isConnected = false`. */
+    private fun seedDisconnectedApi23Plus() {
+        every { connectivityManager.activeNetwork } returns null
+    }
+
+    /** Seed `currentConnectivity() == true` on API 23+. */
+    private fun seedConnectedApi23Plus() {
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = true, validated = true)
+    }
+
+    // region currentConnectivity() — API >= 23
+
+    @Test
+    fun `currentConnectivity returns true when service is not a ConnectivityManager`() {
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns mockk<Any>()
+        assertTrue(checker.currentConnectivity())
+    }
+
+    @Test
+    fun `currentConnectivity returns false when activeNetwork is null on API 23+`() {
+        every { connectivityManager.activeNetwork } returns null
+        assertFalse(checker.currentConnectivity())
+    }
+
+    @Test
+    fun `currentConnectivity returns false when capabilities are null on API 23+`() {
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns null
+        assertFalse(checker.currentConnectivity())
+    }
+
+    @Test
+    fun `currentConnectivity returns true with INTERNET and VALIDATED on API 23+`() {
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = true, validated = true)
+        assertTrue(checker.currentConnectivity())
+    }
+
+    @Test
+    fun `currentConnectivity returns false with INTERNET but not VALIDATED on API 23+ (captive portal)`() {
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = true, validated = false)
+        assertFalse(checker.currentConnectivity())
+    }
+
+    @Test
+    fun `currentConnectivity returns false with neither capability on API 23+`() {
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = false, validated = false)
+        assertFalse(checker.currentConnectivity())
+    }
+
+    // endregion
+
+    // region currentConnectivity() — API 21–22 (deprecated activeNetworkInfo path)
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    fun `currentConnectivity uses activeNetworkInfo isConnected true on API 21-22`() {
+        every { connectivityManager.activeNetworkInfo } returns mockk<NetworkInfo> { every { isConnected } returns true }
+        assertTrue(checker.currentConnectivity())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    fun `currentConnectivity uses activeNetworkInfo isConnected false on API 21-22`() {
+        every { connectivityManager.activeNetworkInfo } returns mockk<NetworkInfo> { every { isConnected } returns false }
+        assertFalse(checker.currentConnectivity())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    fun `currentConnectivity returns false when activeNetworkInfo is null on API 21-22`() {
+        every { connectivityManager.activeNetworkInfo } returns null
+        assertFalse(checker.currentConnectivity())
+    }
+
+    // endregion
+
+    // region hasInternetCapability() — API gating (commit 7173529a)
+
+    @Test
+    fun `hasInternetCapability requires INTERNET and VALIDATED on API 23+`() {
+        assertTrue(checker.hasInternetCapability(capabilities(internet = true, validated = true)))
+        assertFalse(checker.hasInternetCapability(capabilities(internet = true, validated = false)))
+        assertFalse(checker.hasInternetCapability(capabilities(internet = false, validated = true)))
+        assertFalse(checker.hasInternetCapability(capabilities(internet = false, validated = false)))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    fun `hasInternetCapability requires only INTERNET on API 21-22 (does not require VALIDATED)`() {
+        // The 7173529a fix: VALIDATED is never reported on API 21-22, so requiring
+        // it there would read as permanently offline. INTERNET alone must suffice.
+        assertTrue(checker.hasInternetCapability(capabilities(internet = true, validated = false)))
+        assertFalse(checker.hasInternetCapability(capabilities(internet = false, validated = false)))
+    }
+
+    // endregion
+
+    // region start() — registration branch (registerDefaultNetworkCallback vs registerNetworkCallback)
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `start uses registerDefaultNetworkCallback on API 24+`() {
+        seedDisconnectedApi23Plus()
+        checker.start()
+        verify(exactly = 1) { connectivityManager.registerDefaultNetworkCallback(any()) }
+        verify(exactly = 0) {
+            connectivityManager.registerNetworkCallback(any<NetworkRequest>(), any<ConnectivityManager.NetworkCallback>())
+        }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
+    fun `start uses registerNetworkCallback with a request on API 23`() {
+        seedDisconnectedApi23Plus()
+        checker.start()
+        // Note: registerDefaultNetworkCallback is API 24+, so it does not exist on
+        // the API 23 framework Robolectric loads here — we cannot verify(exactly=0)
+        // against it (NoSuchMethodError). The positive assertion below suffices: the
+        // API check in start() is mutually exclusive.
+        verify(exactly = 1) {
+            connectivityManager.registerNetworkCallback(any<NetworkRequest>(), any<ConnectivityManager.NetworkCallback>())
+        }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    fun `start uses registerNetworkCallback with a request on API 21-22`() {
+        every { connectivityManager.activeNetworkInfo } returns null // seed disconnected
+        checker.start()
+        verify(exactly = 1) {
+            connectivityManager.registerNetworkCallback(any<NetworkRequest>(), any<ConnectivityManager.NetworkCallback>())
+        }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `start is idempotent - a second call does not re-register`() {
+        seedDisconnectedApi23Plus()
+        checker.start()
+        checker.start()
+        verify(exactly = 1) { connectivityManager.registerDefaultNetworkCallback(any()) }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `start swallows SecurityException and stays unregistered`() {
+        seedDisconnectedApi23Plus()
+        every { connectivityManager.registerDefaultNetworkCallback(any()) } throws SecurityException("missing permission")
+
+        checker.start() // must not throw
+
+        // No callback was stored, so a later stop() must not try to unregister one.
+        checker.stop()
+        verify(exactly = 0) { connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>()) }
+    }
+
+    // endregion
+
+    // region callback -> state mapping + dedupe
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `network callback emits only on an actual state change (dedupe)`() {
+        seedDisconnectedApi23Plus() // seed isConnected = false
+        val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } returns Unit
+        checker.start()
+        val callback = callbackSlot.captured
+
+        assertTrue(changes.isEmpty()) // start() seeds but does not emit
+
+        callback.onAvailable(network) // false -> true
+        callback.onAvailable(network) // true -> true: deduped
+        callback.onLost(network) // true -> false
+        callback.onLost(network) // false -> false: deduped
+        callback.onCapabilitiesChanged(network, capabilities(internet = true, validated = true)) // false -> true
+        callback.onCapabilitiesChanged(network, capabilities(internet = true, validated = false)) // true -> false (unvalidated)
+
+        assertEquals(listOf(true, false, true, false), changes)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `onCapabilitiesChanged maps INTERNET plus VALIDATED to connected on API 23+`() {
+        seedDisconnectedApi23Plus()
+        val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } returns Unit
+        checker.start()
+
+        callbackSlot.captured.onCapabilitiesChanged(network, capabilities(internet = true, validated = true))
+
+        assertEquals(listOf(true), changes)
+        assertTrue(checker.isConnected)
+    }
+
+    // endregion
+
+    // region stop() — teardown
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `stop unregisters the registered callback`() {
+        seedDisconnectedApi23Plus()
+        val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } returns Unit
+        checker.start()
+
+        checker.stop()
+
+        verify(exactly = 1) { connectivityManager.unregisterNetworkCallback(callbackSlot.captured) }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `stop tolerates IllegalArgumentException and clears the callback`() {
+        seedDisconnectedApi23Plus()
+        checker.start()
+        every {
+            connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
+        } throws IllegalArgumentException("callback not registered")
+
+        checker.stop() // must not throw
+        checker.stop() // second call is a no-op (callback already cleared)
+
+        verify(exactly = 1) { connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>()) }
+    }
+
+    @Test
+    fun `stop is a no-op when never started`() {
+        checker.stop()
+        verify(exactly = 0) { connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>()) }
+    }
+
+    // endregion
+
+    // region desync risk — documents backlog #5
+
+    // The module drops the emit when the React bridge is inactive
+    // (hasActiveCatalystInstance() == false), but ConnectivityChecker has already
+    // advanced its deduped state. This documents that a subsequent same-state
+    // callback is then suppressed, so a dropped transition is not retried until a
+    // *different* transition occurs. See backlog #5 in SDKRN-5-offline-followups.md.
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
+    fun `dedupe advances state before delivery so a dropped change is not retried (documents desync #5)`() {
+        seedConnectedApi23Plus() // isConnected = true
+        val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } returns Unit
+        checker.start()
+        assertTrue(checker.isConnected)
+
+        callbackSlot.captured.onLost(network) // true -> false: listener called once
+        callbackSlot.captured.onLost(network) // false -> false: deduped, listener NOT called again
+
+        assertEquals(listOf(false), changes)
+        assertFalse(checker.isConnected)
+    }
+
+    // endregion
+}

--- a/packages/analytics-react-native/ios/AmplitudeReactNative-Bridging-Header.h
+++ b/packages/analytics-react-native/ios/AmplitudeReactNative-Bridging-Header.h
@@ -1,1 +1,2 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>

--- a/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.m
+++ b/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.m
@@ -1,0 +1,8 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(AmplitudeReactNativeConnectivity, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(getNetworkConnectivityStatus: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.swift
+++ b/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.swift
@@ -1,0 +1,178 @@
+import Foundation
+import React
+import SystemConfiguration
+#if canImport(Network)
+import Network
+#endif
+
+/// Connectivity-only native module bridged back to JS as
+/// `AmplitudeReactNativeConnectivity`. It is intentionally separate from the
+/// request/response `AmplitudeReactNative` module so the `RCTEventEmitter`
+/// lifecycle (listener tracking, start/stop observing) stays isolated.
+///
+/// Connectivity is monitored with `NWPathMonitor` (Network framework) when
+/// available (iOS 12+). The podspec targets iOS 10, so on iOS 10/11 we fall
+/// back to `SCNetworkReachability` (SystemConfiguration) rather than bumping
+/// the deployment target.
+@objc(AmplitudeReactNativeConnectivity)
+class AmplitudeReactNativeConnectivity: RCTEventEmitter {
+
+    private static let connectivityEventName = "AmplitudeNetworkConnectivityChanged"
+
+    private var hasListeners = false
+    private let monitorQueue = DispatchQueue(label: "com.amplitude.reactnative.connectivity")
+
+    // iOS 12+ path
+    private var pathMonitor: AnyObject?
+
+    // iOS 10/11 fallback
+    private var reachability: SCNetworkReachability?
+
+    // Last known connectivity state, used to seed JS and to dedupe.
+    private var isConnected = true
+
+    override init() {
+        super.init()
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    // MARK: RCTEventEmitter
+
+    override func supportedEvents() -> [String]! {
+        return [AmplitudeReactNativeConnectivity.connectivityEventName]
+    }
+
+    @objc
+    override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
+    override func startObserving() {
+        hasListeners = true
+        startMonitoring()
+    }
+
+    override func stopObserving() {
+        hasListeners = false
+        stopMonitoring()
+    }
+
+    // MARK: Exported methods
+
+    /// Returns the current connectivity state. `startObserving` only fires on
+    /// subsequent changes, so JS reads this once on setup to seed the initial
+    /// `offline` value.
+    @objc
+    func getNetworkConnectivityStatus(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        resolve(["isConnected": currentConnectivity()])
+    }
+
+    // MARK: Monitoring
+
+    private func startMonitoring() {
+        if #available(iOS 12, tvOS 12, *) {
+            startPathMonitor()
+        } else {
+            startReachability()
+        }
+    }
+
+    private func stopMonitoring() {
+        if #available(iOS 12, tvOS 12, *) {
+            if let monitor = pathMonitor as? NWPathMonitor {
+                monitor.cancel()
+            }
+            pathMonitor = nil
+        }
+        if let reachability = reachability {
+            SCNetworkReachabilitySetCallback(reachability, nil, nil)
+            SCNetworkReachabilitySetDispatchQueue(reachability, nil)
+            self.reachability = nil
+        }
+    }
+
+    @available(iOS 12, tvOS 12, *)
+    private func startPathMonitor() {
+        guard pathMonitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.handleConnectivityChange(path.status == .satisfied)
+        }
+        monitor.start(queue: monitorQueue)
+        pathMonitor = monitor
+    }
+
+    private func startReachability() {
+        guard reachability == nil else { return }
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+
+        guard let reachability = withUnsafePointer(to: &zeroAddress, { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { address in
+                SCNetworkReachabilityCreateWithAddress(nil, address)
+            }
+        }) else {
+            return
+        }
+        self.reachability = reachability
+
+        var context = SCNetworkReachabilityContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let callback: SCNetworkReachabilityCallBack = { (_, flags, info) in
+            guard let info = info else { return }
+            let instance = Unmanaged<AmplitudeReactNativeConnectivity>.fromOpaque(info).takeUnretainedValue()
+            instance.handleConnectivityChange(AmplitudeReactNativeConnectivity.isReachable(flags))
+        }
+
+        SCNetworkReachabilitySetCallback(reachability, callback, &context)
+        SCNetworkReachabilitySetDispatchQueue(reachability, monitorQueue)
+
+        // Emit the current state once monitoring starts.
+        handleConnectivityChange(currentConnectivity())
+    }
+
+    // MARK: Helpers
+
+    private func handleConnectivityChange(_ connected: Bool) {
+        isConnected = connected
+        guard hasListeners else { return }
+        sendEvent(
+            withName: AmplitudeReactNativeConnectivity.connectivityEventName,
+            body: ["isConnected": connected]
+        )
+    }
+
+    private func currentConnectivity() -> Bool {
+        if #available(iOS 12, tvOS 12, *) {
+            if let monitor = pathMonitor as? NWPathMonitor {
+                return monitor.currentPath.status == .satisfied
+            }
+        }
+        var flags = SCNetworkReachabilityFlags()
+        if let reachability = reachability, SCNetworkReachabilityGetFlags(reachability, &flags) {
+            return AmplitudeReactNativeConnectivity.isReachable(flags)
+        }
+        // Default to connected when we can't determine the state, so we never
+        // wrongly suppress event delivery.
+        return isConnected
+    }
+
+    private static func isReachable(_ flags: SCNetworkReachabilityFlags) -> Bool {
+        let isReachable = flags.contains(.reachable)
+        let needsConnection = flags.contains(.connectionRequired)
+        return isReachable && !needsConnection
+    }
+}

--- a/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.swift
+++ b/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.swift
@@ -14,6 +14,11 @@ import Network
 /// available (iOS 12+). The podspec targets iOS 10, so on iOS 10/11 we fall
 /// back to `SCNetworkReachability` (SystemConfiguration) rather than bumping
 /// the deployment target.
+///
+/// The current connectivity state is always computed on demand from a fresh
+/// `SCNetworkReachability` probe (see `currentConnectivity()`), so the initial
+/// state JS reads via `getNetworkConnectivityStatus` is correct even before the
+/// path monitor has started, and there is no shared mutable state to race on.
 @objc(AmplitudeReactNativeConnectivity)
 class AmplitudeReactNativeConnectivity: RCTEventEmitter {
 
@@ -27,13 +32,6 @@ class AmplitudeReactNativeConnectivity: RCTEventEmitter {
 
     // iOS 10/11 fallback
     private var reachability: SCNetworkReachability?
-
-    // Last known connectivity state, used to seed JS and to dedupe.
-    private var isConnected = true
-
-    override init() {
-        super.init()
-    }
 
     deinit {
         stopMonitoring()
@@ -64,7 +62,8 @@ class AmplitudeReactNativeConnectivity: RCTEventEmitter {
 
     /// Returns the current connectivity state. `startObserving` only fires on
     /// subsequent changes, so JS reads this once on setup to seed the initial
-    /// `offline` value.
+    /// `offline` value. The value is computed from a fresh reachability probe so
+    /// it is correct even before monitoring has started.
     @objc
     func getNetworkConnectivityStatus(
         _ resolve: @escaping RCTPromiseResolveBlock,
@@ -76,6 +75,8 @@ class AmplitudeReactNativeConnectivity: RCTEventEmitter {
     // MARK: Monitoring
 
     private func startMonitoring() {
+        // Replace any existing monitor so repeated startObserving calls don't leak.
+        stopMonitoring()
         if #available(iOS 12, tvOS 12, *) {
             startPathMonitor()
         } else {
@@ -99,28 +100,16 @@ class AmplitudeReactNativeConnectivity: RCTEventEmitter {
 
     @available(iOS 12, tvOS 12, *)
     private func startPathMonitor() {
-        guard pathMonitor == nil else { return }
         let monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { [weak self] path in
-            self?.handleConnectivityChange(path.status == .satisfied)
+            self?.emitConnectivityChange(path.status == .satisfied)
         }
         monitor.start(queue: monitorQueue)
         pathMonitor = monitor
     }
 
     private func startReachability() {
-        guard reachability == nil else { return }
-        var zeroAddress = sockaddr_in()
-        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        zeroAddress.sin_family = sa_family_t(AF_INET)
-
-        guard let reachability = withUnsafePointer(to: &zeroAddress, { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { address in
-                SCNetworkReachabilityCreateWithAddress(nil, address)
-            }
-        }) else {
-            return
-        }
+        guard let reachability = createReachability() else { return }
         self.reachability = reachability
 
         var context = SCNetworkReachabilityContext(
@@ -134,20 +123,16 @@ class AmplitudeReactNativeConnectivity: RCTEventEmitter {
         let callback: SCNetworkReachabilityCallBack = { (_, flags, info) in
             guard let info = info else { return }
             let instance = Unmanaged<AmplitudeReactNativeConnectivity>.fromOpaque(info).takeUnretainedValue()
-            instance.handleConnectivityChange(AmplitudeReactNativeConnectivity.isReachable(flags))
+            instance.emitConnectivityChange(AmplitudeReactNativeConnectivity.isReachable(flags))
         }
 
         SCNetworkReachabilitySetCallback(reachability, callback, &context)
         SCNetworkReachabilitySetDispatchQueue(reachability, monitorQueue)
-
-        // Emit the current state once monitoring starts.
-        handleConnectivityChange(currentConnectivity())
     }
 
     // MARK: Helpers
 
-    private func handleConnectivityChange(_ connected: Bool) {
-        isConnected = connected
+    private func emitConnectivityChange(_ connected: Bool) {
         guard hasListeners else { return }
         sendEvent(
             withName: AmplitudeReactNativeConnectivity.connectivityEventName,
@@ -155,24 +140,34 @@ class AmplitudeReactNativeConnectivity: RCTEventEmitter {
         )
     }
 
+    /// Computes the current connectivity from a fresh `SCNetworkReachability`
+    /// probe. This does not depend on the monitor being started, so it returns a
+    /// correct value when JS seeds the initial state. Defaults to connected when
+    /// the state can't be determined, so we never wrongly suppress sends.
     private func currentConnectivity() -> Bool {
-        if #available(iOS 12, tvOS 12, *) {
-            if let monitor = pathMonitor as? NWPathMonitor {
-                return monitor.currentPath.status == .satisfied
+        guard let reachability = createReachability() else { return true }
+        var flags = SCNetworkReachabilityFlags()
+        guard SCNetworkReachabilityGetFlags(reachability, &flags) else { return true }
+        return AmplitudeReactNativeConnectivity.isReachable(flags)
+    }
+
+    private func createReachability() -> SCNetworkReachability? {
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+
+        return withUnsafePointer(to: &zeroAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { address in
+                SCNetworkReachabilityCreateWithAddress(nil, address)
             }
         }
-        var flags = SCNetworkReachabilityFlags()
-        if let reachability = reachability, SCNetworkReachabilityGetFlags(reachability, &flags) {
-            return AmplitudeReactNativeConnectivity.isReachable(flags)
-        }
-        // Default to connected when we can't determine the state, so we never
-        // wrongly suppress event delivery.
-        return isConnected
     }
 
     private static func isReachable(_ flags: SCNetworkReachabilityFlags) -> Bool {
-        let isReachable = flags.contains(.reachable)
-        let needsConnection = flags.contains(.connectionRequired)
-        return isReachable && !needsConnection
+        let reachable = flags.contains(.reachable)
+        let requiresConnection = flags.contains(.connectionRequired)
+        let canConnectAutomatically = flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic)
+        let canConnectWithoutUserInteraction = canConnectAutomatically && !flags.contains(.interventionRequired)
+        return reachable && (!requiresConnection || canConnectWithoutUserInteraction)
     }
 }

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -1,0 +1,141 @@
+import {
+  getGlobalScope,
+  BeforePlugin,
+  ReactNativeClient,
+  ReactNativeConfig,
+  OfflineDisabled,
+} from '@amplitude/analytics-core';
+import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
+
+export const CONNECTIVITY_EVENT_NAME = 'AmplitudeNetworkConnectivityChanged';
+
+/**
+ * Shape of the native `AmplitudeReactNativeConnectivity` module bridged from
+ * iOS (`RCTEventEmitter` subclass) and Android (`ReactContextBaseJavaModule`).
+ */
+interface ConnectivityNativeModule {
+  getNetworkConnectivityStatus(): Promise<{ isConnected: boolean }>;
+  // `addListener`/`removeListeners` are required by `NativeEventEmitter` so it
+  // doesn't warn; they are no-ops on the JS side here.
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+interface ConnectivityEvent {
+  isConnected: boolean;
+}
+
+interface WebEventListener {
+  type: 'online' | 'offline';
+  handler: () => void;
+}
+
+// `offline` is intentionally omitted from the public `ReactNativeConfig` type,
+// but it exists on the underlying core `Config` instance at runtime and is what
+// the shared `Destination` plugin reads to short-circuit network requests.
+type OfflineConfig = ReactNativeConfig & { offline?: boolean | typeof OfflineDisabled };
+
+export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
+  const name = '@amplitude/plugin-network-checker-react-native';
+  const type = 'before' as const;
+
+  const globalScope = getGlobalScope();
+  let subscription: EmitterSubscription | undefined;
+  let webEventListeners: WebEventListener[] = [];
+
+  const addWebNetworkListener = (listenerType: 'online' | 'offline', handler: () => void) => {
+    /* istanbul ignore else */
+    if (globalScope?.addEventListener) {
+      globalScope.addEventListener(listenerType, handler);
+      webEventListeners.push({ type: listenerType, handler });
+    }
+  };
+
+  const removeWebNetworkListeners = () => {
+    webEventListeners.forEach(({ type: listenerType, handler }) => {
+      /* istanbul ignore next */
+      globalScope?.removeEventListener(listenerType, handler);
+    });
+    webEventListeners = [];
+  };
+
+  const setup = async (config: OfflineConfig, amplitude: ReactNativeClient) => {
+    const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
+
+    // Apply a connectivity change. Comparing against the current `config.offline`
+    // value naturally debounces repeated same-state signals (e.g. Android's
+    // `onCapabilitiesChanged` firing multiple times) so we don't flush-storm on
+    // transient reconnect flapping.
+    const handleConnectivityChange = (isConnected: boolean) => {
+      const offline = !isConnected;
+      if (config.offline === offline) {
+        return;
+      }
+      config.offline = offline;
+      if (isConnected) {
+        config.loggerProvider.debug('Network connectivity changed to online.');
+        // No `ERR_NETWORK_CHANGED` concern on native, so flush immediately.
+        void amplitude.flush();
+      } else {
+        config.loggerProvider.debug('Network connectivity changed to offline.');
+      }
+    };
+
+    // Native mode (iOS / Android): use the bridged connectivity module.
+    if (nativeModule) {
+      const eventEmitter = new NativeEventEmitter(nativeModule);
+      // `startObserving` only fires on subsequent changes, so seed the initial
+      // state from the native module.
+      try {
+        const status = await nativeModule.getNetworkConnectivityStatus();
+        config.offline = !status.isConnected;
+      } catch (e) {
+        config.loggerProvider.debug(`Failed to read initial network connectivity status: ${String(e)}`);
+        config.offline = false;
+      }
+      subscription = eventEmitter.addListener(CONNECTIVITY_EVENT_NAME, (event: ConnectivityEvent) => {
+        handleConnectivityChange(event.isConnected);
+      });
+      return;
+    }
+
+    // Web mode (react-native-web): fall back to `navigator.onLine` + events.
+    if (typeof navigator !== 'undefined') {
+      config.offline = !navigator.onLine;
+
+      addWebNetworkListener('online', () => {
+        config.loggerProvider.debug('Network connectivity changed to online.');
+        config.offline = false;
+        // Flushing immediately on web causes ERR_NETWORK_CHANGED, so delay it.
+        setTimeout(() => {
+          void amplitude.flush();
+        }, config.flushIntervalMillis);
+      });
+
+      addWebNetworkListener('offline', () => {
+        config.loggerProvider.debug('Network connectivity changed to offline.');
+        config.offline = true;
+      });
+      return;
+    }
+
+    // No connectivity source available: assume always online.
+    config.loggerProvider.debug(
+      'Network connectivity checker plugin is disabled because no connectivity source is available.',
+    );
+    config.offline = false;
+  };
+
+  const teardown = async () => {
+    subscription?.remove();
+    subscription = undefined;
+    removeWebNetworkListeners();
+  };
+
+  return {
+    name,
+    type,
+    setup,
+    teardown,
+  };
+};

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -6,6 +6,7 @@ import {
   OfflineDisabled,
 } from '@amplitude/analytics-core';
 import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
+import { isWeb } from '../utils/platform';
 
 export const CONNECTIVITY_EVENT_NAME = 'AmplitudeNetworkConnectivityChanged';
 
@@ -100,7 +101,14 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
     }
 
     // Web mode (react-native-web): fall back to `navigator.onLine` + events.
-    if (typeof navigator !== 'undefined') {
+    // Gate on `isWeb()` (not just `typeof navigator`): React Native defines a
+    // `navigator` polyfill that has no `onLine`, so on a native app where the
+    // connectivity module is missing (e.g. JS upgraded without rebuilding
+    // native, or an autolink failure) this branch would otherwise read
+    // `!navigator.onLine === !undefined === true` and wrongly pin the SDK
+    // offline forever. Offline mode is best-effort: when there's no reliable
+    // connectivity source we fall through to `offline = false` below.
+    if (isWeb() && typeof navigator !== 'undefined') {
       config.offline = !navigator.onLine;
 
       addWebNetworkListener('online', () => {
@@ -119,9 +127,10 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       return;
     }
 
-    // No connectivity source available: assume always online.
+    // Best-effort fallback: no reliable connectivity source (no native module,
+    // not web) → assume online so we never wrongly suppress sends.
     config.loggerProvider.debug(
-      'Network connectivity checker plugin is disabled because no connectivity source is available.',
+      'Network connectivity checker plugin found no connectivity source; defaulting to online.',
     );
     config.offline = false;
   };

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -22,9 +22,11 @@ import {
   setConnectorUserId,
   SpecialEventType,
   AnalyticsClient,
+  OfflineDisabled,
 } from '@amplitude/analytics-core';
 import { CampaignTracker } from './campaign/campaign-tracker';
 import { Context } from './plugins/context';
+import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity-checker';
 import { useReactNativeConfig, createCookieStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
@@ -77,6 +79,12 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     // Step 3: Install plugins
     // Do not track any events before this
+    // Install the network connectivity checker before Destination so that
+    // `config.offline` is set before any flush is scheduled. Skip when offline
+    // mode has been explicitly disabled via the OfflineDisabled sentinel.
+    if ((this.config as { offline?: boolean | typeof OfflineDisabled }).offline !== OfflineDisabled) {
+      await this.add(networkConnectivityCheckerPlugin()).promise;
+    }
     await this.add(new Destination()).promise;
     await this.add(new Context()).promise;
     await this.add(new IdentityEventSender()).promise;

--- a/packages/analytics-react-native/test/mock/setup-mobile.ts
+++ b/packages/analytics-react-native/test/mock/setup-mobile.ts
@@ -60,3 +60,16 @@ NativeModules.AmplitudeReactNative = {
   getLegacyEvents: () => [],
   removeLegacyEvent: () => ({}),
 };
+
+/*
+ * Mock the connectivity-only native module bridged by
+ * `AmplitudeReactNativeConnectivity`. `getNetworkConnectivityStatus` seeds the
+ * initial offline state, while `addListener`/`removeListeners` are required by
+ * `NativeEventEmitter`. Tests emit `AmplitudeNetworkConnectivityChanged` via
+ * `DeviceEventEmitter` (which `NativeEventEmitter` delegates to under the hood).
+ */
+NativeModules.AmplitudeReactNativeConnectivity = {
+  getNetworkConnectivityStatus: jest.fn(async (): Promise<{ isConnected: boolean }> => ({ isConnected: true })),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+};

--- a/packages/analytics-react-native/test/mock/setup-web.ts
+++ b/packages/analytics-react-native/test/mock/setup-web.ts
@@ -1,5 +1,5 @@
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
-import { Platform } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 /*
  * Set the platform OS to mobile.
@@ -17,3 +17,18 @@ jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 // window['navigator'] = { product: "ReactNative" }
+
+/*
+ * Mock the connectivity-only native module bridged by
+ * `AmplitudeReactNativeConnectivity`. It is wired here (in addition to
+ * setup-mobile) so the network-connectivity plugin's native-path tests can run
+ * under the web (jsdom) suite as well. Tests that exercise the
+ * `navigator.onLine` web fallback delete this module first. Tests emit
+ * `AmplitudeNetworkConnectivityChanged` via `DeviceEventEmitter` (which
+ * `NativeEventEmitter` delegates to under the hood).
+ */
+NativeModules.AmplitudeReactNativeConnectivity = {
+  getNetworkConnectivityStatus: jest.fn(async (): Promise<{ isConnected: boolean }> => ({ isConnected: true })),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+};

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -7,6 +7,7 @@ import {
   CONNECTIVITY_EVENT_NAME,
 } from '../../src/plugins/network-connectivity-checker';
 import { useDefaultConfig } from '../helpers/default';
+import * as platform from '../../src/utils/platform';
 
 /**
  * A controllable stand-in for the web global scope so the web-fallback path can
@@ -163,6 +164,9 @@ describe('networkConnectivityCheckerPlugin', () => {
     beforeEach(() => {
       originalModule = NativeModules.AmplitudeReactNativeConnectivity;
       delete (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity;
+      // The web branch is gated on isWeb(); force it so this runs under the
+      // node (test:mobile) suite too, not just jsdom.
+      jest.spyOn(platform, 'isWeb').mockReturnValue(true);
     });
 
     afterEach(() => {
@@ -244,6 +248,7 @@ describe('networkConnectivityCheckerPlugin', () => {
     });
 
     afterEach(() => {
+      jest.restoreAllMocks();
       (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity =
         originalModule;
     });
@@ -260,6 +265,26 @@ describe('networkConnectivityCheckerPlugin', () => {
         expect(offlineOf(config)).toBe(false);
         // teardown is a no-op here and should not throw.
         await expect(plugin.teardown?.()).resolves.not.toThrow();
+      });
+    });
+
+    // Regression: on a NATIVE app where the connectivity module is missing
+    // (e.g. JS upgraded without rebuilding native, or autolink failure), RN
+    // still defines a `navigator` polyfill that has no `onLine`. The plugin
+    // must NOT enter the web branch and pin `offline = !undefined === true`;
+    // offline mode is best-effort, so it defaults to online.
+    test('native app without the connectivity module defaults to online (not stuck offline)', async () => {
+      jest.spyOn(platform, 'isWeb').mockReturnValue(false);
+      // React Native's navigator: defined, but no `onLine` property.
+      await withNavigator({ product: 'ReactNative' } as unknown as { onLine: boolean }, async () => {
+        const config = useDefaultConfig();
+        // Start offline to prove the best-effort fallback resets it to online.
+        (config as { offline?: boolean | null }).offline = true;
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+
+        expect(offlineOf(config)).toBe(false);
       });
     });
   });

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -1,0 +1,266 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NativeModules, DeviceEventEmitter } from 'react-native';
+import { ReactNativeClient } from '@amplitude/analytics-core';
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import {
+  networkConnectivityCheckerPlugin,
+  CONNECTIVITY_EVENT_NAME,
+} from '../../src/plugins/network-connectivity-checker';
+import { useDefaultConfig } from '../helpers/default';
+
+/**
+ * A controllable stand-in for the web global scope so the web-fallback path can
+ * be exercised under both the node (test:mobile) and jsdom (test:web) suites.
+ */
+const createFakeGlobalScope = () => {
+  const handlers: Record<string, Array<() => void>> = {};
+  return {
+    scope: {
+      addEventListener: jest.fn((type: string, handler: () => void) => {
+        (handlers[type] = handlers[type] || []).push(handler);
+      }),
+      removeEventListener: jest.fn((type: string, handler: () => void) => {
+        handlers[type] = (handlers[type] || []).filter((h) => h !== handler);
+      }),
+    } as unknown as typeof globalThis,
+    trigger: (type: 'online' | 'offline') => (handlers[type] || []).forEach((handler) => handler()),
+  };
+};
+
+const withNavigator = (value: { onLine: boolean } | undefined, fn: () => Promise<void>) => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  // eslint-disable-next-line no-restricted-globals
+  Object.defineProperty(globalThis, 'navigator', { value, configurable: true, writable: true });
+  return fn().finally(() => {
+    if (descriptor) {
+      // eslint-disable-next-line no-restricted-globals
+      Object.defineProperty(globalThis, 'navigator', descriptor);
+    }
+  });
+};
+
+const createAmplitudeMock = () =>
+  ({
+    flush: jest.fn(() => ({ promise: Promise.resolve() })),
+  } as unknown as ReactNativeClient);
+
+// `offline` is omitted from the public ReactNativeConfig type but exists on the
+// underlying core Config instance at runtime.
+const offlineOf = (config: object): boolean | null | undefined => (config as { offline?: boolean | null }).offline;
+
+describe('networkConnectivityCheckerPlugin', () => {
+  const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
+    getNetworkConnectivityStatus: jest.Mock;
+    addListener: jest.Mock;
+    removeListeners: jest.Mock;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    connectivityModule.getNetworkConnectivityStatus.mockResolvedValue({ isConnected: true });
+    DeviceEventEmitter.removeAllListeners(CONNECTIVITY_EVENT_NAME);
+  });
+
+  describe('native mode', () => {
+    test('seeds initial offline state from the native module (online)', async () => {
+      connectivityModule.getNetworkConnectivityStatus.mockResolvedValueOnce({ isConnected: true });
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      expect(connectivityModule.getNetworkConnectivityStatus).toHaveBeenCalledTimes(1);
+      expect(offlineOf(config)).toBe(false);
+    });
+
+    test('seeds initial offline state from the native module (offline)', async () => {
+      connectivityModule.getNetworkConnectivityStatus.mockResolvedValueOnce({ isConnected: false });
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      expect(offlineOf(config)).toBe(true);
+    });
+
+    test('defaults to online if the initial status read rejects', async () => {
+      connectivityModule.getNetworkConnectivityStatus.mockRejectedValueOnce(new Error('boom'));
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      expect(offlineOf(config)).toBe(false);
+    });
+
+    test('toggles config.offline on connectivity events', async () => {
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, createAmplitudeMock());
+      expect(offlineOf(config)).toBe(false);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      expect(offlineOf(config)).toBe(true);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      expect(offlineOf(config)).toBe(false);
+    });
+
+    test('flushes immediately on reconnect', async () => {
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, amplitude);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+
+      expect(amplitude.flush).toHaveBeenCalledTimes(1);
+    });
+
+    test('debounces repeated same-state events (no flush storm)', async () => {
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, amplitude);
+
+      // Already online from the initial seed; repeated "online" events are no-ops.
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      expect(amplitude.flush).not.toHaveBeenCalled();
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      expect(offlineOf(config)).toBe(true);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      expect(amplitude.flush).toHaveBeenCalledTimes(1);
+    });
+
+    test('teardown removes the native subscription', async () => {
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      await plugin.teardown?.();
+
+      expect(connectivityModule.removeListeners).toHaveBeenCalled();
+      // After teardown, further events must not mutate config.offline.
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      expect(offlineOf(config)).toBe(false);
+    });
+  });
+
+  /*
+   * Web fallback exercises `navigator.onLine` + online/offline events. The
+   * global scope and navigator are mocked so this runs under both the node
+   * (test:mobile) and jsdom (test:web) suites.
+   */
+  describe('web fallback', () => {
+    let originalModule: unknown;
+
+    beforeEach(() => {
+      originalModule = NativeModules.AmplitudeReactNativeConnectivity;
+      delete (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity =
+        originalModule;
+    });
+
+    test('tracks navigator.onLine and online/offline events', async () => {
+      const { scope, trigger } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: true }, async () => {
+        const config = useDefaultConfig();
+        const amplitude = createAmplitudeMock();
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, amplitude);
+
+        expect(offlineOf(config)).toBe(false);
+        expect(scope.addEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+        expect(scope.addEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
+
+        trigger('offline');
+        expect(offlineOf(config)).toBe(true);
+
+        jest.useFakeTimers();
+        trigger('online');
+        expect(offlineOf(config)).toBe(false);
+        // Web fallback delays the flush by flushIntervalMillis to avoid
+        // ERR_NETWORK_CHANGED.
+        expect(amplitude.flush).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(config.flushIntervalMillis);
+        expect(amplitude.flush).toHaveBeenCalledTimes(1);
+        jest.useRealTimers();
+      });
+    });
+
+    test('sets offline true when navigator starts offline', async () => {
+      const { scope } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: false }, async () => {
+        const config = useDefaultConfig();
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+
+        expect(offlineOf(config)).toBe(true);
+      });
+    });
+
+    test('teardown removes web listeners', async () => {
+      const { scope } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: true }, async () => {
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(useDefaultConfig(), createAmplitudeMock());
+        await plugin.teardown?.();
+
+        expect(scope.removeEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+        expect(scope.removeEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
+      });
+    });
+  });
+
+  /*
+   * Always-online fallback when neither a native module nor a navigator is
+   * available.
+   */
+  describe('always-online fallback', () => {
+    let originalModule: unknown;
+
+    beforeEach(() => {
+      originalModule = NativeModules.AmplitudeReactNativeConnectivity;
+      delete (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity;
+    });
+
+    afterEach(() => {
+      (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity =
+        originalModule;
+    });
+
+    test('falls back to always-online when no native module and no navigator', async () => {
+      await withNavigator(undefined, async () => {
+        const config = useDefaultConfig();
+        // Start non-default to prove the fallback resets it to online.
+        (config as { offline?: boolean | null }).offline = true;
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+
+        expect(offlineOf(config)).toBe(false);
+        // teardown is a no-op here and should not throw.
+        await expect(plugin.teardown?.()).resolves.not.toThrow();
+      });
+    });
+  });
+});

--- a/packages/analytics-react-native/test/plugins/offline-integration.test.ts
+++ b/packages/analytics-react-native/test/plugins/offline-integration.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NativeModules, DeviceEventEmitter } from 'react-native';
+import { MemoryStorage, Status, Event, Payload, Transport, Response, STORAGE_PREFIX } from '@amplitude/analytics-core';
+import { AmplitudeReactNative } from '../../src/react-native-client';
+import { CONNECTIVITY_EVENT_NAME } from '../../src/plugins/network-connectivity-checker';
+import * as CookieMigration from '../../src/cookie-migration';
+
+/**
+ * End-to-end style test: with the connectivity plugin installed by default,
+ * events queue while `config.offline === true` (Destination short-circuits both
+ * schedule and flush) and are flushed once connectivity is restored.
+ */
+describe('offline mode integration', () => {
+  const API_KEY = 'API_KEY';
+
+  const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
+    getNetworkConnectivityStatus: jest.Mock;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    connectivityModule.getNetworkConnectivityStatus.mockResolvedValue({ isConnected: true });
+    DeviceEventEmitter.removeAllListeners(CONNECTIVITY_EVENT_NAME);
+  });
+
+  test('queues events while offline and flushes them on reconnect', async () => {
+    jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
+
+    const sentEvents: Event[] = [];
+    const send = jest.fn(async (_serverUrl: string, payload: Payload): Promise<Response> => {
+      sentEvents.push(...payload.events);
+      return {
+        status: Status.Success,
+        statusCode: 200,
+        body: {
+          eventsIngested: payload.events.length,
+          payloadSizeBytes: 0,
+          serverUploadTime: 0,
+        },
+      };
+    });
+    const transportProvider: Transport = { send };
+    const storageProvider = new MemoryStorage<Event[]>();
+
+    const client = new AmplitudeReactNative();
+    await client.init(API_KEY, undefined, {
+      transportProvider,
+      storageProvider,
+      flushIntervalMillis: 3000,
+      flushQueueSize: 100,
+      attribution: { disabled: true },
+      optOut: false,
+    }).promise;
+
+    // Go offline via the native connectivity signal.
+    DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+
+    // Track events while offline; their promises won't resolve until flushed,
+    // so don't await them here.
+    void client.track('event_while_offline_1').promise;
+    void client.track('event_while_offline_2').promise;
+
+    // Allow the events to be enqueued and persisted to storage.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Nothing is sent while offline, and the queue is persisted.
+    await client.flush().promise;
+    expect(send).not.toHaveBeenCalled();
+    const queued = await storageProvider.get(`${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`);
+    expect(queued?.length).toBe(2);
+
+    // Reconnect → plugin flips config.offline=false and flushes immediately.
+    DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+    await client.flush().promise;
+
+    expect(send).toHaveBeenCalled();
+    expect(sentEvents.map((e) => e.event_type)).toEqual(
+      expect.arrayContaining(['event_while_offline_1', 'event_while_offline_2']),
+    );
+
+    // Storage queue drains after a successful flush.
+    const remaining = await storageProvider.get(`${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`);
+    expect(remaining ?? []).toEqual([]);
+
+    client.shutdown();
+  });
+});

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -223,12 +223,17 @@ describe('react-native-client', () => {
   }
 
   describe('network connectivity checker plugin', () => {
+    const NETWORK_CHECKER_PLUGIN_NAME = '@amplitude/plugin-network-checker-react-native';
+
     test('should install the network connectivity checker by default', async () => {
       jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
       const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
       const client = new AmplitudeReactNative();
+      const addSpy = jest.spyOn(client, 'add');
       await client.init(API_KEY, USER_ID, { ...attributionConfig }).promise;
       expect(installSpy).toHaveBeenCalledTimes(1);
+      // Assert it actually lands in the timeline under the expected name.
+      expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));
       installSpy.mockRestore();
     });
 
@@ -236,6 +241,7 @@ describe('react-native-client', () => {
       jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
       const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
       const client = new AmplitudeReactNative();
+      const addSpy = jest.spyOn(client, 'add');
       await client.init(API_KEY, USER_ID, {
         ...attributionConfig,
         // `offline` is omitted from the public ReactNativeOptions type but is
@@ -243,6 +249,8 @@ describe('react-native-client', () => {
         offline: core.OfflineDisabled,
       } as core.ReactNativeOptions).promise;
       expect(installSpy).not.toHaveBeenCalled();
+      // And it never reaches the timeline.
+      expect(addSpy).not.toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));
       installSpy.mockRestore();
     });
   });

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -11,6 +11,7 @@ import {
 import { isWeb } from '../src/utils/platform';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Config from '../src/config';
+import * as NetworkChecker from '../src/plugins/network-connectivity-checker';
 
 describe('react-native-client', () => {
   const API_KEY = 'API_KEY';
@@ -220,6 +221,31 @@ describe('react-native-client', () => {
       });
     });
   }
+
+  describe('network connectivity checker plugin', () => {
+    test('should install the network connectivity checker by default', async () => {
+      jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
+      const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
+      const client = new AmplitudeReactNative();
+      await client.init(API_KEY, USER_ID, { ...attributionConfig }).promise;
+      expect(installSpy).toHaveBeenCalledTimes(1);
+      installSpy.mockRestore();
+    });
+
+    test('should not install the network connectivity checker when offline is OfflineDisabled', async () => {
+      jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
+      const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
+      const client = new AmplitudeReactNative();
+      await client.init(API_KEY, USER_ID, {
+        ...attributionConfig,
+        // `offline` is omitted from the public ReactNativeOptions type but is
+        // honored by the underlying core Config.
+        offline: core.OfflineDisabled,
+      } as core.ReactNativeOptions).promise;
+      expect(installSpy).not.toHaveBeenCalled();
+      installSpy.mockRestore();
+    });
+  });
 
   describe('getUserId', () => {
     test('should get user id', async () => {


### PR DESCRIPTION
## Summary
Adds offline mode to the React Native SDK: events are queued while the device is offline and flushed on reconnect, driven by a **native connectivity checker** bridged to a JS `BeforePlugin` that flips `config.offline`.

### Core feature
- **iOS** native module `AmplitudeReactNativeConnectivity` (`RCTEventEmitter`): `NWPathMonitor` (iOS 12+) with `SCNetworkReachability` fallback; `getNetworkConnectivityStatus` + `AmplitudeNetworkConnectivityChanged` event.
- **Android** native module `AmplitudeReactNativeConnectivityModule`: `ConnectivityManager.registerDefaultNetworkCallback` (API 24+) / `registerNetworkCallback` fallback (21–23); `ACCESS_NETWORK_STATE` added to manifests. `NET_CAPABILITY_VALIDATED` required on API ≥ 23 (gated so 21–22 aren't permanently offline).
- **JS** `networkConnectivityCheckerPlugin`: native path via `NativeEventEmitter`, `navigator.onLine` web fallback; seeds + flips `config.offline`, flushes on reconnect. Installed before `Destination`; skipped on the `OfflineDisabled` sentinel.
- Tests: plugin unit tests + end-to-end `offline-integration.test.ts`.

### Example-app fix (this PR's latest commit)
The `expo-app` never actually entered offline mode during manual testing — events were attempted (and dropped after retries) instead of queued. **Root cause: a duplicate `react-native` in the bundle.** `packages/analytics-react-native` pins its own `react-native` devDep (0.70.6), so Metro bundled a second copy alongside the app's 0.71.x → two `RCTDeviceEventEmitter` singletons → the SDK's connectivity listener was registered on a different emitter than the native bridge emits to, so live change events never reached the plugin (seeding via the direct `getNetworkConnectivityStatus()` call still worked). Fixed with a `resolver.resolveRequest` in `expo-app/metro.config.js` that forces a single `react-native`/`react` copy. This is an example-app bundling artifact, not an SDK bug — a real consumer installs a single `react-native`.

Also adds **Online/Offline test buttons** and `Debug` logging to the example for manual offline testing.

## Test plan
- ✅ Automated: `test:web` / `test:mobile` green; lint + typecheck clean.
- ✅ **TC1** (online -> offline queue → reconnect flush) verified end-to-end on an Android emulator: 
<div><a href="https://amplitude.zoom.us/clips/share/MIqrL8kmRoC0v-4fEeQkzQ"><p>RN offline local test</p></a><a href="https://amplitude.zoom.us/clips/share/MIqrL8kmRoC0v-4fEeQkzQ"><img style="max-width: 300px; border-radius: 10px;" src="https://file.zoom.us/public/file/MDyebhDTQduY82Et1kaBhg/MS4zLlpDsyKsZH_NsFC2Qt3RQU_nO08NL7ejYPuPj9aJOz8l/iIz3OxilSfuydGHnNFR2gw.jpg" /></a></div>

- ⬜ TC2 (cold-launch offline seed), TC3 (Android API 21–22), TC4 (captive portal), TC5 (web) — still to verify.

> Note: on the Android emulator, use `adb shell svc wifi disable && adb shell svc data disable` to go offline; `cmd connectivity airplane-mode` is unreliable there because the SDK requires `NET_CAPABILITY_VALIDATED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)