### PR TITLE
feat(session-replay-browser): coalesce persisted-sequence page-load backlog drain

### DIFF
--- a/packages/session-replay-browser/e2e/drain-coalesce.spec.ts
+++ b/packages/session-replay-browser/e2e/drain-coalesce.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  SR_API_SUCCESS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  readRouteBody,
+} from './helpers';
+
+/**
+ * E2E for the page-load backlog drain coalescing (SR-4660).
+ *
+ * Scenario: a prior page load left MULTIPLE same-identity sequences persisted in IndexedDB
+ * (sequencesToSend) because their POSTs never completed. On the next page load the SDK replays
+ * that backlog via `sendStoredEvents` → `markCoalesceNextFlush` → `mergeDrainBacklog`, which
+ * collapses the N same-(session, device, api, type, ...) batches into far fewer POSTs (one,
+ * here) — instead of the pre-fix flood of N separate requests.
+ *
+ * How the backlog is created without delivering it (load 1):
+ *   - Mock the track API to HANG (never fulfill). A 200 (even a throttled 200) would clean the
+ *     IDB record via onComplete; an abort/4xx/429 would exhaust retries and also clean it. Only
+ *     a pending request leaves the persisted sequence intact in IDB across the reload.
+ *   - Drive continuous DOM activity with three amp-unmask marker divs (marker-A/B/C). The
+ *     time-based sequence split logic (MIN_INTERVAL=500ms, growing) promotes completed sequences
+ *     into the sequencesToSend store; the hung POSTs never clean them up.
+ *   - Assert as a precondition that >1 marker-bearing sequence is persisted (N), failing loudly
+ *     if multi-sequence persistence couldn't be reproduced rather than weakening the assertion.
+ *
+ * The drain (load 2):
+ *   - Same fixed TEST_SESSION_ID so the IDB store key matches and the backlog is read back.
+ *   - Track API now records bodies and returns clean 200s.
+ *   - Assert the drain produces exactly ONE marker-bearing POST (< N), that the single merged
+ *     body contains marker-A, marker-B AND marker-C (coalesced, not dropped/reordered/split),
+ *     and that the SR-4660 coalesce log fired (proving the drain path, not the throttle path).
+ */
+
+// DB name derived from the apiKey in sr-capture-test.html ('d90c5cf09ca2546a1626272906b99a76').
+const IDB_NAME = 'd90c5cf09c_amp_session_replay_events';
+const LOG_LEVEL_DEBUG = 4;
+
+/**
+ * Track-API mock with two phases controlled by `mode.hang`:
+ *   hang=true  → never fulfill (request stays pending) so the sequence stays persisted in IDB.
+ *   hang=false → record the (gunzipped) body and return a clean 200.
+ * page.route persists across reloads; in-flight hung requests from load 1 are aborted by the
+ * navigation, and load-2 requests take the recording path.
+ */
+async function mockTrackApiHangThenRecord(page: Page): Promise<{ getBodies: () => string[]; mode: { hang: boolean } }> {
+  const bodies: string[] = [];
+  const mode = { hang: true };
+  await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+    if (mode.hang) {
+      // Keep the request pending forever — the persisted sequence is never delivered and
+      // therefore never cleaned from IDB, so it survives the reload.
+      await new Promise<void>(() => {
+        /* never resolves */
+      });
+      return;
+    }
+    bodies.push(readRouteBody(route));
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+  });
+  return { getBodies: () => bodies, mode };
+}
+
+/**
+ * Continuously generates DOM mutations + pointer events for `durationMs`, embedding `marker`
+ * in an amp-unmask div so the marker text survives SR's input-masking privacy filter and is
+ * visible in the captured event stream. Mirrors the marker technique from throttle-merge.spec.ts.
+ */
+async function continuousActivity(page: Page, marker: string, durationMs: number): Promise<void> {
+  await page.evaluate(
+    ({ tag, ms }) => {
+      const markerDiv = document.createElement('div');
+      markerDiv.className = 'amp-unmask';
+      markerDiv.textContent = tag;
+      markerDiv.id = `marker-div-${tag}`;
+      document.body.appendChild(markerDiv);
+
+      return new Promise<void>((resolve) => {
+        const start = Date.now();
+        let i = 0;
+        const tick = () => {
+          if (Date.now() - start >= ms) return resolve();
+          const input = document.getElementById('test-input') as HTMLInputElement | null;
+          if (input) {
+            input.value = `iter-${i++}`;
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+          document.getElementById('test-button')?.click();
+          setTimeout(tick, 50);
+        };
+        tick();
+      });
+    },
+    { tag: marker, ms: durationMs },
+  );
+}
+
+/** Reads the events arrays of every record currently in the sequencesToSend IDB store. */
+function getPersistedSequences(page: Page): Promise<string[][]> {
+  return page.evaluate(
+    (dbName: string): Promise<string[][]> =>
+      new Promise((resolve, reject) => {
+        const req = indexedDB.open(dbName);
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction('sequencesToSend', 'readonly');
+          const out: string[][] = [];
+          const cursorReq = tx.objectStore('sequencesToSend').openCursor();
+          cursorReq.onsuccess = () => {
+            const cursor = cursorReq.result;
+            if (cursor) {
+              const value = cursor.value as { events?: string[] };
+              out.push(value.events ?? []);
+              cursor.continue();
+            }
+          };
+          tx.oncomplete = () => resolve(out);
+          tx.onerror = () => reject(tx.error);
+        };
+      }),
+    IDB_NAME,
+  );
+}
+
+const MARKERS = ['marker-A', 'marker-B', 'marker-C'];
+
+test.describe('page-load drain coalescing (SR-4660)', () => {
+  test('persisted backlog of same-identity sequences drains as one coalesced POST on reload', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+    const { getBodies, mode } = await mockTrackApiHangThenRecord(page);
+
+    // Collect console logs so we can assert the SR-4660 drain coalesce log fired.
+    const consoleLogs: string[] = [];
+    page.on('console', (msg) => consoleLogs.push(msg.text()));
+
+    // ── Load 1: build the persisted backlog (track API hangs, nothing is delivered) ──
+    const url = buildUrl('/session-replay-browser/sr-capture-test.html', {
+      sessionId: TEST_SESSION_ID,
+      storeType: 'idb',
+      logLevel: LOG_LEVEL_DEBUG,
+    });
+    await page.goto(url);
+    await waitForReady(page);
+    // Let rrweb capture its full snapshot and the metadata/debug events settle.
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 2);
+
+    // Drive activity across several sequence-split intervals with three distinct markers, then a
+    // trailing burst so the marker-C sequence is also split out of the (undrained) current slot.
+    await continuousActivity(page, 'marker-A', 800);
+    await continuousActivity(page, 'marker-B', 800);
+    await continuousActivity(page, 'marker-C', 800);
+    await continuousActivity(page, 'tail', 2500);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    // Precondition: multiple same-identity sequences are persisted, and the markers we will look
+    // for post-reload are actually among them. If this can't be reproduced, fail here loudly.
+    const persisted = await getPersistedSequences(page);
+    const persistedCount = persisted.length;
+    const persistedText = persisted.map((events) => events.join('')).join('');
+    expect(persistedCount, `expected >1 persisted sequence to prove coalescing; got ${persistedCount}`).toBeGreaterThan(
+      1,
+    );
+    for (const marker of MARKERS) {
+      expect(persistedText, `marker ${marker} should be persisted in sequencesToSend pre-reload`).toContain(marker);
+    }
+
+    // ── Load 2: reload with the same sessionId; track API now records and returns 200 ──
+    mode.hang = false;
+    await page.reload();
+    await waitForReady(page);
+    // The drain flush is scheduled at timeout 0; give it room to fire (no activity generated,
+    // so no live sequence splits should compete for POSTs during this window).
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS * 3);
+
+    // Only the drain POST(s) carry the markers — the reloaded DOM no longer contains the marker
+    // divs, so fresh live-capture POSTs are marker-free.
+    const bodies = getBodies();
+    const markerBodies = bodies.filter((b) => MARKERS.some((m) => b.includes(m)));
+
+    // Coalesced: N persisted sequences → exactly 1 merged POST (pre-fix this would be N POSTs).
+    expect(
+      markerBodies.length,
+      `expected the ${persistedCount} persisted sequences to coalesce into 1 POST, got ${markerBodies.length}`,
+    ).toBe(1);
+    expect(markerBodies.length).toBeLessThan(persistedCount);
+
+    // The single merged body must carry events from all three persisted sequences — proving the
+    // backlog was coalesced, not dropped, reordered, or split per-marker.
+    for (const marker of MARKERS) {
+      expect(markerBodies[0]).toContain(marker);
+    }
+
+    // The drain-specific coalesce log fired (distinguishes the SR-4660 drain path from the
+    // post-throttle merge path).
+    expect(
+      consoleLogs.some((l) => /coalesced \d+ persisted page-load backlog batches into 1 request/.test(l)),
+      'expected the SR-4660 page-load backlog coalesce log to fire',
+    ).toBe(true);
+  });
+});

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -222,7 +222,7 @@ export const createEventsManager = async <Type extends EventType>({
       return;
     }
     config.loggerProvider.log(`Draining ${sequencesToSend.length} stored sequence(s) from previous session.`);
-    // SR-4660: these persisted sequences are about to be enqueued back-to-back. Without
+    // These persisted sequences are about to be enqueued back-to-back. Without
     // coalescing they flush as N separate POSTs — a request flood on page load. Mark the
     // imminent flush to merge same-identity batches (the enqueues below are synchronous, so
     // the whole backlog lands in the queue before the deferred flush consumes the flag). Skip

--- a/packages/session-replay-browser/src/events/events-manager.ts
+++ b/packages/session-replay-browser/src/events/events-manager.ts
@@ -222,6 +222,14 @@ export const createEventsManager = async <Type extends EventType>({
       return;
     }
     config.loggerProvider.log(`Draining ${sequencesToSend.length} stored sequence(s) from previous session.`);
+    // SR-4660: these persisted sequences are about to be enqueued back-to-back. Without
+    // coalescing they flush as N separate POSTs — a request flood on page load. Mark the
+    // imminent flush to merge same-identity batches (the enqueues below are synchronous, so
+    // the whole backlog lands in the queue before the deferred flush consumes the flag). Skip
+    // the single-sequence case where there's nothing to merge.
+    if (sequencesToSend.length > 1) {
+      trackDestination.markCoalesceNextFlush();
+    }
     sequencesToSend.forEach((sequence) => {
       sendEventsList({
         sequenceId: sequence.sequenceId,

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -101,7 +101,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   // count, so collapsing N queued batches into one POST directly reduces throttle pressure.
   private mergeOnNextFlush = false;
   // Set by markCoalesceNextFlush() before the page-load backlog is enqueued; consumed by
-  // flush() to coalesce the drained persisted sequences (SR-4660). Distinct from
+  // flush() to coalesce the drained persisted sequences. Distinct from
   // mergeOnNextFlush so the drain isn't conflated with a throttle pause for logging.
   private coalesceNextFlush = false;
   // Gates the merge log to once per throttle pause window — mirroring the throttle log's
@@ -226,7 +226,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
    * sequences replayed back-to-back on init via sendStoredEvents). Because those enqueues are
    * synchronous and the flush is deferred to the next tick via schedule(0), the whole backlog
    * lands in the queue before the flag is consumed — collapsing N small POSTs into far fewer
-   * and avoiding the request flood observed on page load (SR-4660). Steady-state live capture
+   * and avoiding the request flood observed on page load. Steady-state live capture
    * never sets this flag, so its sending behavior is unchanged.
    *
    * Schedules a flush so the flag is always consumed by the next flush, even when every
@@ -396,7 +396,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   }
 
   /**
-   * Page-load backlog drain path (SR-4660): on init the SDK replays every persisted sequence
+   * Page-load backlog drain path: on init the SDK replays every persisted sequence
    * from a prior session via sendStoredEvents. Enqueued back-to-back they would flush as N
    * separate POSTs — a request flood on page load that feeds volume spikes and throttling.
    * Reuses the exact same identity-grouped merge as the post-throttle path so the backlog

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -100,6 +100,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   // flush() to merge same-session contexts before sending. Throttling is enforced by request
   // count, so collapsing N queued batches into one POST directly reduces throttle pressure.
   private mergeOnNextFlush = false;
+  // Set by markCoalesceNextFlush() before the page-load backlog is enqueued; consumed by
+  // flush() to coalesce the drained persisted sequences (SR-4660). Distinct from
+  // mergeOnNextFlush so the drain isn't conflated with a throttle pause for logging.
+  private coalesceNextFlush = false;
   // Gates the merge log to once per throttle pause window — mirroring the throttle log's
   // transition-only gating — so a sustained throttle scenario doesn't spam logs every cycle.
   private mergeLogFiredThisPause = false;
@@ -214,6 +218,19 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       attempts: 0,
       timeout: 0,
     });
+  }
+
+  /**
+   * Marks the next scheduled flush to coalesce its queued contexts by destination identity.
+   * Callers use this immediately before enqueuing the page-load backlog drain (many persisted
+   * sequences replayed back-to-back on init via sendStoredEvents). Because those enqueues are
+   * synchronous and the flush is deferred to the next tick via schedule(0), the whole backlog
+   * lands in the queue before the flag is consumed — collapsing N small POSTs into far fewer
+   * and avoiding the request flood observed on page load (SR-4660). Steady-state live capture
+   * never sets this flag, so its sending behavior is unchanged.
+   */
+  markCoalesceNextFlush() {
+    this.coalesceNextFlush = true;
   }
 
   /**
@@ -342,7 +359,13 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
 
     if (this.mergeOnNextFlush) {
       this.mergeOnNextFlush = false;
+      // A throttle merge already coalesces by identity; clear the drain flag too so the
+      // same backlog isn't passed through a redundant second merge on a later flush.
+      this.coalesceNextFlush = false;
       list = this.mergeQueueAfterThrottle(list);
+    } else if (this.coalesceNextFlush) {
+      this.coalesceNextFlush = false;
+      list = this.mergeDrainBacklog(list);
     }
 
     for (const context of list) {
@@ -351,19 +374,53 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   }
 
   /**
-   * Coalesces queued contexts that share the same destination identity so the post-throttle
-   * release sends fewer requests. Identity covers everything that affects the request URL,
-   * routing, or per-request semantics — splitting on any difference keeps each merged POST
-   * indistinguishable from the source contexts it replaced.
+   * Post-throttle release path: coalesce the queued contexts, then log once per pause window.
+   * Delegates the actual merging to the shared coalesceByIdentity helper so the drain path
+   * (mergeDrainBacklog) and this path stay byte-for-byte identical in how they merge.
+   */
+  private mergeQueueAfterThrottle(list: SessionReplayDestinationContext[]): SessionReplayDestinationContext[] {
+    const merged = this.coalesceByIdentity(list);
+    if (merged.length < list.length && !this.mergeLogFiredThisPause) {
+      this.mergeLogFiredThisPause = true;
+      this.loggerProvider.log(
+        `Session replay throttle pause ended; merged ${list.length} queued batches into ${merged.length} request(s)`,
+      );
+    }
+    return merged;
+  }
+
+  /**
+   * Page-load backlog drain path (SR-4660): on init the SDK replays every persisted sequence
+   * from a prior session via sendStoredEvents. Enqueued back-to-back they would flush as N
+   * separate POSTs — a request flood on page load that feeds volume spikes and throttling.
+   * Reuses the exact same identity-grouped merge as the post-throttle path so the backlog
+   * collapses into far fewer requests, with onComplete fanned out so each source IDB record
+   * is still cleaned up exactly once on success.
+   */
+  private mergeDrainBacklog(list: SessionReplayDestinationContext[]): SessionReplayDestinationContext[] {
+    const merged = this.coalesceByIdentity(list);
+    if (merged.length < list.length) {
+      this.loggerProvider.log(
+        `Session replay coalesced ${list.length} persisted page-load backlog batches into ${merged.length} request(s)`,
+      );
+    }
+    return merged;
+  }
+
+  /**
+   * Coalesces queued contexts that share the same destination identity into fewer requests.
+   * Identity covers everything that affects the request URL, routing, or per-request semantics
+   * — splitting on any difference keeps each merged POST indistinguishable from the source
+   * contexts it replaced.
    *
-   * Greedy concat with a soft char-length cap (`MERGE_AFTER_THROTTLE_SOFT_CAP`) keeps merged
+   * Greedy concat with a soft byte-length cap (`MERGE_AFTER_THROTTLE_SOFT_CAP`) keeps merged
    * payloads well under the 413 ceiling; on the rare oversized merge, the existing
    * split-and-retry path still bisects safely.
    *
    * The merged context's `onComplete` fans out to every source context's callback so each
    * underlying IDB sequence record is cleaned up exactly once on success.
    */
-  private mergeQueueAfterThrottle(list: SessionReplayDestinationContext[]): SessionReplayDestinationContext[] {
+  private coalesceByIdentity(list: SessionReplayDestinationContext[]): SessionReplayDestinationContext[] {
     if (list.length <= 1) return list;
 
     const groups = new Map<string, SessionReplayDestinationContext[]>();
@@ -432,12 +489,6 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       flushCurrent();
     }
 
-    if (merged.length < list.length && !this.mergeLogFiredThisPause) {
-      this.mergeLogFiredThisPause = true;
-      this.loggerProvider.log(
-        `Session replay throttle pause ended; merged ${list.length} queued batches into ${merged.length} request(s)`,
-      );
-    }
     return merged;
   }
 

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -228,9 +228,15 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
    * lands in the queue before the flag is consumed — collapsing N small POSTs into far fewer
    * and avoiding the request flood observed on page load (SR-4660). Steady-state live capture
    * never sets this flag, so its sending behavior is unchanged.
+   *
+   * Schedules a flush so the flag is always consumed by the next flush, even when every
+   * backlog sequence is dropped before reaching the queue (e.g. all events oversized) and no
+   * enqueue schedules one itself. Otherwise the flag would stick and a later unrelated live
+   * flush could coalesce live batches as if they were a page-load drain.
    */
   markCoalesceNextFlush() {
     this.coalesceNextFlush = true;
+    this.schedule(0);
   }
 
   /**

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -144,6 +144,40 @@ describe('createEventsManager', () => {
       expect(mockLoggerProvider.log).toHaveBeenCalledWith('Draining 2 stored sequence(s) from previous session.');
     });
 
+    test('coalesces the page-load backlog drain when more than one sequence is stored', async () => {
+      (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValue([
+        { events: [mockEventString], sequenceId: 1, sessionId: 123 },
+        { events: [mockEventString], sequenceId: 2, sessionId: 123 },
+        { events: [mockEventString], sequenceId: 3, sessionId: 123 },
+      ]);
+      const eventsManager = await createEventsManager<'replay'>({
+        config,
+        type: 'replay',
+        storeType: 'idb',
+      });
+      await eventsManager.sendStoredEvents({ deviceId: '1a2b3c' });
+      const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+      // The drain marks the imminent flush to coalesce, then enqueues every sequence so the
+      // backlog flushes as fewer POSTs (SR-4660) instead of one request per stored sequence.
+      expect(trackDestinationInstance.markCoalesceNextFlush).toHaveBeenCalledTimes(1);
+      expect(trackDestinationInstance.sendEventsList).toHaveBeenCalledTimes(3);
+    });
+
+    test('does not coalesce when only a single sequence is stored (nothing to merge)', async () => {
+      (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValue([
+        { events: [mockEventString], sequenceId: 1, sessionId: 123 },
+      ]);
+      const eventsManager = await createEventsManager<'replay'>({
+        config,
+        type: 'replay',
+        storeType: 'idb',
+      });
+      await eventsManager.sendStoredEvents({ deviceId: '1a2b3c' });
+      const trackDestinationInstance = (SessionReplayTrackDestination as jest.Mock).mock.instances[0];
+      expect(trackDestinationInstance.markCoalesceNextFlush).not.toHaveBeenCalled();
+      expect(trackDestinationInstance.sendEventsList).toHaveBeenCalledTimes(1);
+    });
+
     test('should not log drain message when sequences are empty', async () => {
       (mockIDBStore.getSequencesToSend as jest.Mock).mockResolvedValue([]);
       const eventsManager = await createEventsManager<'replay'>({

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1654,6 +1654,140 @@ describe('SessionReplayTrackDestination', () => {
       );
       expect(mergeLogsAfter).toHaveLength(2);
     });
+
+    describe('coalesce page-load backlog drain (SR-4660)', () => {
+      test('markCoalesceNextFlush sets the drain flag, consumed by the next flush', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        expect((trackDestination as any).coalesceNextFlush).toBe(false);
+        trackDestination.markCoalesceNextFlush();
+        expect((trackDestination as any).coalesceNextFlush).toBe(true);
+
+        trackDestination.queue = [baseCtx({ events: ['a'] }), baseCtx({ events: ['b'] })];
+        await trackDestination.flush(true);
+
+        // Flag is consumed so a later unrelated flush isn't accidentally coalesced.
+        expect((trackDestination as any).coalesceNextFlush).toBe(false);
+      });
+
+      test('drain of multiple same-identity batches collapses into one POST and fans out onComplete', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        const onCompleteA = jest.fn().mockResolvedValue(undefined);
+        const onCompleteB = jest.fn().mockResolvedValue(undefined);
+        const onCompleteC = jest.fn().mockResolvedValue(undefined);
+        trackDestination.queue = [
+          baseCtx({ events: ['a1', 'a2'], onComplete: onCompleteA }),
+          baseCtx({ events: ['b1'], onComplete: onCompleteB }),
+          baseCtx({ events: ['c1', 'c2'], onComplete: onCompleteC }),
+        ];
+        trackDestination.markCoalesceNextFlush();
+
+        await trackDestination.flush(true);
+
+        expect(sendSpy).toHaveBeenCalledTimes(1);
+        const merged = sendSpy.mock.calls[0][0];
+        expect(merged.events).toEqual(['a1', 'a2', 'b1', 'c1', 'c2']);
+
+        // Each source IDB record is cleaned up exactly once.
+        await merged.onComplete();
+        expect(onCompleteA).toHaveBeenCalledTimes(1);
+        expect(onCompleteB).toHaveBeenCalledTimes(1);
+        expect(onCompleteC).toHaveBeenCalledTimes(1);
+      });
+
+      test('drain logs the coalesced backlog count when a merge actually happened', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        trackDestination.queue = [baseCtx({ events: ['a'] }), baseCtx({ events: ['b'] }), baseCtx({ events: ['c'] })];
+        trackDestination.markCoalesceNextFlush();
+
+        await trackDestination.flush(true);
+
+        const drainLogs = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
+          (c) => typeof c[0] === 'string' && c[0].includes('persisted page-load backlog batches into'),
+        );
+        expect(drainLogs).toHaveLength(1);
+        expect(drainLogs[0][0]).toContain('coalesced 3 persisted page-load backlog batches into 1 request(s)');
+      });
+
+      test('drain does NOT merge different-identity batches', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        // Different sessions must not be coalesced — each keeps its own POST.
+        trackDestination.queue = [baseCtx({ sessionId: 1, events: ['a'] }), baseCtx({ sessionId: 2, events: ['b'] })];
+        trackDestination.markCoalesceNextFlush();
+
+        await trackDestination.flush(true);
+
+        expect(sendSpy).toHaveBeenCalledTimes(2);
+        // A no-op merge (no group shrank) must not emit the drain log.
+        const drainLogs = (mockLoggerProvider.log as jest.Mock).mock.calls.filter(
+          (c) => typeof c[0] === 'string' && c[0].includes('persisted page-load backlog batches into'),
+        );
+        expect(drainLogs).toHaveLength(0);
+      });
+
+      test('drain still splits an oversized merge across multiple POSTs', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        // Each event is just over half the soft cap, so any two together exceed it — the
+        // greedy merge must flush one-per-context, mirroring the throttle path's behavior.
+        const big = 'x'.repeat(800_000);
+        trackDestination.queue = [baseCtx({ events: [big] }), baseCtx({ events: [big] }), baseCtx({ events: [big] })];
+        trackDestination.markCoalesceNextFlush();
+
+        await trackDestination.flush(true);
+
+        expect(sendSpy).toHaveBeenCalledTimes(3);
+      });
+
+      test('a throttle merge on the same flush consumes the drain flag too (no double merge)', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        // Both flags set: throttle takes precedence and its merge already coalesces, so the
+        // drain flag must be cleared to avoid a redundant second merge on a later flush.
+        trackDestination.queue = [baseCtx({ events: ['a'] }), baseCtx({ events: ['b'] })];
+        (trackDestination as any).mergeOnNextFlush = true;
+        (trackDestination as any).coalesceNextFlush = true;
+
+        await trackDestination.flush(true);
+
+        expect((trackDestination as any).mergeOnNextFlush).toBe(false);
+        expect((trackDestination as any).coalesceNextFlush).toBe(false);
+      });
+
+      test('end-to-end: drained backlog enqueued via sendEventsList flushes as one coalesced POST', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        (global.fetch as jest.Mock).mockResolvedValue({
+          status: 200,
+          headers: { get: jest.fn().mockReturnValue(null) },
+        });
+
+        // Mirror events-manager.sendStoredEvents: mark, then enqueue each persisted sequence.
+        trackDestination.markCoalesceNextFlush();
+        const onCompleteA = jest.fn().mockResolvedValue(undefined);
+        const onCompleteB = jest.fn().mockResolvedValue(undefined);
+        trackDestination.sendEventsList(baseCtx({ events: ['a'], onComplete: onCompleteA }) as any);
+        trackDestination.sendEventsList(baseCtx({ events: ['b'], onComplete: onCompleteB }) as any);
+
+        await runScheduleTimers();
+
+        // One coalesced POST instead of one-per-sequence.
+        const fetchCalls = (global.fetch as jest.Mock).mock.calls;
+        expect(fetchCalls).toHaveLength(1);
+        const body = JSON.parse(fetchCalls[0][1].body as string);
+        expect(body.events).toEqual(['a', 'b']);
+        expect(onCompleteA).toHaveBeenCalled();
+        expect(onCompleteB).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('worker support', () => {

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1753,9 +1753,9 @@ describe('SessionReplayTrackDestination', () => {
         const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
         const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
 
-        // Each event is just over half the soft cap, so any two together exceed it — the
-        // greedy merge must flush one-per-context, mirroring the throttle path's behavior.
-        const big = 'x'.repeat(800_000);
+        // Each context is just under the cap; together they exceed it. Expect a split into 3.
+        // Derived from the constant so it tracks MAX_EVENT_LIST_SIZE changes: > soft cap / 2.
+        const big = 'x'.repeat(Math.floor(MERGE_AFTER_THROTTLE_SOFT_CAP / 2) + 100_000);
         trackDestination.queue = [baseCtx({ events: [big] }), baseCtx({ events: [big] }), baseCtx({ events: [big] })];
         trackDestination.markCoalesceNextFlush();
 

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1671,6 +1671,23 @@ describe('SessionReplayTrackDestination', () => {
         expect((trackDestination as any).coalesceNextFlush).toBe(false);
       });
 
+      test('markCoalesceNextFlush self-schedules a flush so the flag never sticks when nothing is enqueued', async () => {
+        const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+        const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
+
+        // Mimic the page-load drain where every persisted sequence is dropped before reaching
+        // the queue (e.g. all events oversized), so no addToQueue/schedule runs.
+        trackDestination.markCoalesceNextFlush();
+        expect((trackDestination as any).coalesceNextFlush).toBe(true);
+
+        await jest.runAllTimersAsync();
+
+        // The self-scheduled flush consumes the flag with an empty queue — no POST, and a later
+        // unrelated live flush can't be mis-coalesced as a page-load drain.
+        expect(sendSpy).not.toHaveBeenCalled();
+        expect((trackDestination as any).coalesceNextFlush).toBe(false);
+      });
+
       test('drain of multiple same-identity batches collapses into one POST and fans out onComplete', async () => {
         const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
         const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

Linear: **SR-4660**

On page load the Session Replay SDK drains every persisted event sequence from a prior session via `sendStoredEvents` and enqueues them back-to-back. With no coalescing and no spacing this flushed as **N separate POSTs** in a single flush — a request flood on page load (the "page-load backlog drain") that feeds request-volume spikes and server-side throttling.

This PR coalesces that drain by **reusing the proven post-throttle merge** instead of inventing a second mechanism:

- Extracted the existing identity-grouped merge body into a shared `coalesceByIdentity(list)` helper.
- The throttle path (`mergeQueueAfterThrottle`) now delegates to it — **byte-for-byte identical merge behavior**, plus its existing once-per-pause log.
- Added a drain path (`mergeDrainBacklog`) that uses the same helper, gated by a new `markCoalesceNextFlush()` flag.
- `events-manager.sendStoredEvents` calls `markCoalesceNextFlush()` before enqueuing the backlog (only when >1 sequence). Because those enqueues are synchronous and the flush is deferred to the next tick via `schedule(0)`, the whole backlog lands in the queue before the flag is consumed, so many small same-identity persisted batches collapse into far fewer POSTs.

### onComplete fan-out safety
The merged context's `onComplete` fans out to **every** source context's callback (via `Promise.allSettled`), so each underlying IDB sequence record is still cleaned up **exactly once** on success — preserving the existing recovery semantics. The 413 split-and-retry path already handles a merged context's fanned-out cleanup.

### Behavior preservation
- Steady-state live capture is untouched — it never sets the flag, so its sending behavior is unchanged.
- Different destination identities (session/device/api/type/zone/sampleRate/version) are **never** merged.
- Oversized merges still split safely via the soft byte cap + existing 413 bisect path.
- If a throttle merge and a drain land on the same flush, the throttle path runs and clears the drain flag too (no redundant double-merge).

### Spacing — deferred
Spacing the drained requests over the flush cadence is **deferred as a follow-up**. The coalescing alone removes the per-sequence fan-out (the dominant source of the flood); spacing adds timer/retry-interaction complexity for marginal additional benefit and is best shipped/measured separately.

## Test plan
Unit tests added/extended in `packages/session-replay-browser/test/` (package gate is ~100% coverage; all new branches covered):

- [x] Page-load drain of multiple same-identity persisted batches → **one** coalesced POST.
- [x] Each source `onComplete` still fires **exactly once**.
- [x] Different-identity batches are **not** merged (separate POSTs, no drain log).
- [x] Oversized merge still splits into multiple POSTs.
- [x] `markCoalesceNextFlush` flag is set and consumed by the next flush; throttle path also clears it.
- [x] `events-manager` marks coalescing only when >1 sequence; single sequence is left alone.
- [x] End-to-end: enqueue via `sendEventsList` → single coalesced fetch with merged events.
- [x] `pnpm --filter @amplitude/session-replay-browser test` → 1017 passing, 100% statements/branches/functions/lines.
- [x] `pnpm lint` (package) clean, `pnpm docs:check` passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flush/merge behavior on init for multi-sequence IDB drains; logic is gated and reuses existing merge paths, but incorrect coalescing could affect delivery or IDB cleanup via onComplete fan-out.
> 
> **Overview**
> Fixes **SR-4660** by coalescing multiple persisted IndexedDB sequences on page load into fewer track API POSTs instead of one request per stored sequence.
> 
> **`sendStoredEvents`** now calls **`markCoalesceNextFlush()`** when more than one sequence is drained, before enqueuing each batch synchronously.
> 
> **`SessionReplayTrackDestination`** adds a drain-specific **`coalesceNextFlush`** flag (separate from throttle **`mergeOnNextFlush`**), **`markCoalesceNextFlush()`** (sets the flag and **`schedule(0)`** so it cannot stick), and **`mergeDrainBacklog`** on flush. Post-throttle merging is refactored to share **`coalesceByIdentity`** with the drain path so merge semantics and **`onComplete`** fan-out stay the same; throttle wins if both flags are set on one flush.
> 
> Coverage includes unit tests for events-manager and track-destination, plus a Playwright e2e that builds a hung-POST backlog, reloads, and asserts a single coalesced POST with all markers and the drain log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60422bd0d90b751b4bdf4ad53d1205564d9b967a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->