### PR TITLE
feat(session-replay-browser): add eagerFullSnapshotSend, captureFullSnapshotOnFocus, and max event size config options

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -109,6 +109,10 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         captureAdoptedStyleSheets: this.options.captureAdoptedStyleSheets,
         crossOriginIframes: this.options.crossOriginIframes,
         flushIntervalConfig: this.options.flushIntervalConfig,
+        eagerFullSnapshotSend: this.options.eagerFullSnapshotSend,
+        captureFullSnapshotOnFocus: this.options.captureFullSnapshotOnFocus,
+        maxPersistedEventsSizeBytes: this.options.maxPersistedEventsSizeBytes,
+        maxSingleEventSizeBytes: this.options.maxSingleEventSizeBytes,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -189,4 +189,20 @@ export interface SessionReplayOptions {
    * @see {@link StandaloneSessionReplayOptions.flushIntervalConfig}
    */
   flushIntervalConfig?: FlushIntervalConfig;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.eagerFullSnapshotSend}
+   */
+  eagerFullSnapshotSend?: boolean;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.captureFullSnapshotOnFocus}
+   */
+  captureFullSnapshotOnFocus?: boolean;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.maxPersistedEventsSizeBytes}
+   */
+  maxPersistedEventsSizeBytes?: number;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.maxSingleEventSizeBytes}
+   */
+  maxSingleEventSizeBytes?: number;
 }

--- a/packages/plugin-session-replay-browser/test/session-replay.test.ts
+++ b/packages/plugin-session-replay-browser/test/session-replay.test.ts
@@ -170,6 +170,43 @@ describe('SessionReplayPlugin', () => {
       );
     });
 
+    test('should pass the GA perf knobs through to session replay when provided', async () => {
+      const sessionReplay = new SessionReplayPlugin({
+        eagerFullSnapshotSend: false,
+        captureFullSnapshotOnFocus: false,
+        maxPersistedEventsSizeBytes: 2000000,
+        maxSingleEventSizeBytes: 1000000,
+      });
+
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
+
+      expect(init).toHaveBeenCalledWith(
+        'static_key',
+        expect.objectContaining({
+          eagerFullSnapshotSend: false,
+          captureFullSnapshotOnFocus: false,
+          maxPersistedEventsSizeBytes: 2000000,
+          maxSingleEventSizeBytes: 1000000,
+        }),
+      );
+    });
+
+    test('should pass the GA perf knobs as undefined when not set', async () => {
+      const sessionReplay = new SessionReplayPlugin();
+
+      await sessionReplay.setup?.(mockConfig, mockAmplitude);
+
+      expect(init).toHaveBeenCalledWith(
+        'static_key',
+        expect.objectContaining({
+          eagerFullSnapshotSend: undefined,
+          captureFullSnapshotOnFocus: undefined,
+          maxPersistedEventsSizeBytes: undefined,
+          maxSingleEventSizeBytes: undefined,
+        }),
+      );
+    });
+
     describe('defaultTracking', () => {
       test('should not change defaultTracking when forceSessionTracking is not defined', async () => {
         const sessionReplay = new SessionReplayPlugin();

--- a/packages/session-replay-browser/e2e/README.md
+++ b/packages/session-replay-browser/e2e/README.md
@@ -87,6 +87,10 @@ accepts URL params to configure the SDK:
 | `deviceId` | `test-device-id` | Device ID |
 | `logLevel` | `0` | SDK log level (4 = DEBUG, useful for troubleshooting) |
 | `useWebWorker` | `false` | Passes `useWebWorker: true` to `init()`, enabling the web worker send path |
+| `eagerFullSnapshotSend` | _unset_ | Passes `eagerFullSnapshotSend` (`true`/`false`) to `init()`; omitted preserves the SDK default |
+| `captureFullSnapshotOnFocus` | _unset_ | Passes `captureFullSnapshotOnFocus` (`true`/`false`) to `init()`; omitted preserves the SDK default |
+| `maxPersistedEventsSizeBytes` | _unset_ | Passes `maxPersistedEventsSizeBytes` (number) to `init()`; omitted preserves the SDK default |
+| `maxSingleEventSizeBytes` | _unset_ | Passes `maxSingleEventSizeBytes` (number) to `init()`; omitted preserves the SDK default |
 
 After `init()` resolves, the page sets `window.srReady = true`. Tests wait on this
 before asserting anything. The SDK instance is exposed as `window.sessionReplay`.

--- a/packages/session-replay-browser/e2e/perf-knobs.spec.ts
+++ b/packages/session-replay-browser/e2e/perf-knobs.spec.ts
@@ -1,0 +1,295 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import {
+  SR_API_SUCCESS,
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  EVENT_FULL_SNAPSHOT,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  readRouteBody,
+} from './helpers';
+
+/**
+ * E2E coverage for the GA'd SR performance knobs promoted to top-level
+ * SessionReplayLocalConfig options in PR #1806. Defaults preserve current behavior:
+ *   - eagerFullSnapshotSend (default true)
+ *   - captureFullSnapshotOnFocus (default true)
+ *   - maxSingleEventSizeBytes (default 9_000_000)
+ *   - maxPersistedEventsSizeBytes (default 700_000)
+ *
+ * Each test asserts a behavior-visible difference between the knob's enabled and
+ * disabled states through the full real-browser pipeline (Vite + worker + rrweb +
+ * the mocked track API).
+ */
+
+function decodeEvents(rawBody: string): Array<Record<string, unknown>> {
+  if (!rawBody) return [];
+  let payload: { events?: unknown[] };
+  try {
+    payload = JSON.parse(rawBody) as { events?: unknown[] };
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(payload.events)) return [];
+  const results: Array<Record<string, unknown>> = [];
+  for (const eventStr of payload.events) {
+    if (typeof eventStr !== 'string') continue;
+    try {
+      results.push(JSON.parse(eventStr) as Record<string, unknown>);
+    } catch {
+      // skip unparseable events
+    }
+  }
+  return results;
+}
+
+function countFullSnapshots(bodies: string[]): number {
+  return bodies.flatMap(decodeEvents).filter((e) => e['type'] === EVENT_FULL_SNAPSHOT).length;
+}
+
+/** Mocks the track API and exposes the raw POST bodies received, in order. */
+async function captureBodies(page: Page): Promise<{ getBodies: () => string[] }> {
+  const rawBodies: string[] = [];
+  await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+    rawBodies.push(readRouteBody(route));
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+  });
+  return { getBodies: () => rawBodies };
+}
+
+async function blurAndFlush(page: Page): Promise<void> {
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+  await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+}
+
+// ─── captureFullSnapshotOnFocus ───────────────────────────────────────────────
+//
+// A window `focus` event fired after recording is stable forces an extra
+// takeFullSnapshot when the knob is enabled (the default). When disabled, the
+// focusListener returns early and no additional full snapshot is produced. We
+// count EVENT_FULL_SNAPSHOT (type 2) events in the decoded request bodies.
+
+test.describe('captureFullSnapshotOnFocus', () => {
+  test('default (true): a focus event after stable recording produces an additional full snapshot', async ({
+    page,
+  }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureBodies(page);
+
+    // Listen before goto so the eager init send doesn't race past us.
+    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        captureFullSnapshotOnFocus: true,
+      }),
+    );
+    await waitForReady(page);
+    await requestPromise;
+    // Let the initial recording fully stabilize so focus hits the takeFullSnapshot branch.
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Baseline: exactly one full snapshot from init.
+    await blurAndFlush(page);
+    expect(countFullSnapshots(getBodies())).toBe(1);
+
+    // Focus → extra full snapshot.
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await blurAndFlush(page);
+
+    expect(countFullSnapshots(getBodies())).toBe(2);
+  });
+
+  test('false: a focus event after stable recording produces no additional full snapshot', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureBodies(page);
+
+    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        captureFullSnapshotOnFocus: false,
+      }),
+    );
+    await waitForReady(page);
+    await requestPromise;
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    await blurAndFlush(page);
+    expect(countFullSnapshots(getBodies())).toBe(1);
+
+    // Focus is a no-op for the full-snapshot path when the knob is off.
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+    await blurAndFlush(page);
+
+    expect(countFullSnapshots(getBodies())).toBe(1);
+  });
+});
+
+// ─── eagerFullSnapshotSend ────────────────────────────────────────────────────
+//
+// With the knob enabled (default), the initial full snapshot is sent to the track
+// API immediately on capture — without any blur/flush. With it disabled, the eager
+// send is suppressed: no request goes out on a quiet page until an explicit
+// blur+flush drains the buffer (the snapshot is still buffered, just not sent eagerly).
+
+test.describe('eagerFullSnapshotSend', () => {
+  test('default (true): the initial full snapshot is sent promptly without an explicit flush', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureBodies(page);
+
+    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
+    await waitForReady(page);
+
+    // The eager send fires the request — no blur/flush issued by the test.
+    await requestPromise;
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    expect(getBodies().length).toBeGreaterThan(0);
+    expect(countFullSnapshots(getBodies())).toBeGreaterThanOrEqual(1);
+  });
+
+  test('false: no request is sent on a quiet page until an explicit flush', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies } = await captureBodies(page);
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: false,
+      }),
+    );
+    await waitForReady(page);
+    // Quiet window: no DOM interaction, so no interval-driven split fires. With eager
+    // send suppressed and the onFullSnapshotProcessed callback undefined, nothing should
+    // POST during this window.
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 5);
+
+    expect(getBodies().length).toBe(0);
+
+    // The snapshot is still buffered — an explicit flush drains it and delivers the snapshot.
+    await blurAndFlush(page);
+
+    expect(getBodies().length).toBeGreaterThan(0);
+    expect(countFullSnapshots(getBodies())).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── maxSingleEventSizeBytes ──────────────────────────────────────────────────
+//
+// Mirrors size-limits.spec.ts but drives the threshold via the new config knob
+// instead of the hard-coded MAX_SINGLE_EVENT_SIZE constant. A full snapshot sized
+// between the lowered cap and the SDK default is dropped at capture time when the
+// knob lowers the cap, but delivered normally under the default.
+
+test.describe('maxSingleEventSizeBytes', () => {
+  // 1 MB cap: well above the 1 KB config floor, well below the 9 MB default.
+  const CONFIGURED_CAP = 1_000_000;
+  // ~2 MB attribute → the next full snapshot serializes to > 1 MB but << 9 MB, so it
+  // crosses the configured cap while staying under the default.
+  const MID_ATTR_LENGTH = 2_000_000;
+
+  async function injectMidNode(page: Page): Promise<void> {
+    await page.evaluate((len) => {
+      const div = document.createElement('div');
+      div.setAttribute('data-mid', 'x'.repeat(len));
+      document.body.appendChild(div);
+    }, MID_ATTR_LENGTH);
+  }
+
+  /** Mocks the track API, collecting (sessionId → events) per request. */
+  async function captureBySession(page: Page) {
+    const calls: { sessionId: string; events: Array<Record<string, unknown>> }[] = [];
+    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+      const url = new URL(route.request().url());
+      calls.push({
+        sessionId: url.searchParams.get('session_id') ?? '',
+        events: decodeEvents(readRouteBody(route)),
+      });
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+    return () => calls;
+  }
+
+  test('lowered cap drops a full snapshot that exceeds the configured threshold', async ({ page }) => {
+    const NEW_SESSION_ID = TEST_SESSION_ID + 60_000;
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const getCalls = await captureBySession(page);
+
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        maxSingleEventSizeBytes: CONFIGURED_CAP,
+      }),
+    );
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Grow the DOM, then rotate sessions so rrweb takes a fresh (now-oversized) snapshot.
+    await injectMidNode(page);
+    await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      (id) => (window as any).sessionReplay.setSessionId(id).promise as Promise<void>,
+      NEW_SESSION_ID,
+    );
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 6);
+
+    const newSessionEvents = getCalls()
+      .filter((c) => c.sessionId === String(NEW_SESSION_ID))
+      .flatMap((c) => c.events);
+
+    // The oversized full snapshot was dropped by the capture-time guard at the configured cap.
+    expect(newSessionEvents.find((e) => e['type'] === EVENT_FULL_SNAPSHOT)).toBeUndefined();
+    // Every event that did reach the wire is under the configured cap.
+    for (const event of newSessionEvents) {
+      expect(new Blob([JSON.stringify(event)]).size).toBeLessThanOrEqual(CONFIGURED_CAP);
+    }
+    // Control: the original (small) session delivered its full snapshot normally.
+    const originalEvents = getCalls()
+      .filter((c) => c.sessionId === String(TEST_SESSION_ID))
+      .flatMap((c) => c.events);
+    expect(originalEvents.find((e) => e['type'] === EVENT_FULL_SNAPSHOT)).toBeDefined();
+  });
+
+  test('default cap delivers the same mid-sized snapshot (knob is the discriminator)', async ({ page }) => {
+    const NEW_SESSION_ID = TEST_SESSION_ID + 60_000;
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const getCalls = await captureBySession(page);
+
+    // No maxSingleEventSizeBytes param → SDK default (9 MB).
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    await injectMidNode(page);
+    await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      (id) => (window as any).sessionReplay.setSessionId(id).promise as Promise<void>,
+      NEW_SESSION_ID,
+    );
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 6);
+
+    const newSessionEvents = getCalls()
+      .filter((c) => c.sessionId === String(NEW_SESSION_ID))
+      .flatMap((c) => c.events);
+
+    // Under the default cap the same ~2 MB snapshot is delivered, proving the drop above
+    // was caused by the lowered knob and not the injection itself.
+    expect(newSessionEvents.find((e) => e['type'] === EVENT_FULL_SNAPSHOT)).toBeDefined();
+  });
+});

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -50,6 +50,10 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   crossOriginIframes?: CrossOriginIframesConfig;
   fullSnapshotIntervalMs?: number;
   flushIntervalConfig?: FlushIntervalConfig;
+  eagerFullSnapshotSend?: boolean;
+  captureFullSnapshotOnFocus?: boolean;
+  maxPersistedEventsSizeBytes?: number;
+  maxSingleEventSizeBytes?: number;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -79,6 +83,30 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     this.captureDocumentTitle = options.captureDocumentTitle ?? false;
     if (options.fullSnapshotIntervalMs !== undefined) {
       this.fullSnapshotIntervalMs = options.fullSnapshotIntervalMs;
+    }
+    if (options.eagerFullSnapshotSend !== undefined) {
+      this.eagerFullSnapshotSend = options.eagerFullSnapshotSend;
+    }
+    if (options.captureFullSnapshotOnFocus !== undefined) {
+      this.captureFullSnapshotOnFocus = options.captureFullSnapshotOnFocus;
+    }
+    if (options.maxPersistedEventsSizeBytes !== undefined) {
+      this.maxPersistedEventsSizeBytes = sanitizeByteSize(
+        options.maxPersistedEventsSizeBytes,
+        MIN_EVENT_BYTE_SIZE,
+        MAX_PERSISTED_EVENTS_SIZE_CEILING,
+        'maxPersistedEventsSizeBytes',
+        this.loggerProvider,
+      );
+    }
+    if (options.maxSingleEventSizeBytes !== undefined) {
+      this.maxSingleEventSizeBytes = sanitizeByteSize(
+        options.maxSingleEventSizeBytes,
+        MIN_EVENT_BYTE_SIZE,
+        MAX_SINGLE_EVENT_SIZE_CEILING,
+        'maxSingleEventSizeBytes',
+        this.loggerProvider,
+      );
     }
 
     // Auto-include .amp-unmask as a default unmaskSelector entry so it works
@@ -122,6 +150,41 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
 // Customers wanting fewer requests should be raising the value, not lowering it; the floor
 // is just a defensive guard against typos and unsigned-int rollovers.
 const MIN_FLUSH_INTERVAL_FLOOR_MS = 100;
+
+// Shared 1 KB floor for the byte-size overrides — small enough to exercise splitting/drops
+// while debugging, large enough to avoid a 0/negative config that splits on every event.
+const MIN_EVENT_BYTE_SIZE = 1_000;
+// Batch cap ceiling: stay under the SR ingest service's 10 MB decompressed split threshold
+// (above which the server splits the batch itself) with headroom for the request wrapper.
+const MAX_PERSISTED_EVENTS_SIZE_CEILING = 8_000_000;
+// Single-event ceiling: the server rejects a single event above ~10 MB, so never allow an
+// override to exceed that.
+const MAX_SINGLE_EVENT_SIZE_CEILING = 10_000_000;
+
+// Defensive bounds for the byte-size overrides. Non-finite inputs are ignored (fall back to
+// the SDK default); out-of-range values are clamped and logged so a typo can't silently
+// disable splitting or push past the server's limits.
+function sanitizeByteSize(
+  raw: number,
+  min: number,
+  max: number,
+  name: string,
+  loggerProvider: ILogger,
+): number | undefined {
+  if (!Number.isFinite(raw)) {
+    loggerProvider.warn(`${name} value is not a finite number (got ${String(raw)}); ignoring.`);
+    return undefined;
+  }
+  if (raw < min) {
+    loggerProvider.warn(`${name} ${raw} is below floor ${min}; clamping.`);
+    return min;
+  }
+  if (raw > max) {
+    loggerProvider.warn(`${name} ${raw} exceeds ceiling ${max}; clamping.`);
+    return max;
+  }
+  return raw;
+}
 
 function sanitizeFlushIntervalConfig(raw: FlushIntervalConfig, loggerProvider: ILogger): FlushIntervalConfig {
   const sanitized: FlushIntervalConfig = {};

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -266,6 +266,58 @@ export interface SessionReplayLocalConfig extends IConfig {
    * back-pressuring the SDK on session start.
    */
   flushIntervalConfig?: FlushIntervalConfig;
+  /**
+   * When true (default), every rrweb full snapshot is flushed to the server immediately so
+   * replays become playable as early as possible. Set to `false` to defer full-snapshot
+   * sends to the normal interval/size flush cadence instead. The snapshot is still compressed
+   * and buffered immediately either way (ordering and page-exit beacon coverage are preserved);
+   * only the eager network send is suppressed. Disabling reduces request volume for pages that
+   * produce many full snapshots (e.g. focus-driven or `fullSnapshotIntervalMs` checkouts),
+   * especially when many SDK instances run on the same page.
+   *
+   * @defaultValue true
+   */
+  eagerFullSnapshotSend?: boolean;
+  /**
+   * When true (default), the window `focus` listener forces a fresh rrweb full snapshot
+   * (`takeFullSnapshot`) every time the page regains focus, so the replay reflects any DOM
+   * changes that happened while the tab was backgrounded. Set to `false` to skip the
+   * on-focus full snapshot entirely (recording simply continues from the existing stream).
+   *
+   * On pages with heavy focus churn (e.g. embedded iframes, inline editors that repeatedly
+   * steal and return focus) this fires constantly, and when combined with
+   * `eagerFullSnapshotSend` each focus produces an immediate network send — the primary
+   * driver of focus-driven request storms. Disabling removes the snapshot (and therefore the
+   * send) at the cost of slightly staler post-focus frames.
+   *
+   * @defaultValue true
+   */
+  captureFullSnapshotOnFocus?: boolean;
+  /**
+   * Raw (uncompressed) UTF-8 byte cap for a single buffered events list before the store
+   * splits it into its own request. Larger values produce fewer, larger requests (the primary
+   * steady-state lever for request volume); smaller values split sooner. Payloads are gzipped
+   * on the wire, so several hundred KB of replay JSON compresses to well under 100 KB.
+   *
+   * Advanced/debug knob — the default already balances request volume against the server's
+   * decompressed-size split threshold. Clamped to a safe range; values outside it are clamped
+   * and logged. Defaults to the SDK's internal `MAX_EVENT_LIST_SIZE`.
+   *
+   * @defaultValue 700000
+   */
+  maxPersistedEventsSizeBytes?: number;
+  /**
+   * Raw (uncompressed) UTF-8 byte cap for a single rrweb event. Events larger than this are
+   * dropped (with a warning) both at capture time and as a pre-send backstop, because the SR
+   * ingest service rejects a single event above ~10 MB. Lower this to exercise drop behavior
+   * for large full snapshots while debugging.
+   *
+   * Advanced/debug knob. Clamped to a safe range; values outside it are clamped and logged.
+   * Defaults to the SDK's internal `MAX_SINGLE_EVENT_SIZE`.
+   *
+   * @defaultValue 9000000
+   */
+  maxSingleEventSizeBytes?: number;
 }
 
 export interface FlushIntervalConfig {

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -160,7 +160,7 @@ export class EventCompressor {
     // UTF-8 byte size, not JS char count: a 9 M-char string of CJK/emoji can be 18–27 MB
     // on the wire and would otherwise slip past a char-count guard.
     const eventSizeBytes = new Blob([compressedEvent]).size;
-    if (eventSizeBytes > MAX_SINGLE_EVENT_SIZE) {
+    if (eventSizeBytes > (this.config.maxSingleEventSizeBytes ?? MAX_SINGLE_EVENT_SIZE)) {
       this.config.loggerProvider.warn(
         `Session replay event dropped: serialized size ${Math.round(
           eventSizeBytes / 1024,

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -30,6 +30,7 @@ export const createEventsManager = async <Type extends EventType>({
   config,
   minInterval,
   maxInterval,
+  maxPersistedEventsSize,
   type,
   payloadBatcher,
   storeType,
@@ -40,11 +41,15 @@ export const createEventsManager = async <Type extends EventType>({
   type: Type;
   minInterval?: number;
   maxInterval?: number;
+  maxPersistedEventsSize?: number;
   payloadBatcher?: PayloadBatcher;
   storeType: StoreType;
   trackDestinationWorkerScript?: string;
   shouldSend?: () => boolean;
 }): Promise<EventsManagerWithBeacon<Type>> => {
+  // Configurable per-single-event drop cap (defaults to MAX_SINGLE_EVENT_SIZE); enforced both
+  // here as a pre-send backstop and at capture time in EventCompressor.
+  const maxSingleEventSize = config.maxSingleEventSizeBytes ?? MAX_SINGLE_EVENT_SIZE;
   const trackDestination = new SessionReplayTrackDestination({
     ...config,
     loggerProvider: config.loggerProvider,
@@ -57,6 +62,7 @@ export const createEventsManager = async <Type extends EventType>({
       loggerProvider: config.loggerProvider,
       maxInterval,
       minInterval,
+      maxPersistedEventsSize,
     });
   };
 
@@ -83,6 +89,7 @@ export const createEventsManager = async <Type extends EventType>({
       loggerProvider: config.loggerProvider,
       minInterval,
       maxInterval,
+      maxPersistedEventsSize,
       apiKey: config.apiKey,
       onPersistentFailure: () => {
         void switchToMemoryStore();
@@ -132,7 +139,7 @@ export const createEventsManager = async <Type extends EventType>({
     // storeCurrentSequence/sendStoredEvents which bypass the capture-time check).
     // Compare UTF-8 byte size, not JS char count, to match the server-side limit.
     const sizedEvents = rawEvents.map((e) => ({ event: e, bytes: new Blob([e]).size }));
-    const oversized = sizedEvents.filter((s) => s.bytes > MAX_SINGLE_EVENT_SIZE);
+    const oversized = sizedEvents.filter((s) => s.bytes > maxSingleEventSize);
     if (oversized.length > 0) {
       config.loggerProvider.warn(
         `Dropping ${oversized.length} oversized event(s) from session replay sequence before send. Sizes: ${oversized
@@ -143,9 +150,7 @@ export const createEventsManager = async <Type extends EventType>({
       );
     }
     const events =
-      oversized.length > 0
-        ? sizedEvents.filter((s) => s.bytes <= MAX_SINGLE_EVENT_SIZE).map((s) => s.event)
-        : rawEvents;
+      oversized.length > 0 ? sizedEvents.filter((s) => s.bytes <= maxSingleEventSize).map((s) => s.event) : rawEvents;
     if (events.length === 0) {
       store.cleanUpSessionEventsStore(sessionId, sequenceId).catch((e) => {
         config.loggerProvider.warn('Failed to clean up session replay events store:', e);

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -298,6 +298,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
         type: 'replay',
         minInterval: this.config.flushIntervalConfig?.minIntervalMs,
         maxInterval: this.config.flushIntervalConfig?.maxIntervalMs,
+        maxPersistedEventsSize: this.config.maxPersistedEventsSizeBytes,
         storeType,
         trackDestinationWorkerScript,
         shouldSend: () => !this.isBelowMinSessionDuration(),
@@ -317,6 +318,7 @@ export class SessionReplay implements AmplitudeSessionReplay {
           type: 'interaction',
           minInterval: this.config.interactionConfig.trackEveryNms ?? INTERACTION_MIN_INTERVAL,
           maxInterval: INTERACTION_MAX_INTERVAL,
+          maxPersistedEventsSize: this.config.maxPersistedEventsSizeBytes,
           payloadBatcher,
           storeType,
           trackDestinationWorkerScript,
@@ -334,12 +336,20 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.eventCompressor.terminate();
     }
 
+    // Eager full-snapshot send is tunable. When `eagerFullSnapshotSend` is true (default),
+    // every full snapshot triggers an immediate flush so replays are playable as early as
+    // possible (the SR-3115 contract). Setting it to false keeps the snapshot compressed and
+    // buffered immediately (ordering + beacon coverage on page exit preserved) but defers the
+    // network send to the normal interval/size cadence — useful for customers running many
+    // SDK instances per page where eager per-snapshot sends (focus/checkout driven) multiply
+    // into a request storm.
+    const onFullSnapshotProcessed = this.config.eagerFullSnapshotSend === false ? undefined : () => this.sendEvents();
     this.eventCompressor = new EventCompressor(
       this.eventsManager,
       this.config,
       this.getDeviceId(),
       compressionWorkerScript,
-      () => this.sendEvents(),
+      onFullSnapshotProcessed,
     );
 
     // Flush any events that arrived while eventCompressor was not yet ready
@@ -521,6 +531,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
 
   focusListener = () => {
     if (this.recordCancelCallback && this.recordFunction) {
+      // Recording is already active. The on-focus full snapshot is tunable: when
+      // `captureFullSnapshotOnFocus` is false we skip it entirely so high focus-churn pages
+      // don't generate a full snapshot (and, with eager send, a network request) per focus.
+      if (this.config?.captureFullSnapshotOnFocus === false) {
+        return;
+      }
       try {
         this.recordFunction.takeFullSnapshot(true);
       } catch (error) {

--- a/packages/session-replay-browser/test/base-events-store.test.ts
+++ b/packages/session-replay-browser/test/base-events-store.test.ts
@@ -74,6 +74,28 @@ describe('BaseEventsStore', () => {
     });
   });
 
+  describe('maxPersistedEventsSize threshold', () => {
+    test('splits when the buffered list reaches the configured byte cap', () => {
+      // cap = 1000. One 996-byte ASCII event + overhead(2) = 998 < 1000 → no split.
+      // Adding another 996-byte event would push well past 1000 → split.
+      const store = new InMemoryEventsStore({
+        loggerProvider: mockLoggerProvider,
+        maxPersistedEventsSize: 1_000,
+      });
+      const event = 'a'.repeat(996);
+      expect(store.shouldSplitEventsList([], event)).toBe(false);
+      expect(store.shouldSplitEventsList([event], event)).toBe(true);
+    });
+
+    test('does not split a small event under the default cap when omitted', () => {
+      // Default MAX_EVENT_LIST_SIZE (700 KB) — a tiny event is nowhere near it.
+      const store = new InMemoryEventsStore({
+        loggerProvider: mockLoggerProvider,
+      });
+      expect(store.shouldSplitEventsList([], 'small-event')).toBe(false);
+    });
+  });
+
   test('should split based on time', async () => {
     jest.useFakeTimers().setSystemTime(Date.now());
     const store = new InMemoryEventsStore({

--- a/packages/session-replay-browser/test/config/local-config.test.ts
+++ b/packages/session-replay-browser/test/config/local-config.test.ts
@@ -133,4 +133,178 @@ describe('SessionReplayLocalConfig', () => {
       expect(config.enableTransportCompression).toBe(true);
     });
   });
+
+  describe('eagerFullSnapshotSend', () => {
+    let logger: ILogger;
+
+    beforeEach(() => {
+      logger = new Logger();
+    });
+
+    test('is undefined when option is omitted (defaults to eager send downstream)', () => {
+      const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
+      expect(config.eagerFullSnapshotSend).toBeUndefined();
+    });
+
+    test('passes through false', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        eagerFullSnapshotSend: false,
+      });
+      expect(config.eagerFullSnapshotSend).toBe(false);
+    });
+
+    test('passes through true', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        eagerFullSnapshotSend: true,
+      });
+      expect(config.eagerFullSnapshotSend).toBe(true);
+    });
+  });
+
+  describe('captureFullSnapshotOnFocus', () => {
+    let logger: ILogger;
+
+    beforeEach(() => {
+      logger = new Logger();
+    });
+
+    test('is undefined when option is omitted (defaults to on-focus snapshot downstream)', () => {
+      const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
+      expect(config.captureFullSnapshotOnFocus).toBeUndefined();
+    });
+
+    test('passes through false', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        captureFullSnapshotOnFocus: false,
+      });
+      expect(config.captureFullSnapshotOnFocus).toBe(false);
+    });
+
+    test('passes through true', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        captureFullSnapshotOnFocus: true,
+      });
+      expect(config.captureFullSnapshotOnFocus).toBe(true);
+    });
+  });
+
+  describe('maxPersistedEventsSizeBytes', () => {
+    let warnSpy: jest.SpyInstance;
+    let logger: ILogger;
+
+    beforeEach(() => {
+      logger = new Logger();
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {
+        /* swallow */
+      });
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test('is undefined when option is omitted (defaults to MAX_EVENT_LIST_SIZE downstream)', () => {
+      const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
+      expect(config.maxPersistedEventsSizeBytes).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('passes through an in-range value', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxPersistedEventsSizeBytes: 1_000_000,
+      });
+      expect(config.maxPersistedEventsSizeBytes).toBe(1_000_000);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('clamps a value below the floor and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxPersistedEventsSizeBytes: 10,
+      });
+      expect(config.maxPersistedEventsSizeBytes).toBe(1_000);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('maxPersistedEventsSizeBytes'));
+    });
+
+    test('clamps a value above the ceiling and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxPersistedEventsSizeBytes: 50_000_000,
+      });
+      expect(config.maxPersistedEventsSizeBytes).toBe(8_000_000);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('exceeds ceiling'));
+    });
+
+    test('ignores a non-finite value and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxPersistedEventsSizeBytes: Number.NaN,
+      });
+      expect(config.maxPersistedEventsSizeBytes).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not a finite number'));
+    });
+  });
+
+  describe('maxSingleEventSizeBytes', () => {
+    let warnSpy: jest.SpyInstance;
+    let logger: ILogger;
+
+    beforeEach(() => {
+      logger = new Logger();
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {
+        /* swallow */
+      });
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test('is undefined when option is omitted (defaults to MAX_SINGLE_EVENT_SIZE downstream)', () => {
+      const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
+      expect(config.maxSingleEventSizeBytes).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('passes through an in-range value', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxSingleEventSizeBytes: 5_000_000,
+      });
+      expect(config.maxSingleEventSizeBytes).toBe(5_000_000);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('clamps a value below the floor and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxSingleEventSizeBytes: 100,
+      });
+      expect(config.maxSingleEventSizeBytes).toBe(1_000);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('is below floor'));
+    });
+
+    test('clamps a value above the ceiling and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxSingleEventSizeBytes: 50_000_000,
+      });
+      expect(config.maxSingleEventSizeBytes).toBe(10_000_000);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('maxSingleEventSizeBytes'));
+    });
+
+    test('ignores a non-finite value and warns', () => {
+      const config = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: logger,
+        maxSingleEventSizeBytes: Number.POSITIVE_INFINITY,
+      });
+      expect(config.maxSingleEventSizeBytes).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not a finite number'));
+    });
+  });
 });

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -108,6 +108,41 @@ describe('EventCompressor', () => {
     expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('exceeds maximum allowed event size'));
   });
 
+  test('enforces a lowered maxSingleEventSizeBytes at capture time', async () => {
+    const smallCapConfig = new SessionReplayLocalConfig('static_key', {
+      loggerProvider: mockLoggerProvider,
+      sampleRate: 1,
+      maxSingleEventSizeBytes: 1_000,
+    });
+    const smallCapManager = await createEventsManager<'replay'>({
+      config: smallCapConfig,
+      type: 'replay',
+      storeType: 'memory',
+    });
+    const smallCapCompressor = new EventCompressor(smallCapManager, smallCapConfig, deviceId);
+    smallCapCompressor.canUseIdleCallback = false;
+    const addEventMock = jest.spyOn(smallCapManager, 'addEvent');
+
+    // ~2 KB payload: under the 9 MB default but over the 1 KB override.
+    const event = { ...mockEvent, data: { payload: 'x'.repeat(2_000) } } as unknown as eventWithTime;
+    smallCapCompressor.enqueueEvent(event, sessionId);
+
+    expect(addEventMock).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('exceeds maximum allowed event size'));
+  });
+
+  test('keeps an event below the default cap when maxSingleEventSizeBytes is omitted', () => {
+    eventCompressor.canUseIdleCallback = false;
+    const addEventMock = jest.spyOn(eventsManager, 'addEvent');
+
+    // ~2 KB payload: well under the 9 MB default, so it should be stored, not dropped.
+    const event = { ...mockEvent, data: { payload: 'x'.repeat(2_000) } } as unknown as eventWithTime;
+    eventCompressor.enqueueEvent(event, sessionId);
+
+    expect(addEventMock).toHaveBeenCalled();
+  });
+
   test('should process events in the queue and add compressed events', () => {
     eventCompressor.taskQueue.push({ event: mockEvent, sessionId });
     eventCompressor.taskQueue.push({ event: mockEvent, sessionId });

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -287,6 +287,31 @@ describe('createEventsManager', () => {
         cleanUpError,
       );
     });
+
+    test('uses a lowered maxSingleEventSizeBytes as the pre-send drop threshold', async () => {
+      const smallCapConfig = new SessionReplayLocalConfig('static_key', {
+        loggerProvider: mockLoggerProvider,
+        sampleRate: 1,
+        maxSingleEventSizeBytes: 1_000,
+      });
+      // ~2 KB event: under the 9 MB default but over the 1 KB override.
+      const mediumEvent = 'y'.repeat(2_000);
+      (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValue([
+        { events: [mockEventString, mediumEvent], sequenceId: 1, sessionId: 123 },
+      ]);
+      const eventsManager = await createEventsManager<'replay'>({
+        config: smallCapConfig,
+        type: 'replay',
+        storeType: 'idb',
+      });
+      await eventsManager.sendStoredEvents({ deviceId: '1a2b3c' });
+      jest.runAllTimers();
+
+      const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+      const mockSendEventsList = trackDestinationInstance.sendEventsList;
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('oversized'));
+      expect(mockSendEventsList).toHaveBeenCalledWith(expect.objectContaining({ events: [mockEventString] }));
+    });
   });
 
   describe('addEvent', () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1068,6 +1068,66 @@ describe('SessionReplay', () => {
 
         expect(warnSpy).toHaveBeenCalledWith('Failed to take full snapshot on focus:', testError);
       });
+
+      test('takes the on-focus full snapshot by default (captureFullSnapshotOnFocus omitted)', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        const takeFullSnapshotMock = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = { takeFullSnapshot: takeFullSnapshotMock };
+
+        sessionReplay.focusListener();
+
+        expect(takeFullSnapshotMock).toHaveBeenCalledWith(true);
+      });
+
+      test('suppresses the on-focus full snapshot when captureFullSnapshotOnFocus is false', async () => {
+        await sessionReplay.init(apiKey, { ...mockOptions, captureFullSnapshotOnFocus: false }).promise;
+        const takeFullSnapshotMock = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = { takeFullSnapshot: takeFullSnapshotMock };
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+
+        sessionReplay.focusListener();
+
+        expect(takeFullSnapshotMock).not.toHaveBeenCalled();
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+      });
+
+      test('still takes the on-focus full snapshot when config is not yet set', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        const takeFullSnapshotMock = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = { takeFullSnapshot: takeFullSnapshotMock };
+        // Defensive nullish branch: config absent → default (take the snapshot).
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).config = undefined;
+
+        sessionReplay.focusListener();
+
+        expect(takeFullSnapshotMock).toHaveBeenCalledWith(true);
+      });
+    });
+
+    describe('eagerFullSnapshotSend', () => {
+      test('wires an onFullSnapshotProcessed callback that flushes by default', async () => {
+        await sessionReplay.init(apiKey, mockOptions).promise;
+        const sendEventsSpy = jest.spyOn(sessionReplay, 'sendEvents').mockImplementation(() => undefined);
+
+        expect(sessionReplay.eventCompressor?.onFullSnapshotProcessed).toBeDefined();
+        sessionReplay.eventCompressor?.onFullSnapshotProcessed?.();
+        expect(sendEventsSpy).toHaveBeenCalledTimes(1);
+      });
+
+      test('leaves onFullSnapshotProcessed undefined when eagerFullSnapshotSend is false', async () => {
+        await sessionReplay.init(apiKey, { ...mockOptions, eagerFullSnapshotSend: false }).promise;
+        expect(sessionReplay.eventCompressor?.onFullSnapshotProcessed).toBeUndefined();
+      });
     });
 
     test('it should not call initialize if the document does not have focus', () => {

--- a/test-server/session-replay-browser/sr-capture-test.html
+++ b/test-server/session-replay-browser/sr-capture-test.html
@@ -38,6 +38,18 @@
               ...(flushMaxIntervalMs !== undefined ? { maxIntervalMs: flushMaxIntervalMs } : {}),
             }
           : undefined;
+      // Perf-config knobs (PR #1806). Each is only passed to init() when its URL param is
+      // present, so omitting a param preserves the SDK default behavior.
+      const parseBool = (raw) => (raw === null ? undefined : raw === 'true');
+      const parseByteSize = (raw) => {
+        if (raw === null) return undefined;
+        const n = Number(raw);
+        return Number.isNaN(n) ? undefined : n;
+      };
+      const eagerFullSnapshotSend = parseBool(params.get('eagerFullSnapshotSend'));
+      const captureFullSnapshotOnFocus = parseBool(params.get('captureFullSnapshotOnFocus'));
+      const maxPersistedEventsSizeBytes = parseByteSize(params.get('maxPersistedEventsSizeBytes'));
+      const maxSingleEventSizeBytes = parseByteSize(params.get('maxSingleEventSizeBytes'));
 
       void (async () => {
         try {
@@ -51,6 +63,10 @@
             performanceConfig: { enabled: true, mergeMutations },
             ...(storeType ? { storeType } : {}),
             ...(flushIntervalConfig ? { flushIntervalConfig } : {}),
+            ...(eagerFullSnapshotSend !== undefined ? { eagerFullSnapshotSend } : {}),
+            ...(captureFullSnapshotOnFocus !== undefined ? { captureFullSnapshotOnFocus } : {}),
+            ...(maxPersistedEventsSizeBytes !== undefined ? { maxPersistedEventsSizeBytes } : {}),
+            ...(maxSingleEventSizeBytes !== undefined ? { maxSingleEventSizeBytes } : {}),
           }).promise;
         } catch (err) {
           document.getElementById('status').textContent = 'error: ' + err.message;


### PR DESCRIPTION
## Summary

GAs the Session Replay "canary-only" performance tuning knobs (from `sr-4646-rc2`) into the mainline `@amplitude/session-replay-browser` config so consuming apps no longer need to pass them as untyped/unknown options. All four are now first-class, documented (TSDoc), tested config options.

**Every default preserves today's behavior** — this is a no-op behavior change unless a consumer explicitly opts in.

### Options added

| Option | Type | Default (= current behavior) | Effect when changed |
| --- | --- | --- | --- |
| `eagerFullSnapshotSend` | `boolean` | `true` (eager send on every full snapshot) | `false` keeps the snapshot compressed/buffered but defers the network send to the normal interval/size cadence — avoids focus/checkout-driven request storms when many SDK instances run per page |
| `captureFullSnapshotOnFocus` | `boolean` | `true` (snapshot on window `focus`) | `false` skips the on-focus `takeFullSnapshot(true)` entirely on high focus-churn pages |
| `maxPersistedEventsSizeBytes` | `number` | `MAX_EVENT_LIST_SIZE` (700,000) | raw UTF-8 byte cap before the store splits a batch into its own request; clamped to `[1KB, 8MB]` and logged |
| `maxSingleEventSizeBytes` | `number` | `MAX_SINGLE_EVENT_SIZE` (9,000,000) | raw UTF-8 byte cap for a single rrweb event (dropped above this, at capture time and pre-send); clamped to `[1KB, 10MB]` and logged |

### Wiring
- Types + TSDoc in `config/types.ts`; parsed/sanitized in `local-config.ts` (`sanitizeByteSize` clamps + logs).
- `eagerFullSnapshotSend` gates the `onFullSnapshotProcessed` callback passed to `EventCompressor`.
- `captureFullSnapshotOnFocus` early-returns in `focusListener`.
- `maxPersistedEventsSizeBytes` flows through `createEventsManager` into the memory/IDB stores (`BaseEventsStore.shouldSplitEventsList`).
- `maxSingleEventSizeBytes` enforced in `EventCompressor` (capture time) and `events-manager` (pre-send backstop).

### Placement note
Placed as top-level `SessionReplayLocalConfig` options (matching the `sr-4646-rc2` reference impl and the existing `fullSnapshotIntervalMs` / `flushIntervalConfig` perf knobs), rather than nested under `SessionReplayPerformanceConfig`. This keeps the shape identical to what consumers already pass, so no canary alias is needed.

Note: `MAX_EVENT_LIST_SIZE` / `MAX_SINGLE_EVENT_SIZE` constants are intentionally **not** changed (canary bumped the batch cap to 2 MB) — defaults stay at mainline values.

Refs SR-4646.

## Test plan
- [x] `pnpm build` (session-replay + deps)
- [x] `pnpm docs:check`
- [x] `pnpm --filter @amplitude/session-replay-browser test` — 1034 tests pass, 100% statements/branches/functions/lines
- [x] `pnpm lint` (0 errors)
- New unit tests cover each knob on/off + defaults: focus snapshot suppressed when `captureFullSnapshotOnFocus:false`, eager send callback omitted when `eagerFullSnapshotSend:false`, byte-size clamping/passthrough, store split threshold, and per-event drop at configured thresholds.



_This PR's contribution to the bundle:_ the `eagerFullSnapshotSend` / `captureFullSnapshotOnFocus` / `maxPersistedEventsSizeBytes` / `maxSingleEventSizeBytes` knobs are exercised in the canary via the `session-replay-sdk-perf-config` flag payload (e.g. 6 MB persisted-size cap). Defaults preserve current behavior.

## Production canary validation

These changes shipped together as the **`sr-perf-reliability` canary bundle** (rc2 → rc3, PRs #1806/#1814/#1807/#1808/#1798), gated behind the `sr-perf-reliability-canary` Amplitude Experiment flag at **100%** in onenav prod — amp-on-amp traffic (Amplitude 2.0 + the HubSpot CRM Records page), `sampleRate: 1`. Live in production for multiple days; currently ~89% of canary traffic with no regressions, **zero 413s**, and no new error modes.

**Apples-to-apples on appid 187520** (Amplitude 2.0 — same app/users, `quota_exceeded = 0%` so this is a clean throttle comparison, differing only by which SR bundle a session loaded):

| window | build | success | throttle |
| --- | --- | --- | --- |
| Jun 11 (full day) | **rc3 (this bundle)** | **99.8%** | **0.02%** |
| Jun 11 (full day) | prod 1.31.0 | 96.7% | 2.95% |
| trailing 24h | **rc3 (this bundle)** | **99.8%** | **0.03%** |
| trailing 24h | prod 1.31.0 | 97.8% | 1.88% |

→ ~150x throttle reduction and ~+3pp success vs the GA build on identical app/users. rc3 is on par with the other canary builds (rc2, sr-4646) — all at the reliability floor.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect when replay data is sent and which events are dropped or split; mis-tuned values could delay replay availability or increase request volume, though defaults preserve current behavior.
> 
> **Overview**
> Promotes four Session Replay **performance tuning knobs** to first-class, documented `init()` options on `@amplitude/session-replay-browser` and forwards them through `@amplitude/plugin-session-replay-browser`. **Omitting any option keeps today’s behavior** (defaults are applied downstream when unset).
> 
> **`eagerFullSnapshotSend`** — when explicitly `false`, full snapshots are still compressed/buffered but **`onFullSnapshotProcessed` no longer triggers an immediate `sendEvents()`**; sends follow the normal flush cadence.
> 
> **`captureFullSnapshotOnFocus`** — when `false`, **`focusListener` skips `takeFullSnapshot`** on refocus.
> 
> **`maxPersistedEventsSizeBytes`** — configurable batch split threshold, passed into memory/IDB stores via `createEventsManager`.
> 
> **`maxSingleEventSizeBytes`** — overrides the hard-coded drop cap in **`EventCompressor`** (capture) and **`events-manager`** (pre-send). Byte-size options are **sanitized** in `local-config` (`sanitizeByteSize`: clamp + warn).
> 
> Adds unit tests, a new **`perf-knobs.spec.ts`** e2e suite, and URL params on the capture test page for exercising knobs in the browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce91c67f075796b7eea3b4579227373a2641b6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
