### PR TITLE
chore(examples): add Maestro TC1 offline-queue/reconnect-flush test for expo-app

### DIFF
--- a/SDKRN-5-offline-followups.md
+++ b/SDKRN-5-offline-followups.md
@@ -1,0 +1,159 @@
+# SDKRN-5 — offline mode follow-ups
+
+Tracking doc for the React Native offline-mode feature (PR #1796): manual
+verification, the test-case matrix, and the UI-test (Maestro) work that stacks on
+top of it.
+
+## Feature recap
+
+Events queue while the device is offline and flush on reconnect, driven by a
+native connectivity checker (`AmplitudeReactNativeConnectivity`, iOS + Android)
+bridged to a JS `BeforePlugin` (`networkConnectivityCheckerPlugin`) that flips
+`config.offline`. The shared `Destination` plugin short-circuits `schedule()` /
+`flush()` and keeps the queue while `config.offline === true`, then flushes on
+reconnect. The plugin is installed before `Destination` and skipped on the
+`OfflineDisabled` sentinel.
+
+## Test-case matrix
+
+| TC  | Scenario                                   | Status |
+| --- | ------------------------------------------ | ------ |
+| TC1 | Offline queue -> reconnect flush           | ✅ manual; ⚙️ Maestro (see below) |
+| TC2 | Cold-launch offline seed                   | ⬜ to verify |
+| TC3 | Android API 21–22 fallback callback        | ⬜ to verify |
+| TC4 | Captive portal (validated vs connected)    | ⬜ to verify |
+| TC5 | Web (`navigator.onLine`)                   | ⬜ to verify |
+
+### TC1 — offline queue -> reconnect flush (definition)
+
+1. Launch the app **online**; the launch-time event uploads (HTTP 200).
+2. Track an event while online — it uploads.
+3. Go **offline**.
+4. Track event(s) — they must **QUEUE** in memory, with **no** network attempt
+   (`Destination.flush()` short-circuits; "Skipping flush while offline." logs).
+5. **Reconnect**.
+6. The queued events **FLUSH** — a real upload with a `serverUploadTime` in the
+   response.
+
+### TC1 — manual verification log
+
+Verified end-to-end on an **Android emulator** after the Metro dedupe fix:
+
+- Offline: tapping the Offline-test button queued events with **no** network
+  attempts ("Skipping flush while offline." at `Debug`).
+- Reconnect: the SDK flushed immediately and the batch uploaded successfully
+  (200, `serverUploadTime` present in the response body).
+
+Pre-fix, the app never actually entered offline mode — events were attempted and
+dropped after retries instead of queued. **Root cause:** a duplicate
+`react-native` in the bundle (`packages/analytics-react-native` pins its own
+`react-native` 0.70.6 devDep, so Metro bundled a second copy alongside the app's
+0.71.x). Two copies => two `RCTDeviceEventEmitter` singletons => the SDK's
+`NativeEventEmitter` listener was registered on a different emitter than the
+native bridge emitted to, so live connectivity-change events never reached the
+plugin (only the initial `getNetworkConnectivityStatus()` seed worked). Fixed via
+`resolver.resolveRequest` in `expo-app/metro.config.js` forcing a single
+`react-native` / `react`. **Requires `expo start --clear`** to drop the stale
+bundler cache. This is an example-app bundling artifact, not an SDK bug — a real
+consumer installs a single `react-native`.
+
+### Android emulator caveats
+
+- On API >= 23 the connectivity checker requires `NET_CAPABILITY_VALIDATED`
+  (gated so API 21–22 aren't treated as permanently offline). Emulators can keep
+  reporting a validated network, so **`cmd connectivity airplane-mode` /
+  `setAirplaneMode` are unreliable** for forcing the SDK offline there.
+- The reliable trigger is disabling the radios directly:
+
+  ```
+  adb shell svc wifi disable && adb shell svc data disable   # go offline
+  adb shell svc wifi enable  && adb shell svc data enable    # reconnect
+  ```
+
+---
+
+## TC1 as a Maestro UI test — feasibility findings
+
+**Goal:** express TC1 (launch online -> send -> go offline -> track [must queue]
+-> reconnect -> queued events flush) as an automated Maestro flow on the
+`expo-app`.
+
+### Conclusion
+
+**Not cleanly expressible as a single hermetic Maestro flow**, for two reasons —
+but it *is* testable with (a) small UI instrumentation in `App.tsx` and (b) a
+hybrid Maestro-flow + adb driver. Both are now in the repo:
+
+- Instrumentation: `examples/react-native/expo-app/App.tsx` — a TC1 status panel.
+- Self-contained flow (best-effort): `.maestro/tc1-offline-queue-flush.yaml`.
+- Reliable hybrid driver: `.maestro/run-tc1.sh`.
+
+### Blocker 1 — toggling connectivity from a flow
+
+What Maestro can do for connectivity and whether it produces a *real* offline
+state for this SDK:
+
+| Mechanism | In-flow? | Produces real offline for this SDK? |
+| --- | --- | --- |
+| `setAirplaneMode` (Android) | ✅ yes; keeps app + JS state alive | ⚠️ **unreliable on emulators** — airplane mode may not drop `NET_CAPABILITY_VALIDATED`; works on physical devices / well-behaved emulators |
+| `- runScript` shim | ✅ yes | ❌ no — `runScript` is a JS sandbox (GraalJS), not a shell; it cannot run `adb`/`svc` |
+| External `adb shell svc wifi/data disable` | ❌ not from inside a flow | ✅ **yes** — the verified trigger |
+
+So the only *in-flow* primitive (`setAirplaneMode`) is exactly the one the manual
+testing found unreliable on the emulator. The reliable trigger (`adb svc ...`)
+has to be orchestrated **around** Maestro from a shell script, because Maestro
+deliberately has no shell-exec step.
+
+### Blocker 2 — assertions are UI-only
+
+Maestro asserts on visible UI, not logcat or network. TC1's "queued vs sent"
+distinction was previously only observable in `Debug` logs. Fixed by adding a
+minimal, example-only **TC1 status panel** to `App.tsx`:
+
+| Label | SDK state it surfaces |
+| --- | --- |
+| `Offline: <bool>` | live `config.offline` (captured via a tiny enrichment plugin + polled — there's no JS event to subscribe to) |
+| `Queued: <n>` | in-memory queue depth = number of `track()` promises still pending. A track promise only resolves once a send is *attempted* (`fulfillRequest`); offline short-circuits flush, so pending == queued. |
+| `Uploaded: <n>` | count of events whose promise resolved with **HTTP 200** |
+| `Last: <…>` | last flush outcome — `"… → queued (offline)"` (the UI equivalent of "Skipping flush while offline.") vs the resolved `"… → 200 Event tracked successfully"` after reconnect |
+
+This makes every TC1 transition `assertVisible`-able. `Queued: 2` holding while
+`Offline: true` (despite RN's 1s `flushIntervalMillis`) is the positive proof of
+queueing; `Queued: 0` + the `200` `Last:` line after reconnect proves the flush.
+
+### What ships
+
+1. **`.maestro/tc1-offline-queue-flush.yaml`** — self-contained flow using
+   `setAirplaneMode`. Full TC1 assert sequence. The clean path on physical
+   devices / emulators where airplane mode registers as a real network loss. If
+   `Offline: true` times out on your emulator, that's Blocker 1 — use the driver.
+
+2. **`.maestro/run-tc1.sh`** — hybrid driver (recommended on emulators). Runs the
+   flow in three phases as separate `maestro test` invocations against the *same*
+   running app, interleaving `adb shell svc wifi/data disable|enable` between
+   phases. Only phase 1 launches/clears state; phases 2–3 attach to the
+   foregrounded app so the in-memory queue + counters survive the toggles.
+
+### Requirements / limitations to be aware of
+
+- **Real key + reachability.** `Uploaded` / the `200` `Last:` assertion need a
+  real `AMPLITUDE_API_KEY` (inlined via `babel.config.js`) and reachability to
+  `api2.amplitude.com`. With a dummy key the queue still drains on reconnect, but
+  `Uploaded` won't increment — in that case assert only on `Offline:` + `Queued:`.
+- **Deduped bundle.** Must be built after the `metro.config.js` dedupe fix, with
+  `expo start --clear`; otherwise live connectivity events never reach the plugin.
+- **Needs a real device/emulator.** This is an instrumented UI test; it cannot run
+  in a headless JS-only CI runner. Run it on a device, a CI runner with an Android
+  emulator (radios togglable via adb), or a device farm. Maestro Cloud does **not**
+  expose adb svc / arbitrary shell, so the `run-tc1.sh` path needs a self-hosted
+  emulator; on Maestro Cloud only the `setAirplaneMode` flow is usable (subject to
+  Blocker 1 on that fleet's emulators).
+
+### Alternatives considered
+
+- **Detox** — can mock/disable network at the native layer and assert in-process,
+  avoiding both blockers, but it's a heavier harness not currently set up here.
+- **Pure Maestro Cloud** — viable only for the `setAirplaneMode` flow and only
+  where that fleet's devices honor airplane mode for this SDK.
+- **Hybrid Maestro + adb (chosen)** — lowest-friction given the existing Maestro
+  setup; the adb driver makes the connectivity toggle deterministic.

--- a/examples/react-native/expo-app/.maestro/run-tc1.sh
+++ b/examples/react-native/expo-app/.maestro/run-tc1.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# TC1 (offline queue -> reconnect flush) — adb-driven hybrid driver.
+#
+# Why this exists
+# ---------------
+# `tc1-offline-queue-flush.yaml` is the self-contained flow and uses Maestro's
+# in-flow `setAirplaneMode`. On many Android *emulators* airplane mode does not
+# reliably register as offline for this SDK: on API >= 23 the native connectivity
+# checker requires NET_CAPABILITY_VALIDATED, and the emulator can keep reporting a
+# validated network even in airplane mode. The trigger verified during manual TC1
+# testing is, instead:
+#
+#       adb shell svc wifi disable && adb shell svc data disable
+#
+# Maestro cannot run adb/shell from inside a flow (its `runScript` is a JS sandbox,
+# not a shell), so this script orchestrates the connectivity toggles *around*
+# Maestro sub-flows. The phases run as separate `maestro test` invocations against
+# the SAME running app process — only phase 1 launches/clears state; phases 2 and 3
+# attach to the already-foregrounded app so the in-memory queue and the on-screen
+# Queued/Uploaded counters survive across the toggles. Do NOT kill the app between
+# phases.
+#
+# Usage
+# -----
+#   examples/react-native/expo-app/.maestro/run-tc1.sh
+#
+# The app must already be built and installed (with the deduped Metro config —
+# `expo start --clear`) and a real AMPLITUDE_API_KEY inlined so the reconnect
+# upload returns 200. Env overrides:
+#   APP_ID      Android applicationId          (default: com.amplitude.expoapp)
+#   ADB_SERIAL  target device/emulator serial  (default: adb's default device)
+#
+set -euo pipefail
+
+APP_ID="${APP_ID:-com.amplitude.expoapp}"
+ADB=(adb)
+if [[ -n "${ADB_SERIAL:-}" ]]; then
+  ADB=(adb -s "${ADB_SERIAL}")
+fi
+
+command -v adb >/dev/null     || { echo "error: adb not found on PATH"; exit 1; }
+command -v maestro >/dev/null || { echo "error: maestro not found on PATH"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"; echo "+ restoring connectivity"; "${ADB[@]}" shell svc wifi enable || true; "${ADB[@]}" shell svc data enable || true' EXIT
+
+# --- phase flows (generated; kept tiny and adb-toggle-friendly) ---------------
+cat >"${WORK}/phase1-online.yaml" <<YAML
+appId: ${APP_ID}
+---
+# Online baseline: launch fresh, confirm online, send, confirm the queue drains.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      text: "Home Screen"
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      text: "Offline: false"
+    timeout: 30000
+- tapOn: "Online test"
+- extendedWaitUntil:
+    visible:
+      text: "Queued: 0"
+    timeout: 30000
+YAML
+
+cat >"${WORK}/phase2-offline.yaml" <<YAML
+appId: ${APP_ID}
+---
+# App is already running and now offline (radios disabled by the driver). Events
+# tracked here must QUEUE, not send. No launchApp: keep the JS state alive.
+- extendedWaitUntil:
+    visible:
+      text: "Offline: true"
+    timeout: 30000
+- tapOn: "Offline test"
+- tapOn: "Offline test"
+- assertVisible:
+    text: "Queued: 2"
+- assertVisible:
+    text: "Last: RN Expo Offline Test → queued (offline)"
+YAML
+
+cat >"${WORK}/phase3-flush.yaml" <<YAML
+appId: ${APP_ID}
+---
+# Radios re-enabled by the driver: the SDK flushes the queued events on reconnect.
+- extendedWaitUntil:
+    visible:
+      text: "Offline: false"
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      text: "Queued: 0"
+    timeout: 30000
+- assertVisible:
+    text: "Last: RN Expo Offline Test → 200 Event tracked successfully"
+YAML
+
+echo "+ phase 1: online baseline"
+maestro test "${WORK}/phase1-online.yaml"
+
+echo "+ going offline: svc wifi/data disable"
+"${ADB[@]}" shell svc wifi disable
+"${ADB[@]}" shell svc data disable
+sleep 5
+
+echo "+ phase 2: track while offline (must queue)"
+maestro test "${WORK}/phase2-offline.yaml"
+
+echo "+ reconnecting: svc wifi/data enable"
+"${ADB[@]}" shell svc wifi enable
+"${ADB[@]}" shell svc data enable
+sleep 8
+
+echo "+ phase 3: reconnect flush"
+maestro test "${WORK}/phase3-flush.yaml"
+
+echo "+ TC1 passed"

--- a/examples/react-native/expo-app/.maestro/tc1-offline-queue-flush.yaml
+++ b/examples/react-native/expo-app/.maestro/tc1-offline-queue-flush.yaml
@@ -1,0 +1,92 @@
+appId: com.amplitude.expoapp
+# iOS bundle id is com.amplitude.expo-app — change `appId` above to run on iOS.
+# (setAirplaneMode is Android-only, so the connectivity toggle below is Android.)
+---
+# =============================================================================
+# TC1 — offline queue -> reconnect flush (SDKRN-5)
+#
+# Sequence under test:
+#   launch online -> events upload -> go offline -> track (events must QUEUE,
+#   not send) -> reconnect -> queued events FLUSH.
+#
+# Maestro asserts on visible UI only, so this flow relies on the TC1 status panel
+# added to App.tsx (Offline / Queued / Uploaded / Last). See App.tsx for how each
+# label maps to SDK state.
+#
+# CONNECTIVITY TOGGLE — IMPORTANT CAVEAT:
+# This flow uses Maestro's in-flow `setAirplaneMode`, which keeps the app process
+# (and therefore the in-memory queue + counters) alive across the toggle. Airplane
+# mode drops ALL radios, so the default network is lost (onLost) and the SDK sees
+# isConnected=false. This is the clean, self-contained path and works on physical
+# devices and on emulators that propagate airplane mode as a real network loss.
+#
+# On many Android *emulators*, airplane mode does NOT reliably register as offline
+# for this SDK: on API >= 23 the connectivity checker requires
+# NET_CAPABILITY_VALIDATED, and the emulator can keep reporting a validated
+# network. If the "Offline: true" assertion below times out on your emulator, use
+# the adb-driven driver instead, which toggles the radios directly:
+#       examples/react-native/expo-app/.maestro/run-tc1.sh
+# (it runs `adb shell svc wifi disable && adb shell svc data disable`, the trigger
+# verified during manual TC1 testing — see SDKRN-5-offline-followups.md).
+#
+# PREREQUISITES:
+#   * A real AMPLITUDE_API_KEY inlined at build time (babel.config.js) and network
+#     reachability to api2.amplitude.com, so "Uploaded"/200 assertions hold. With a
+#     dummy key the queue still drains on reconnect but Uploaded won't increment;
+#     in that case assert on "Queued: 0" + "Offline: false" only.
+#   * Built with the deduped Metro config (`expo start --clear` after the
+#     metro.config.js react-native dedupe fix), otherwise live connectivity change
+#     events never reach the plugin and offline mode only sees the initial seed.
+# =============================================================================
+
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      text: "Home Screen"
+    timeout: 30000
+
+# --- Phase 1: online baseline -------------------------------------------------
+# The launch-time event and any prior taps should upload while online, draining
+# the in-memory queue back to 0.
+- extendedWaitUntil:
+    visible:
+      text: "Offline: false"
+    timeout: 30000
+- tapOn: "Online test"
+- extendedWaitUntil:
+    visible:
+      text: "Queued: 0"
+    timeout: 30000
+
+# --- Phase 2: go offline; tracked events must QUEUE, not send -----------------
+- setAirplaneMode: enabled
+- extendedWaitUntil:
+    visible:
+      text: "Offline: true"
+    timeout: 30000
+- tapOn: "Offline test"
+- tapOn: "Offline test"
+# Both events are held in memory: flush() is short-circuited while offline.
+# (RN flushIntervalMillis is 1s, so if offline mode were broken these would have
+# drained by the time this assertion runs.)
+- assertVisible:
+    text: "Queued: 2"
+# UI-observable equivalent of the "Skipping flush while offline." debug log:
+- assertVisible:
+    text: "Last: RN Expo Offline Test → queued (offline)"
+
+# --- Phase 3: reconnect; queued events must FLUSH -----------------------------
+- setAirplaneMode: disabled
+- extendedWaitUntil:
+    visible:
+      text: "Offline: false"
+    timeout: 30000
+# On reconnect the plugin flushes immediately; the two queued events drain.
+- extendedWaitUntil:
+    visible:
+      text: "Queued: 0"
+    timeout: 30000
+# Proof the drained events were actually uploaded (requires a real key + network).
+- assertVisible:
+    text: "Last: RN Expo Offline Test → 200 Event tracked successfully"

--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -1,18 +1,120 @@
 import {Button, StyleSheet, Text, View} from 'react-native';
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {identify, Identify, init, track, add, Types} from '@amplitude/analytics-react-native';
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 const Stack = createNativeStackNavigator();
 
-function HomeScreen({ navigation }) {
+// ---------------------------------------------------------------------------
+// TC1 (offline queue -> reconnect flush) instrumentation — EXAMPLE-APP ONLY.
+//
+// Offline mode is normally only observable in Debug logs ("Skipping flush while
+// offline.", upload/serverUploadTime). Maestro asserts on visible UI, not logs,
+// so we surface the three pieces of state TC1 cares about as on-screen labels:
+//
+//   * Offline  — the live value of `config.offline` (flipped by the native
+//                connectivity checker plugin). There is no JS event to subscribe
+//                to, so we capture the shared `config` via a tiny enrichment
+//                plugin and poll it.
+//   * Queued   — events that have been track()'d but whose promise has not yet
+//                resolved. The Destination plugin only resolves a track promise
+//                once a send is *attempted* (fulfillRequest). While offline,
+//                flush() is short-circuited, so the promise stays pending — i.e.
+//                this counter is the in-memory queue depth.
+//   * Uploaded — events whose promise resolved with HTTP 200 (a real upload).
+//   * Last     — the last flush outcome: "queued (offline)" when an event is
+//                tracked while offline (the UI-observable equivalent of the
+//                "Skipping flush while offline." log line) vs the resolved
+//                "<code> <message>" (e.g. "200 Event tracked successfully")
+//                once it actually flushes after reconnect.
+//
+// Keep this small and example-appropriate; it is test scaffolding, not SDK code.
+// ---------------------------------------------------------------------------
+
+type TcState = {
+  offline: boolean | null;
+  queued: number;
+  uploaded: number;
+  last: string;
+};
+
+const tc: TcState = {offline: null, queued: 0, uploaded: 0, last: '—'};
+const tcListeners = new Set<() => void>();
+const notifyTc = () => tcListeners.forEach((listener) => listener());
+
+// The connectivity plugin mutates `config.offline` on the shared config instance.
+// All plugins receive that same instance in setup(), so capturing it here lets the
+// UI read the live offline flag.
+let capturedConfig: {offline?: boolean | null} | null = null;
+const offlineProbePlugin: Types.EnrichmentPlugin = {
+  name: 'expo-offline-probe',
+  type: 'enrichment',
+  setup: async (config) => {
+    capturedConfig = config as unknown as {offline?: boolean | null};
+  },
+  execute: async (event) => event,
+};
+
+// track() wrapper that feeds the on-screen counters.
+function trackObserved(eventType: string) {
+  tc.queued += 1;
+  tc.last = capturedConfig?.offline ? `${eventType} → queued (offline)` : `${eventType} → sending…`;
+  notifyTc();
+  track(eventType)
+    .promise.then((result) => {
+      tc.queued -= 1;
+      if (result.code === 200) {
+        tc.uploaded += 1;
+      }
+      tc.last = `${result.event.event_type} → ${result.code} ${result.message}`;
+      notifyTc();
+    })
+    .catch((e: unknown) => {
+      tc.queued -= 1;
+      tc.last = `error: ${String(e)}`;
+      notifyTc();
+    });
+}
+
+function useTcState(): TcState {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const listener = () => force((n) => n + 1);
+    tcListeners.add(listener);
+    // config.offline is flipped imperatively by the plugin; poll it so the label
+    // tracks live connectivity changes.
+    const pollId = setInterval(() => {
+      const next = capturedConfig?.offline ?? null;
+      const normalized = next === null ? null : !!next;
+      if (normalized !== tc.offline) {
+        tc.offline = normalized;
+        notifyTc();
+      }
+    }, 500);
+    return () => {
+      tcListeners.delete(listener);
+      clearInterval(pollId);
+    };
+  }, []);
+  return tc;
+}
+
+function HomeScreen({ navigation }: {navigation: any}) {
+  const state = useTcState();
   return (
     <View style={styles.container}>
       <Text>Home Screen</Text>
-      <Button title="Online test" onPress={() => track('RN Expo Online Test')} />
-      <Button title="Offline test" onPress={() => track('RN Expo Offline Test')} />
+      <Button title="Online test" onPress={() => trackObserved('RN Expo Online Test')} />
+      <Button title="Offline test" onPress={() => trackObserved('RN Expo Offline Test')} />
       <Button title="Go to Settings" onPress={() => navigation.navigate('Settings')} />
+      {/* TC1 status panel — asserted on by examples/.../.maestro/tc1-* flows. */}
+      <View style={styles.status}>
+        <Text testID="tc-offline">Offline: {state.offline === null ? 'unknown' : String(state.offline)}</Text>
+        <Text testID="tc-queued">Queued: {state.queued}</Text>
+        <Text testID="tc-uploaded">Uploaded: {state.uploaded}</Text>
+        <Text testID="tc-last">Last: {state.last}</Text>
+      </View>
     </View>
   );
 }
@@ -29,6 +131,8 @@ function SettingsScreen({navigation}: {navigation: any}) {
 export default function App() {
   useEffect(() => {
     (async () => {
+        // Capture the shared config before init so config.offline is observable.
+        add(offlineProbePlugin);
         // AMPLITUDE_API_KEY is inlined at bundle time (see babel.config.js).
         await init(process.env.AMPLITUDE_API_KEY || 'YOUR_API_KEY', 'react-native-user-id', {
           // Debug so offline-mode log lines ("Skipping flush while offline.",
@@ -36,7 +140,7 @@ export default function App() {
           logLevel: Types.LogLevel.Debug,
           // autocapture: { } // <-- todo
         }).promise;
-        track('expo-app/react-native/test-event');
+        trackObserved('expo-app/react-native/test-event');
         await identify(new Identify().set('react-native-test', 'yes')).promise;
     })();
   }, []);
@@ -56,5 +160,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  status: {
+    marginTop: 24,
+    alignItems: 'center',
   },
 });


### PR DESCRIPTION
## Summary

Stacked on #1796 (SDKRN-5 offline mode). Adds an automated **Maestro UI test for
TC1** — *launch online → send → go offline → track (events must **queue**, not
send) → reconnect → queued events **flush*** — to `examples/react-native/expo-app`,
along with the minimal UI instrumentation it requires and a feasibility write-up.

## Feasibility finding (assessed first)

TC1 is **not cleanly expressible as one hermetic Maestro flow**, for two reasons:

1. **Toggling connectivity in-flow is unreliable for this SDK.** Maestro's only
   in-flow primitive is `setAirplaneMode`; on emulators that often doesn't drop
   `NET_CAPABILITY_VALIDATED`, so the SDK never goes offline. The verified trigger
   is `adb shell svc wifi disable && adb shell svc data disable`, and Maestro
   can't run shell/adb from a flow (`runScript` is a JS sandbox, not a shell).
2. **Maestro asserts on visible UI only** — TC1's "queued vs sent" was previously
   observable only in Debug logs.

So it ships as **instrumentation + two runners**:

- **`App.tsx`** — an example-only **TC1 status panel**: `Offline` (live
  `config.offline`, captured via a tiny enrichment plugin + polled), `Queued`
  (pending `track()` promises = in-memory queue depth; a promise only resolves
  once a send is *attempted*, which offline short-circuits), `Uploaded` (200s),
  and `Last` (`… → queued (offline)` vs `… → 200 Event tracked successfully`).
- **`.maestro/tc1-offline-queue-flush.yaml`** — self-contained flow using
  `setAirplaneMode`; the clean path on devices/emulators that honor it.
- **`.maestro/run-tc1.sh`** — hybrid driver that toggles connectivity out-of-band
  with `adb svc wifi/data` around three Maestro sub-flows (only phase 1
  launches/clears state; phases 2–3 attach to the running app so the in-memory
  queue + counters survive the toggles). Reliable on emulators.
- **`SDKRN-5-offline-followups.md`** — TC1 definition, manual-verification log,
  Android emulator caveats, and the full Maestro feasibility findings.

## Test plan / limitations

- ⚙️ **Not run in this environment** — no Android emulator / Maestro / adb here.
  This is an instrumented UI test; it needs a real device, a CI runner with an
  emulator whose radios are togglable via adb, or a device farm.
- Requires a real `AMPLITUDE_API_KEY` + reachability for the `Uploaded` / `200`
  assertions; with a dummy key, assert only on `Offline:` + `Queued:`.
- Build with the deduped Metro config from #1796 (`expo start --clear`), else live
  connectivity events never reach the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjZAnUsPVZvP1fvLsmupoS)_