### PR TITLE
fix(session-replay-browser): add request timeout/AbortController to send path

### DIFF
--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -113,6 +113,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         captureFullSnapshotOnFocus: this.options.captureFullSnapshotOnFocus,
         maxPersistedEventsSizeBytes: this.options.maxPersistedEventsSizeBytes,
         maxSingleEventSizeBytes: this.options.maxSingleEventSizeBytes,
+        sendTimeoutMs: this.options.sendTimeoutMs,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -212,4 +212,8 @@ export interface SessionReplayOptions {
    * @see {@link StandaloneSessionReplayOptions.maxSingleEventSizeBytes}
    */
   maxSingleEventSizeBytes?: number;
+  /**
+   * @see {@link StandaloneSessionReplayOptions.sendTimeoutMs}
+   */
+  sendTimeoutMs?: number;
 }

--- a/packages/session-replay-browser/e2e/send-timeout.spec.ts
+++ b/packages/session-replay-browser/e2e/send-timeout.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import {
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+} from './helpers';
+
+/**
+ * Mirrors SEND_TIMEOUT_MS from src/constants.ts (10s). The e2e suite drives the *built*
+ * SDK as a black box, so we keep a local copy rather than importing an internal constant.
+ */
+const SEND_TIMEOUT_MS = 10_000;
+
+type HungRequestMock = {
+  getAttempts: () => number;
+  getSuccesses: () => number;
+  /**
+   * True once a clean 200 has landed at least ~SEND_TIMEOUT_MS after the first (hung)
+   * request. A delivery that late could only have happened because the stalled request
+   * was aborted on timeout and its batch recovered (retried, or a later queued batch
+   * drained) — i.e. the serial flush queue did NOT permanently block on the hung send.
+   */
+  hasRecoveredDelivery: () => boolean;
+};
+
+/**
+ * Routes the track API so the FIRST POST hangs forever (the route is never resolved, so
+ * the SDK's per-request AbortController is the only thing that can free it after
+ * SEND_TIMEOUT_MS), while every subsequent POST returns a clean 200. This reproduces the
+ * "one request stuck pending forever" scenario PR #1808 fixes: without the timeout/abort
+ * the hung request would head-of-line-block the serial flush queue indefinitely.
+ */
+async function mockFirstSendHangs(page: Page): Promise<HungRequestMock> {
+  let attempts = 0;
+  let successes = 0;
+  let firstRequestAt: number | null = null;
+  const successAts: number[] = [];
+
+  await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+    // A CORS preflight (if the browser issues one) isn't part of the send budget — never
+    // hang it, and don't count it as a send attempt.
+    if (route.request().method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, body: '' });
+      return;
+    }
+
+    attempts += 1;
+    if (firstRequestAt === null) firstRequestAt = Date.now();
+
+    if (attempts === 1) {
+      // Hang the very first POST: return without resolving the route so the request stays
+      // pending. The SDK must abort it after SEND_TIMEOUT_MS; we deliberately never fulfill.
+      return;
+    }
+
+    successes += 1;
+    successAts.push(Date.now());
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 200 }) });
+  });
+
+  return {
+    getAttempts: () => attempts,
+    getSuccesses: () => successes,
+    hasRecoveredDelivery: () =>
+      firstRequestAt !== null && successAts.some((t) => t - (firstRequestAt as number) >= SEND_TIMEOUT_MS - 1500),
+  };
+}
+
+const SEND_PATHS = [
+  { name: 'main-thread fetch', useWebWorker: false },
+  { name: 'web worker', useWebWorker: true },
+] as const;
+
+test.describe('send timeout — a hung request does not block the flush queue (#1808)', () => {
+  for (const { name, useWebWorker } of SEND_PATHS) {
+    test(`${name}: request stuck past SEND_TIMEOUT_MS aborts and delivery recovers`, async ({ page }) => {
+      // SEND_TIMEOUT_MS is 10s and the abort is followed by a retry/backoff, so the run
+      // exceeds the 30s default per-test timeout. Give it generous headroom.
+      test.setTimeout(60_000);
+
+      await mockRemoteConfig(page, remoteConfigRecording);
+      const mock = await mockFirstSendHangs(page);
+
+      await page.goto(
+        buildUrl('/session-replay-browser/sr-capture-test.html', {
+          sessionId: TEST_SESSION_ID,
+          useWebWorker,
+        }),
+      );
+      await waitForReady(page);
+      // Let rrweb capture its initial full snapshot so there's a real batch to send.
+      await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+      // blur → sendEvents → sendCurrentSequenceEvents → trackDestination.addToQueue →
+      // schedule(0) → flush(true): dispatches the snapshot batch through the retry-enabled
+      // send path. The mock hangs this first POST.
+      await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+
+      // The first send must actually go out (and then hang) before we can prove recovery.
+      await expect.poll(() => mock.getAttempts(), { timeout: 15_000 }).toBeGreaterThan(0);
+
+      // After SEND_TIMEOUT_MS the hung request is aborted. On the main-thread path the abort
+      // surfaces as an AbortError routed through handleOtherResponse (retry budget); on the
+      // worker path the worker's own AbortController retries and the main thread stops
+      // awaiting so the loop proceeds. Either way a clean 200 must land ~10s after the hung
+      // request — proving the queue recovered rather than stalling forever.
+      await expect.poll(() => mock.hasRecoveredDelivery(), { timeout: 45_000, intervals: [500] }).toBe(true);
+
+      // Sanity: at least the hung attempt + one more, and at least one successful delivery.
+      expect(mock.getAttempts()).toBeGreaterThanOrEqual(2);
+      expect(mock.getSuccesses()).toBeGreaterThanOrEqual(1);
+    });
+  }
+});

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -42,6 +42,7 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   performanceConfig?: SessionReplayPerformanceConfig;
   useWebWorker?: boolean;
   enableTransportCompression?: boolean;
+  sendTimeoutMs?: number;
   applyBackgroundColorToBlockedElements?: boolean;
   enableUrlChangePolling?: boolean;
   urlChangePollingInterval?: number;
@@ -136,6 +137,9 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
       }
     }
     this.enableTransportCompression = options.enableTransportCompression ?? true;
+    // Pass through undefined so the track destination applies its SEND_TIMEOUT_MS default;
+    // an explicit 0 is preserved (disables the timeout).
+    this.sendTimeoutMs = options.sendTimeoutMs;
     this.captureAdoptedStyleSheets = options.captureAdoptedStyleSheets ?? true;
     if (options.crossOriginIframes) {
       this.crossOriginIframes = options.crossOriginIframes;

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -200,6 +200,23 @@ export interface SessionReplayLocalConfig extends IConfig {
    */
   enableTransportCompression?: boolean;
 
+  /**
+   * Milliseconds to wait for a send request before aborting it. `fetch()` has no native
+   * timeout, so a request stuck "pending" would block the serial flush loop indefinitely;
+   * the SDK aborts after this many ms and routes the abort as a retryable failure.
+   *
+   * Set to `0` (or a negative value) to disable the timeout entirely — note this
+   * reintroduces the head-of-line-blocking risk a wedged request can cause, so it is
+   * intended only as a diagnostic/experiment opt-out.
+   *
+   * Tuning this higher is useful when large, slow-but-succeeding uploads are being aborted
+   * at the default and counted as failures (which also triggers a retry, inflating request
+   * volume / throttle pressure).
+   *
+   * @defaultValue 10000
+   */
+  sendTimeoutMs?: number;
+
   userProperties?: { [key: string]: any };
 
   /**

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -48,6 +48,11 @@ export const KB_SIZE = 1024;
 export const MAX_URL_LENGTH = 1000;
 export const RETRY_TIMEOUT_MS = 1000;
 export const MAX_KEEPALIVE_BYTES = 64 * 1024; // browser keepalive budget shared with sendBeacon
+// Per-request send timeout. fetch() has no native timeout, so a single hung request
+// (stuck "pending" forever) would otherwise block the serial flush loop indefinitely —
+// head-of-line blocking that stalls every queued batch behind it. We abort after this
+// many ms so each send always settles and the queue keeps draining.
+export const SEND_TIMEOUT_MS = 10_000;
 
 // Server returns 200 + this header for "no-retry" drops (throttle / capture disabled / out-of-range).
 // See projects/sessionreplay/sessionreplay-ingestion/.../SessionReplayError.java.

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -72,6 +72,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   // retain pre-flag behavior. The local-config layer also defaults to true; this
   // belt-and-braces default protects direct constructor callers (e.g. tests).
   private enableTransportCompression: boolean;
+  // Milliseconds before an in-flight send is aborted; <= 0 disables the abort/timeout.
+  // Defaults to SEND_TIMEOUT_MS. Configurable so large slow-but-succeeding uploads aren't
+  // killed (and retried) at an over-aggressive default. See config.sendTimeoutMs.
+  private sendTimeoutMs: number;
   private scheduled: ReturnType<typeof setTimeout> | null = null;
   payloadBatcher: PayloadBatcher;
   queue: SessionReplayDestinationContext[] = [];
@@ -107,17 +111,20 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     payloadBatcher,
     workerScript,
     enableTransportCompression,
+    sendTimeoutMs,
   }: {
     trackServerUrl?: string;
     loggerProvider: ILogger;
     payloadBatcher?: PayloadBatcher;
     workerScript?: string;
     enableTransportCompression?: boolean;
+    sendTimeoutMs?: number;
   }) {
     this.loggerProvider = loggerProvider;
     this.payloadBatcher = payloadBatcher ? payloadBatcher : (payload) => payload;
     this.trackServerUrl = trackServerUrl;
     this.enableTransportCompression = enableTransportCompression ?? true;
+    this.sendTimeoutMs = sendTimeoutMs ?? SEND_TIMEOUT_MS;
 
     if (workerScript) {
       try {
@@ -483,19 +490,25 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       // completeRequest: like the worker-crash path above, the events were never confirmed
       // delivered, so onComplete must not fire and the IDB/memory store must stay intact for
       // recovery by sendStoredEvents.
-      const timeout = setTimeout(() => {
-        const pending = this.pendingWorkerRequests.get(id);
-        if (!pending) return;
-        this.pendingWorkerRequests.delete(id);
-        // Retain the context so a *late* worker complete/payload_too_large can still settle the
-        // store record (see timedOutWorkerRequests). Without this, a worker that ultimately
-        // delivers after we stopped awaiting would leave the record behind → duplicate upload.
-        this.rememberTimedOutRequest(id, pending.context);
-        this.loggerProvider.warn(
-          `Session replay worker send timed out after ${SEND_TIMEOUT_MS}ms; leaving events for retry`,
-        );
-        pending.resolve();
-      }, SEND_TIMEOUT_MS);
+      // sendTimeoutMs <= 0 disables the wait timer entirely: we then rely solely on the
+      // worker's own complete/payload_too_large message to settle. This reintroduces the
+      // hang risk this timer guards against, so it is an explicit experiment opt-out.
+      const timeout =
+        this.sendTimeoutMs > 0
+          ? setTimeout(() => {
+              const pending = this.pendingWorkerRequests.get(id);
+              if (!pending) return;
+              this.pendingWorkerRequests.delete(id);
+              // Retain the context so a *late* worker complete/payload_too_large can still settle the
+              // store record (see timedOutWorkerRequests). Without this, a worker that ultimately
+              // delivers after we stopped awaiting would leave the record behind → duplicate upload.
+              this.rememberTimedOutRequest(id, pending.context);
+              this.loggerProvider.warn(
+                `Session replay worker send timed out after ${this.sendTimeoutMs}ms; leaving events for retry`,
+              );
+              pending.resolve();
+            }, this.sendTimeoutMs)
+          : undefined;
       this.pendingWorkerRequests.set(id, { context, resolve, timeout });
       worker.postMessage({
         type: 'send',
@@ -516,6 +529,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           currentUrl: getCurrentUrl(),
           sdkVersion: VERSION,
           enableTransportCompression: this.enableTransportCompression,
+          sendTimeoutMs: this.sendTimeoutMs,
         },
       });
     });
@@ -597,16 +611,21 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         this.completeRequest({ context });
         return;
       }
-      const sendTimeout = setTimeout(() => {
-        controller.abort();
-      }, SEND_TIMEOUT_MS);
+      // sendTimeoutMs <= 0 disables the abort: the request can then hang indefinitely
+      // (head-of-line blocking the serial flush). Explicit experiment opt-out only.
+      const sendTimeout =
+        this.sendTimeoutMs > 0
+          ? setTimeout(() => {
+              controller.abort();
+            }, this.sendTimeoutMs)
+          : undefined;
       let res: Response;
       try {
         res = await fetch(serverUrl, options);
       } finally {
         // Clear on success and on error alike so a settled request never leaves an armed
         // timer that would abort a later reused controller or fire a stray callback.
-        clearTimeout(sendTimeout);
+        if (sendTimeout) clearTimeout(sendTimeout);
       }
       if (res === null) {
         this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE });

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -58,6 +58,11 @@ export type PayloadBatcher = ({ version, events }: { version: number; events: st
 // sessions are time-bounded in practice, this cap is just a defensive ceiling.
 const MAX_KILLED_SESSIONS = 256;
 
+// Defensive ceiling on retained timed-out worker requests (see timedOutWorkerRequests).
+// In normal operation each entry is removed when the worker's late message arrives; this
+// cap only guards the pathological case of a wedged worker that never replies at all.
+const MAX_TIMED_OUT_WORKER_REQUESTS = 256;
+
 export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrackDestination {
   loggerProvider: ILogger;
   storageKey = '';
@@ -76,6 +81,13 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     string,
     { context: SessionReplayDestinationContext; resolve: () => void; timeout?: ReturnType<typeof setTimeout> }
   >();
+  // Requests the main thread stopped awaiting after SEND_TIMEOUT_MS (so the serial flush
+  // loop could proceed) but whose worker may still be retrying in the background. We keep
+  // the context — bounded, like killedSessions — so a *late* worker complete/payload_too_large
+  // can still run completeRequest and settle the store record. Without this the late message
+  // is dropped (its id is gone from pendingWorkerRequests), so a successful late delivery would
+  // leave the IDB/memory record behind for sendStoredEvents to re-upload as duplicate replay data.
+  private timedOutWorkerRequests = new Map<string, SessionReplayDestinationContext>();
   // Server back-pressure state, fed by the X-Session-Replay-Event-Skipped header on 200s.
   // The server uses this header (instead of 4xx) to signal a deliberate no-retry drop so SDKs
   // don't retry-storm. We honor it here by slowing or stopping our flush schedule.
@@ -130,6 +142,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
             pending.resolve();
           }
           this.pendingWorkerRequests.clear();
+          // The worker is gone, so no late completion can arrive for timed-out requests either.
+          // Drop the retained contexts to free memory; their store records stay intact (we never
+          // completeRequest here) so sendStoredEvents can recover them on next init.
+          this.timedOutWorkerRequests.clear();
         };
         worker.onmessage = (e: MessageEvent<WorkerMessage>) => {
           const msg = e.data;
@@ -144,6 +160,14 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
               this.handlePayloadTooLargeResponse(pending.context, msg.isWaf);
               pending.resolve();
               this.pendingWorkerRequests.delete(msg.id);
+            } else {
+              // Late message for a request the main thread already timed out: the worker still
+              // determined the payload was too large, so split-and-retry off the original record.
+              const timedOut = this.timedOutWorkerRequests.get(msg.id);
+              if (timedOut) {
+                this.timedOutWorkerRequests.delete(msg.id);
+                this.handlePayloadTooLargeResponse(timedOut, msg.isWaf);
+              }
             }
           } else if (msg.type === 'complete') {
             const pending = this.pendingWorkerRequests.get(msg.id);
@@ -155,6 +179,18 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
               this.completeRequest({ context: pending.context });
               pending.resolve();
               this.pendingWorkerRequests.delete(msg.id);
+            } else {
+              // Late completion for a request the main thread already timed out. The worker's
+              // actual outcome (delivered, or retries exhausted) is authoritative, so settle the
+              // store record by it rather than leaving it behind for sendStoredEvents to re-upload.
+              const timedOut = this.timedOutWorkerRequests.get(msg.id);
+              if (timedOut) {
+                this.timedOutWorkerRequests.delete(msg.id);
+                if (msg.skipCode !== undefined) {
+                  this.applyServerDirective(timedOut.sessionId, msg.skipCode);
+                }
+                this.completeRequest({ context: timedOut });
+              }
             }
           }
         };
@@ -451,6 +487,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         const pending = this.pendingWorkerRequests.get(id);
         if (!pending) return;
         this.pendingWorkerRequests.delete(id);
+        // Retain the context so a *late* worker complete/payload_too_large can still settle the
+        // store record (see timedOutWorkerRequests). Without this, a worker that ultimately
+        // delivers after we stopped awaiting would leave the record behind → duplicate upload.
+        this.rememberTimedOutRequest(id, pending.context);
         this.loggerProvider.warn(
           `Session replay worker send timed out after ${SEND_TIMEOUT_MS}ms; leaving events for retry`,
         );
@@ -479,6 +519,18 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         },
       });
     });
+  }
+
+  private rememberTimedOutRequest(id: string, context: SessionReplayDestinationContext) {
+    this.timedOutWorkerRequests.set(id, context);
+    // Bound memory: a wedged worker that never replies must not let this grow without limit.
+    // Map preserves insertion order, so deleting the first key evicts the oldest entry.
+    if (this.timedOutWorkerRequests.size > MAX_TIMED_OUT_WORKER_REQUESTS) {
+      for (const oldest of this.timedOutWorkerRequests.keys()) {
+        this.timedOutWorkerRequests.delete(oldest);
+        break;
+      }
+    }
   }
 
   private async sendOnMainThread(

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -642,7 +642,11 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       // are enabled. completeRequest fires onComplete exactly once via either branch
       // (handleOtherResponse only completes on retry exhaustion), so onComplete can't fire
       // twice. Non-abort errors keep the original complete-with-error behavior.
-      const isAbort = e instanceof Error && e.name === 'AbortError';
+      // Browsers reject an aborted fetch with a DOMException named 'AbortError', which is NOT an
+      // Error instance — an `instanceof Error` check would misroute every send-timeout abort to
+      // the fatal completeRequest path, defeating the retry. Match on the name across any thrown
+      // object (DOMException or Error) instead.
+      const isAbort = !!e && typeof e === 'object' && (e as { name?: unknown }).name === 'AbortError';
       if (isAbort && useRetry) {
         await this.handleOtherResponse(context);
       } else {

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -25,6 +25,7 @@ import {
   EVENT_SKIP_CODE_CAPTURE_DISABLED,
   THROTTLED_FLUSH_PAUSE_MS,
   MERGE_AFTER_THROTTLE_SOFT_CAP,
+  SEND_TIMEOUT_MS,
 } from './constants';
 import { gzipJson } from './utils/gzip';
 
@@ -71,7 +72,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   queue: SessionReplayDestinationContext[] = [];
   private worker?: Worker;
   private sendIdCounter = 0;
-  private pendingWorkerRequests = new Map<string, { context: SessionReplayDestinationContext; resolve: () => void }>();
+  private pendingWorkerRequests = new Map<
+    string,
+    { context: SessionReplayDestinationContext; resolve: () => void; timeout?: ReturnType<typeof setTimeout> }
+  >();
   // Server back-pressure state, fed by the X-Session-Replay-Event-Skipped header on 200s.
   // The server uses this header (instead of 4xx) to signal a deliberate no-retry drop so SDKs
   // don't retry-storm. We honor it here by slowing or stopping our flush schedule.
@@ -119,6 +123,9 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           // here — the events were never delivered, so onComplete must not fire and the
           // IDB/memory store entries must remain intact for recovery by sendStoredEvents.
           for (const [, pending] of this.pendingWorkerRequests) {
+            // Cancel the per-request timeout — onerror already settles every pending
+            // promise, so leaving the timer armed would fire a spurious timeout warn later.
+            if (pending.timeout) clearTimeout(pending.timeout);
             loggerProvider.warn(`Session replay event send failed due to worker crash: ${e.message}`);
             pending.resolve();
           }
@@ -133,6 +140,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           } else if (msg.type === 'payload_too_large') {
             const pending = this.pendingWorkerRequests.get(msg.id);
             if (pending) {
+              if (pending.timeout) clearTimeout(pending.timeout);
               this.handlePayloadTooLargeResponse(pending.context, msg.isWaf);
               pending.resolve();
               this.pendingWorkerRequests.delete(msg.id);
@@ -140,6 +148,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           } else if (msg.type === 'complete') {
             const pending = this.pendingWorkerRequests.get(msg.id);
             if (pending) {
+              if (pending.timeout) clearTimeout(pending.timeout);
               if (msg.skipCode !== undefined) {
                 this.applyServerDirective(pending.context.sessionId, msg.skipCode);
               }
@@ -431,7 +440,23 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   ): Promise<void> {
     const id = `${++this.sendIdCounter}`;
     return new Promise<void>((resolve) => {
-      this.pendingWorkerRequests.set(id, { context, resolve });
+      // The worker only resolves this promise when it posts back complete/payload_too_large.
+      // If the worker's own fetch hangs, no message ever arrives, so this promise — and the
+      // serial flush loop awaiting it — would hang forever while pendingWorkerRequests grows
+      // unbounded. On timeout we resolve so flush() proceeds, but deliberately do NOT call
+      // completeRequest: like the worker-crash path above, the events were never confirmed
+      // delivered, so onComplete must not fire and the IDB/memory store must stay intact for
+      // recovery by sendStoredEvents.
+      const timeout = setTimeout(() => {
+        const pending = this.pendingWorkerRequests.get(id);
+        if (!pending) return;
+        this.pendingWorkerRequests.delete(id);
+        this.loggerProvider.warn(
+          `Session replay worker send timed out after ${SEND_TIMEOUT_MS}ms; leaving events for retry`,
+        );
+        pending.resolve();
+      }, SEND_TIMEOUT_MS);
+      this.pendingWorkerRequests.set(id, { context, resolve, timeout });
       worker.postMessage({
         type: 'send',
         id,
@@ -485,6 +510,11 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           ? await gzipJson(payloadJson, globalScope)
           : null;
       const payloadSize = gzipped ? gzipped.byteLength : new Blob([payloadJson]).size;
+      // fetch() has no native timeout. A request stuck "pending" forever would block the
+      // serial flush loop indefinitely (head-of-line blocking), so we abort it after
+      // SEND_TIMEOUT_MS. The abort surfaces as an AbortError in the catch below, where it's
+      // routed as a retryable network failure when useRetry is true.
+      const controller = new AbortController();
       const options: RequestInit = {
         headers: {
           'Content-Type': 'application/json',
@@ -502,6 +532,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
         // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
         keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
+        signal: controller.signal,
       };
 
       const serverUrl = `${getServerUrl(context.serverZone, this.trackServerUrl)}?${urlParams.toString()}`;
@@ -514,7 +545,17 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         this.completeRequest({ context });
         return;
       }
-      const res = await fetch(serverUrl, options);
+      const sendTimeout = setTimeout(() => {
+        controller.abort();
+      }, SEND_TIMEOUT_MS);
+      let res: Response;
+      try {
+        res = await fetch(serverUrl, options);
+      } finally {
+        // Clear on success and on error alike so a settled request never leaves an armed
+        // timer that would abort a later reused controller or fire a stray callback.
+        clearTimeout(sendTimeout);
+      }
       if (res === null) {
         this.completeRequest({ context, err: UNEXPECTED_ERROR_MESSAGE });
         return;
@@ -543,7 +584,18 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         await this.handleReponse(res.status, context, responseBody);
       }
     } catch (e) {
-      this.completeRequest({ context, err: e as string });
+      // A send timeout aborts the fetch, which rejects with an AbortError. Treat that as a
+      // transient network failure and route it through the same retry budget/backoff as a
+      // 5xx (so a single stalled request doesn't permanently drop the batch) when retries
+      // are enabled. completeRequest fires onComplete exactly once via either branch
+      // (handleOtherResponse only completes on retry exhaustion), so onComplete can't fire
+      // twice. Non-abort errors keep the original complete-with-error behavior.
+      const isAbort = e instanceof Error && e.name === 'AbortError';
+      if (isAbort && useRetry) {
+        await this.handleOtherResponse(context);
+      } else {
+        this.completeRequest({ context, err: e as string });
+      }
     }
   }
 

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -30,6 +30,10 @@ interface SendContext {
   // Optional for backwards compatibility with messages from older main-thread code
   // that doesn't forward the flag; absence is treated as enabled (default true).
   enableTransportCompression?: boolean;
+  // Milliseconds before the worker aborts the in-flight fetch; <= 0 disables the abort.
+  // Optional for backwards compatibility with older main-thread code that doesn't forward
+  // it; absence falls back to SEND_TIMEOUT_MS.
+  sendTimeoutMs?: number;
 }
 
 async function doFetch(
@@ -45,6 +49,10 @@ async function doFetch(
   // undefined when the response was not a 2xx (caller should not interpret as a directive).
   skipCode?: string | null;
 }> {
+  // <= 0 disables the abort (no timer); otherwise honor the forwarded value, falling back
+  // to the default when older main-thread code doesn't send one. Declared here (not inside
+  // try) so the AbortError message in catch can reference it.
+  const sendTimeoutMs = context.sendTimeoutMs ?? SEND_TIMEOUT_MS;
   try {
     // Treat an absent flag as enabled so messages from older main-thread builds that
     // don't forward the field keep working unchanged. Only an explicit `false` opts out.
@@ -74,9 +82,12 @@ async function doFetch(
     // fetch() has no native timeout; abort a hung request so it surfaces as a retryable
     // failure instead of silently wedging the worker (and the awaiting orchestrator).
     const controller = new AbortController();
-    const timeout = setTimeout(() => {
-      controller.abort();
-    }, SEND_TIMEOUT_MS);
+    const timeout =
+      sendTimeoutMs > 0
+        ? setTimeout(() => {
+            controller.abort();
+          }, sendTimeoutMs)
+        : undefined;
     let res: Response | null;
     try {
       res = await fetch(serverUrl, {
@@ -89,7 +100,7 @@ async function doFetch(
         signal: controller.signal,
       });
     } finally {
-      clearTimeout(timeout);
+      if (timeout) clearTimeout(timeout);
     }
     if (res === null) {
       return { shouldRetry: false, success: false, message: UNEXPECTED_ERROR_MESSAGE };
@@ -132,7 +143,7 @@ async function doFetch(
       return {
         shouldRetry: true,
         success: false,
-        message: `Session replay worker request timed out after ${SEND_TIMEOUT_MS}ms`,
+        message: `Session replay worker request timed out after ${sendTimeoutMs}ms`,
       };
     }
     return { shouldRetry: false, success: false, message: String(e) };

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -6,6 +6,7 @@ import {
   MAX_URL_LENGTH,
   MAX_KEEPALIVE_BYTES,
   RETRY_TIMEOUT_MS,
+  SEND_TIMEOUT_MS,
   WAF_PAYLOAD_TOO_LARGE_PATTERN,
 } from '../constants';
 import { MAX_RETRIES_EXCEEDED_MESSAGE, UNEXPECTED_ERROR_MESSAGE, UNEXPECTED_NETWORK_ERROR_MESSAGE } from '../messages';
@@ -70,14 +71,26 @@ async function doFetch(
       ...(gzipped ? { 'Content-Encoding': 'gzip' } : {}),
     };
     const payloadSize = gzipped ? gzipped.byteLength : new Blob([payloadJson]).size;
-    const res = await fetch(serverUrl, {
-      method: 'POST',
-      headers,
-      body: (gzipped ?? payloadJson) as BodyInit,
-      // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
-      // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
-      keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
-    });
+    // fetch() has no native timeout; abort a hung request so it surfaces as a retryable
+    // failure instead of silently wedging the worker (and the awaiting orchestrator).
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, SEND_TIMEOUT_MS);
+    let res: Response | null;
+    try {
+      res = await fetch(serverUrl, {
+        method: 'POST',
+        headers,
+        body: (gzipped ?? payloadJson) as BodyInit,
+        // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
+        // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
+        keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (res === null) {
       return { shouldRetry: false, success: false, message: UNEXPECTED_ERROR_MESSAGE };
     }
@@ -111,6 +124,16 @@ async function doFetch(
     }
     return { shouldRetry: false, success: false, message: UNEXPECTED_NETWORK_ERROR_MESSAGE };
   } catch (e) {
+    // A timeout aborts the fetch, rejecting with an AbortError. That's transient — let
+    // sendWithRetry's budget retry it, mirroring the 5xx/408/429/499 path. Other errors
+    // stay non-retryable as before.
+    if (e instanceof Error && e.name === 'AbortError') {
+      return {
+        shouldRetry: true,
+        success: false,
+        message: `Session replay worker request timed out after ${SEND_TIMEOUT_MS}ms`,
+      };
+    }
     return { shouldRetry: false, success: false, message: String(e) };
   }
 }

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -126,8 +126,9 @@ async function doFetch(
   } catch (e) {
     // A timeout aborts the fetch, rejecting with an AbortError. That's transient — let
     // sendWithRetry's budget retry it, mirroring the 5xx/408/429/499 path. Other errors
-    // stay non-retryable as before.
-    if (e instanceof Error && e.name === 'AbortError') {
+    // stay non-retryable as before. Browsers reject with a DOMException named 'AbortError'
+    // (not an Error instance), so match on the name rather than using `instanceof Error`.
+    if (!!e && typeof e === 'object' && (e as { name?: unknown }).name === 'AbortError') {
       return {
         shouldRetry: true,
         success: false,

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -608,6 +608,28 @@ describe('SessionReplayTrackDestination', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.any(Error));
     });
+
+    test('a DOMException abort (not an Error instance) is still retried when useRetry=true', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const handleOther = jest.spyOn(trackDestination, 'handleOtherResponse');
+      // Real browsers reject an aborted fetch with a DOMException named 'AbortError', which is
+      // NOT an Error instance — the retry path must still trigger instead of completing fatally.
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(
+          (_url: string, options: RequestInit) =>
+            new Promise((_resolve, reject) => {
+              options.signal?.addEventListener('abort', () => reject({ name: 'AbortError', message: 'aborted' }));
+            }),
+        )
+        .mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+
+      const sendPromise = trackDestination.send(timeoutContext(), true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      expect(handleOther).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('keepalive', () => {

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -3,6 +3,7 @@ import { ILogger, ServerZone } from '@amplitude/analytics-core';
 import { SessionReplayDestinationContext } from 'src/typings/session-replay';
 import { MERGE_AFTER_THROTTLE_SOFT_CAP } from '../src/constants';
 import { SessionReplayTrackDestination } from '../src/track-destination';
+import { SEND_TIMEOUT_MS } from '../src/constants';
 import { VERSION } from '../src/version';
 
 type MockedLogger = jest.Mocked<ILogger>;
@@ -381,6 +382,7 @@ describe('SessionReplayTrackDestination', () => {
           },
           method: 'POST',
           keepalive: true,
+          signal: expect.any(AbortSignal),
         },
       );
     });
@@ -420,6 +422,7 @@ describe('SessionReplayTrackDestination', () => {
           },
           method: 'POST',
           keepalive: true,
+          signal: expect.any(AbortSignal),
         },
       );
     });
@@ -510,6 +513,100 @@ describe('SessionReplayTrackDestination', () => {
 
       await trackDestination.send(context, false);
       expect(addToQueue).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('send timeout (AbortController)', () => {
+    const timeoutContext = (
+      overrides: Partial<SessionReplayDestinationContext> = {},
+    ): SessionReplayDestinationContext => ({
+      events: [mockEventString],
+      sessionId: 123,
+      apiKey,
+      attempts: 0,
+      timeout: 0,
+      flushMaxRetries: 2,
+      deviceId: '1a2b3c',
+      sampleRate: 1,
+      serverZone: ServerZone.US,
+      type: 'replay',
+      onComplete: mockOnComplete,
+      ...overrides,
+    });
+
+    // A fetch that never settles on its own — it only rejects when its AbortSignal fires,
+    // simulating a request stuck "pending" forever until our timeout aborts it. The rejection
+    // mirrors the real browser behavior: an Error whose name is 'AbortError'.
+    const abortError = () => {
+      const e = new Error('The operation was aborted');
+      e.name = 'AbortError';
+      return e;
+    };
+    const hangUntilAborted = () =>
+      jest.fn((_url: string, options: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => reject(abortError()));
+        });
+      });
+
+    test('timeout fires and triggers a retry when useRetry=true', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(hangUntilAborted())
+        .mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+
+      const sendPromise = trackDestination.send(timeoutContext(), true);
+      // Drains the abort timer (rejects fetch), then the retry backoff timer and the
+      // successful second send.
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('timeout with useRetry=false completes with error and does not retry', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const addToQueue = jest.spyOn(trackDestination, 'addToQueue');
+      (global.fetch as jest.Mock).mockImplementationOnce(hangUntilAborted());
+
+      const sendPromise = trackDestination.send(timeoutContext(), false);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(addToQueue).not.toHaveBeenCalled();
+      expect(mockOnComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('timer is cleared on normal completion so no stray abort fires', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const clearSpy = jest.spyOn(global, 'clearTimeout');
+      (global.fetch as jest.Mock).mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+
+      await trackDestination.send(timeoutContext(), false);
+      // The send timeout must have been cleared in the finally block on the success path.
+      expect(clearSpy).toHaveBeenCalled();
+
+      // Advancing past the timeout window must not fire a stray abort/warn or re-complete.
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS + 1);
+      expect(mockOnComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('a non-abort fetch rejection completes with error and does not retry even when useRetry=true', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const handleOther = jest.spyOn(trackDestination, 'handleOtherResponse');
+      // A plain network Error (not an AbortError) must keep the original complete-with-error
+      // behavior rather than being misrouted through the timeout retry path.
+      (global.fetch as jest.Mock).mockImplementationOnce(() => Promise.reject(new Error('boom')));
+
+      const sendPromise = trackDestination.send(timeoutContext(), true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      expect(handleOther).not.toHaveBeenCalled();
+      expect(mockOnComplete).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 
@@ -1027,6 +1124,9 @@ describe('SessionReplayTrackDestination', () => {
 
       expect((trackDestination as any).flushPauseUntilMs).toBe(0);
 
+      // send() now registers (and immediately clears) its own request-timeout setTimeout, so
+      // reset the spy to isolate the schedule() call we're asserting on.
+      setTimeoutSpy.mockClear();
       // A fresh schedule call now uses the requested timeout, with no pause carry-over.
       trackDestination.schedule(500);
       expect(setTimeoutSpy.mock.calls[0][1]).toBe(500);
@@ -1658,6 +1758,110 @@ describe('SessionReplayTrackDestination', () => {
 
       await sendPromise;
       expect(mockWorker.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'send' }));
+    });
+
+    test('worker send timeout resolves the pending promise without completeRequest', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const completeSpy = jest.spyOn(trackDestination, 'completeRequest');
+
+      // The worker never posts back — emulating its own fetch hanging forever.
+      const sendPromise = trackDestination.send(mockContext, true);
+      expect((trackDestination as any).pendingWorkerRequests.size).toBe(1);
+
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      await sendPromise;
+
+      // Must resolve so flush() proceeds, but must NOT completeRequest — events were never
+      // confirmed delivered, so onComplete stays unfired and the store entry is left for recovery.
+      expect(completeSpy).not.toHaveBeenCalled();
+      expect(mockContext.onComplete).not.toHaveBeenCalled();
+      expect((trackDestination as any).pendingWorkerRequests.size).toBe(0);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
+    });
+
+    test('worker timeout timer is cleared when a real response arrives', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+
+      const sendPromise = trackDestination.send(mockContext, false);
+      const pendingEntries = [...(trackDestination as any).pendingWorkerRequests.entries()];
+      const [id] = pendingEntries[0] as [string, { resolve: () => void }];
+      mockWorker.onmessage?.({ data: { type: 'complete', id } } as MessageEvent);
+      await sendPromise;
+
+      // After a real completion the timer is cleared, so advancing past the timeout window
+      // must not fire the timeout warn.
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS + 1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
+    });
+
+    test('worker onerror clears the per-request timeout for in-flight sends', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      mockWorker.onerror?.({
+        preventDefault: jest.fn(),
+        message: 'boom',
+        filename: 'blob:test',
+        lineno: 1,
+      } as unknown as ErrorEvent);
+      await sendPromise;
+
+      // onerror cleared the per-request timer, so advancing past the window must not also
+      // fire the timeout warn.
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS + 1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
+    });
+
+    test('worker payload_too_large clears the per-request timeout', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      jest.spyOn(trackDestination, 'handlePayloadTooLargeResponse').mockReturnValue(undefined);
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      const [id] = [...(trackDestination as any).pendingWorkerRequests.keys()] as string[];
+      mockWorker.onmessage?.({ data: { type: 'payload_too_large', id, isWaf: false } } as MessageEvent);
+      await sendPromise;
+
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS + 1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
+    });
+
+    test('worker send timeout is a no-op if the request was already settled (race guard)', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      const pending = [...(trackDestination as any).pendingWorkerRequests.entries()][0] as [
+        string,
+        { resolve: () => void },
+      ];
+      const [id, entry] = pending;
+      // Simulate the entry being removed by another path without the timer being cleared, so
+      // the timeout fires with no pending request — the guard must return without warning.
+      (trackDestination as any).pendingWorkerRequests.delete(id);
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      entry.resolve();
+      await sendPromise;
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
     });
 
     test('send via worker uses 0 when flushMaxRetries is undefined', async () => {

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1864,6 +1864,131 @@ describe('SessionReplayTrackDestination', () => {
       expect(mockLoggerProvider.warn).not.toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
     });
 
+    test('late worker complete (success) for a timed-out request settles the store record', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const completeSpy = jest.spyOn(trackDestination, 'completeRequest');
+      const directiveSpy = jest.spyOn(trackDestination as any, 'applyServerDirective');
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      const [id] = [...(trackDestination as any).pendingWorkerRequests.keys()] as string[];
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      await sendPromise;
+      expect(completeSpy).not.toHaveBeenCalled();
+      expect((trackDestination as any).timedOutWorkerRequests.size).toBe(1);
+
+      // The worker finished delivering after the main thread already stopped awaiting it.
+      mockWorker.onmessage?.({ data: { type: 'complete', id, skipCode: null } } as MessageEvent);
+
+      expect(directiveSpy).toHaveBeenCalledWith(mockContext.sessionId, null);
+      expect(completeSpy).toHaveBeenCalledWith({ context: mockContext });
+      expect((trackDestination as any).timedOutWorkerRequests.size).toBe(0);
+    });
+
+    test('late worker complete (retries exhausted) for a timed-out request settles without directive', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const completeSpy = jest.spyOn(trackDestination, 'completeRequest');
+      const directiveSpy = jest.spyOn(trackDestination as any, 'applyServerDirective');
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      const [id] = [...(trackDestination as any).pendingWorkerRequests.keys()] as string[];
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      await sendPromise;
+
+      // No skipCode → the worker exhausted retries without a 2xx; settle (drop) the record.
+      mockWorker.onmessage?.({ data: { type: 'complete', id } } as MessageEvent);
+
+      expect(directiveSpy).not.toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalledWith({ context: mockContext });
+      expect((trackDestination as any).timedOutWorkerRequests.size).toBe(0);
+    });
+
+    test('late worker complete for an unknown id is a no-op', () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const completeSpy = jest.spyOn(trackDestination, 'completeRequest');
+      mockWorker.onmessage?.({ data: { type: 'complete', id: 'never-existed', skipCode: null } } as MessageEvent);
+      expect(completeSpy).not.toHaveBeenCalled();
+    });
+
+    test('late worker payload_too_large for a timed-out request splits off the original record', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const handleSpy = jest.spyOn(trackDestination, 'handlePayloadTooLargeResponse').mockReturnValue(undefined);
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      const [id] = [...(trackDestination as any).pendingWorkerRequests.keys()] as string[];
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      await sendPromise;
+
+      mockWorker.onmessage?.({ data: { type: 'payload_too_large', id, isWaf: true } } as MessageEvent);
+
+      expect(handleSpy).toHaveBeenCalledWith(mockContext, true);
+      expect((trackDestination as any).timedOutWorkerRequests.size).toBe(0);
+    });
+
+    test('late worker payload_too_large for an unknown id is a no-op', () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const handleSpy = jest.spyOn(trackDestination, 'handlePayloadTooLargeResponse').mockReturnValue(undefined);
+      mockWorker.onmessage?.({
+        data: { type: 'payload_too_large', id: 'never-existed', isWaf: false },
+      } as MessageEvent);
+      expect(handleSpy).not.toHaveBeenCalled();
+    });
+
+    test('timed-out worker requests are bounded (oldest evicted past the cap)', () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const cap = 256;
+      for (let i = 0; i < cap + 5; i++) {
+        (trackDestination as any).rememberTimedOutRequest(`id-${i}`, mockContext);
+      }
+      const map = (trackDestination as any).timedOutWorkerRequests as Map<string, unknown>;
+      expect(map.size).toBe(cap);
+      // The first five inserted ids are the oldest and must have been evicted.
+      expect(map.has('id-0')).toBe(false);
+      expect(map.has('id-4')).toBe(false);
+      expect(map.has('id-5')).toBe(true);
+    });
+
+    test('worker onerror drops retained timed-out requests', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+      });
+      const completeSpy = jest.spyOn(trackDestination, 'completeRequest');
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      await sendPromise;
+      expect((trackDestination as any).timedOutWorkerRequests.size).toBe(1);
+
+      mockWorker.onerror?.({
+        preventDefault: jest.fn(),
+        message: 'boom',
+        filename: 'blob:test',
+        lineno: 1,
+      } as unknown as ErrorEvent);
+
+      // Memory freed, but the record is intentionally NOT completed (left for sendStoredEvents).
+      expect((trackDestination as any).timedOutWorkerRequests.size).toBe(0);
+      expect(completeSpy).not.toHaveBeenCalled();
+    });
+
     test('send via worker uses 0 when flushMaxRetries is undefined', async () => {
       const trackDestination = new SessionReplayTrackDestination({
         loggerProvider: mockLoggerProvider,

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1849,6 +1849,32 @@ describe('SessionReplayTrackDestination', () => {
       expect(mockLoggerProvider.warn).toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
     });
 
+    test('sendTimeoutMs of 0 arms no worker-wait timer (send relies on the worker reply)', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+        sendTimeoutMs: 0,
+      });
+
+      const sendPromise = trackDestination.send(mockContext, true);
+      const [, entry] = [...(trackDestination as any).pendingWorkerRequests.entries()][0] as [
+        string,
+        { timeout?: ReturnType<typeof setTimeout> },
+      ];
+      // No wait timer is armed when the timeout is disabled.
+      expect(entry.timeout).toBeUndefined();
+
+      // Advancing past the default window must not fire the timeout warn (there is no timer).
+      jest.advanceTimersByTime(SEND_TIMEOUT_MS + 1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).not.toHaveBeenCalledWith(expect.stringContaining('worker send timed out'));
+
+      // Settle via the worker reply so the pending promise resolves.
+      const [id] = [...(trackDestination as any).pendingWorkerRequests.keys()] as string[];
+      mockWorker.onmessage?.({ data: { type: 'complete', id } } as MessageEvent);
+      await sendPromise;
+    });
+
     test('worker timeout timer is cleared when a real response arrives', async () => {
       const trackDestination = new SessionReplayTrackDestination({
         loggerProvider: mockLoggerProvider,

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -592,6 +592,50 @@ describe('SessionReplayTrackDestination', () => {
       expect(mockOnComplete).toHaveBeenCalledTimes(1);
     });
 
+    test('arms the abort timer at the configured sendTimeoutMs instead of the default', async () => {
+      const setSpy = jest.spyOn(global, 'setTimeout');
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        sendTimeoutMs: 30_000,
+      });
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(hangUntilAborted())
+        .mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+
+      const sendPromise = trackDestination.send(timeoutContext(), true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      // The abort must be scheduled at the configured value, not SEND_TIMEOUT_MS.
+      expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
+      // And it still aborts → retries to the successful second attempt.
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('sendTimeoutMs of 0 disables the abort: a slow request is not aborted past the default window', async () => {
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        sendTimeoutMs: 0,
+      });
+      // Succeeds on its own well after the default timeout would have aborted it.
+      const slowSuccess = jest.fn(
+        (_url: string, options: RequestInit) =>
+          new Promise((resolve, reject) => {
+            options.signal?.addEventListener('abort', () => reject(abortError()));
+            setTimeout(() => resolve({ status: 200 } as Response), SEND_TIMEOUT_MS * 2);
+          }),
+      );
+      (global.fetch as jest.Mock).mockImplementationOnce(slowSuccess);
+
+      const sendPromise = trackDestination.send(timeoutContext(), true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      // No abort-triggered retry — the single slow request completed successfully.
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockOnComplete).toHaveBeenCalledTimes(1);
+    });
+
     test('a non-abort fetch rejection completes with error and does not retry even when useRetry=true', async () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const handleOther = jest.spyOn(trackDestination, 'handleOtherResponse');

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -252,6 +252,38 @@ describe('worker/track-destination', () => {
     expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'to2' });
   });
 
+  test('arms the abort timer at context.sendTimeoutMs when provided', async () => {
+    const setSpy = jest.spyOn(global, 'setTimeout');
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+
+    await invokeOnMessage({
+      type: 'send',
+      id: 'st1',
+      payload: basePayload,
+      context: { ...baseContext, sendTimeoutMs: 25_000 },
+      useRetry: false,
+    });
+
+    expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 25_000);
+  });
+
+  test('does not arm an abort timer when context.sendTimeoutMs is 0', async () => {
+    const setSpy = jest.spyOn(global, 'setTimeout');
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+
+    await invokeOnMessage({
+      type: 'send',
+      id: 'st2',
+      payload: basePayload,
+      context: { ...baseContext, sendTimeoutMs: 0 },
+      useRetry: false,
+    });
+
+    // A successful single-attempt send with the abort disabled schedules no timer at all.
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'st2', skipCode: null });
+  });
+
   test('retries a DOMException abort (not an Error instance) when useRetry=true', async () => {
     const realSetTimeout = global.setTimeout;
     jest

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -252,6 +252,35 @@ describe('worker/track-destination', () => {
     expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'to2' });
   });
 
+  test('retries a DOMException abort (not an Error instance) when useRetry=true', async () => {
+    const realSetTimeout = global.setTimeout;
+    jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn) => realSetTimeout(fn, 0) as unknown as ReturnType<typeof setTimeout>);
+
+    // Browsers reject an aborted fetch with a DOMException named 'AbortError', which is NOT an
+    // Error instance. It must still be detected as a retryable timeout.
+    mockFetch
+      .mockImplementationOnce(
+        (_url: string, options: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            options.signal?.addEventListener('abort', () => reject({ name: 'AbortError', message: 'aborted' }));
+          }),
+      )
+      .mockResolvedValueOnce({ status: 200 });
+
+    await invokeOnMessage({
+      type: 'send',
+      id: 'to3',
+      payload: basePayload,
+      context: { ...baseContext, flushMaxRetries: 2 },
+      useRetry: true,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'to3', skipCode: null });
+  });
+
   test('posts warn and complete on fetch network error', async () => {
     mockFetch.mockRejectedValueOnce(new Error('network failure'));
     await invokeOnMessage({ type: 'send', id: '6', payload: basePayload, context: baseContext, useRetry: false });

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -202,6 +202,56 @@ describe('worker/track-destination', () => {
     expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '5' });
   });
 
+  // A fetch that hangs until its AbortSignal fires, simulating a stuck "pending" request.
+  // The rejection mirrors real browser behavior: an Error whose name is 'AbortError'.
+  const abortError = () => {
+    const e = new Error('The operation was aborted');
+    e.name = 'AbortError';
+    return e;
+  };
+  const hangUntilAborted = () => (_url: string, options: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () => reject(abortError()));
+    });
+
+  test('aborts a hung request on timeout and retries when useRetry=true', async () => {
+    // Fire all timers (the abort timeout and the retry backoff) immediately so the test is fast.
+    const realSetTimeout = global.setTimeout;
+    jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn) => realSetTimeout(fn, 0) as unknown as ReturnType<typeof setTimeout>);
+
+    mockFetch.mockImplementationOnce(hangUntilAborted()).mockResolvedValueOnce({ status: 200 });
+
+    await invokeOnMessage({
+      type: 'send',
+      id: 'to1',
+      payload: basePayload,
+      context: { ...baseContext, flushMaxRetries: 2 },
+      useRetry: true,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'to1', skipCode: null });
+  });
+
+  test('timeout with useRetry=false posts a timed-out warn and completes without retrying', async () => {
+    const realSetTimeout = global.setTimeout;
+    jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn) => realSetTimeout(fn, 0) as unknown as ReturnType<typeof setTimeout>);
+
+    mockFetch.mockImplementationOnce(hangUntilAborted());
+
+    await invokeOnMessage({ type: 'send', id: 'to2', payload: basePayload, context: baseContext, useRetry: false });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warn', id: 'to2', message: expect.stringContaining('timed out') }),
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'to2' });
+  });
+
   test('posts warn and complete on fetch network error', async () => {
     mockFetch.mockRejectedValueOnce(new Error('network failure'));
     await invokeOnMessage({ type: 'send', id: '6', payload: basePayload, context: baseContext, useRetry: false });
@@ -210,6 +260,18 @@ describe('worker/track-destination', () => {
       expect.objectContaining({ type: 'warn', id: '6', message: expect.stringContaining('network failure') }),
     );
     expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '6' });
+  });
+
+  test('treats a non-Error rejection as a non-retryable failure (not a timeout)', async () => {
+    // A thrown non-Error value (e.g. a bare string) must not be mistaken for an AbortError,
+    // so it completes without retrying.
+    mockFetch.mockRejectedValueOnce('string failure');
+    await invokeOnMessage({ type: 'send', id: '6b', payload: basePayload, context: baseContext, useRetry: false });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warn', id: '6b', message: expect.stringContaining('string failure') }),
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: '6b' });
   });
 
   test('uses EU server URL when serverZone is EU', async () => {


### PR DESCRIPTION
## Summary

Session Replay sends were vulnerable to **head-of-line blocking**: `flush()` drains the queue serially (`for (const ctx of list) await this.send(ctx, useRetry)`), and the send paths had **no request timeout**.

- **Main thread** (`sendOnMainThread`): `await fetch(serverUrl, options)` has no native timeout / no `AbortController`. A single request stuck "pending forever" (confirmed via HAR analysis) means the awaited `send` never resolves, so the serial flush loop is blocked indefinitely — stalling **all** subsequent queued sends for that destination.
- **Worker** (`sendViaWorker`): the returned Promise only resolves when the worker posts back `complete`/`payload_too_large`. If the worker's own fetch hangs, that Promise never resolves and `pendingWorkerRequests` grows unbounded.

## Fix

- **`SEND_TIMEOUT_MS`** constant (default `10000ms`) added to `constants.ts`.
- **Main thread**: wrap the fetch with an `AbortController` + timer. On timeout the fetch is aborted; the resulting `AbortError` is caught and routed through `handleOtherResponse` (retry budget/backoff) when `useRetry` is true, or `completeRequest`-with-error when false. `onComplete` fires exactly once. The timer is cleared in a `finally` so a settled request never leaves an armed timer.
- **Worker orchestrator** (`sendViaWorker`): arm a timer when dispatching. If no response arrives in time, **resolve the pending promise without `completeRequest`** (mirroring the existing worker-crash handling — events were never confirmed delivered, so `onComplete` must not fire and the IDB/memory store stays intact for recovery), delete it from `pendingWorkerRequests`, and log a warn. The timer is cleared on every real response (`complete`, `payload_too_large`, `onerror`).
- **Worker fetch** (`src/worker/track-destination.ts`): the worker source is a plain TS file compiled by rollup, so an equivalent `AbortController` timeout was straightforward to add there too. On timeout it returns a retryable failure so `sendWithRetry`'s budget handles it.

Abort detection uses the `AbortError` name rather than a flag, which is robust against fake-timer ordering in tests.

This addresses the "request stuck in pending forever" reliability issue. Related context: **SR-4660**.

## Test plan

- [x] New unit tests in `test/track-destination.test.ts` and `test/worker/track-destination.test.ts` (Jest fake timers): main-thread timeout triggers retry when `useRetry=true`; timeout with `useRetry=false` completes with error; non-abort rejection is not misrouted; worker timeout resolves the pending promise without `completeRequest`; timers cleared on normal completion / `onerror` / `payload_too_large`.
- [x] `pnpm build` (incl. worker bundle) green
- [x] `pnpm --filter @amplitude/session-replay-browser test` green — 1020 tests, **100% statements/branches/functions/lines** (coverage gate enforced)
- [x] `pnpm lint` (eslint + prettier) green
- [x] `pnpm docs:check` green



_This PR's contribution to the bundle:_ the send-path `AbortController` timeout (`SEND_TIMEOUT_MS`/`sendTimeoutMs`) is active in the canary build. No stuck-pending head-of-line stalls observed in production; the success/throttle numbers above are with it live.

## Production canary validation

These changes shipped together as the **`sr-perf-reliability` canary bundle** (rc2 → rc3, PRs #1806/#1814/#1807/#1808/#1798), gated behind the `sr-perf-reliability-canary` Amplitude Experiment flag at **100%** in onenav prod — amp-on-amp traffic (Amplitude 2.0 + the HubSpot CRM Records page), `sampleRate: 1`. Live in production for multiple days; currently ~89% of canary traffic with no regressions, **zero 413s**, and no new error modes.

**Apples-to-apples on appid 187520** (Amplitude 2.0 — same app/users, `quota_exceeded = 0%` so this is a clean throttle comparison, differing only by which SR bundle a session loaded):

| window | build | success | throttle |
| --- | --- | --- | --- |
| Jun 11 (full day) | **rc3 (this bundle)** | **99.8%** | **0.02%** |
| Jun 11 (full day) | prod 1.31.0 | 96.7% | 2.95% |
| trailing 24h | **rc3 (this bundle)** | **99.8%** | **0.03%** |
| trailing 24h | prod 1.31.0 | 97.8% | 1.88% |

→ ~150x throttle reduction and ~+3pp success vs the GA build on identical app/users. rc3 is on par with the other canary builds (rc2, sr-4646) — all at the reliability floor.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core replay delivery and retry behavior for all uploads; mis-tuned timeouts could abort slow-but-valid uploads or alter duplicate-recovery edge cases on late worker completions.
> 
> **Overview**
> Fixes **head-of-line blocking** in Session Replay uploads: a single `fetch` stuck in “pending” could block the serial flush loop forever because there was no request timeout.
> 
> Adds **`SEND_TIMEOUT_MS` (10s default)** and optional **`sendTimeoutMs`** on standalone/plugin config (including **`0` to disable**). **Main-thread sends** use `AbortController` + timer; **`AbortError`** is treated as retryable when `useRetry` is true (detected by `name === 'AbortError'`, not `instanceof Error`). **Worker path**: the worker fetch gets the same abort; the main thread also times out waiting for worker replies, resolves without `completeRequest`, and keeps contexts in **`timedOutWorkerRequests`** so late `complete` / `payload_too_large` messages can still settle store records and avoid duplicate re-uploads.
> 
> Coverage includes expanded unit tests and a Playwright e2e that hangs the first POST and asserts the flush queue recovers for both main-thread and web-worker sends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7932f8fecb5e8675235e506ceaf6349d24d04b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
