### PR TITLE
feat(analytics-react-native): offline connectivity plugin + JS wiring (SDKRN-5) [1/5]

### DIFF
--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -6,7 +6,7 @@ type HiddenOptions = 'apiKey' | 'lastEventId';
 
 export type ReactNativeOptions = Omit<Partial<ReactNativeConfig>, HiddenOptions>;
 
-export interface ReactNativeConfig extends Omit<IConfig, 'offline' | 'requestMetadata'> {
+export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   trackingOptions: ReactNativeTrackingOptions;
   trackingSessionEvents?: boolean;
   migrateLegacyData?: boolean;

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativeConnectivityModule.kt
@@ -1,0 +1,51 @@
+package com.amplitude.reactnative
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
+
+const val CONNECTIVITY_MODULE_NAME = "AmplitudeReactNativeConnectivity"
+
+/**
+ * No-op placeholder for the connectivity native module, bridged back to JS as
+ * [CONNECTIVITY_MODULE_NAME]. It exists so the JS
+ * `networkConnectivityCheckerPlugin` can bind to a real native module and seed
+ * an initial "online" state; it never reports going offline.
+ *
+ * Real `ConnectivityManager` monitoring is added in a follow-up PR that replaces
+ * this file. Until then, offline mode is a no-op on Android —
+ * [getNetworkConnectivityStatus] always reports connected, so the SDK never
+ * wrongly suppresses sends.
+ */
+@ReactModule(name = CONNECTIVITY_MODULE_NAME)
+class AmplitudeReactNativeConnectivityModule(
+    reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String {
+        return CONNECTIVITY_MODULE_NAME
+    }
+
+    // Required so `NativeEventEmitter` doesn't warn on the JS side.
+    @ReactMethod
+    fun addListener(eventName: String) {
+        // No-op placeholder.
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+        // No-op placeholder.
+    }
+
+    /**
+     * JS reads this once on setup to seed the initial `offline` value. The
+     * placeholder always reports connected.
+     */
+    @ReactMethod
+    fun getNetworkConnectivityStatus(promise: Promise) {
+        promise.resolve(Arguments.createMap().apply { putBoolean("isConnected", true) })
+    }
+}

--- a/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativePackage.java
+++ b/packages/analytics-react-native/android/src/main/java/com/amplitude/reactnative/AmplitudeReactNativePackage.java
@@ -17,6 +17,7 @@ public class AmplitudeReactNativePackage implements ReactPackage {
     public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new AmplitudeReactNativeModule(reactContext));
+        modules.add(new AmplitudeReactNativeConnectivityModule(reactContext));
         return modules;
     }
 

--- a/packages/analytics-react-native/ios/AmplitudeReactNative-Bridging-Header.h
+++ b/packages/analytics-react-native/ios/AmplitudeReactNative-Bridging-Header.h
@@ -1,1 +1,2 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>

--- a/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.m
+++ b/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.m
@@ -1,0 +1,8 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(AmplitudeReactNativeConnectivity, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(getNetworkConnectivityStatus: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.swift
+++ b/packages/analytics-react-native/ios/AmplitudeReactNativeConnectivity.swift
@@ -1,0 +1,36 @@
+import Foundation
+import React
+
+/// No-op placeholder for the connectivity native module, bridged back to JS as
+/// `AmplitudeReactNativeConnectivity`. It exists so the JS
+/// `networkConnectivityCheckerPlugin` can bind to a real native module and seed
+/// an initial "online" state; it never reports going offline.
+///
+/// Real connectivity monitoring (`NWPathMonitor` / `SCNetworkReachability`) is
+/// added in a follow-up PR that replaces this file. Until then, offline mode is
+/// a no-op on iOS — `getNetworkConnectivityStatus` always reports connected, so
+/// the SDK never wrongly suppresses sends.
+@objc(AmplitudeReactNativeConnectivity)
+class AmplitudeReactNativeConnectivity: RCTEventEmitter {
+
+    private static let connectivityEventName = "AmplitudeNetworkConnectivityChanged"
+
+    override func supportedEvents() -> [String]! {
+        return [AmplitudeReactNativeConnectivity.connectivityEventName]
+    }
+
+    @objc
+    override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
+    /// JS reads this once on setup to seed the initial `offline` value. The
+    /// placeholder always reports connected.
+    @objc
+    func getNetworkConnectivityStatus(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        resolve(["isConnected": true])
+    }
+}

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -48,22 +48,25 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   const setup = async (config: ReactNativeConfig, amplitude: ReactNativeClient) => {
     const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
 
-    const handleConnectivityChange = (isConnected: boolean) => {
+    const handleConnectivityChange = (isConnected: boolean, { deferFlush = false } = {}) => {
+      config.loggerProvider.debug(`Network connectivity status: ${isConnected ? 'online' : 'offline'}.`);
       const offline = !isConnected;
       if (config.offline === offline) {
         return;
       }
       config.offline = offline;
-      if (isConnected) {
-        config.loggerProvider.debug('Network connectivity changed to online.');
-        // No `ERR_NETWORK_CHANGED` on native, so flush immediately.
-        void amplitude.flush();
+      if (!isConnected) {
+        return;
+      }
+      if (deferFlush) {
+        setTimeout(() => {
+          void amplitude.flush();
+        }, config.flushIntervalMillis);
       } else {
-        config.loggerProvider.debug('Network connectivity changed to offline.');
+        void amplitude.flush();
       }
     };
 
-    // Native (iOS/Android): use the bridged module.
     if (nativeModule) {
       const eventEmitter = new NativeEventEmitter(nativeModule);
       // `startObserving` only fires on changes, so seed the initial state.
@@ -71,7 +74,7 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
         const status = await nativeModule.getNetworkConnectivityStatus();
         config.offline = !status.isConnected;
       } catch (e) {
-        config.loggerProvider.debug(`Failed to read initial network connectivity status: ${String(e)}`);
+        config.loggerProvider.warn(`Failed to read initial network connectivity status: ${String(e)}`);
         config.offline = false;
       }
       subscription = eventEmitter.addListener(CONNECTIVITY_EVENT_NAME, (event: ConnectivityEvent) => {
@@ -83,33 +86,15 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
     // Web (react-native-web): use `navigator.onLine`. Gate on `isWeb()` because
     // RN's `navigator` polyfill has no `onLine` — without this, a native app
     // missing the module would read `!undefined === true` and pin itself offline.
-    if (isWeb() && typeof navigator !== 'undefined') {
-      config.offline = !navigator.onLine;
-
-      addWebNetworkListener('online', () => {
-        if (config.offline === false) {
-          return;
-        }
-        config.loggerProvider.debug('Network connectivity changed to online.');
-        config.offline = false;
-        // Immediate flush on web causes ERR_NETWORK_CHANGED, so delay it.
-        setTimeout(() => {
-          void amplitude.flush();
-        }, config.flushIntervalMillis);
-      });
-
-      addWebNetworkListener('offline', () => {
-        if (config.offline === true) {
-          return;
-        }
-        config.loggerProvider.debug('Network connectivity changed to offline.');
-        config.offline = true;
-      });
+    const nav = globalScope?.navigator;
+    if (isWeb() && nav) {
+      config.offline = !nav.onLine;
+      addWebNetworkListener('online', () => handleConnectivityChange(true, { deferFlush: true }));
+      addWebNetworkListener('offline', () => handleConnectivityChange(false));
       return;
     }
 
-    // No connectivity source (no native module, not web) → assume online.
-    config.loggerProvider.debug(
+    config.loggerProvider.warn(
       'Network connectivity checker plugin found no connectivity source; defaulting to online.',
     );
     config.offline = false;

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -4,14 +4,10 @@ import { isWeb } from '../utils/platform';
 
 export const CONNECTIVITY_EVENT_NAME = 'AmplitudeNetworkConnectivityChanged';
 
-/**
- * Shape of the native `AmplitudeReactNativeConnectivity` module bridged from
- * iOS (`RCTEventEmitter` subclass) and Android (`ReactContextBaseJavaModule`).
- */
+/** Native `AmplitudeReactNativeConnectivity` module bridged from iOS/Android. */
 interface ConnectivityNativeModule {
   getNetworkConnectivityStatus(): Promise<{ isConnected: boolean }>;
-  // `addListener`/`removeListeners` are required by `NativeEventEmitter` so it
-  // doesn't warn; they are no-ops on the JS side here.
+  // Required by `NativeEventEmitter`; no-ops on the JS side.
   addListener(eventName: string): void;
   removeListeners(count: number): void;
 }
@@ -52,10 +48,8 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   const setup = async (config: ReactNativeConfig, amplitude: ReactNativeClient) => {
     const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
 
-    // Apply a connectivity change. Comparing against the current `config.offline`
-    // value naturally debounces repeated same-state signals (e.g. Android's
-    // `onCapabilitiesChanged` firing multiple times) so we don't flush-storm on
-    // transient reconnect flapping.
+    // Comparing against current `config.offline` debounces repeated same-state
+    // signals so we don't flush-storm on reconnect flapping.
     const handleConnectivityChange = (isConnected: boolean) => {
       const offline = !isConnected;
       if (config.offline === offline) {
@@ -64,18 +58,17 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       config.offline = offline;
       if (isConnected) {
         config.loggerProvider.debug('Network connectivity changed to online.');
-        // No `ERR_NETWORK_CHANGED` concern on native, so flush immediately.
+        // No `ERR_NETWORK_CHANGED` on native, so flush immediately.
         void amplitude.flush();
       } else {
         config.loggerProvider.debug('Network connectivity changed to offline.');
       }
     };
 
-    // Native mode (iOS / Android): use the bridged connectivity module.
+    // Native (iOS/Android): use the bridged module.
     if (nativeModule) {
       const eventEmitter = new NativeEventEmitter(nativeModule);
-      // `startObserving` only fires on subsequent changes, so seed the initial
-      // state from the native module.
+      // `startObserving` only fires on changes, so seed the initial state.
       try {
         const status = await nativeModule.getNetworkConnectivityStatus();
         config.offline = !status.isConnected;
@@ -89,21 +82,16 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       return;
     }
 
-    // Web mode (react-native-web): fall back to `navigator.onLine` + events.
-    // Gate on `isWeb()` (not just `typeof navigator`): React Native defines a
-    // `navigator` polyfill that has no `onLine`, so on a native app where the
-    // connectivity module is missing (e.g. JS upgraded without rebuilding
-    // native, or an autolink failure) this branch would otherwise read
-    // `!navigator.onLine === !undefined === true` and wrongly pin the SDK
-    // offline forever. Offline mode is best-effort: when there's no reliable
-    // connectivity source we fall through to `offline = false` below.
+    // Web (react-native-web): use `navigator.onLine`. Gate on `isWeb()` because
+    // RN's `navigator` polyfill has no `onLine` — without this, a native app
+    // missing the module would read `!undefined === true` and pin itself offline.
     if (isWeb() && typeof navigator !== 'undefined') {
       config.offline = !navigator.onLine;
 
       addWebNetworkListener('online', () => {
         config.loggerProvider.debug('Network connectivity changed to online.');
         config.offline = false;
-        // Flushing immediately on web causes ERR_NETWORK_CHANGED, so delay it.
+        // Immediate flush on web causes ERR_NETWORK_CHANGED, so delay it.
         setTimeout(() => {
           void amplitude.flush();
         }, config.flushIntervalMillis);
@@ -116,8 +104,7 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       return;
     }
 
-    // Best-effort fallback: no reliable connectivity source (no native module,
-    // not web) → assume online so we never wrongly suppress sends.
+    // No connectivity source (no native module, not web) → assume online.
     config.loggerProvider.debug(
       'Network connectivity checker plugin found no connectivity source; defaulting to online.',
     );

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -87,6 +87,9 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       config.offline = !navigator.onLine;
 
       addWebNetworkListener('online', () => {
+        if (config.offline === false) {
+          return;
+        }
         config.loggerProvider.debug('Network connectivity changed to online.');
         config.offline = false;
         // Immediate flush on web causes ERR_NETWORK_CHANGED, so delay it.

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -99,6 +99,9 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
       });
 
       addWebNetworkListener('offline', () => {
+        if (config.offline === true) {
+          return;
+        }
         config.loggerProvider.debug('Network connectivity changed to offline.');
         config.offline = true;
       });

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -48,8 +48,8 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   const setup = async (config: ReactNativeConfig, amplitude: ReactNativeClient) => {
     const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
 
-    // Comparing against current `config.offline` debounces repeated same-state
-    // signals so we don't flush-storm on reconnect flapping.
+    // Only act on actual state transitions: ignore updates that match the
+    // current `config.offline`, since native platforms re-emit the same state.
     const handleConnectivityChange = (isConnected: boolean) => {
       const offline = !isConnected;
       if (config.offline === offline) {

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -48,8 +48,6 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   const setup = async (config: ReactNativeConfig, amplitude: ReactNativeClient) => {
     const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
 
-    // Only act on actual state transitions: ignore updates that match the
-    // current `config.offline`, since native platforms re-emit the same state.
     const handleConnectivityChange = (isConnected: boolean) => {
       const offline = !isConnected;
       if (config.offline === offline) {

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -1,10 +1,4 @@
-import {
-  getGlobalScope,
-  BeforePlugin,
-  ReactNativeClient,
-  ReactNativeConfig,
-  OfflineDisabled,
-} from '@amplitude/analytics-core';
+import { getGlobalScope, BeforePlugin, ReactNativeClient, ReactNativeConfig } from '@amplitude/analytics-core';
 import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
 import { isWeb } from '../utils/platform';
 
@@ -31,11 +25,6 @@ interface WebEventListener {
   handler: () => void;
 }
 
-// `offline` is intentionally omitted from the public `ReactNativeConfig` type,
-// but it exists on the underlying core `Config` instance at runtime and is what
-// the shared `Destination` plugin reads to short-circuit network requests.
-type OfflineConfig = ReactNativeConfig & { offline?: boolean | typeof OfflineDisabled };
-
 export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
   const name = '@amplitude/plugin-network-checker-react-native';
   const type = 'before' as const;
@@ -60,7 +49,7 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
     webEventListeners = [];
   };
 
-  const setup = async (config: OfflineConfig, amplitude: ReactNativeClient) => {
+  const setup = async (config: ReactNativeConfig, amplitude: ReactNativeClient) => {
     const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
 
     // Apply a connectivity change. Comparing against the current `config.offline`

--- a/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-react-native/src/plugins/network-connectivity-checker.ts
@@ -1,0 +1,150 @@
+import {
+  getGlobalScope,
+  BeforePlugin,
+  ReactNativeClient,
+  ReactNativeConfig,
+  OfflineDisabled,
+} from '@amplitude/analytics-core';
+import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
+import { isWeb } from '../utils/platform';
+
+export const CONNECTIVITY_EVENT_NAME = 'AmplitudeNetworkConnectivityChanged';
+
+/**
+ * Shape of the native `AmplitudeReactNativeConnectivity` module bridged from
+ * iOS (`RCTEventEmitter` subclass) and Android (`ReactContextBaseJavaModule`).
+ */
+interface ConnectivityNativeModule {
+  getNetworkConnectivityStatus(): Promise<{ isConnected: boolean }>;
+  // `addListener`/`removeListeners` are required by `NativeEventEmitter` so it
+  // doesn't warn; they are no-ops on the JS side here.
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+interface ConnectivityEvent {
+  isConnected: boolean;
+}
+
+interface WebEventListener {
+  type: 'online' | 'offline';
+  handler: () => void;
+}
+
+// `offline` is intentionally omitted from the public `ReactNativeConfig` type,
+// but it exists on the underlying core `Config` instance at runtime and is what
+// the shared `Destination` plugin reads to short-circuit network requests.
+type OfflineConfig = ReactNativeConfig & { offline?: boolean | typeof OfflineDisabled };
+
+export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
+  const name = '@amplitude/plugin-network-checker-react-native';
+  const type = 'before' as const;
+
+  const globalScope = getGlobalScope();
+  let subscription: EmitterSubscription | undefined;
+  let webEventListeners: WebEventListener[] = [];
+
+  const addWebNetworkListener = (listenerType: 'online' | 'offline', handler: () => void) => {
+    /* istanbul ignore else */
+    if (globalScope?.addEventListener) {
+      globalScope.addEventListener(listenerType, handler);
+      webEventListeners.push({ type: listenerType, handler });
+    }
+  };
+
+  const removeWebNetworkListeners = () => {
+    webEventListeners.forEach(({ type: listenerType, handler }) => {
+      /* istanbul ignore next */
+      globalScope?.removeEventListener(listenerType, handler);
+    });
+    webEventListeners = [];
+  };
+
+  const setup = async (config: OfflineConfig, amplitude: ReactNativeClient) => {
+    const nativeModule = NativeModules.AmplitudeReactNativeConnectivity as ConnectivityNativeModule | undefined;
+
+    // Apply a connectivity change. Comparing against the current `config.offline`
+    // value naturally debounces repeated same-state signals (e.g. Android's
+    // `onCapabilitiesChanged` firing multiple times) so we don't flush-storm on
+    // transient reconnect flapping.
+    const handleConnectivityChange = (isConnected: boolean) => {
+      const offline = !isConnected;
+      if (config.offline === offline) {
+        return;
+      }
+      config.offline = offline;
+      if (isConnected) {
+        config.loggerProvider.debug('Network connectivity changed to online.');
+        // No `ERR_NETWORK_CHANGED` concern on native, so flush immediately.
+        void amplitude.flush();
+      } else {
+        config.loggerProvider.debug('Network connectivity changed to offline.');
+      }
+    };
+
+    // Native mode (iOS / Android): use the bridged connectivity module.
+    if (nativeModule) {
+      const eventEmitter = new NativeEventEmitter(nativeModule);
+      // `startObserving` only fires on subsequent changes, so seed the initial
+      // state from the native module.
+      try {
+        const status = await nativeModule.getNetworkConnectivityStatus();
+        config.offline = !status.isConnected;
+      } catch (e) {
+        config.loggerProvider.debug(`Failed to read initial network connectivity status: ${String(e)}`);
+        config.offline = false;
+      }
+      subscription = eventEmitter.addListener(CONNECTIVITY_EVENT_NAME, (event: ConnectivityEvent) => {
+        handleConnectivityChange(event.isConnected);
+      });
+      return;
+    }
+
+    // Web mode (react-native-web): fall back to `navigator.onLine` + events.
+    // Gate on `isWeb()` (not just `typeof navigator`): React Native defines a
+    // `navigator` polyfill that has no `onLine`, so on a native app where the
+    // connectivity module is missing (e.g. JS upgraded without rebuilding
+    // native, or an autolink failure) this branch would otherwise read
+    // `!navigator.onLine === !undefined === true` and wrongly pin the SDK
+    // offline forever. Offline mode is best-effort: when there's no reliable
+    // connectivity source we fall through to `offline = false` below.
+    if (isWeb() && typeof navigator !== 'undefined') {
+      config.offline = !navigator.onLine;
+
+      addWebNetworkListener('online', () => {
+        config.loggerProvider.debug('Network connectivity changed to online.');
+        config.offline = false;
+        // Flushing immediately on web causes ERR_NETWORK_CHANGED, so delay it.
+        setTimeout(() => {
+          void amplitude.flush();
+        }, config.flushIntervalMillis);
+      });
+
+      addWebNetworkListener('offline', () => {
+        config.loggerProvider.debug('Network connectivity changed to offline.');
+        config.offline = true;
+      });
+      return;
+    }
+
+    // Best-effort fallback: no reliable connectivity source (no native module,
+    // not web) → assume online so we never wrongly suppress sends.
+    config.loggerProvider.debug(
+      'Network connectivity checker plugin found no connectivity source; defaulting to online.',
+    );
+    config.offline = false;
+  };
+
+  const teardown = async () => {
+    subscription?.remove();
+    subscription = undefined;
+    removeWebNetworkListeners();
+  };
+
+  return {
+    name,
+    type,
+    setup,
+    teardown,
+  };
+};

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -79,9 +79,8 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     // Step 3: Install plugins
     // Do not track any events before this
-    // Install the network connectivity checker before Destination so that
-    // `config.offline` is set before any flush is scheduled. Skip when offline
-    // mode has been explicitly disabled via the OfflineDisabled sentinel.
+    // Install before Destination so `config.offline` is set before any flush.
+    // Skip when offline mode is disabled via the OfflineDisabled sentinel.
     if (this.config.offline !== OfflineDisabled) {
       await this.add(networkConnectivityCheckerPlugin()).promise;
     }

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -82,7 +82,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     // Install the network connectivity checker before Destination so that
     // `config.offline` is set before any flush is scheduled. Skip when offline
     // mode has been explicitly disabled via the OfflineDisabled sentinel.
-    if ((this.config as { offline?: boolean | typeof OfflineDisabled }).offline !== OfflineDisabled) {
+    if (this.config.offline !== OfflineDisabled) {
       await this.add(networkConnectivityCheckerPlugin()).promise;
     }
     await this.add(new Destination()).promise;

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -22,9 +22,11 @@ import {
   setConnectorUserId,
   SpecialEventType,
   AnalyticsClient,
+  OfflineDisabled,
 } from '@amplitude/analytics-core';
 import { CampaignTracker } from './campaign/campaign-tracker';
 import { Context } from './plugins/context';
+import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity-checker';
 import { useReactNativeConfig, createCookieStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
@@ -77,6 +79,12 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     // Step 3: Install plugins
     // Do not track any events before this
+    // Install the network connectivity checker before Destination so that
+    // `config.offline` is set before any flush is scheduled. Skip when offline
+    // mode has been explicitly disabled via the OfflineDisabled sentinel.
+    if ((this.config as { offline?: boolean | typeof OfflineDisabled }).offline !== OfflineDisabled) {
+      await this.add(networkConnectivityCheckerPlugin()).promise;
+    }
     await this.add(new Destination()).promise;
     await this.add(new Context()).promise;
     await this.add(new IdentityEventSender()).promise;

--- a/packages/analytics-react-native/test/mock/setup-mobile.ts
+++ b/packages/analytics-react-native/test/mock/setup-mobile.ts
@@ -60,3 +60,16 @@ NativeModules.AmplitudeReactNative = {
   getLegacyEvents: () => [],
   removeLegacyEvent: () => ({}),
 };
+
+/*
+ * Mock the connectivity-only native module bridged by
+ * `AmplitudeReactNativeConnectivity`. `getNetworkConnectivityStatus` seeds the
+ * initial offline state, while `addListener`/`removeListeners` are required by
+ * `NativeEventEmitter`. Tests emit `AmplitudeNetworkConnectivityChanged` via
+ * `DeviceEventEmitter` (which `NativeEventEmitter` delegates to under the hood).
+ */
+NativeModules.AmplitudeReactNativeConnectivity = {
+  getNetworkConnectivityStatus: jest.fn(async (): Promise<{ isConnected: boolean }> => ({ isConnected: true })),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+};

--- a/packages/analytics-react-native/test/mock/setup-web.ts
+++ b/packages/analytics-react-native/test/mock/setup-web.ts
@@ -1,5 +1,5 @@
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
-import { Platform } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 /*
  * Set the platform OS to mobile.
@@ -17,3 +17,18 @@ jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 // window['navigator'] = { product: "ReactNative" }
+
+/*
+ * Mock the connectivity-only native module bridged by
+ * `AmplitudeReactNativeConnectivity`. It is wired here (in addition to
+ * setup-mobile) so the network-connectivity plugin's native-path tests can run
+ * under the web (jsdom) suite as well. Tests that exercise the
+ * `navigator.onLine` web fallback delete this module first. Tests emit
+ * `AmplitudeNetworkConnectivityChanged` via `DeviceEventEmitter` (which
+ * `NativeEventEmitter` delegates to under the hood).
+ */
+NativeModules.AmplitudeReactNativeConnectivity = {
+  getNetworkConnectivityStatus: jest.fn(async (): Promise<{ isConnected: boolean }> => ({ isConnected: true })),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+};

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -119,7 +119,7 @@ describe('networkConnectivityCheckerPlugin', () => {
       expect(amplitude.flush).toHaveBeenCalledTimes(1);
     });
 
-    test('debounces repeated same-state events (no flush storm)', async () => {
+    test('ignores repeated same-state events (no redundant flush)', async () => {
       const config = useDefaultConfig();
       const amplitude = createAmplitudeMock();
       const plugin = networkConnectivityCheckerPlugin();

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -222,6 +222,25 @@ describe('networkConnectivityCheckerPlugin', () => {
       });
     });
 
+    test('ignores offline events while already offline (no redundant work)', async () => {
+      const { scope, trigger } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: false }, async () => {
+        const config = useDefaultConfig();
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+        expect(config.offline).toBe(true);
+
+        const debugSpy = jest.spyOn(config.loggerProvider, 'debug');
+        trigger('offline');
+        trigger('offline');
+        expect(config.offline).toBe(true);
+        expect(debugSpy).not.toHaveBeenCalled();
+      });
+    });
+
     test('sets offline true when navigator starts offline', async () => {
       const { scope } = createFakeGlobalScope();
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -10,13 +10,14 @@ import { useDefaultConfig } from '../helpers/default';
 import * as platform from '../../src/utils/platform';
 
 /**
- * A controllable stand-in for the web global scope so the web-fallback path can
- * be exercised under both the node (test:mobile) and jsdom (test:web) suites.
+ * A controllable stand-in for the web global scope so the web-mode path can be
+ * exercised under both the node (test:mobile) and jsdom (test:web) suites.
  */
-const createFakeGlobalScope = () => {
+const createFakeGlobalScope = (navigator?: { onLine: boolean }) => {
   const handlers: Record<string, Array<() => void>> = {};
   return {
     scope: {
+      navigator,
       addEventListener: jest.fn((type: string, handler: () => void) => {
         (handlers[type] = handlers[type] || []).push(handler);
       }),
@@ -59,12 +60,20 @@ describe('networkConnectivityCheckerPlugin', () => {
   });
 
   describe('native mode', () => {
+    let config: ReturnType<typeof useDefaultConfig>;
+    let amplitude: ReactNativeClient;
+    let plugin: ReturnType<typeof networkConnectivityCheckerPlugin>;
+
+    beforeEach(() => {
+      config = useDefaultConfig();
+      amplitude = createAmplitudeMock();
+      plugin = networkConnectivityCheckerPlugin();
+    });
+
     test('seeds initial offline state from the native module (online)', async () => {
       connectivityModule.getNetworkConnectivityStatus.mockResolvedValueOnce({ isConnected: true });
-      const config = useDefaultConfig();
-      const plugin = networkConnectivityCheckerPlugin();
 
-      await plugin.setup?.(config, createAmplitudeMock());
+      await plugin.setup?.(config, amplitude);
 
       expect(connectivityModule.getNetworkConnectivityStatus).toHaveBeenCalledTimes(1);
       expect(config.offline).toBe(false);
@@ -72,28 +81,22 @@ describe('networkConnectivityCheckerPlugin', () => {
 
     test('seeds initial offline state from the native module (offline)', async () => {
       connectivityModule.getNetworkConnectivityStatus.mockResolvedValueOnce({ isConnected: false });
-      const config = useDefaultConfig();
-      const plugin = networkConnectivityCheckerPlugin();
 
-      await plugin.setup?.(config, createAmplitudeMock());
+      await plugin.setup?.(config, amplitude);
 
       expect(config.offline).toBe(true);
     });
 
     test('defaults to online if the initial status read rejects', async () => {
       connectivityModule.getNetworkConnectivityStatus.mockRejectedValueOnce(new Error('boom'));
-      const config = useDefaultConfig();
-      const plugin = networkConnectivityCheckerPlugin();
 
-      await plugin.setup?.(config, createAmplitudeMock());
+      await plugin.setup?.(config, amplitude);
 
       expect(config.offline).toBe(false);
     });
 
     test('toggles config.offline on connectivity events', async () => {
-      const config = useDefaultConfig();
-      const plugin = networkConnectivityCheckerPlugin();
-      await plugin.setup?.(config, createAmplitudeMock());
+      await plugin.setup?.(config, amplitude);
       expect(config.offline).toBe(false);
 
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
@@ -104,9 +107,6 @@ describe('networkConnectivityCheckerPlugin', () => {
     });
 
     test('flushes immediately on reconnect', async () => {
-      const config = useDefaultConfig();
-      const amplitude = createAmplitudeMock();
-      const plugin = networkConnectivityCheckerPlugin();
       await plugin.setup?.(config, amplitude);
 
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
@@ -116,9 +116,6 @@ describe('networkConnectivityCheckerPlugin', () => {
     });
 
     test('ignores repeated same-state events (no redundant flush)', async () => {
-      const config = useDefaultConfig();
-      const amplitude = createAmplitudeMock();
-      const plugin = networkConnectivityCheckerPlugin();
       await plugin.setup?.(config, amplitude);
 
       // Already online from the initial seed; repeated "online" events are no-ops.
@@ -136,9 +133,7 @@ describe('networkConnectivityCheckerPlugin', () => {
     });
 
     test('teardown removes the native subscription', async () => {
-      const config = useDefaultConfig();
-      const plugin = networkConnectivityCheckerPlugin();
-      await plugin.setup?.(config, createAmplitudeMock());
+      await plugin.setup?.(config, amplitude);
 
       await plugin.teardown?.();
 
@@ -150,11 +145,11 @@ describe('networkConnectivityCheckerPlugin', () => {
   });
 
   /*
-   * Web fallback exercises `navigator.onLine` + online/offline events. The
-   * global scope and navigator are mocked so this runs under both the node
-   * (test:mobile) and jsdom (test:web) suites.
+   * Web mode uses `navigator.onLine` + online/offline events. The global scope
+   * and navigator are mocked so this runs under both the node (test:mobile) and
+   * jsdom (test:web) suites.
    */
-  describe('web fallback', () => {
+  describe('web mode', () => {
     let originalModule: unknown;
 
     beforeEach(() => {
@@ -172,102 +167,91 @@ describe('networkConnectivityCheckerPlugin', () => {
     });
 
     test('tracks navigator.onLine and online/offline events', async () => {
-      const { scope, trigger } = createFakeGlobalScope();
+      const { scope, trigger } = createFakeGlobalScope({ onLine: true });
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
 
-      await withNavigator({ onLine: true }, async () => {
-        const config = useDefaultConfig();
-        const amplitude = createAmplitudeMock();
-        const plugin = networkConnectivityCheckerPlugin();
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
 
-        await plugin.setup?.(config, amplitude);
+      await plugin.setup?.(config, amplitude);
 
-        expect(config.offline).toBe(false);
-        expect(scope.addEventListener).toHaveBeenCalledWith('online', expect.any(Function));
-        expect(scope.addEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
+      expect(config.offline).toBe(false);
+      expect(scope.addEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+      expect(scope.addEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
 
-        trigger('offline');
-        expect(config.offline).toBe(true);
+      trigger('offline');
+      expect(config.offline).toBe(true);
 
-        jest.useFakeTimers();
-        trigger('online');
-        expect(config.offline).toBe(false);
-        // Web fallback delays the flush by flushIntervalMillis to avoid
-        // ERR_NETWORK_CHANGED.
-        expect(amplitude.flush).not.toHaveBeenCalled();
-        jest.advanceTimersByTime(config.flushIntervalMillis);
-        expect(amplitude.flush).toHaveBeenCalledTimes(1);
-        jest.useRealTimers();
-      });
+      jest.useFakeTimers();
+      trigger('online');
+      expect(config.offline).toBe(false);
+      // Web mode delays the flush by flushIntervalMillis to avoid ERR_NETWORK_CHANGED.
+      expect(amplitude.flush).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(config.flushIntervalMillis);
+      expect(amplitude.flush).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
     });
 
     test('ignores online events while already online (no redundant flush)', async () => {
-      const { scope, trigger } = createFakeGlobalScope();
+      const { scope, trigger } = createFakeGlobalScope({ onLine: true });
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
 
-      await withNavigator({ onLine: true }, async () => {
-        const config = useDefaultConfig();
-        const amplitude = createAmplitudeMock();
-        const plugin = networkConnectivityCheckerPlugin();
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
 
-        await plugin.setup?.(config, amplitude);
-        expect(config.offline).toBe(false);
+      await plugin.setup?.(config, amplitude);
+      expect(config.offline).toBe(false);
 
-        jest.useFakeTimers();
-        trigger('online');
-        trigger('online');
-        jest.advanceTimersByTime(config.flushIntervalMillis);
-        expect(amplitude.flush).not.toHaveBeenCalled();
-        jest.useRealTimers();
-      });
+      jest.useFakeTimers();
+      trigger('online');
+      trigger('online');
+      jest.advanceTimersByTime(config.flushIntervalMillis);
+      expect(amplitude.flush).not.toHaveBeenCalled();
+      jest.useRealTimers();
     });
 
-    test('ignores offline events while already offline (no redundant work)', async () => {
-      const { scope, trigger } = createFakeGlobalScope();
+    test('stays offline on repeated offline events (no flush)', async () => {
+      const { scope, trigger } = createFakeGlobalScope({ onLine: false });
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
 
-      await withNavigator({ onLine: false }, async () => {
-        const config = useDefaultConfig();
-        const plugin = networkConnectivityCheckerPlugin();
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
 
-        await plugin.setup?.(config, createAmplitudeMock());
-        expect(config.offline).toBe(true);
+      await plugin.setup?.(config, amplitude);
+      expect(config.offline).toBe(true);
 
-        const debugSpy = jest.spyOn(config.loggerProvider, 'debug');
-        trigger('offline');
-        trigger('offline');
-        expect(config.offline).toBe(true);
-        expect(debugSpy).not.toHaveBeenCalled();
-      });
+      trigger('offline');
+      trigger('offline');
+      expect(config.offline).toBe(true);
+      expect(amplitude.flush).not.toHaveBeenCalled();
     });
 
     test('sets offline true when navigator starts offline', async () => {
-      const { scope } = createFakeGlobalScope();
+      const { scope } = createFakeGlobalScope({ onLine: false });
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
 
-      await withNavigator({ onLine: false }, async () => {
-        const config = useDefaultConfig();
-        const plugin = networkConnectivityCheckerPlugin();
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
 
-        await plugin.setup?.(config, createAmplitudeMock());
+      await plugin.setup?.(config, createAmplitudeMock());
 
-        expect(config.offline).toBe(true);
-      });
+      expect(config.offline).toBe(true);
     });
 
     test('teardown removes web listeners', async () => {
-      const { scope } = createFakeGlobalScope();
+      const { scope } = createFakeGlobalScope({ onLine: true });
       jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
 
-      await withNavigator({ onLine: true }, async () => {
-        const plugin = networkConnectivityCheckerPlugin();
+      const plugin = networkConnectivityCheckerPlugin();
 
-        await plugin.setup?.(useDefaultConfig(), createAmplitudeMock());
-        await plugin.teardown?.();
+      await plugin.setup?.(useDefaultConfig(), createAmplitudeMock());
+      await plugin.teardown?.();
 
-        expect(scope.removeEventListener).toHaveBeenCalledWith('online', expect.any(Function));
-        expect(scope.removeEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
-      });
+      expect(scope.removeEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+      expect(scope.removeEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
     });
   });
 

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -1,0 +1,291 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NativeModules, DeviceEventEmitter } from 'react-native';
+import { ReactNativeClient } from '@amplitude/analytics-core';
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import {
+  networkConnectivityCheckerPlugin,
+  CONNECTIVITY_EVENT_NAME,
+} from '../../src/plugins/network-connectivity-checker';
+import { useDefaultConfig } from '../helpers/default';
+import * as platform from '../../src/utils/platform';
+
+/**
+ * A controllable stand-in for the web global scope so the web-fallback path can
+ * be exercised under both the node (test:mobile) and jsdom (test:web) suites.
+ */
+const createFakeGlobalScope = () => {
+  const handlers: Record<string, Array<() => void>> = {};
+  return {
+    scope: {
+      addEventListener: jest.fn((type: string, handler: () => void) => {
+        (handlers[type] = handlers[type] || []).push(handler);
+      }),
+      removeEventListener: jest.fn((type: string, handler: () => void) => {
+        handlers[type] = (handlers[type] || []).filter((h) => h !== handler);
+      }),
+    } as unknown as typeof globalThis,
+    trigger: (type: 'online' | 'offline') => (handlers[type] || []).forEach((handler) => handler()),
+  };
+};
+
+const withNavigator = (value: { onLine: boolean } | undefined, fn: () => Promise<void>) => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  // eslint-disable-next-line no-restricted-globals
+  Object.defineProperty(globalThis, 'navigator', { value, configurable: true, writable: true });
+  return fn().finally(() => {
+    if (descriptor) {
+      // eslint-disable-next-line no-restricted-globals
+      Object.defineProperty(globalThis, 'navigator', descriptor);
+    }
+  });
+};
+
+const createAmplitudeMock = () =>
+  ({
+    flush: jest.fn(() => ({ promise: Promise.resolve() })),
+  } as unknown as ReactNativeClient);
+
+// `offline` is omitted from the public ReactNativeConfig type but exists on the
+// underlying core Config instance at runtime.
+const offlineOf = (config: object): boolean | null | undefined => (config as { offline?: boolean | null }).offline;
+
+describe('networkConnectivityCheckerPlugin', () => {
+  const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
+    getNetworkConnectivityStatus: jest.Mock;
+    addListener: jest.Mock;
+    removeListeners: jest.Mock;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    connectivityModule.getNetworkConnectivityStatus.mockResolvedValue({ isConnected: true });
+    DeviceEventEmitter.removeAllListeners(CONNECTIVITY_EVENT_NAME);
+  });
+
+  describe('native mode', () => {
+    test('seeds initial offline state from the native module (online)', async () => {
+      connectivityModule.getNetworkConnectivityStatus.mockResolvedValueOnce({ isConnected: true });
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      expect(connectivityModule.getNetworkConnectivityStatus).toHaveBeenCalledTimes(1);
+      expect(offlineOf(config)).toBe(false);
+    });
+
+    test('seeds initial offline state from the native module (offline)', async () => {
+      connectivityModule.getNetworkConnectivityStatus.mockResolvedValueOnce({ isConnected: false });
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      expect(offlineOf(config)).toBe(true);
+    });
+
+    test('defaults to online if the initial status read rejects', async () => {
+      connectivityModule.getNetworkConnectivityStatus.mockRejectedValueOnce(new Error('boom'));
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      expect(offlineOf(config)).toBe(false);
+    });
+
+    test('toggles config.offline on connectivity events', async () => {
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, createAmplitudeMock());
+      expect(offlineOf(config)).toBe(false);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      expect(offlineOf(config)).toBe(true);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      expect(offlineOf(config)).toBe(false);
+    });
+
+    test('flushes immediately on reconnect', async () => {
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, amplitude);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+
+      expect(amplitude.flush).toHaveBeenCalledTimes(1);
+    });
+
+    test('debounces repeated same-state events (no flush storm)', async () => {
+      const config = useDefaultConfig();
+      const amplitude = createAmplitudeMock();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, amplitude);
+
+      // Already online from the initial seed; repeated "online" events are no-ops.
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      expect(amplitude.flush).not.toHaveBeenCalled();
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      expect(offlineOf(config)).toBe(true);
+
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+      expect(amplitude.flush).toHaveBeenCalledTimes(1);
+    });
+
+    test('teardown removes the native subscription', async () => {
+      const config = useDefaultConfig();
+      const plugin = networkConnectivityCheckerPlugin();
+      await plugin.setup?.(config, createAmplitudeMock());
+
+      await plugin.teardown?.();
+
+      expect(connectivityModule.removeListeners).toHaveBeenCalled();
+      // After teardown, further events must not mutate config.offline.
+      DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+      expect(offlineOf(config)).toBe(false);
+    });
+  });
+
+  /*
+   * Web fallback exercises `navigator.onLine` + online/offline events. The
+   * global scope and navigator are mocked so this runs under both the node
+   * (test:mobile) and jsdom (test:web) suites.
+   */
+  describe('web fallback', () => {
+    let originalModule: unknown;
+
+    beforeEach(() => {
+      originalModule = NativeModules.AmplitudeReactNativeConnectivity;
+      delete (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity;
+      // The web branch is gated on isWeb(); force it so this runs under the
+      // node (test:mobile) suite too, not just jsdom.
+      jest.spyOn(platform, 'isWeb').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity =
+        originalModule;
+    });
+
+    test('tracks navigator.onLine and online/offline events', async () => {
+      const { scope, trigger } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: true }, async () => {
+        const config = useDefaultConfig();
+        const amplitude = createAmplitudeMock();
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, amplitude);
+
+        expect(offlineOf(config)).toBe(false);
+        expect(scope.addEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+        expect(scope.addEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
+
+        trigger('offline');
+        expect(offlineOf(config)).toBe(true);
+
+        jest.useFakeTimers();
+        trigger('online');
+        expect(offlineOf(config)).toBe(false);
+        // Web fallback delays the flush by flushIntervalMillis to avoid
+        // ERR_NETWORK_CHANGED.
+        expect(amplitude.flush).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(config.flushIntervalMillis);
+        expect(amplitude.flush).toHaveBeenCalledTimes(1);
+        jest.useRealTimers();
+      });
+    });
+
+    test('sets offline true when navigator starts offline', async () => {
+      const { scope } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: false }, async () => {
+        const config = useDefaultConfig();
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+
+        expect(offlineOf(config)).toBe(true);
+      });
+    });
+
+    test('teardown removes web listeners', async () => {
+      const { scope } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: true }, async () => {
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(useDefaultConfig(), createAmplitudeMock());
+        await plugin.teardown?.();
+
+        expect(scope.removeEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+        expect(scope.removeEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
+      });
+    });
+  });
+
+  /*
+   * Always-online fallback when neither a native module nor a navigator is
+   * available.
+   */
+  describe('always-online fallback', () => {
+    let originalModule: unknown;
+
+    beforeEach(() => {
+      originalModule = NativeModules.AmplitudeReactNativeConnectivity;
+      delete (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      (NativeModules as { AmplitudeReactNativeConnectivity?: unknown }).AmplitudeReactNativeConnectivity =
+        originalModule;
+    });
+
+    test('falls back to always-online when no native module and no navigator', async () => {
+      await withNavigator(undefined, async () => {
+        const config = useDefaultConfig();
+        // Start non-default to prove the fallback resets it to online.
+        (config as { offline?: boolean | null }).offline = true;
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+
+        expect(offlineOf(config)).toBe(false);
+        // teardown is a no-op here and should not throw.
+        await expect(plugin.teardown?.()).resolves.not.toThrow();
+      });
+    });
+
+    // Regression: on a NATIVE app where the connectivity module is missing
+    // (e.g. JS upgraded without rebuilding native, or autolink failure), RN
+    // still defines a `navigator` polyfill that has no `onLine`. The plugin
+    // must NOT enter the web branch and pin `offline = !undefined === true`;
+    // offline mode is best-effort, so it defaults to online.
+    test('native app without the connectivity module defaults to online (not stuck offline)', async () => {
+      jest.spyOn(platform, 'isWeb').mockReturnValue(false);
+      // React Native's navigator: defined, but no `onLine` property.
+      await withNavigator({ product: 'ReactNative' } as unknown as { onLine: boolean }, async () => {
+        const config = useDefaultConfig();
+        // Start offline to prove the best-effort fallback resets it to online.
+        (config as { offline?: boolean | null }).offline = true;
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, createAmplitudeMock());
+
+        expect(offlineOf(config)).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-react-native/test/plugins/network-connectivity-checker.test.ts
@@ -45,10 +45,6 @@ const createAmplitudeMock = () =>
     flush: jest.fn(() => ({ promise: Promise.resolve() })),
   } as unknown as ReactNativeClient);
 
-// `offline` is omitted from the public ReactNativeConfig type but exists on the
-// underlying core Config instance at runtime.
-const offlineOf = (config: object): boolean | null | undefined => (config as { offline?: boolean | null }).offline;
-
 describe('networkConnectivityCheckerPlugin', () => {
   const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
     getNetworkConnectivityStatus: jest.Mock;
@@ -71,7 +67,7 @@ describe('networkConnectivityCheckerPlugin', () => {
       await plugin.setup?.(config, createAmplitudeMock());
 
       expect(connectivityModule.getNetworkConnectivityStatus).toHaveBeenCalledTimes(1);
-      expect(offlineOf(config)).toBe(false);
+      expect(config.offline).toBe(false);
     });
 
     test('seeds initial offline state from the native module (offline)', async () => {
@@ -81,7 +77,7 @@ describe('networkConnectivityCheckerPlugin', () => {
 
       await plugin.setup?.(config, createAmplitudeMock());
 
-      expect(offlineOf(config)).toBe(true);
+      expect(config.offline).toBe(true);
     });
 
     test('defaults to online if the initial status read rejects', async () => {
@@ -91,20 +87,20 @@ describe('networkConnectivityCheckerPlugin', () => {
 
       await plugin.setup?.(config, createAmplitudeMock());
 
-      expect(offlineOf(config)).toBe(false);
+      expect(config.offline).toBe(false);
     });
 
     test('toggles config.offline on connectivity events', async () => {
       const config = useDefaultConfig();
       const plugin = networkConnectivityCheckerPlugin();
       await plugin.setup?.(config, createAmplitudeMock());
-      expect(offlineOf(config)).toBe(false);
+      expect(config.offline).toBe(false);
 
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
-      expect(offlineOf(config)).toBe(true);
+      expect(config.offline).toBe(true);
 
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
-      expect(offlineOf(config)).toBe(false);
+      expect(config.offline).toBe(false);
     });
 
     test('flushes immediately on reconnect', async () => {
@@ -132,7 +128,7 @@ describe('networkConnectivityCheckerPlugin', () => {
 
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
-      expect(offlineOf(config)).toBe(true);
+      expect(config.offline).toBe(true);
 
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
@@ -149,7 +145,7 @@ describe('networkConnectivityCheckerPlugin', () => {
       expect(connectivityModule.removeListeners).toHaveBeenCalled();
       // After teardown, further events must not mutate config.offline.
       DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
-      expect(offlineOf(config)).toBe(false);
+      expect(config.offline).toBe(false);
     });
   });
 
@@ -186,21 +182,42 @@ describe('networkConnectivityCheckerPlugin', () => {
 
         await plugin.setup?.(config, amplitude);
 
-        expect(offlineOf(config)).toBe(false);
+        expect(config.offline).toBe(false);
         expect(scope.addEventListener).toHaveBeenCalledWith('online', expect.any(Function));
         expect(scope.addEventListener).toHaveBeenCalledWith('offline', expect.any(Function));
 
         trigger('offline');
-        expect(offlineOf(config)).toBe(true);
+        expect(config.offline).toBe(true);
 
         jest.useFakeTimers();
         trigger('online');
-        expect(offlineOf(config)).toBe(false);
+        expect(config.offline).toBe(false);
         // Web fallback delays the flush by flushIntervalMillis to avoid
         // ERR_NETWORK_CHANGED.
         expect(amplitude.flush).not.toHaveBeenCalled();
         jest.advanceTimersByTime(config.flushIntervalMillis);
         expect(amplitude.flush).toHaveBeenCalledTimes(1);
+        jest.useRealTimers();
+      });
+    });
+
+    test('ignores online events while already online (no redundant flush)', async () => {
+      const { scope, trigger } = createFakeGlobalScope();
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue(scope);
+
+      await withNavigator({ onLine: true }, async () => {
+        const config = useDefaultConfig();
+        const amplitude = createAmplitudeMock();
+        const plugin = networkConnectivityCheckerPlugin();
+
+        await plugin.setup?.(config, amplitude);
+        expect(config.offline).toBe(false);
+
+        jest.useFakeTimers();
+        trigger('online');
+        trigger('online');
+        jest.advanceTimersByTime(config.flushIntervalMillis);
+        expect(amplitude.flush).not.toHaveBeenCalled();
         jest.useRealTimers();
       });
     });
@@ -215,7 +232,7 @@ describe('networkConnectivityCheckerPlugin', () => {
 
         await plugin.setup?.(config, createAmplitudeMock());
 
-        expect(offlineOf(config)).toBe(true);
+        expect(config.offline).toBe(true);
       });
     });
 
@@ -257,12 +274,12 @@ describe('networkConnectivityCheckerPlugin', () => {
       await withNavigator(undefined, async () => {
         const config = useDefaultConfig();
         // Start non-default to prove the fallback resets it to online.
-        (config as { offline?: boolean | null }).offline = true;
+        config.offline = true;
         const plugin = networkConnectivityCheckerPlugin();
 
         await plugin.setup?.(config, createAmplitudeMock());
 
-        expect(offlineOf(config)).toBe(false);
+        expect(config.offline).toBe(false);
         // teardown is a no-op here and should not throw.
         await expect(plugin.teardown?.()).resolves.not.toThrow();
       });
@@ -279,12 +296,12 @@ describe('networkConnectivityCheckerPlugin', () => {
       await withNavigator({ product: 'ReactNative' } as unknown as { onLine: boolean }, async () => {
         const config = useDefaultConfig();
         // Start offline to prove the best-effort fallback resets it to online.
-        (config as { offline?: boolean | null }).offline = true;
+        config.offline = true;
         const plugin = networkConnectivityCheckerPlugin();
 
         await plugin.setup?.(config, createAmplitudeMock());
 
-        expect(offlineOf(config)).toBe(false);
+        expect(config.offline).toBe(false);
       });
     });
   });

--- a/packages/analytics-react-native/test/plugins/offline-integration.test.ts
+++ b/packages/analytics-react-native/test/plugins/offline-integration.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { NativeModules, DeviceEventEmitter } from 'react-native';
+import { MemoryStorage, Status, Event, Payload, Transport, Response, STORAGE_PREFIX } from '@amplitude/analytics-core';
+import { AmplitudeReactNative } from '../../src/react-native-client';
+import { CONNECTIVITY_EVENT_NAME } from '../../src/plugins/network-connectivity-checker';
+import * as CookieMigration from '../../src/cookie-migration';
+
+/**
+ * End-to-end style test: with the connectivity plugin installed by default,
+ * events queue while `config.offline === true` (Destination short-circuits both
+ * schedule and flush) and are flushed once connectivity is restored.
+ */
+describe('offline mode integration', () => {
+  const API_KEY = 'API_KEY';
+
+  const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
+    getNetworkConnectivityStatus: jest.Mock;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    connectivityModule.getNetworkConnectivityStatus.mockResolvedValue({ isConnected: true });
+    DeviceEventEmitter.removeAllListeners(CONNECTIVITY_EVENT_NAME);
+  });
+
+  test('queues events while offline and flushes them on reconnect', async () => {
+    jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
+
+    const sentEvents: Event[] = [];
+    const send = jest.fn(async (_serverUrl: string, payload: Payload): Promise<Response> => {
+      sentEvents.push(...payload.events);
+      return {
+        status: Status.Success,
+        statusCode: 200,
+        body: {
+          eventsIngested: payload.events.length,
+          payloadSizeBytes: 0,
+          serverUploadTime: 0,
+        },
+      };
+    });
+    const transportProvider: Transport = { send };
+    const storageProvider = new MemoryStorage<Event[]>();
+
+    const client = new AmplitudeReactNative();
+    await client.init(API_KEY, undefined, {
+      transportProvider,
+      storageProvider,
+      flushIntervalMillis: 3000,
+      flushQueueSize: 100,
+      attribution: { disabled: true },
+      optOut: false,
+    }).promise;
+
+    // Go offline via the native connectivity signal.
+    DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: false });
+
+    // Track events while offline; their promises won't resolve until flushed,
+    // so don't await them here.
+    void client.track('event_while_offline_1').promise;
+    void client.track('event_while_offline_2').promise;
+
+    // Allow the events to be enqueued and persisted to storage.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Nothing is sent while offline, and the queue is persisted.
+    await client.flush().promise;
+    expect(send).not.toHaveBeenCalled();
+    const queued = await storageProvider.get(`${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`);
+    expect(queued?.length).toBe(2);
+
+    // Reconnect → plugin flips config.offline=false and flushes immediately.
+    DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected: true });
+    await client.flush().promise;
+
+    expect(send).toHaveBeenCalled();
+    expect(sentEvents.map((e) => e.event_type)).toEqual(
+      expect.arrayContaining(['event_while_offline_1', 'event_while_offline_2']),
+    );
+
+    // Storage queue drains after a successful flush.
+    const remaining = await storageProvider.get(`${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`);
+    expect(remaining ?? []).toEqual([]);
+
+    client.shutdown();
+  });
+});

--- a/packages/analytics-react-native/test/plugins/offline-integration.test.ts
+++ b/packages/analytics-react-native/test/plugins/offline-integration.test.ts
@@ -13,11 +13,22 @@ import * as CookieMigration from '../../src/cookie-migration';
 describe('offline mode integration', () => {
   const API_KEY = 'API_KEY';
 
+  // Run pending fake timers and flush microtasks in lockstep, repeatedly, to
+  // drive the Timeline's async `setTimeout(0)` apply chain to completion under
+  // fake timers (the async timer helpers can't be used in the RN jest env).
+  const drainTimers = async () => {
+    for (let i = 0; i < 20; i++) {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+    }
+  };
+
   const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
     getNetworkConnectivityStatus: jest.Mock;
   };
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
     connectivityModule.getNetworkConnectivityStatus.mockResolvedValue({ isConnected: true });
     DeviceEventEmitter.removeAllListeners(CONNECTIVITY_EVENT_NAME);
@@ -57,11 +68,16 @@ describe('offline mode integration', () => {
 
     // Track events while offline; their promises won't resolve until flushed,
     // so don't await them here.
+    jest.useFakeTimers();
     void client.track('event_while_offline_1').promise;
     void client.track('event_while_offline_2').promise;
-
-    // Allow the events to be enqueued and persisted to storage.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Deterministically drain the Timeline instead of waiting a fixed delay.
+    // The Timeline applies events via a chain of `setTimeout(0)` callbacks, each
+    // awaiting async plugin work. The react-native jest environment can't use the
+    // async timer helpers (they deadlock on its `setImmediate` polyfill), so
+    // alternate running pending timers with microtask flushes.
+    await drainTimers();
+    jest.useRealTimers();
 
     // Nothing is sent while offline, and the queue is persisted.
     await client.flush().promise;

--- a/packages/analytics-react-native/test/plugins/offline-integration.test.ts
+++ b/packages/analytics-react-native/test/plugins/offline-integration.test.ts
@@ -13,22 +13,11 @@ import * as CookieMigration from '../../src/cookie-migration';
 describe('offline mode integration', () => {
   const API_KEY = 'API_KEY';
 
-  // Run pending fake timers and flush microtasks in lockstep, repeatedly, to
-  // drive the Timeline's async `setTimeout(0)` apply chain to completion under
-  // fake timers (the async timer helpers can't be used in the RN jest env).
-  const drainTimers = async () => {
-    for (let i = 0; i < 20; i++) {
-      jest.runOnlyPendingTimers();
-      await Promise.resolve();
-    }
-  };
-
   const connectivityModule = NativeModules.AmplitudeReactNativeConnectivity as {
     getNetworkConnectivityStatus: jest.Mock;
   };
 
   afterEach(() => {
-    jest.useRealTimers();
     jest.clearAllMocks();
     connectivityModule.getNetworkConnectivityStatus.mockResolvedValue({ isConnected: true });
     DeviceEventEmitter.removeAllListeners(CONNECTIVITY_EVENT_NAME);
@@ -52,6 +41,20 @@ describe('offline mode integration', () => {
     });
     const transportProvider: Transport = { send };
     const storageProvider = new MemoryStorage<Event[]>();
+    const storageKey = `${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`;
+
+    // Resolves once both offline events have been persisted. The Destination
+    // calls storageProvider.set() as it queues each event, so awaiting this is
+    // deterministic — no fixed delay or timer polling needed.
+    const realSet = storageProvider.set.bind(storageProvider);
+    const bothEventsPersisted = new Promise<void>((resolve) => {
+      jest.spyOn(storageProvider, 'set').mockImplementation(async (key, value) => {
+        await realSet(key, value);
+        if (value.length === 2) {
+          resolve();
+        }
+      });
+    });
 
     const client = new AmplitudeReactNative();
     await client.init(API_KEY, undefined, {
@@ -68,21 +71,14 @@ describe('offline mode integration', () => {
 
     // Track events while offline; their promises won't resolve until flushed,
     // so don't await them here.
-    jest.useFakeTimers();
     void client.track('event_while_offline_1').promise;
     void client.track('event_while_offline_2').promise;
-    // Deterministically drain the Timeline instead of waiting a fixed delay.
-    // The Timeline applies events via a chain of `setTimeout(0)` callbacks, each
-    // awaiting async plugin work. The react-native jest environment can't use the
-    // async timer helpers (they deadlock on its `setImmediate` polyfill), so
-    // alternate running pending timers with microtask flushes.
-    await drainTimers();
-    jest.useRealTimers();
+    await bothEventsPersisted;
 
     // Nothing is sent while offline, and the queue is persisted.
     await client.flush().promise;
     expect(send).not.toHaveBeenCalled();
-    const queued = await storageProvider.get(`${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`);
+    const queued = await storageProvider.get(storageKey);
     expect(queued?.length).toBe(2);
 
     // Reconnect → plugin flips config.offline=false and flushes immediately.
@@ -95,7 +91,7 @@ describe('offline mode integration', () => {
     );
 
     // Storage queue drains after a successful flush.
-    const remaining = await storageProvider.get(`${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`);
+    const remaining = await storageProvider.get(storageKey);
     expect(remaining ?? []).toEqual([]);
 
     client.shutdown();

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -225,23 +225,29 @@ describe('react-native-client', () => {
   describe('network connectivity checker plugin', () => {
     const NETWORK_CHECKER_PLUGIN_NAME = '@amplitude/plugin-network-checker-react-native';
 
-    test('should install the network connectivity checker by default', async () => {
+    let installSpy: jest.SpyInstance;
+    let client: AmplitudeReactNative;
+    let addSpy: jest.SpyInstance;
+
+    beforeEach(() => {
       jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
-      const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
-      const client = new AmplitudeReactNative();
-      const addSpy = jest.spyOn(client, 'add');
+      installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
+      client = new AmplitudeReactNative();
+      addSpy = jest.spyOn(client, 'add');
+    });
+
+    afterEach(() => {
+      installSpy.mockRestore();
+    });
+
+    test('should install the network connectivity checker by default', async () => {
       await client.init(API_KEY, USER_ID, { ...attributionConfig }).promise;
       expect(installSpy).toHaveBeenCalledTimes(1);
       // Assert it actually lands in the timeline under the expected name.
       expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));
-      installSpy.mockRestore();
     });
 
     test('should not install the network connectivity checker when offline is OfflineDisabled', async () => {
-      jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
-      const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
-      const client = new AmplitudeReactNative();
-      const addSpy = jest.spyOn(client, 'add');
       await client.init(API_KEY, USER_ID, {
         ...attributionConfig,
         offline: core.OfflineDisabled,
@@ -249,7 +255,6 @@ describe('react-native-client', () => {
       expect(installSpy).not.toHaveBeenCalled();
       // And it never reaches the timeline.
       expect(addSpy).not.toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));
-      installSpy.mockRestore();
     });
   });
 

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -11,6 +11,7 @@ import {
 import { isWeb } from '../src/utils/platform';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Config from '../src/config';
+import * as NetworkChecker from '../src/plugins/network-connectivity-checker';
 
 describe('react-native-client', () => {
   const API_KEY = 'API_KEY';
@@ -220,6 +221,39 @@ describe('react-native-client', () => {
       });
     });
   }
+
+  describe('network connectivity checker plugin', () => {
+    const NETWORK_CHECKER_PLUGIN_NAME = '@amplitude/plugin-network-checker-react-native';
+
+    test('should install the network connectivity checker by default', async () => {
+      jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
+      const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
+      const client = new AmplitudeReactNative();
+      const addSpy = jest.spyOn(client, 'add');
+      await client.init(API_KEY, USER_ID, { ...attributionConfig }).promise;
+      expect(installSpy).toHaveBeenCalledTimes(1);
+      // Assert it actually lands in the timeline under the expected name.
+      expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));
+      installSpy.mockRestore();
+    });
+
+    test('should not install the network connectivity checker when offline is OfflineDisabled', async () => {
+      jest.spyOn(CookieMigration, 'parseOldCookies').mockResolvedValueOnce({ optOut: false });
+      const installSpy = jest.spyOn(NetworkChecker, 'networkConnectivityCheckerPlugin');
+      const client = new AmplitudeReactNative();
+      const addSpy = jest.spyOn(client, 'add');
+      await client.init(API_KEY, USER_ID, {
+        ...attributionConfig,
+        // `offline` is omitted from the public ReactNativeOptions type but is
+        // honored by the underlying core Config.
+        offline: core.OfflineDisabled,
+      } as core.ReactNativeOptions).promise;
+      expect(installSpy).not.toHaveBeenCalled();
+      // And it never reaches the timeline.
+      expect(addSpy).not.toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));
+      installSpy.mockRestore();
+    });
+  });
 
   describe('getUserId', () => {
     test('should get user id', async () => {

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -244,10 +244,8 @@ describe('react-native-client', () => {
       const addSpy = jest.spyOn(client, 'add');
       await client.init(API_KEY, USER_ID, {
         ...attributionConfig,
-        // `offline` is omitted from the public ReactNativeOptions type but is
-        // honored by the underlying core Config.
         offline: core.OfflineDisabled,
-      } as core.ReactNativeOptions).promise;
+      }).promise;
       expect(installSpy).not.toHaveBeenCalled();
       // And it never reaches the timeline.
       expect(addSpy).not.toHaveBeenCalledWith(expect.objectContaining({ name: NETWORK_CHECKER_PLUGIN_NAME }));


### PR DESCRIPTION
## Summary
**PR 1 of 5** — splitting the SDKRN-5 offline-mode feature (originally #1796) into a reviewable, **non-breaking** stack. Each PR leaves the SDK runnable when merged in order.

This PR adds the **cross-platform JS** pieces + **no-op native placeholders**:
- `networkConnectivityCheckerPlugin` (`BeforePlugin`): seeds and flips `config.offline` from the native connectivity module (or `navigator.onLine` on web); flushes on reconnect; best-effort falls back to online when no connectivity source exists.
- Client wiring in `_init` (installs before `Destination`, skips on the `OfflineDisabled` sentinel).
- Plugin unit tests + end-to-end `offline-integration.test.ts` (native bridge mocked in the jest setups).
- **No-op `AmplitudeReactNativeConnectivity` native stubs** (iOS Swift + Android Kotlin) that register the module and always report connected, so JS has a real module to bind to.

### Why non-breaking
After this PR, offline mode is a **no-op** (the stubs always report "online") — behavior is identical to pre-feature. The real platform monitors arrive in the follow-ups:

| PR | Adds | Base |
|----|------|------|
| **#1 (this)** | JS plugin + wiring + tests + no-op native stubs | `main` |
| #2 | Real iOS module (`NWPathMonitor`/`SCNetworkReachability`) — replaces iOS stub | #1 |
| #3 | Real Android module (`ConnectivityManager`) + `ACCESS_NETWORK_STATE` — replaces Android stub | #2 |
| #4 | Robolectric tests for the Android module | #3 |
| #5 | Example `expo-app` (RN dedupe + offline test buttons) — independent | `main` |

## Test plan
- ✅ `analytics-react-native` typecheck + lint clean
- ✅ jest **106/106 pass** (web + mobile; the native bridge is mocked, so the stubs don't affect the suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init plugin order and `config.offline` driving Destination behavior; production impact is limited while native stubs always report online, but react-native-web uses real `navigator.onLine` and mis-detection could affect sends.
> 
> **Overview**
> Adds **offline-mode plumbing** for React Native analytics: a `networkConnectivityCheckerPlugin` that seeds and updates `config.offline` from `AmplitudeReactNativeConnectivity` (native) or `navigator.onLine` on react-native-web, flushes on reconnect (immediate on native, delayed on web), and **defaults to online** when no connectivity source exists (including a regression guard for native apps missing the module).
> 
> `AmplitudeReactNative` now installs that plugin **before** `Destination` by default and skips it when `offline: OfflineDisabled`. **iOS/Android no-op native modules** register the bridge and always return connected so shipping this alone does not suppress sends; real monitors land in follow-up PRs.
> 
> `ReactNativeConfig` no longer omits `offline` from `IConfig`. Jest mocks, plugin unit tests, client init tests, and an offline integration test cover queue-while-offline / flush-on-reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5a73be90844ce3196d03d402a564fccce50842. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->