### PR TITLE
fix(analytics-react-native): "can't find variable btoa error" message

### DIFF
--- a/packages/analytics-core/src/storage/cookie.ts
+++ b/packages/analytics-core/src/storage/cookie.ts
@@ -176,6 +176,17 @@ export class CookieStorage<T> implements Storage<T> {
 
   private setSync(key: string, value: T | null): void {
     try {
+      const globalScope = getGlobalScope() as GlobalScopeWithCookieStore;
+
+      // typeguard for non-browser environments
+      if (
+        !globalScope ||
+        !globalScope.document ||
+        typeof globalScope.btoa !== 'function' ||
+        typeof globalScope.encodeURIComponent !== 'function'
+      ) {
+        return;
+      }
       const expirationDays = this.options.expirationDays ?? 0;
       const expires = value !== null ? expirationDays : -1;
       let expireDate: Date | undefined = undefined;
@@ -184,7 +195,7 @@ export class CookieStorage<T> implements Storage<T> {
         date.setTime(date.getTime() + expires * 24 * 60 * 60 * 1000);
         expireDate = date;
       }
-      let str = `${key}=${btoa(encodeURIComponent(JSON.stringify(value)))}`;
+      let str = `${key}=${globalScope.btoa(globalScope.encodeURIComponent(JSON.stringify(value)))}`;
       if (expireDate) {
         str += `; expires=${expireDate.toUTCString()}`;
       }
@@ -198,10 +209,7 @@ export class CookieStorage<T> implements Storage<T> {
       if (this.options.sameSite) {
         str += `; SameSite=${this.options.sameSite}`;
       }
-      const globalScope = getGlobalScope();
-      if (globalScope?.document) {
-        globalScope.document.cookie = str;
-      }
+      globalScope.document.cookie = str;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(`Amplitude Logger [Error]: Failed to set cookie for key: ${key}. Error: ${errorMessage}`);

--- a/packages/analytics-core/test/storage/cookies.test.ts
+++ b/packages/analytics-core/test/storage/cookies.test.ts
@@ -47,17 +47,68 @@ describe('cookies', () => {
       expect(await cookies.isEnabled()).toBe(true);
     });
 
-    describe('when document is not available', () => {
+    describe('when environment is missing global scope', () => {
+      let consoleErrorSpy: jest.SpyInstance;
       let getGlobalScopeSpy: jest.SpyInstance;
       beforeEach(() => {
         getGlobalScopeSpy = jest.spyOn(GlobalScopeModule, 'getGlobalScope').mockReturnValue({} as typeof globalThis);
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       });
       afterEach(() => {
+        consoleErrorSpy.mockRestore();
         getGlobalScopeSpy.mockRestore();
       });
-      test('should return false', async () => {
-        const cookies = new CookieStorage();
-        expect(await cookies.isEnabled()).toBe(false);
+
+      describe('where global scope is undefined', () => {
+        beforeEach(() => {
+          getGlobalScopeSpy.mockImplementation(() => undefined);
+        });
+        test('should return false', async () => {
+          const cookies = new CookieStorage();
+          expect(await cookies.isEnabled()).toBe(false);
+          expect(consoleErrorSpy.mock.calls.length).toBe(0);
+        });
+      });
+
+      describe('where document is not available', () => {
+        beforeEach(() => {
+          getGlobalScopeSpy.mockImplementation(() => ({ document: undefined }));
+        });
+        test('should return false', async () => {
+          const cookies = new CookieStorage();
+          expect(await cookies.isEnabled()).toBe(false);
+          expect(consoleErrorSpy.mock.calls.length).toBe(0);
+        });
+      });
+
+      describe('where btoa are not available in global scope', () => {
+        beforeEach(() => {
+          getGlobalScopeSpy.mockImplementation(() => ({
+            document: {},
+            btoa: undefined,
+            encodeURIComponent: undefined,
+          }));
+        });
+        test('should return false', async () => {
+          const cookies = new CookieStorage();
+          expect(await cookies.isEnabled()).toBe(false);
+          expect(consoleErrorSpy.mock.calls.length).toBe(0);
+        });
+      });
+
+      describe('where encodeURIComponent are not available in global scope', () => {
+        beforeEach(() => {
+          getGlobalScopeSpy.mockImplementation(() => ({
+            document: {},
+            btoa: () => ({}),
+            encodeURIComponent: undefined,
+          }));
+        });
+        test('should return false', async () => {
+          const cookies = new CookieStorage();
+          expect(await cookies.isEnabled()).toBe(false);
+          expect(consoleErrorSpy.mock.calls.length).toBe(0);
+        });
       });
     });
 


### PR DESCRIPTION
### Summary

Before: <img src="https://uploads.linear.app/2f38ee1f-255b-4d7b-8788-ae4cd8fb9c9c/408d5ad9-31cf-4da4-b142-ead62ed10379/ebd1203d-8278-4846-b551-1a98911e42c4?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzJmMzhlZTFmLTI1NWItNGQ3Yi04Nzg4LWFlNGNkOGZiOWM5Yy80MDhkNWFkOS0zMWNmLTRkYTQtYjE0Mi1lYWQ2MmVkMTAzNzkvZWJkMTIwM2QtODI3OC00ODQ2LWI1NTEtMWE5ODkxMWU0MmM0IiwiaWF0IjoxNzgwNTkyMjQ3LCJleHAiOjE4MTIxNjI4MDd9.OmeFHtGg4Jjb3VCA2YoI6oEj8r7ED3dbDyu9mNDnFLw " alt="Screenshot 2026-06-04 at 9 27 20 AM" width="1029" data-linear-height="698" />

After: <img src="https://uploads.linear.app/2f38ee1f-255b-4d7b-8788-ae4cd8fb9c9c/b42d78b6-726a-45cf-8901-ab3e7c82b071/a7244924-a9af-4ce6-8106-a0d794157373?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzJmMzhlZTFmLTI1NWItNGQ3Yi04Nzg4LWFlNGNkOGZiOWM5Yy9iNDJkNzhiNi03MjZhLTQ1Y2YtODkwMS1hYjNlN2M4MmIwNzEvYTcyNDQ5MjQtYTlhZi00Y2U2LTgxMDYtYTBkNzk0MTU3MzczIiwiaWF0IjoxNzgwNTkyMjQ3LCJleHAiOjE4MTIxNjI4MDd9.mF1pRW6s7DT-7nS5PLBotNSItgdnZFrx38rvJl2RnG0 " alt="Screenshot 2026-06-04 at 9 28 01 AM" width="1051" data-linear-height="758" />

The cookie setter was trying to use `btoa` and `encodeUriComponent` which aren't available in the global scope. This PR checks if this variables are available first, before using them, and if they aren't there just return early.

Also refactored it so that it also looks for `document` to be available on the global scope and also returns early.

Tests:

* Manual tests (see screenshots above)
* Unit tests to cover the different cases where global scope and variables on global scope aren't available. And if they aren't available `isEnabled` should return `false`.

### Checklist

- [X] Does your PR title have the correct [title format](<https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions>)?
- Does your PR have a breaking change?:

---

> \[!NOTE\]<br>**Low Risk**<br>Small defensive change in cookie write path with expanded unit tests; behavior unchanged in normal browser/jsdom environments.
>
> **Overview**<br>Fixes React Native crashes from `CookieStorage.setSync` calling bare `btoa` / `encodeURIComponent` when those APIs are not on the global object.
>
> `setSync` now resolves the global scope first and **returns without writing** if `btoa`, `encodeURIComponent`, or `document` is missing, and encodes via `globalScope.btoa(globalScope.encodeURIComponent(...))` instead of globals. Cookie writes are skipped quietly in those environments rather than throwing.
>
> `isEnabled` tests are expanded for undefined global scope, missing `document`, and missing `btoa`**/**`encodeURIComponent`, asserting `false` and **no** `console.error` from the early exit path.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit f84d3922a1b17b8bacd793940c4c99f051998f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive guard on the cookie write path with expanded unit tests; browser/jsdom behavior is unchanged when globals are present.
> 
> **Overview**
> Fixes React Native (and similar) crashes where **`CookieStorage.setSync`** referenced bare **`btoa`** / **`encodeURIComponent`**, which are not always on the global object.
> 
> **`setSync`** now resolves the global scope up front and **returns without writing** when **`document`**, **`btoa`**, or **`encodeURIComponent`** is missing. Encoding uses **`globalScope.btoa(globalScope.encodeURIComponent(...))`** when those APIs exist, so cookie writes are skipped quietly instead of throwing.
> 
> **`isEnabled`** unit tests are split to cover undefined global scope, missing **`document`**, and missing **`btoa`** / **`encodeURIComponent`**, expecting **`false`** and **no** **`console.error`** on the early-exit path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41aceb6fda87ddfb9cf49312116dd0fcbd7bf344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->