### PR TITLE
fix(analytics-browser): only flush on actual offline->online transition

### DIFF
--- a/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
+++ b/packages/analytics-browser/src/plugins/network-connectivity-checker.ts
@@ -42,6 +42,9 @@ export const networkConnectivityCheckerPlugin = (): BeforePlugin => {
     config.offline = !navigator.onLine;
 
     addNetworkListener('online', () => {
+      if (config.offline === false) {
+        return;
+      }
       config.loggerProvider.debug('Network connectivity changed to online.');
       config.offline = false;
       // Flush immediately will cause ERR_NETWORK_CHANGED

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -876,6 +876,8 @@ describe('browser-client', () => {
 
     test('should listen for network change to online', async () => {
       jest.useFakeTimers();
+      // Start offline so the online event represents a real offline->online transition.
+      const onLineMock = jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
       const addEventListenerMock = jest.spyOn(window, 'addEventListener');
       const flush = jest.spyOn(client, 'flush').mockReturnValue({ promise: Promise.resolve() });
       const loggerProvider = {
@@ -891,6 +893,8 @@ describe('browser-client', () => {
         defaultTracking: false,
         loggerProvider: loggerProvider,
       }).promise;
+      expect(client.config.offline).toBe(true);
+
       window.dispatchEvent(new Event('online'));
 
       expect(addEventListenerMock).toHaveBeenCalledWith('online', expect.any(Function));
@@ -901,6 +905,7 @@ describe('browser-client', () => {
       expect(flush).toHaveBeenCalledTimes(1);
 
       jest.useRealTimers();
+      onLineMock.mockRestore();
       addEventListenerMock.mockRestore();
       flush.mockRestore();
     });

--- a/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
+++ b/packages/analytics-browser/test/plugins/network-connectivity-checker.test.ts
@@ -3,13 +3,34 @@
 import { createAmplitudeMock, createConfigurationMock } from '../helpers/mock';
 import { networkConnectivityCheckerPlugin } from '../../src/plugins/network-connectivity-checker';
 import * as AnalyticsCore from '@amplitude/analytics-core';
+import type { BeforePlugin } from '@amplitude/analytics-core';
 
 describe('networkConnectivityCheckerPlugin', () => {
   const amplitude = createAmplitudeMock();
   const config = createConfigurationMock();
+  let plugins: BeforePlugin[];
+
+  // Track every plugin so its network listeners can be torn down after each
+  // test, preventing stale listeners from leaking across tests.
+  const createPlugin = (): BeforePlugin => {
+    const plugin = networkConnectivityCheckerPlugin();
+    plugins.push(plugin);
+    return plugin;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugins = [];
+  });
+
+  afterEach(async () => {
+    for (const plugin of plugins) {
+      await plugin.teardown?.();
+    }
+  });
 
   test('should set up correctly when online', async () => {
-    const plugin = networkConnectivityCheckerPlugin();
+    const plugin = createPlugin();
     jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
     const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
 
@@ -22,7 +43,7 @@ describe('networkConnectivityCheckerPlugin', () => {
   });
 
   test('should set up correctly when offline', async () => {
-    const plugin = networkConnectivityCheckerPlugin();
+    const plugin = createPlugin();
     jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
     const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
 
@@ -34,8 +55,44 @@ describe('networkConnectivityCheckerPlugin', () => {
     addEventListenerSpy.mockRestore();
   });
 
+  test('should flush when transitioning from offline to online', async () => {
+    jest.useFakeTimers();
+    const plugin = createPlugin();
+    jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+    const onlineConfig = createConfigurationMock();
+
+    await plugin.setup?.(onlineConfig, amplitude);
+    expect(onlineConfig.offline).toEqual(true);
+
+    window.dispatchEvent(new Event('online'));
+    expect(onlineConfig.offline).toEqual(false);
+
+    jest.advanceTimersByTime(onlineConfig.flushIntervalMillis);
+    expect(amplitude.flush).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  test('should not flush on online event when already online', async () => {
+    jest.useFakeTimers();
+    const plugin = createPlugin();
+    jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    const onlineConfig = createConfigurationMock();
+
+    await plugin.setup?.(onlineConfig, amplitude);
+    expect(onlineConfig.offline).toEqual(false);
+
+    window.dispatchEvent(new Event('online'));
+    window.dispatchEvent(new Event('online'));
+
+    jest.advanceTimersByTime(onlineConfig.flushIntervalMillis);
+    expect(amplitude.flush).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
   test('should teardown plugin', async () => {
-    const plugin = networkConnectivityCheckerPlugin();
+    const plugin = createPlugin();
     const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
 
     await plugin.setup?.(createConfigurationMock(), amplitude);
@@ -46,7 +103,7 @@ describe('networkConnectivityCheckerPlugin', () => {
   });
 
   test('should do nothing when not on a browser', async () => {
-    const plugin = networkConnectivityCheckerPlugin();
+    const plugin = createPlugin();
     // @ts-expect-error we are mocking a node.js environment
     jest.spyOn(window, 'navigator', 'get').mockReturnValue(undefined);
     const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
@@ -62,7 +119,7 @@ describe('networkConnectivityCheckerPlugin', () => {
     const getGlobalScopeMock = jest
       .spyOn(AnalyticsCore, 'getGlobalScope')
       .mockReturnValue({} as unknown as typeof globalThis);
-    const plugin = networkConnectivityCheckerPlugin();
+    const plugin = createPlugin();
 
     await expect(plugin.setup?.(config, amplitude)).resolves.not.toThrow();
     await expect(plugin.teardown?.()).resolves.not.toThrow();
@@ -72,7 +129,7 @@ describe('networkConnectivityCheckerPlugin', () => {
 
   test('should not throw if globalScope.addEventListener is not available', async () => {
     jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({} as unknown as typeof globalThis);
-    const plugin = networkConnectivityCheckerPlugin();
+    const plugin = createPlugin();
 
     await expect(plugin.setup?.(config, amplitude)).resolves.not.toThrow();
   });


### PR DESCRIPTION
## Summary

The browser SDK's network connectivity checker plugin scheduled a flush on **every** `online` event, even when the SDK was already online. Repeated `online` events (e.g. the browser firing `online` while connectivity never actually dropped) therefore scheduled redundant flushes, each of which could surface `ERR_NETWORK_CHANGED`.

This adds an early-return guard so the `online` handler only acts on a genuine offline→online transition (it skips when `config.offline` is already `false`).

This mirrors the same guard added to the react-native connectivity plugin in PR #1802 (flagged by Copilot review) — the browser SDK had the identical gap.

```ts
addNetworkListener('online', () => {
  if (config.offline === false) {
    return;
  }
  config.loggerProvider.debug('Network connectivity changed to online.');
  config.offline = false;
  // Flush immediately will cause ERR_NETWORK_CHANGED
  setTimeout(() => {
    amplitude.flush();
  }, config.flushIntervalMillis);
});
```

The `offline` handler is unchanged.

## Tests

- Added `should not flush on online event when already online` to `network-connectivity-checker.test.ts`: starts online, fires `online` twice, advances timers by `flushIntervalMillis`, asserts `flush` was not called.
- Added `should flush when transitioning from offline to online` to the same file to lock in the real-transition path (the guard must not break it).
- Added per-test plugin teardown (`createPlugin` tracker + `afterEach`) so stale `online` listeners from earlier tests don't leak into the flush-count assertions.
- Updated the existing `browser-client.test.ts` "should listen for network change to online" test: it previously relied on the now-removed redundant-flush behavior (it dispatched `online` while already online). It now starts offline (`navigator.onLine === false`) so it exercises a genuine offline→online transition.

## Test plan

- `pnpm --filter @amplitude/analytics-browser run typecheck` — passes
- `pnpm --filter @amplitude/analytics-browser run test` — 508 passed, 508 total (24 suites), 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)