### PR TITLE
chore(analytics-react-native): raise min iOS/tvOS to 13.0 (SDKRN-5) [2.2/5]

### DIFF
--- a/packages/analytics-react-native/amplitude-react-native.podspec
+++ b/packages/analytics-react-native/amplitude-react-native.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.platforms = { :ios => "10.0", :tvos => "10.0" }
+  # Mirrors Amplitude-Swift's deployment targets.
+  s.platforms = { :ios => "13.0", :tvos => "13.0" }
   s.source = { :git => "https://github.com/amplitude/Amplitude-TypeScript.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
## Summary
Raises the `amplitude-react-native` podspec minimum deployment target from iOS/tvOS **10.0** to **13.0**, mirroring [Amplitude-Swift](https://github.com/amplitude/Amplitude-Swift/blob/main/AmplitudeSwift.podspec) (`ios 13.0 / tvos 13.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)