### PR TITLE
fix(analytics-browser): return trackVideo errors instead of throwing

### DIFF
--- a/packages/analytics-browser/src/video-capture/video-capture.ts
+++ b/packages/analytics-browser/src/video-capture/video-capture.ts
@@ -1,4 +1,11 @@
-import { VideoState, VideoObserver, BrowserClient, EmbeddedVideoPlayer, VideoVendor } from '@amplitude/analytics-core';
+import {
+  VideoState,
+  VideoObserver,
+  BrowserClient,
+  EmbeddedVideoPlayer,
+  VideoVendor,
+  UUID,
+} from '@amplitude/analytics-core';
 
 export class VideoCapture {
   private videoEl: HTMLVideoElement | null = null;
@@ -61,7 +68,7 @@ export class VideoCapture {
   captureVideoStarted(): VideoCapture {
     this.listeners.push((previousState, nextState) => {
       if (previousState.playbackState !== 'playing' && nextState.playbackState === 'playing') {
-        // placeholder for Heartbeat Start Event
+        // TODO: placeholder for Heartbeat Start Event
         this.amplitude.track('Video Content Started', {
           ...nextState.lastEvent,
           ...this.extraEventProperties,
@@ -136,6 +143,10 @@ export type VideoCaptureOptions = {
   extraEventProperties?: Record<string, string | number | boolean>;
 };
 
+type UntrackVideoResult = () => void;
+
+export type TrackVideoResult = UntrackVideoResult | Error;
+
 /**
  * Track video analytics events for an HTML video element or embedded video player.js instance.
  *
@@ -151,7 +162,7 @@ export function trackVideo(
   amplitude: BrowserClient,
   videoEl: HTMLVideoElement | EmbeddedVideoPlayer,
   options: VideoCaptureOptions = {},
-): () => void {
+): TrackVideoResult {
   const videoCapture = new VideoCapture(amplitude);
   if (videoEl instanceof HTMLVideoElement) {
     videoCapture.withVideoElement(videoEl);
@@ -161,11 +172,20 @@ export function trackVideo(
   if (options.vendor) {
     videoCapture.withVendor(options.vendor);
   }
-  videoCapture
-    .withExtraEventProperties(options.extraEventProperties ?? {})
-    .captureVideoStarted()
-    .captureVideoStopped()
-    .start();
+  const extraEventProperties = options.extraEventProperties ?? {};
+
+  try {
+    videoCapture
+      .withExtraEventProperties({
+        view_session_id: UUID(),
+        ...extraEventProperties,
+      })
+      .captureVideoStarted()
+      .captureVideoStopped()
+      .start();
+  } catch (error) {
+    return error as Error;
+  }
 
   return () => videoCapture.stop();
 }

--- a/packages/analytics-browser/test/video-capture/video-capture.test.ts
+++ b/packages/analytics-browser/test/video-capture/video-capture.test.ts
@@ -121,6 +121,7 @@ describe('VideoCapture', () => {
         duration: 10,
         hello: 'world',
         number: 123,
+        view_session_id: expect.any(String),
       });
       currentVideoObserver!.emitStateChange(
         { playbackState: 'playing', lastEvent: { duration: 10, last_position: undefined } },
@@ -131,8 +132,9 @@ describe('VideoCapture', () => {
         last_position: 5,
         hello: 'world',
         number: 123,
+        view_session_id: expect.any(String),
       });
-      stopVideoCapture();
+      typeof stopVideoCapture === 'function' && stopVideoCapture();
       currentVideoObserver!.emitStateChange(
         { playbackState: 'paused', lastEvent: { duration: 10, last_position: 5 } },
         { playbackState: 'playing', lastEvent: { duration: 10, last_position: undefined } },
@@ -153,6 +155,7 @@ describe('VideoCapture', () => {
       );
       expect(mockAmplitude.track).toHaveBeenCalledWith('Video Content Started', {
         duration: 10,
+        view_session_id: expect.any(String),
       });
       currentVideoObserver!.emitStateChange(
         { playbackState: 'playing', lastEvent: { duration: 10, last_position: undefined } },
@@ -161,8 +164,14 @@ describe('VideoCapture', () => {
       expect(mockAmplitude.track).toHaveBeenCalledWith('Video Content Stopped', {
         duration: 10,
         last_position: 5,
+        view_session_id: expect.any(String),
       });
-      stopVideoCapture();
+      typeof stopVideoCapture === 'function' && stopVideoCapture();
+    });
+
+    it('should return an error if the video element is not specified', () => {
+      const stopVideoCapture = trackVideo(mockAmplitude, null as unknown as HTMLVideoElement);
+      expect(stopVideoCapture).toBeInstanceOf(Error);
     });
   });
 });


### PR DESCRIPTION
### Summary

* Return errors from trackVideo instead of throwing them to prevent risk of an error taking down an application
* Add a "view_session_id" parameter to video events so that we can distinguish different views at different times on the same video


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental video API behavior change is localized; callers must handle Error returns but there is no auth or data-pipeline risk.
> 
> **Overview**
> **`trackVideo`** now returns either an **untrack callback** or an **`Error`** instead of always returning a function, so setup failures (e.g. missing video element) no longer throw and can’t crash the host app. Callers should treat the return value as **`TrackVideoResult`** and only invoke cleanup when it’s a function.
> 
> Each successful **`trackVideo`** session automatically adds a **`view_session_id`** (from **`UUID()`**) to extra event properties on **Video Content Started** and **Video Content Stopped**, so repeated plays of the same asset can be grouped by view. Tests assert the new property and the error return path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54163290cd0b7c505e46c336603a450414550b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->