### PR TITLE
fix(segment-session-replay-plugin-react-native): defer start() when native session ID is -1 (autoStart:false bug)

### DIFF
--- a/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
+++ b/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
@@ -2,6 +2,7 @@ import { Plugin, PluginType, type SegmentEvent, EventType, SegmentClient } from 
 
 import {
   type SessionReplayConfig,
+  getSessionId as getSRSessionId,
   getSessionReplayProperties,
   init,
   setDeviceId,
@@ -41,6 +42,10 @@ export class SegmentSessionReplayPlugin extends Plugin {
   // because `configure` is not asynchronous
   private initPromise: Promise<void> | null = null;
 
+  // True when start() was called but deferred because no valid session ID (> 0)
+  // was available yet.  Flushed by execute() once a valid id arrives.
+  private pendingStart = false;
+
   constructor(config: SessionReplayConfig) {
     super();
     this.sessionReplayConfig = config;
@@ -64,6 +69,16 @@ export class SegmentSessionReplayPlugin extends Plugin {
     await setSessionId(sessionId);
     await setDeviceId(deviceId);
 
+    // Flush a deferred start() once the first valid session ID arrives.
+    // start() may have been called before any event flowed through here, at
+    // which point the native SDK's session ID was still -1 (the default
+    // sentinel).  We wait until we have a real id (> 0) before starting
+    // native recording to avoid corrupting the replay with sessionId -1.
+    if (this.pendingStart && sessionId > 0) {
+      this.pendingStart = false;
+      await start();
+    }
+
     if (event.type === EventType.TrackEvent || event.type === EventType.ScreenEvent) {
       const properties = await getSessionReplayProperties();
       event.properties = { ...event.properties, ...properties };
@@ -79,7 +94,16 @@ export class SegmentSessionReplayPlugin extends Plugin {
 
   async start(): Promise<void> {
     await this.initPromise;
-    await start();
+    // The native SDK defaults sessionId to -1 until the first Segment event
+    // flows through execute() and calls setSessionId() with a real value.
+    // Starting under -1 would tag the entire recording with an invalid session,
+    // so we defer if the current id is not yet valid (> 0).
+    const currentSessionId = await getSRSessionId();
+    if (currentSessionId !== null && currentSessionId > 0) {
+      await start();
+    } else {
+      this.pendingStart = true;
+    }
   }
 
   async stop(): Promise<void> {

--- a/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
+++ b/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
@@ -34,6 +34,7 @@ import {
   init,
   setDeviceId,
   setSessionId,
+  getSessionId,
   getSessionReplayProperties,
   start,
   stop,
@@ -45,6 +46,7 @@ jest.mock('@amplitude/session-replay-react-native', () => ({
   init: jest.fn(),
   setDeviceId: jest.fn(),
   setSessionId: jest.fn(),
+  getSessionId: jest.fn(),
   getSessionReplayProperties: jest.fn(),
   start: jest.fn(),
   stop: jest.fn(),
@@ -57,6 +59,9 @@ describe('SegmentSessionReplayPlugin', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Default: native SDK has not yet received a real session ID (the -1 sentinel).
+    (getSessionId as jest.Mock).mockResolvedValue(-1);
 
     mockConfig = {
       apiKey: 'test-api-key',
@@ -266,9 +271,85 @@ describe('SegmentSessionReplayPlugin', () => {
   });
 
   describe('start', () => {
-    it('should call start', async () => {
+    it('should call native start immediately when a valid session ID already exists', async () => {
+      (getSessionId as jest.Mock).mockResolvedValue(1700000000000);
+
       await plugin.start();
-      expect(start).toHaveBeenCalled();
+
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT call native start when session ID is -1 (autoStart:false bug)', async () => {
+      // SR SDK still has the default -1 sentinel — no real session ID yet.
+      (getSessionId as jest.Mock).mockResolvedValue(-1);
+
+      await plugin.start();
+
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call native start when session ID is null', async () => {
+      (getSessionId as jest.Mock).mockResolvedValue(null);
+
+      await plugin.start();
+
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it('should flush deferred start on the first execute() with a valid session ID', async () => {
+      // Simulate autoStart:false → start() before any event
+      (getSessionId as jest.Mock).mockResolvedValue(-1);
+      await plugin.start();
+      expect(start).not.toHaveBeenCalled();
+
+      // First real event arrives carrying the actual session ID
+      const mockEvent: SegmentEvent = {
+        type: EventType.TrackEvent,
+        event: 'app_opened',
+        properties: { session_id: '1700000000000' },
+        context: { device: { id: 'device-abc' } },
+      } as any;
+      (getSessionReplayProperties as jest.Mock).mockResolvedValue({});
+
+      await plugin.execute(mockEvent);
+
+      // Native start() should now have been called exactly once with the real id.
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT flush deferred start when execute() carries sessionId -1', async () => {
+      (getSessionId as jest.Mock).mockResolvedValue(-1);
+      await plugin.start();
+
+      const mockEvent: SegmentEvent = {
+        type: EventType.TrackEvent,
+        event: 'no_session_yet',
+        properties: {},
+        context: {},
+      } as any;
+      (getSessionReplayProperties as jest.Mock).mockResolvedValue({});
+
+      await plugin.execute(mockEvent);
+
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it('should flush deferred start only once across multiple execute() calls', async () => {
+      (getSessionId as jest.Mock).mockResolvedValue(-1);
+      await plugin.start();
+
+      const eventWithSession: SegmentEvent = {
+        type: EventType.TrackEvent,
+        event: 'button_clicked',
+        properties: { session_id: '1700000000000' },
+        context: { device: { id: 'device-abc' } },
+      } as any;
+      (getSessionReplayProperties as jest.Mock).mockResolvedValue({});
+
+      await plugin.execute(eventWithSession);
+      await plugin.execute(eventWithSession);
+
+      expect(start).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Problem

When using `segment-session-replay-plugin-react-native` with `autoStart: false`, Session Replay reports `sessionId: -1` for the entire recording, making it unroutable and unviewable in Amplitude.

**Customer impact:** Zendesk #396256 / YaraPlus (Org 56519).

---

## Root Cause

**File:** `packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts` ~L80–83

The plugin's `start()` method called the native SR `start()` unconditionally:

```typescript
async start(): Promise<void> {
  await this.initPromise;
  await start();  // ← no session-ID guard!
}
```

The native SDK's `sessionId` defaults to `-1` (see `session-replay-config.ts:122`). The real Amplitude session ID is only applied when the first Segment event flows through `execute()`, which calls `setSessionId()`.

With `autoStart: false`, the customer calls `start()` **before** any event → native recording begins under session `-1`.

---

## Cross-Platform Context

| Platform | Guard | Behaviour |
|----------|-------|-----------|
| iOS | `canStart` requires `sessionId > 0` (SessionReplay.swift:271–278) | `start()` is a safe no-op under `-1`; self-heals when real id arrives |
| Android | `isSessionIdValid()` (`sessionId > 0L`) in `shouldRecord()` | Recording refused (not corrupted) until valid id exists |
| Browser | Sentinel is `undefined` (falsy) | Guards block naturally |
| **RN (before fix)** | **None** | Recording starts under `-1` ← **the bug** |

---

## Fix

**Plugin-level fix** (minimal, safe, unblocks customers immediately):

1. Import `getSessionId` from `@amplitude/session-replay-react-native` (already exported; previously unused in this plugin).
2. In `start()`: read the current native session ID. If it is `null` or `<= 0`, set `pendingStart = true` and return without calling native `start()`.
3. In `execute()`: after `setSessionId(sessionId)` applies a valid id (`> 0`), if `pendingStart` is set, clear it and call native `start()` immediately.

This mirrors the iOS/Android semantics: do not start recording under an invalid session id; auto-start once a valid id exists.

### Why plugin-level (not standalone-SDK-level)?

The plugin is the only consumer that calls `start()` before `execute()` has run. A standalone-SDK-level guard would also be valuable as defense-in-depth (benefits all RN consumers, not just the Segment plugin), but it is a larger change that touches the native bridge state machine. Keeping it separate ensures this customer-unblocking fix lands quickly.

**Recommended follow-up (standalone SDK):** Mirror iOS's `canStart` / Android's `isSessionIdValid` guard inside `session-replay.ts:start()` — refuse to start when `fullConfig.sessionId <= 0` and auto-start (or emit a callback) when a valid id is later set via `setSessionId()`. Tracked as a separate hardening task.

---

## Changes

| File | Change |
|------|--------|
| `src/segment-session-replay-plugin.ts` | Import `getSessionId as getSRSessionId`; add `pendingStart` flag; guard `start()` and flush in `execute()` |
| `test/segment-session-replay-plugin.test.ts` | Add `getSessionId` mock; add 5 new tests covering the bug and the fix |

---

## Test Results

All **20 tests pass** (15 pre-existing + 5 new):

New tests added:
- ✅ `start()` calls native start immediately when a valid session ID already exists
- ✅ `start()` does NOT call native start when session ID is `-1` (the bug reproduction)
- ✅ `start()` does NOT call native start when session ID is `null`
- ✅ Deferred start flushes on first `execute()` with a valid session ID
- ✅ Deferred start does NOT flush when `execute()` carries `sessionId -1`
- ✅ Deferred start flushes only once across multiple `execute()` calls

Lint (`eslint src/ test/`): **No issues found**
TypeCheck (`tsc --noEmit`): **No errors**

---

## Customer Workarounds (until this is released)

1. Use `autoStart: true` (the default) — `execute()` runs before the customer can call `start()`.
2. Call `start()` only **after** the first `analytics.track()` / `analytics.screen()` event has been sent — by then `execute()` has applied a real session ID.

---

## Checklist

- [x] Bug reproduced and understood
- [x] Fix implemented (plugin-level)
- [x] Unit tests added (5 new tests)
- [x] All tests pass
- [x] Lint clean (src + test)
- [x] TypeScript types check
- [ ] Changelog entry (will add before merge)
- [ ] Standalone-SDK follow-up tracked

Made with [Cursor](https://cursor.com)