### PR TITLE
ci: record v2.x releases in Linear after npm publish

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -178,6 +178,21 @@ jobs:
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
+      # Record the published release in Linear (continuous pipeline). Runs only after a
+      # successful npm publish, so each Linear release maps 1:1 to a real release. The
+      # release is named after the analytics-browser version since lerna versions packages
+      # independently and there is no single repo-wide version.
+      - name: Read analytics-browser version
+        id: linear-version
+        run: echo "version=$(node -p "require('./packages/analytics-browser/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@3b634623620454bac33390451a1dd15ba78e3dc4 # v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          version: ${{ steps.linear-version.outputs.version }}
+
   prerelease:
     name: Prerelease feature branch
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -179,14 +179,28 @@ jobs:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
       # Record the published release in Linear (continuous pipeline). Runs only after a
-      # successful npm publish, so each Linear release maps 1:1 to a real release. The
-      # release is named after the analytics-browser version since lerna versions packages
-      # independently and there is no single repo-wide version.
-      - name: Read analytics-browser version
+      # successful npm publish, so each Linear release maps 1:1 to a real release, named
+      # after the analytics-browser version. Because lerna versions packages independently,
+      # only sync when this release actually bumped analytics-browser (its package.json
+      # changed in the lerna release commit) — otherwise its unchanged version would collide
+      # with the label of a previous Linear release. Tracking is best-effort: a Linear
+      # failure must not fail an already-published release.
+      - name: Determine analytics-browser release
         id: linear-version
-        run: echo "version=$(node -p "require('./packages/analytics-browser/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          version=$(node -p "require('./packages/analytics-browser/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if git diff --name-only HEAD~1 HEAD -- packages/analytics-browser/package.json | grep -q .; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "analytics-browser bumped to $version in this release; will sync to Linear"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "analytics-browser not part of this release; skipping Linear sync"
+          fi
 
       - name: Sync release to Linear
+        if: ${{ steps.linear-version.outputs.published == 'true' }}
+        continue-on-error: true
         uses: linear/linear-release-action@3b634623620454bac33390451a1dd15ba78e3dc4 # v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}


### PR DESCRIPTION
## What

Integrate [Linear Release](https://github.com/linear/linear-release) tracking into the **Publish v2.x** workflow. Two steps are added to the end of the `deploy` job:

- **Determine analytics-browser release** — reads `packages/analytics-browser/package.json` version and detects whether this release's lerna commit actually bumped that package.
- **Sync release to Linear** — runs `linear-release sync` (continuous pipeline) keyed to that version, only when analytics-browser was part of the release.

## Why this placement

The stock continuous example triggers on every push to `main`, but this repo ships on-demand via `workflow_dispatch`, not on every merge. Hooking into the `deploy` job instead means:

- A Linear release is recorded **only after a successful `lerna version` + npm publish** — 1:1 with real releases.
- It inherits the job's existing `if: releaseType == 'release'` gate, so prereleases and dry-runs don't create releases.
- The job already checks out with `fetch-depth: 0`, which the CLI requires.
- The action is pinned to a commit SHA (`3b63462` = `v0`), matching how this repo pins every other third-party action.

## Version labelling (independent versions)

Lerna versions packages independently, so there is no single repo-wide version. Releases are labelled with the `@amplitude/analytics-browser` version, **but only synced when this release actually bumped analytics-browser** (detected via the package.json change in the lerna release commit). A publish that bumps only other packages is skipped, so it can't reuse a prior release's version label.

## Best-effort

The sync step is `continue-on-error: true`. Linear tracking is metadata layered on top of the irreversible npm publish, so a Linear outage or a missing access key surfaces as a warning rather than red-X'ing an already-published release.

## Follow-up required before this works

- [x] Create a **Continuous** release pipeline in Linear (Settings → Releases) and copy its access key. https://linear.app/amplitude/settings/releases/pipelines/amplitude-typescript-analytics-browser
- [x] Add a repo secret named `LINEAR_ACCESS_KEY` with that key (Settings → Secrets and variables → Actions). Added to `npm-release` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only metadata step after publish, gated and best-effort; requires a new secret but does not change npm or application code.
> 
> **Overview**
> After a successful **Publish v2.x** `deploy` release (post-`pnpm deploy:publish`), the workflow now optionally records the ship in **Linear** via a continuous release pipeline.
> 
> A new step reads `@amplitude/analytics-browser`’s version from `packages/analytics-browser/package.json` and sets `published=true` only when that file changed in the latest commit (`HEAD~1..HEAD`), so independent Lerna bumps that skip analytics-browser do not reuse an existing Linear release label. When `published` is true, **Sync release to Linear** runs the pinned `linear/linear-release-action` with `command: sync` and `secrets.LINEAR_ACCESS_KEY`. The step uses **`continue-on-error: true`** so Linear issues do not fail an already-published npm release. Prerelease/dry-run jobs are unchanged.
> 
> **Follow-up:** configure a Continuous pipeline in Linear and add the `LINEAR_ACCESS_KEY` repo secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db4094e7752d4ab74fccc9fc9358a478ebb7941. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->