### PR TITLE
chore: require npm release environment

### DIFF
--- a/.github/workflows/publish-single-package.yml
+++ b/.github/workflows/publish-single-package.yml
@@ -48,6 +48,7 @@ jobs:
   publish-package:
     name: Publish New Package (Beta/Alpha with Latest Tag)
     runs-on: ubuntu-latest
+    environment: npm-release
     needs: [authorize]
     permissions:
       id-token: write

--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -26,6 +26,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: npm-release
     needs: [authorize]
     permissions:
       id-token: write

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -92,6 +92,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: npm-release
     needs: [authorize, e2e]
     if: ${{ github.event.inputs.releaseType == 'release' }}
     permissions:
@@ -180,6 +181,7 @@ jobs:
   prerelease:
     name: Prerelease feature branch
     runs-on: ubuntu-latest
+    environment: npm-release
     needs: [authorize, e2e]
     if: ${{ github.event.inputs.releaseType == 'prerelease' || github.event.inputs.releaseType == 'dry-run' }}
     permissions:


### PR DESCRIPTION
## Summary
- add the npm-release environment gate to npm publish workflow jobs

## Testing
- ruby YAML parse check for edited workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds an approval gate before publish jobs; no application or publish script logic is modified.
> 
> **Overview**
> Adds **`environment: npm-release`** to every GitHub Actions job that publishes to npm, so those runs must pass the repo’s **`npm-release`** environment protection (e.g. required reviewers) before deploy steps execute.
> 
> **`publish-v1.yml`**: `deploy` only. **`publish-v2.yml`**: `deploy` (stable release) and `prerelease` (prerelease/dry-run path that can publish). **`publish-single-package.yml`**: `publish-package`. Authorization and E2E jobs are unchanged; only publish-capable jobs are gated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a736aec327bcc3e27cd609c1243e28aeef65c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->