### PR TITLE
fix(session-replay-browser): restore 2 MB MAX_EVENT_LIST_SIZE default

### DIFF
--- a/packages/session-replay-browser/e2e/size-limits.spec.ts
+++ b/packages/session-replay-browser/e2e/size-limits.spec.ts
@@ -206,7 +206,7 @@ test.describe('WAF 413 bisect-retry', () => {
 // ─── Empty-batch leak (SR-4284) ───────────────────────────────────────────────
 
 test.describe('empty batch leak (SR-4284)', () => {
-  // A single rrweb event between MAX_EVENT_LIST_SIZE (700 KB) and MAX_SINGLE_EVENT_SIZE
+  // A single rrweb event between MAX_EVENT_LIST_SIZE (2 MB) and MAX_SINGLE_EVENT_SIZE
   // (9 MB) passes the per-event capture-time guard but, when it lands in
   // addEventToCurrentSequence with an empty buffer, drives shouldSplitEventsList's
   // size-constraint branch true on a zero-event buffer. Pre-fix the split path
@@ -216,7 +216,7 @@ test.describe('empty batch leak (SR-4284)', () => {
   // POSTs and no empty rows to ever be persisted in IDB.
 
   // 2× the list cap: comfortably under the per-event cap. The rrweb full snapshot
-  // serializing this attribute will be > 700 KB but << 9 MB, so it bypasses the
+  // serializing this attribute will be > 2 MB but << 9 MB, so it bypasses the
   // capture-time drop and exercises the SR-4284 store-layer path.
   const MID_SIZE_ATTR_LENGTH = MAX_EVENT_LIST_SIZE * 2;
 
@@ -266,7 +266,7 @@ test.describe('empty batch leak (SR-4284)', () => {
     await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
-    // Now mutate the DOM with a > 700 KB attribute. rrweb emits an incremental
+    // Now mutate the DOM with a > 2 MB attribute. rrweb emits an incremental
     // mutation event that, serialized, exceeds MAX_EVENT_LIST_SIZE. It lands in
     // addEventToCurrentSequence on a slot that already exists with events:[] —
     // shouldSplitEventsList's size-constraint branch fires on a zero-event buffer.

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -19,10 +19,18 @@ export const SESSION_REPLAY_SERVER_URL = 'https://api-sr.amplitude.com/sessions/
 export const SESSION_REPLAY_EU_URL = 'https://api-sr.eu.amplitude.com/sessions/v2/track';
 export const SESSION_REPLAY_STAGING_URL = 'https://api-sr.stag2.amplitude.com/sessions/v2/track';
 export const STORAGE_PREFIX = `${AMPLITUDE_PREFIX}_replay_unsent`;
-// Reduced from 1,000,000 to leave headroom for double-JSON-encoding overhead and the
-// uncompressed fallback path. The HTTP body is ~10-30% larger than raw string length
-// because events are re-serialized inside the { version, events } wrapper at send time.
-export const MAX_EVENT_LIST_SIZE = 700_000;
+// Raw (uncompressed) UTF-8 byte cap for a single batched events list before the store splits
+// it into its own request. Larger batches mean fewer requests — the primary steady-state lever
+// for request volume — while the time-based flush (flushIntervalConfig) still controls send
+// cadence, so this only decides whether a single high-activity flush gets split into multiple
+// requests. Set to 2 MB: gzipped on the wire that's ~0.2 MB, far under the SR ingest service's
+// 10,000,000-byte decompressed split threshold (nova SessionReplayServletV2 splits batches above
+// it server-side and only 413s a single >10 MB event), and well clear of the ~10-30% wrapper/
+// JSON-escaping overhead. Kept at 2 MB (not higher) so it stays a safe POST body on the
+// no-CompressionStream fallback path (raw == wire there) and keeps per-session memory/IDB
+// buffering modest on low-end devices. A smaller cap (e.g. 700 KB) splits busy-page flushes
+// into several more requests/session and drives SR ingest request-rate throttling.
+export const MAX_EVENT_LIST_SIZE = 2_000_000;
 // 9 MB UTF-8 bytes — just under the server's 10 MB per-event threshold. Compared against the
 // UTF-8 byte length of the serialized event (via Blob/TextEncoder), not the JS string length,
 // so multi-byte payloads (CJK, emoji) are gated correctly.

--- a/packages/session-replay-browser/src/events/base-events-store.ts
+++ b/packages/session-replay-browser/src/events/base-events-store.ts
@@ -91,8 +91,8 @@ export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
     // - Commas between events: events.length - 1 bytes
     // - Double quotes wrapping each event string: events.length * 2 bytes
     // Note: does not include the outer { version, events } wrapper (~22 bytes) or
-    // per-event JSON-escaping of " and \ characters; the reduced MAX_EVENT_LIST_SIZE
-    // cap (700 KB vs 1 MB) provides headroom for those.
+    // per-event JSON-escaping of " and \ characters; the 2 MB MAX_EVENT_LIST_SIZE cap
+    // stays well under the server's 10 MB decompressed split threshold even with those.
     const overhead = 2 + Math.max(0, events.length - 1) + events.length * 2;
 
     return totalSize + overhead;

--- a/packages/session-replay-browser/src/events/events-idb-store.ts
+++ b/packages/session-replay-browser/src/events/events-idb-store.ts
@@ -473,7 +473,7 @@ export class SessionReplayEventsIDBStore extends BaseEventsStore<number> {
       const eventsToSend = ownedSequence.events;
 
       // shouldSplitEventsList can return true with an empty buffer when a single
-      // incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB) — the size-constraint
+      // incoming event is larger than MAX_EVENT_LIST_SIZE (2 MB) — the size-constraint
       // branch fires regardless of current length. Don't write a zero-event row to
       // sequencesToSend (which would later POST as an empty body, the SR-4284 root
       // cause); just claim the slot for the new event without finalizing anything.

--- a/packages/session-replay-browser/src/events/events-memory-store.ts
+++ b/packages/session-replay-browser/src/events/events-memory-store.ts
@@ -72,7 +72,7 @@ export class InMemoryEventsStore extends BaseEventsStore<number> {
 
     let sequenceReturn: SendingSequencesReturn<number> | undefined;
     // shouldSplitEventsList can return true with an empty buffer when a single
-    // incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB) — the size-constraint
+    // incoming event is larger than MAX_EVENT_LIST_SIZE (2 MB) — the size-constraint
     // branch fires regardless of current length. Don't finalize a zero-event sequence
     // (the SR-4284 root cause); just hold the incoming event in the buffer.
     // shouldSplitEventsList's time-elapsed branch only fires when events.length > 0

--- a/packages/session-replay-browser/test/events-idb-store.test.ts
+++ b/packages/session-replay-browser/test/events-idb-store.test.ts
@@ -302,7 +302,7 @@ describe('SessionReplayEventsIDBStore', () => {
     });
 
     // SR-4284: shouldSplitEventsList can return true with an empty buffer when a
-    // single incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB) — the size
+    // single incoming event is larger than MAX_EVENT_LIST_SIZE (2 MB) — the size
     // branch fires regardless of current length. The split path must NOT write a
     // zero-event row to sequencesToSend; just claim the slot for the incoming event.
     test('does not write empty sequencesToSend row when split fires on empty buffer', async () => {

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -657,6 +657,9 @@ describe('createEventsManager', () => {
       // Use the real memory store so shouldSplitEventsList can trigger a split.
       // eventA sits just under the cap so it doesn't split on its own; eventB then pushes the
       // batch over MAX_EVENT_LIST_SIZE. Derived from the constant so it tracks cap changes.
+      // 10 bytes of slack exceeds getEventsArraySize's 4-byte overhead for a 1-event list
+      // (2 + 0 + 2) plus eventB's payload, so eventA stays under the cap alone but crosses
+      // it once eventB is appended.
       const eventA = 'a'.repeat(MAX_EVENT_LIST_SIZE - 10);
       const eventB = JSON.stringify({ type: 3, timestamp: 2 });
 

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { ILogger } from '@amplitude/analytics-core';
 import { SessionReplayLocalConfig } from '../src/config/local-config';
+import { MAX_EVENT_LIST_SIZE } from '../src/constants';
 import * as SessionReplayIDB from '../src/events/events-idb-store';
 import { createEventsManager } from '../src/events/events-manager';
 import { SessionReplayTrackDestination } from '../src/track-destination';
@@ -654,12 +655,13 @@ describe('createEventsManager', () => {
         storeType: 'memory',
       });
       // Use the real memory store so shouldSplitEventsList can trigger a split.
-      // eventA must be large enough that eventA + eventB >= MAX_EVENT_LIST_SIZE (1_000_000).
-      const eventA = 'a'.repeat(999_990);
+      // eventA sits just under the cap so it doesn't split on its own; eventB then pushes the
+      // batch over MAX_EVENT_LIST_SIZE. Derived from the constant so it tracks cap changes.
+      const eventA = 'a'.repeat(MAX_EVENT_LIST_SIZE - 10);
       const eventB = JSON.stringify({ type: 3, timestamp: 2 });
 
       eventsManager.addEvent({ event: { type: 'replay', data: eventA }, sessionId: 123, deviceId: '1a2b3c' });
-      // Force split: eventB pushes the batch over the 1 MB limit
+      // Force split: eventB pushes the batch over the MAX_EVENT_LIST_SIZE limit
       eventsManager.addEvent({ event: { type: 'replay', data: eventB }, sessionId: 123, deviceId: '1a2b3c' });
 
       // Let the async addEventToCurrentSequence chains settle (two microtask ticks).

--- a/packages/session-replay-browser/test/events-memory-store.test.ts
+++ b/packages/session-replay-browser/test/events-memory-store.test.ts
@@ -126,7 +126,7 @@ describe('InMemoryEventsStore', () => {
   describe('addEventToCurrentSequence empty-buffer split guard (SR-4284)', () => {
     // Repro for the SR-4284 root cause: shouldSplitEventsList can return true even when
     // the current buffer is empty, because the size-constraint branch fires when a
-    // single incoming event is larger than MAX_EVENT_LIST_SIZE (700 KB). Without the
+    // single incoming event is larger than MAX_EVENT_LIST_SIZE (2 MB). Without the
     // guard, addSequence would finalize a zero-event sequence that later POSTs as an
     // empty body and 400s on the server.
     test('does not finalize a zero-event sequence when buffer is empty', async () => {

--- a/packages/session-replay-browser/test/track-destination.test.ts
+++ b/packages/session-replay-browser/test/track-destination.test.ts
@@ -1,6 +1,7 @@
 import * as AnalyticsCore from '@amplitude/analytics-core';
 import { ILogger, ServerZone } from '@amplitude/analytics-core';
 import { SessionReplayDestinationContext } from 'src/typings/session-replay';
+import { MERGE_AFTER_THROTTLE_SOFT_CAP } from '../src/constants';
 import { SessionReplayTrackDestination } from '../src/track-destination';
 import { VERSION } from '../src/version';
 
@@ -1151,8 +1152,9 @@ describe('SessionReplayTrackDestination', () => {
       const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
       const sendSpy = jest.spyOn(trackDestination, 'send').mockResolvedValue(undefined);
 
-      // Each context is just under the cap; together they exceed it. Expect a split into 3.
-      const big = 'x'.repeat(800_000); // > MERGE_AFTER_THROTTLE_SOFT_CAP / 2 (= 700_000)
+      // Each context is just over half the cap, so any two together exceed it. Expect a split
+      // into 3. Derived from the constant so it tracks MAX_EVENT_LIST_SIZE changes.
+      const big = 'x'.repeat(Math.floor(MERGE_AFTER_THROTTLE_SOFT_CAP / 2) + 100_000);
       trackDestination.queue = [baseCtx({ events: [big] }), baseCtx({ events: [big] }), baseCtx({ events: [big] })];
       (trackDestination as any).mergeOnNextFlush = true;
 


### PR DESCRIPTION
## Summary
- Restores `MAX_EVENT_LIST_SIZE` to **2 MB** (mainline had drifted to 700 KB). This is the events-list byte cap that decides when the store splits a high-activity flush into its own request.
- A 700 KB cap splits a busy-page flush into ~3× more requests than the 2 MB cap the `sr-4646` SR build shipped. SR ingest throttling is **request-count based** (per org/app/**device** rate — nova `SessionReplayServletV2` increments a Redis counter by 1/request, device threshold ~5 rps), so the smaller cap drove extra per-device requests and triggered throttling on high-activity pages (e.g. HubSpot CRM).
- The time-based flush (`flushIntervalConfig`) still controls send cadence; this only affects whether a single large flush is split. 2 MB gzips to ~0.2 MB — far under the server's 10 MB decompressed split threshold — and stays a safe POST body on the no-`CompressionStream` fallback path.
- Tests that pinned the old literal now derive from the constant so they track future cap changes.

## Context
The `sr-perf-reliability` RC was cut from `main`, which had independently reduced this cap to 700 KB, so it missed the `sr-4646` build's 2 MB bump (its "primary steady-state lever for request volume"). This aligns mainline so future GA cuts don't reintroduce the request-rate regression. Runtime override via `maxPersistedEventsSizeBytes` is unchanged.

## Test plan
- [x] `pnpm --filter @amplitude/session-replay-browser test` — 1003 passed, 100% coverage
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default upload batching and ingest request volume for all clients using the default cap; behavior is intentional but can affect throttling, memory/IDB buffering, and uncompressed POST size on older browsers.
> 
> **Overview**
> Raises **`MAX_EVENT_LIST_SIZE`** from **700 KB to 2 MB** in session-replay-browser so the event store splits high-activity flushes into fewer ingest POSTs. The smaller cap had increased per-device request count and contributed to SR ingest **request-rate throttling** on busy pages; flush cadence is unchanged—only the batch byte limit before a split moves.
> 
> Documentation in `constants.ts` and store comments is expanded to explain the tradeoff (gzip vs uncompressed fallback, server 10 MB split threshold). **Unit/e2e tests** that used fixed sizes now derive thresholds from **`MAX_EVENT_LIST_SIZE`** / **`MERGE_AFTER_THROTTLE_SOFT_CAP`** so they stay aligned if the cap changes again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4da3a48cb3b497e9e352caea4d3fcdad44f2ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->