### PR TITLE
fix(analytics-browser): defer session_start until Context plugin is ready

### DIFF
--- a/packages/analytics-browser/src/browser-client.ts
+++ b/packages/analytics-browser/src/browser-client.ts
@@ -261,7 +261,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
       await this.webAttribution.init();
     }
 
-    // Step 3: Set session ID
+    // Step 3: Resolve initial session ID (session events are sent after plugins are installed)
     // Priority 1: `options.sessionId`
     // Priority 2: sessionId from url if it's Number and ampTimestamp is valid
     // Priority 3: last known sessionId from user identity storage
@@ -284,7 +284,7 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
       deferredSessionId = Date.now();
     }
 
-    this.setSessionId(options.sessionId ?? querySessionId ?? deferredSessionId ?? this.config.sessionId);
+    const initialSessionId = options.sessionId ?? querySessionId ?? deferredSessionId ?? this.config.sessionId;
 
     if (this.config.optOut) {
       this.timeline.addOptOutListener(async (optOut) => {
@@ -315,6 +315,9 @@ export class AmplitudeBrowser extends AmplitudeCore implements BrowserClient, An
     await this.add(new Destination({ diagnosticsClient })).promise;
     await this.add(new Context()).promise;
     await this.add(new IdentityEventSender()).promise;
+
+    // Emit session events only after Context plugin can enrich them with device_id and library.
+    this.setSessionId(initialSessionId);
 
     // Notify if DET is enabled
     detNotify(this.config);

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -157,6 +157,57 @@ describe('browser-client', () => {
       });
     });
 
+    test('should enrich session_start during init with device_id and library', async () => {
+      const sentEvents: Array<Record<string, unknown>> = [];
+      const transportProvider = {
+        send: jest.fn((_url: string, payload: { events: Array<Record<string, unknown>> }) => {
+          sentEvents.push(...payload.events);
+          return Promise.resolve({
+            status: core.Status.Success,
+            statusCode: 200,
+            body: {
+              eventsIngested: payload.events.length,
+              payloadSizeBytes: 1,
+              serverUploadTime: 1,
+            },
+          });
+        }),
+      };
+      const createTransportSpy = jest
+        .spyOn(Config, 'createTransport')
+        .mockReturnValue(transportProvider as unknown as ReturnType<typeof Config.createTransport>);
+
+      jest.spyOn(CookieMigration, 'parseLegacyCookies').mockResolvedValueOnce({
+        optOut: false,
+        sessionId: 1,
+        lastEventId: 100,
+        lastEventTime: Date.now() - 31 * 60 * 1000,
+      });
+
+      const newSessionId = Date.now();
+      await client.init(apiKey, userId, {
+        deviceId,
+        sessionId: newSessionId,
+        flushQueueSize: 1,
+        flushIntervalMillis: 1,
+        defaultTracking: {
+          ...defaultTracking,
+          sessions: true,
+        },
+        fetchRemoteConfig: false,
+      }).promise;
+      await client.flush().promise;
+      createTransportSpy.mockRestore();
+
+      const sessionStartEvents = sentEvents.filter((event) => event.event_type === 'session_start');
+
+      expect(sessionStartEvents.length).toBeGreaterThan(0);
+      sessionStartEvents.forEach((event) => {
+        expect(event.device_id).toBeDefined();
+        expect(event.library).toBeDefined();
+      });
+    });
+
     test('should use remote config by default', async () => {
       await client.init(apiKey).promise;
       expect(MockedRemoteConfigClient).toHaveBeenCalled();


### PR DESCRIPTION
### Summary

**Linear:** [SR-4611 — Investigate session replay plugin and `session_start` 400s](https://linear.app/amplitude/issue/SR-4611)

Fixes intermittent 400 ingestion errors where `session_start` events were missing both `user_id` and `device_id` (Pet Media app 628463).

During `AmplitudeBrowser._init()`, `setSessionId()` was called before the Context plugin was registered. Because `super._init()` sets `isReady = true` first, session events could dispatch before Context enriched them with `device_id`, `user_id`, and `library` — matching the bad payloads from DPL-258.

This moves `setSessionId()` to run after `Destination`, `Context`, and `IdentityEventSender` are installed.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

### Test plan

- [x] Added regression test: `should enrich session_start during init with device_id and library`
- [x] All 138 `browser-client` tests pass locally

<details>
<summary>AI Prompt</summary>

Investigate SR-4611 (session replay plugin and session_start 400s), post findings on the ticket, and implement a fix for the SDK init race causing missing device_id on session_start events.

</details>