### PR TITLE
chore(examples): dedupe react-native in expo-app Metro + offline test buttons [5/5]

### DIFF
--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -10,6 +10,8 @@ function HomeScreen({ navigation }) {
   return (
     <View style={styles.container}>
       <Text>Home Screen</Text>
+      <Button title="Online test" onPress={() => track('RN Expo Online Test')} />
+      <Button title="Offline test" onPress={() => track('RN Expo Offline Test')} />
       <Button title="Go to Settings" onPress={() => navigation.navigate('Settings')} />
     </View>
   );
@@ -29,7 +31,9 @@ export default function App() {
     (async () => {
         // AMPLITUDE_API_KEY is inlined at bundle time (see babel.config.js).
         await init(process.env.AMPLITUDE_API_KEY || 'YOUR_API_KEY', 'react-native-user-id', {
-          logLevel: Types.LogLevel.Error,
+          // Debug so offline-mode log lines ("Skipping flush while offline.",
+          // flush/upload) are visible when manually testing connectivity.
+          logLevel: Types.LogLevel.Debug,
           // autocapture: { } // <-- todo
         }).promise;
         track('expo-app/react-native/test-event');

--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -31,8 +31,6 @@ export default function App() {
     (async () => {
         // AMPLITUDE_API_KEY is inlined at bundle time (see babel.config.js).
         await init(process.env.AMPLITUDE_API_KEY || 'YOUR_API_KEY', 'react-native-user-id', {
-          // Debug so offline-mode log lines ("Skipping flush while offline.",
-          // flush/upload) are visible when manually testing connectivity.
           logLevel: Types.LogLevel.Debug,
           // autocapture: { } // <-- todo
         }).promise;

--- a/examples/react-native/expo-app/metro.config.js
+++ b/examples/react-native/expo-app/metro.config.js
@@ -16,10 +16,32 @@ config.watchFolders = [
   path.join(packagesRoot, 'plugin-page-view-tracking-browser'),
 ];
 config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
-// `packages/analytics-react-native` pins its own react-native devDep; force the app's copy.
-config.resolver.extraNodeModules = {
+
+// Force a SINGLE copy of react-native / react for the whole bundle.
+//
+// `packages/analytics-react-native` pins its own `react-native` devDep (0.70.6),
+// so Metro resolves the workspace-linked SDK's `react-native` imports to that
+// NESTED copy — a second react-native in the bundle alongside the app's 0.71.x.
+// A duplicate react-native means a duplicate `RCTDeviceEventEmitter` singleton:
+// the native bridge emits connectivity events on the APP's emitter, but the SDK's
+// `NativeEventEmitter` listener is registered on the duplicate's emitter, so the
+// SDK never receives `AmplitudeNetworkConnectivityChanged` events and offline mode
+// only ever sees the initial seed (never live changes). `extraNodeModules` is just
+// a resolution *fallback* and doesn't override the nested copy, so redirect
+// explicitly via `resolveRequest`.
+const forcedSingletons = {
   'react-native': path.resolve(projectRoot, 'node_modules/react-native'),
   react: path.resolve(projectRoot, 'node_modules/react'),
+};
+config.resolver.extraNodeModules = forcedSingletons;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  for (const [name, dir] of Object.entries(forcedSingletons)) {
+    if (moduleName === name || moduleName.startsWith(name + '/')) {
+      const target = path.join(dir, moduleName.slice(name.length));
+      return context.resolveRequest(context, target, platform);
+    }
+  }
+  return context.resolveRequest(context, moduleName, platform);
 };
 
 module.exports = config;

--- a/examples/react-native/expo-app/metro.config.js
+++ b/examples/react-native/expo-app/metro.config.js
@@ -17,18 +17,12 @@ config.watchFolders = [
 ];
 config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
 
-// Force a SINGLE copy of react-native / react for the whole bundle.
-//
-// `packages/analytics-react-native` pins its own `react-native` devDep (0.70.6),
-// so Metro resolves the workspace-linked SDK's `react-native` imports to that
-// NESTED copy — a second react-native in the bundle alongside the app's 0.71.x.
-// A duplicate react-native means a duplicate `RCTDeviceEventEmitter` singleton:
-// the native bridge emits connectivity events on the APP's emitter, but the SDK's
-// `NativeEventEmitter` listener is registered on the duplicate's emitter, so the
-// SDK never receives `AmplitudeNetworkConnectivityChanged` events and offline mode
-// only ever sees the initial seed (never live changes). `extraNodeModules` is just
-// a resolution *fallback* and doesn't override the nested copy, so redirect
-// explicitly via `resolveRequest`.
+// Force a single copy of react-native / react across the bundle. The SDK pins
+// its own react-native devDep, so Metro would otherwise resolve the workspace-
+// linked SDK's imports to that nested copy and bundle two react-natives (two
+// RCTDeviceEventEmitter singletons, so the SDK misses connectivity events).
+// extraNodeModules is only a fallback and won't override the nested copy, so
+// redirect explicitly via resolveRequest.
 const forcedSingletons = {
   'react-native': path.resolve(projectRoot, 'node_modules/react-native'),
   react: path.resolve(projectRoot, 'node_modules/react'),


### PR DESCRIPTION
## Summary
**PR 5 of the SDKRN-5 offline split** https://github.com/amplitude/Amplitude-TypeScript/pull/1796 — but **independent of the SDK stack** (#1802 → … ), so it can be reviewed **in parallel**. Based on `main`.

Example-app (`expo-app`) changes for manual offline testing:
- **`metro.config.js`** — `resolver.resolveRequest` forcing a single `react-native` / `react` copy. The workspace SDK pins its own `react-native` devDep, so Metro otherwise bundles a **second** copy → two `RCTDeviceEventEmitter` singletons → native events never reach the SDK's JS listener. `extraNodeModules` alone is only a fallback and doesn't override the nested copy. (Latent bundling bug worth fixing regardless; it's also the prerequisite for the offline feature to work in this example.) Requires `expo start --clear`.
- **`App.tsx`** — "Online test" / "Offline test" `track()` buttons + `logLevel: Debug` for observable offline log lines.

## Relation to the stack
| PR | Adds | Base |
|----|------|------|
| #1802 | JS plugin + wiring + tests + no-op native stubs | `main` |
| (next) | Real iOS module | #1802 |
| (next) | Real Android module | ↑ |
| (next) | Robolectric tests | ↑ |
| **this (#5)** | Example app (Metro dedupe + buttons) | **`main` — independent** |

## Test plan
- Example-only (no SDK source, no jest coverage). Verified manually: built/ran `expo-app` on an Android emulator, toggled `adb shell svc wifi/data disable|enable`, confirmed offline events queue and flush on reconnect (server `serverUploadTime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only Metro and UI tweaks; no SDK, auth, or production runtime changes.
> 
> **Overview**
> Updates the **expo-app** example so manual offline/online Amplitude testing is reliable and easy to trigger.
> 
> **Metro** now uses a custom `resolver.resolveRequest` (along with `extraNodeModules`) so every `react-native` and `react` import resolves to the app’s `node_modules`. Without that redirect, the workspace-linked SDK’s nested `react-native` devDep can end up in the bundle twice, which breaks connectivity-related native events reaching the SDK.
> 
> **App** adds **Online test** and **Offline test** buttons that fire distinct `track()` events, and sets Amplitude `logLevel` to **Debug** (from **Error**) so offline queue/flush behavior is visible in logs during manual runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e3e29894f9935fd385eb4b8c57bb16465092b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->