### PR TITLE
fix(analytics-browser): use safe JSON stringify in remote config log messages

### DIFF
--- a/packages/analytics-browser/src/config/joined-config.ts
+++ b/packages/analytics-browser/src/config/joined-config.ts
@@ -7,6 +7,7 @@ import {
   NetworkTrackingOptions,
   NetworkCaptureRule,
   SAFE_HEADERS,
+  safeJsonStringify,
 } from '@amplitude/analytics-core';
 
 export interface AutocaptureOptionsRemoteConfig extends AutocaptureOptions {
@@ -215,7 +216,7 @@ export function updateBrowserConfigWithRemoteConfig(
   try {
     browserConfig.loggerProvider.debug(
       'Update browser config with remote configuration:',
-      JSON.stringify(remoteConfig),
+      safeJsonStringify(remoteConfig),
     );
 
     // type cast error will be thrown if remoteConfig is not a valid RemoteConfigBrowserSDK
@@ -309,7 +310,7 @@ export function updateBrowserConfigWithRemoteConfig(
       }
     }
 
-    browserConfig.loggerProvider.debug('Browser config after remote config update:', JSON.stringify(browserConfig));
+    browserConfig.loggerProvider.debug('Browser config after remote config update:', safeJsonStringify(browserConfig));
   } catch (e) {
     browserConfig.loggerProvider.error('Failed to apply remote configuration because of error: ', e);
   }


### PR DESCRIPTION
### Summary

In Zone.js, the Promise class is decorated with extra properties, that can cause circular references, which breaks JSON.stringify; this switches it to "safeJsonStringify" to prevent this

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no effect on config merge behavior or analytics payloads.
> 
> **Overview**
> Replaces **`JSON.stringify`** with **`safeJsonStringify`** from `@amplitude/analytics-core` in the two debug log lines inside **`updateBrowserConfigWithRemoteConfig`** (remote config before merge and browser config after merge).
> 
> This avoids logging failures when config objects contain circular references—for example when Zone.js decorates **`Promise`**—so remote config application no longer throws during debug logging in those environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b29169b2bc90269539275edef450bac947164db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->