### PR TITLE
refactor(analytics-browser): remove unused cursor pointer code from a…

### DIFF
--- a/packages/plugin-autocapture-browser/src/helpers.ts
+++ b/packages/plugin-autocapture-browser/src/helpers.ts
@@ -38,7 +38,6 @@ export const isUrlAllowed = (autocaptureOptions: ElementInteractionsOptions): bo
 export const createShouldTrackEvent = (
   autocaptureOptions: ElementInteractionsOptions,
   allowlist: string[], // this can be any type of css selector allow list
-  isAlwaysCaptureCursorPointer = false,
 ): shouldTrackEvent => {
   return (actionType: ActionType, element: Element) => {
     const { shouldTrackEventResolver } = autocaptureOptions;
@@ -69,12 +68,6 @@ export const createShouldTrackEvent = (
       }
     }
 
-    const isCursorPointer = isElementPointerCursor(element, actionType);
-
-    if (isAlwaysCaptureCursorPointer && isCursorPointer) {
-      return true;
-    }
-
     /* istanbul ignore if */
     if (allowlist) {
       const hasMatchAnyAllowedSelector = allowlist.some((selector) => !!element?.matches?.(selector));
@@ -88,14 +81,8 @@ export const createShouldTrackEvent = (
       case 'select':
       case 'textarea':
         return actionType === 'change' || actionType === 'click';
-      default: {
-        /* istanbul ignore next */
-        /* istanbul ignore next */
-        if (isCursorPointer) {
-          return true;
-        }
+      default:
         return actionType === 'click';
-      }
     }
   };
 };

--- a/packages/plugin-autocapture-browser/test/helpers.test.ts
+++ b/packages/plugin-autocapture-browser/test/helpers.test.ts
@@ -623,26 +623,6 @@ describe('autocapture-plugin helpers', () => {
       expect(shouldTrackEvent('click', document as unknown as Element)).toEqual(false);
     });
 
-    test('should track any element with pointer cursor when isAlwaysCaptureCursorPointer is true', () => {
-      const element = document.createElement('div');
-      const style = document.createElement('style');
-      style.textContent = '.pointer { cursor: pointer; }';
-      document.head.appendChild(style);
-      element.className = 'pointer';
-
-      const shouldTrackEvent = createShouldTrackEvent(
-        {
-          pageUrlAllowlist: undefined,
-          shouldTrackEventResolver: undefined,
-        },
-        [],
-        true, // isAlwaysCaptureCursorPointer
-      );
-
-      expect(shouldTrackEvent('click', element)).toEqual(true);
-      document.head.removeChild(style);
-    });
-
     test('should respect pageUrlExcludelist configuration', () => {
       // Mock window.location to a test URL
       mockWindowLocationFromURL(new URL('https://www.test.com/page'));


### PR DESCRIPTION
### Summary

The `isAlwaysCaptureCursorPointer` parameter in `createShouldTrackEvent` is not used anywhere. Taking it out to simplify the code and reduce the bytes in our bundle.


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no callers using the removed parameter; default click tracking for generic elements is unchanged in practice.
> 
> **Overview**
> Removes dead **cursor-pointer** tracking from `createShouldTrackEvent` in the browser autocapture plugin: the unused `isAlwaysCaptureCursorPointer` argument and the branches that called `isElementPointerCursor` to auto-track clicks on pointer-styled elements.
> 
> Non-form elements now use a single rule—track only **`click`** actions (after existing URL, allowlist, and sensitive-input checks)—which matches current call sites and trims bundle size. **`isElementPointerCursor`** stays exported for the data extractor’s separate capture path.
> 
> Tests that covered the removed flag are deleted; remaining `createShouldTrackEvent` tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d980f77c756b0f4ee9f802ccf902bd5493e30f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->