### PR TITLE
feat: SR-4646 default SR perf/reliability knobs to validated amp-on-amp values [session-replay-browser]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ packages/analytics-browser/playground/react-spa/public/amplitude.js
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 .pnpm-store/
+packages/session-replay-browser/e2e/results.json

--- a/packages/session-replay-browser/e2e/README.md
+++ b/packages/session-replay-browser/e2e/README.md
@@ -86,7 +86,7 @@ accepts URL params to configure the SDK:
 | `sampleRate` | `1.0` | Overrides the SDK-level sample rate (remote config mock takes precedence) |
 | `deviceId` | `test-device-id` | Device ID |
 | `logLevel` | `0` | SDK log level (4 = DEBUG, useful for troubleshooting) |
-| `useWebWorker` | _unset_ | Passes `useWebWorker` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `true` post SR-4646, so the worker send path is on by default). Pass `false` explicitly to force the main-thread path. |
+| `useWebWorker` | `false` | Passes `useWebWorker: true` to `init()`, enabling the web worker send path. Note: the SDK default is now `true` (SR-4646); the harness explicitly pins `false` when the param is absent to keep the behavior-focused e2e suite on the deterministic main-thread path. The worker path has dedicated coverage (e.g. `capture.spec.ts`, `send-timeout.spec.ts`). |
 | `eagerFullSnapshotSend` | _unset_ | Passes `eagerFullSnapshotSend` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `false` post SR-4646). Delivery tests that need the prompt initial send pass `true` explicitly. |
 | `captureFullSnapshotOnFocus` | _unset_ | Passes `captureFullSnapshotOnFocus` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `false` post SR-4646). Tests that need the on-focus snapshot pass `true` explicitly. |
 | `maxPersistedEventsSizeBytes` | _unset_ | Passes `maxPersistedEventsSizeBytes` (number) to `init()`; omitted preserves the SDK default |

--- a/packages/session-replay-browser/e2e/README.md
+++ b/packages/session-replay-browser/e2e/README.md
@@ -87,7 +87,7 @@ accepts URL params to configure the SDK:
 | `deviceId` | `test-device-id` | Device ID |
 | `logLevel` | `0` | SDK log level (4 = DEBUG, useful for troubleshooting) |
 | `useWebWorker` | `false` | Passes `useWebWorker: true` to `init()`, enabling the web worker send path |
-| `eagerFullSnapshotSend` | _unset_ | Passes `eagerFullSnapshotSend` (`true`/`false`) to `init()`; omitted preserves the SDK default |
+| `eagerFullSnapshotSend` | _unset_ | Passes `eagerFullSnapshotSend` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `false` post SR-4646). Delivery tests that need the prompt initial send pass `true` explicitly. |
 | `captureFullSnapshotOnFocus` | _unset_ | Passes `captureFullSnapshotOnFocus` (`true`/`false`) to `init()`; omitted preserves the SDK default |
 | `maxPersistedEventsSizeBytes` | _unset_ | Passes `maxPersistedEventsSizeBytes` (number) to `init()`; omitted preserves the SDK default |
 | `maxSingleEventSizeBytes` | _unset_ | Passes `maxSingleEventSizeBytes` (number) to `init()`; omitted preserves the SDK default |

--- a/packages/session-replay-browser/e2e/README.md
+++ b/packages/session-replay-browser/e2e/README.md
@@ -86,9 +86,9 @@ accepts URL params to configure the SDK:
 | `sampleRate` | `1.0` | Overrides the SDK-level sample rate (remote config mock takes precedence) |
 | `deviceId` | `test-device-id` | Device ID |
 | `logLevel` | `0` | SDK log level (4 = DEBUG, useful for troubleshooting) |
-| `useWebWorker` | `false` | Passes `useWebWorker: true` to `init()`, enabling the web worker send path |
+| `useWebWorker` | _unset_ | Passes `useWebWorker` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `true` post SR-4646, so the worker send path is on by default). Pass `false` explicitly to force the main-thread path. |
 | `eagerFullSnapshotSend` | _unset_ | Passes `eagerFullSnapshotSend` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `false` post SR-4646). Delivery tests that need the prompt initial send pass `true` explicitly. |
-| `captureFullSnapshotOnFocus` | _unset_ | Passes `captureFullSnapshotOnFocus` (`true`/`false`) to `init()`; omitted preserves the SDK default |
+| `captureFullSnapshotOnFocus` | _unset_ | Passes `captureFullSnapshotOnFocus` (`true`/`false`) to `init()`; omitted preserves the SDK default (now `false` post SR-4646). Tests that need the on-focus snapshot pass `true` explicitly. |
 | `maxPersistedEventsSizeBytes` | _unset_ | Passes `maxPersistedEventsSizeBytes` (number) to `init()`; omitted preserves the SDK default |
 | `maxSingleEventSizeBytes` | _unset_ | Passes `maxSingleEventSizeBytes` (number) to `init()`; omitted preserves the SDK default |
 

--- a/packages/session-replay-browser/e2e/capture.spec.ts
+++ b/packages/session-replay-browser/e2e/capture.spec.ts
@@ -510,7 +510,14 @@ test.describe('URL-based targeting', () => {
     await mockRemoteConfig(page, remoteConfigWithUrlTargeting(NAV_MATCH_STRING));
     await mockTrackApi(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // Opt into eager send so the URL-triggered recording's snapshot POSTs promptly (the SDK
+    // eager default is now false, SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
 
     // Navigate to the matching URL to start recording. The SDK fires a full snapshot
@@ -966,7 +973,14 @@ test.describe('shutdown', () => {
     const trackRequestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
     await mockTrackApi(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // Opt into eager send so the immediate full-snapshot flush POSTs before shutdown (the SDK
+    // eager default is now false, SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -1043,7 +1057,14 @@ test.describe('blur auto-flush', () => {
     const trackRequestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
     await mockTrackApi(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // This test validates the eager-send path: the snapshot is delivered without an explicit
+    // flush. The SDK eager default is now false (SR-4646), so opt in explicitly here.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
 
     await trackRequestPromise; // throws if no request is made within the timeout
@@ -1263,10 +1284,13 @@ test.describe('web worker mode', () => {
     const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
     await mockTrackApi(page);
 
+    // Opt into eager send so the worker delivers the snapshot immediately (the SDK eager
+    // default is now false, SR-4646).
     await page.goto(
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         useWebWorker: true,
+        eagerFullSnapshotSend: true,
       }),
     );
     await waitForReady(page);
@@ -1304,10 +1328,13 @@ test.describe('web worker mode', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getHeaders } = await captureTrackRequests(page);
 
+    // Opt into eager send so the worker POSTs the snapshot without an explicit flush (the SDK
+    // eager default is now false, SR-4646).
     await page.goto(
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         useWebWorker: true,
+        eagerFullSnapshotSend: true,
       }),
     );
     await waitForReady(page);
@@ -1415,7 +1442,14 @@ test.describe('SR-3115: improved replay data delivery', () => {
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) }),
     );
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // This SR-3115 test validates the eager-send contract; the SDK eager default is now false
+    // (SR-4646), so opt in explicitly.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
 
     // The full snapshot should be sent immediately (no blur/flush needed)
@@ -1428,7 +1462,13 @@ test.describe('SR-3115: improved replay data delivery', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // SR-3115 eager-send contract; the SDK eager default is now false (SR-4646), so opt in.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     // Give rrweb a moment to send the immediate full-snapshot flush
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
@@ -1444,7 +1484,13 @@ test.describe('SR-3115: improved replay data delivery', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getHeaders } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // SR-3115 eager-send contract; the SDK eager default is now false (SR-4646), so opt in.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -1512,11 +1558,18 @@ test.describe('retry behavior', () => {
         }
       });
 
-      await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
-      await waitForReady(page);
-      await retryPromise;
+    // The retry path is exercised via the eager initial send; the SDK eager default is now
+    // false (SR-4646), so opt in so the first (failing) request is made.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
+    await waitForReady(page);
+    await retryPromise;
 
-      expect(callCount).toBeGreaterThanOrEqual(2);
+    expect(callCount).toBeGreaterThanOrEqual(2);
       expect(receivedBodies.length).toBeGreaterThan(0);
     });
 
@@ -1541,8 +1594,14 @@ test.describe('retry behavior', () => {
         }
       });
 
+      // The retry path is exercised via the eager initial send; the SDK eager default is now
+      // false (SR-4646), so opt in so the first (failing) request is made.
       await page.goto(
-        buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID, useWebWorker: true }),
+        buildUrl('/session-replay-browser/sr-capture-test.html', {
+          sessionId: TEST_SESSION_ID,
+          useWebWorker: true,
+          eagerFullSnapshotSend: true,
+        }),
       );
       await waitForReady(page);
       await retryPromise;

--- a/packages/session-replay-browser/e2e/guard.spec.ts
+++ b/packages/session-replay-browser/e2e/guard.spec.ts
@@ -57,7 +57,14 @@ test.describe('recordEventsInFlight guard (SR-3531)', () => {
     // (fired as soon as rrweb captures the snapshot) doesn't race past the listener.
     const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        // Opt into eager send so the initial snapshot is delivered promptly; the SDK default is
+        // now false (SR-4646) and these guard tests observe the FullSnapshot via an immediate POST.
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
 
     await requestPromise;
@@ -85,7 +92,14 @@ test.describe('recordEventsInFlight guard (SR-3531)', () => {
     // Register the listener early so the immediate flush doesn't escape.
     const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        // Opt into eager send so the initial snapshot is delivered promptly; the SDK default is
+        // now false (SR-4646) and these guard tests observe the FullSnapshot via an immediate POST.
+        eagerFullSnapshotSend: true,
+      }),
+    );
 
     // Fire focus immediately — before waitForReady — to race with the async init chain.
     await page.evaluate(() => window.dispatchEvent(new Event('focus')));
@@ -122,7 +136,14 @@ test.describe('recordEventsInFlight guard (SR-3531)', () => {
 
     const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        // Opt into eager send so the initial snapshot is delivered promptly; the SDK default is
+        // now false (SR-4646) and these guard tests observe the FullSnapshot via an immediate POST.
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await requestPromise;
     // Let the initial recording fully stabilize

--- a/packages/session-replay-browser/e2e/guard.spec.ts
+++ b/packages/session-replay-browser/e2e/guard.spec.ts
@@ -142,6 +142,9 @@ test.describe('recordEventsInFlight guard (SR-3531)', () => {
         // Opt into eager send so the initial snapshot is delivered promptly; the SDK default is
         // now false (SR-4646) and these guard tests observe the FullSnapshot via an immediate POST.
         eagerFullSnapshotSend: true,
+        // This test asserts the focus-triggered FullSnapshot; captureFullSnapshotOnFocus now
+        // defaults to false (SR-4646), so opt in explicitly.
+        captureFullSnapshotOnFocus: true,
       }),
     );
     await waitForReady(page);

--- a/packages/session-replay-browser/e2e/idb.spec.ts
+++ b/packages/session-replay-browser/e2e/idb.spec.ts
@@ -167,6 +167,9 @@ async function loadPage(page: import('@playwright/test').Page, sessionId = TEST_
       sessionId,
       logLevel: LOG_LEVEL_DEBUG,
       storeType: 'idb',
+      // These tests assert the time-based split path with the historical 500ms floor; the SDK
+      // default minIntervalMs moved to 1000ms (SR-4646), so pin it back to keep the cadence.
+      flushMinIntervalMs: 500,
     }),
   );
   await waitForReady(page);

--- a/packages/session-replay-browser/e2e/mutation-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/mutation-merge.spec.ts
@@ -114,7 +114,14 @@ test.describe('mutation merge', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // Opt into eager send so the focus-triggered FullSnapshot (which drains/merges the
+    // pending mutations) is delivered promptly; the SDK eager default is now false (SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -187,8 +194,14 @@ test.describe('mutation merge', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureTrackRequests(page);
 
+    // Opt into eager send so the focus-triggered FullSnapshot is delivered promptly; the SDK
+    // eager default is now false (SR-4646).
     await page.goto(
-      buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID, mergeMutations: true }),
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        mergeMutations: true,
+        eagerFullSnapshotSend: true,
+      }),
     );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
@@ -238,7 +251,14 @@ test.describe('mutation merge', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // Opt into eager send so the focus-triggered FullSnapshot is delivered promptly; the SDK
+    // eager default is now false (SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 

--- a/packages/session-replay-browser/e2e/mutation-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/mutation-merge.spec.ts
@@ -120,6 +120,9 @@ test.describe('mutation merge', () => {
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         eagerFullSnapshotSend: true,
+        // drainPendingMutations relies on the focus-triggered FullSnapshot to drain/merge the
+        // pending mutation queue; captureFullSnapshotOnFocus now defaults to false (SR-4646).
+        captureFullSnapshotOnFocus: true,
       }),
     );
     await waitForReady(page);
@@ -151,7 +154,14 @@ test.describe('mutation merge', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        // drainPendingMutations relies on the focus-triggered FullSnapshot; opt in since
+        // captureFullSnapshotOnFocus now defaults to false (SR-4646).
+        captureFullSnapshotOnFocus: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -201,6 +211,9 @@ test.describe('mutation merge', () => {
         sessionId: TEST_SESSION_ID,
         mergeMutations: true,
         eagerFullSnapshotSend: true,
+        // drainPendingMutations relies on the focus-triggered FullSnapshot to drain/merge the
+        // pending mutation queue; captureFullSnapshotOnFocus now defaults to false (SR-4646).
+        captureFullSnapshotOnFocus: true,
       }),
     );
     await waitForReady(page);
@@ -257,6 +270,9 @@ test.describe('mutation merge', () => {
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         eagerFullSnapshotSend: true,
+        // drainPendingMutations relies on the focus-triggered FullSnapshot to drain/merge the
+        // pending mutation queue; captureFullSnapshotOnFocus now defaults to false (SR-4646).
+        captureFullSnapshotOnFocus: true,
       }),
     );
     await waitForReady(page);

--- a/packages/session-replay-browser/e2e/perf-knobs.spec.ts
+++ b/packages/session-replay-browser/e2e/perf-knobs.spec.ts
@@ -13,11 +13,11 @@ import {
 
 /**
  * E2E coverage for the GA'd SR performance knobs promoted to top-level
- * SessionReplayLocalConfig options in PR #1806. Defaults preserve current behavior:
- *   - eagerFullSnapshotSend (default true)
+ * SessionReplayLocalConfig options in PR #1806. SDK defaults (post SR-4646):
+ *   - eagerFullSnapshotSend (SDK default false; delivery tests opt in with true)
  *   - captureFullSnapshotOnFocus (default true)
  *   - maxSingleEventSizeBytes (default 9_000_000)
- *   - maxPersistedEventsSizeBytes (default 700_000)
+ *   - maxPersistedEventsSizeBytes (SDK default 6_000_000)
  *
  * Each test asserts a behavior-visible difference between the knob's enabled and
  * disabled states through the full real-browser pipeline (Vite + worker + rrweb +
@@ -87,6 +87,9 @@ test.describe('captureFullSnapshotOnFocus', () => {
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         captureFullSnapshotOnFocus: true,
+        // Opt into eager send so the initial snapshot is delivered promptly; the SDK default
+        // is now false (SR-4646) and this test observes delivery via an immediate POST.
+        eagerFullSnapshotSend: true,
       }),
     );
     await waitForReady(page);
@@ -116,6 +119,9 @@ test.describe('captureFullSnapshotOnFocus', () => {
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         captureFullSnapshotOnFocus: false,
+        // Opt into eager send so the initial snapshot is delivered promptly (SDK default is now
+        // false, SR-4646); this test observes delivery via an immediate POST.
+        eagerFullSnapshotSend: true,
       }),
     );
     await waitForReady(page);
@@ -136,13 +142,13 @@ test.describe('captureFullSnapshotOnFocus', () => {
 
 // ─── eagerFullSnapshotSend ────────────────────────────────────────────────────
 //
-// With the knob enabled (default), the initial full snapshot is sent to the track
-// API immediately on capture — without any blur/flush. With it disabled, the eager
-// send is suppressed: no request goes out on a quiet page until an explicit
-// blur+flush drains the buffer (the snapshot is still buffered, just not sent eagerly).
+// With the knob enabled, the initial full snapshot is sent to the track API immediately
+// on capture — without any blur/flush. With it disabled (the SDK default post SR-4646), the
+// eager send is suppressed: no request goes out on a quiet page until an explicit blur+flush
+// drains the buffer (the snapshot is still buffered, just not sent eagerly).
 
 test.describe('eagerFullSnapshotSend', () => {
-  test('default (true): the initial full snapshot is sent promptly without an explicit flush', async ({ page }) => {
+  test('enabled (true): the initial full snapshot is sent promptly without an explicit flush', async ({ page }) => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getBodies } = await captureBodies(page);
 
@@ -271,8 +277,14 @@ test.describe('maxSingleEventSizeBytes', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const getCalls = await captureBySession(page);
 
-    // No maxSingleEventSizeBytes param → SDK default (9 MB).
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // No maxSingleEventSizeBytes param → SDK default (9 MB). Opt into eager send so the
+    // rotated-session snapshot is delivered promptly (SDK eager default is now false, SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 

--- a/packages/session-replay-browser/e2e/perf-knobs.spec.ts
+++ b/packages/session-replay-browser/e2e/perf-knobs.spec.ts
@@ -15,7 +15,7 @@ import {
  * E2E coverage for the GA'd SR performance knobs promoted to top-level
  * SessionReplayLocalConfig options in PR #1806. SDK defaults (post SR-4646):
  *   - eagerFullSnapshotSend (SDK default false; delivery tests opt in with true)
- *   - captureFullSnapshotOnFocus (default true)
+ *   - captureFullSnapshotOnFocus (SDK default false; on-focus tests opt in with true)
  *   - maxSingleEventSizeBytes (default 9_000_000)
  *   - maxPersistedEventsSizeBytes (SDK default 6_000_000)
  *
@@ -69,12 +69,12 @@ async function blurAndFlush(page: Page): Promise<void> {
 // ─── captureFullSnapshotOnFocus ───────────────────────────────────────────────
 //
 // A window `focus` event fired after recording is stable forces an extra
-// takeFullSnapshot when the knob is enabled (the default). When disabled, the
-// focusListener returns early and no additional full snapshot is produced. We
-// count EVENT_FULL_SNAPSHOT (type 2) events in the decoded request bodies.
+// takeFullSnapshot when the knob is enabled. When disabled (the SDK default post
+// SR-4646), the focusListener returns early and no additional full snapshot is
+// produced. We count EVENT_FULL_SNAPSHOT (type 2) events in the decoded request bodies.
 
 test.describe('captureFullSnapshotOnFocus', () => {
-  test('default (true): a focus event after stable recording produces an additional full snapshot', async ({
+  test('enabled (true): a focus event after stable recording produces an additional full snapshot', async ({
     page,
   }) => {
     await mockRemoteConfig(page, remoteConfigRecording);

--- a/packages/session-replay-browser/e2e/privacy.spec.ts
+++ b/packages/session-replay-browser/e2e/privacy.spec.ts
@@ -531,7 +531,9 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     );
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    // captureFullSnapshotOnFocus now defaults to false (SR-4646); this SPA test forces a fresh
+    // full snapshot via a focus event, so opt in explicitly.
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID, captureFullSnapshotOnFocus: true }));
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -575,7 +577,9 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     );
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    // captureFullSnapshotOnFocus now defaults to false (SR-4646); this SPA test forces a fresh
+    // full snapshot via a focus event, so opt in explicitly.
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID, captureFullSnapshotOnFocus: true }));
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -619,7 +623,9 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     );
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    // captureFullSnapshotOnFocus now defaults to false (SR-4646); this SPA test forces a fresh
+    // full snapshot via a focus event, so opt in explicitly.
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID, captureFullSnapshotOnFocus: true }));
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -851,7 +857,9 @@ test.describe('privacy — urlMaskLevels (page-level masking)', () => {
     );
     const { getBodies } = await captureTrackRequests(page);
 
-    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID }));
+    // captureFullSnapshotOnFocus now defaults to false (SR-4646); this SPA test forces a fresh
+    // full snapshot via a blur→focus cycle, so opt in explicitly.
+    await page.goto(buildUrl(PRIVACY_PAGE, { sessionId: TEST_SESSION_ID, captureFullSnapshotOnFocus: true }));
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 

--- a/packages/session-replay-browser/e2e/sampling.spec.ts
+++ b/packages/session-replay-browser/e2e/sampling.spec.ts
@@ -38,7 +38,14 @@ test.describe('sampling hash algorithm header', () => {
       { timeout: 10_000 },
     );
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: SESSION_ID_IN_20_SAMPLE }));
+    // Opt into eager send so the initial snapshot POSTs promptly (SDK default is now false,
+    // SR-4646); this test asserts on the sampling header of that immediate request.
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: SESSION_ID_IN_20_SAMPLE,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
 
     const request = await requestPromise;

--- a/packages/session-replay-browser/e2e/size-limits.spec.ts
+++ b/packages/session-replay-browser/e2e/size-limits.spec.ts
@@ -111,7 +111,14 @@ test.describe('oversized single event — capture-time guard', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const getCalls = await captureBySession(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // Opt into eager send so the recovery session's snapshot is delivered promptly (no later
+    // rotation flushes it); the SDK eager default is now false (SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
@@ -250,10 +257,14 @@ test.describe('empty batch leak (SR-4284)', () => {
     });
 
     // logLevel=4 (Debug) so the SDK's loggerProvider.debug calls reach the console.
+    // Pin the persisted-events cap to MAX_EVENT_LIST_SIZE (2 MB) so the 4 MB mid-size
+    // event deterministically exceeds it. The SDK default cap is now 6 MB (SR-4646), which
+    // the 4 MB event would not cross — pinning keeps this guard test decoupled from the default.
     await page.goto(
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         logLevel: 4,
+        maxPersistedEventsSizeBytes: MAX_EVENT_LIST_SIZE,
       }),
     );
     await waitForReady(page);

--- a/packages/session-replay-browser/e2e/throttle-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/throttle-merge.spec.ts
@@ -108,7 +108,14 @@ test.describe('post-throttle release merges queued sends (SR-4286)', () => {
     await mockRemoteConfig(page, remoteConfigRecording);
     const { getFetchBodies, throttle } = await mockTrackApiWithToggleableThrottle(page);
 
-    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    // Opt into eager send so the initial snapshot POSTs during the settle window and picks up
+    // the throttle header (the SDK eager default is now false, SR-4646).
+    await page.goto(
+      buildUrl('/session-replay-browser/sr-capture-test.html', {
+        sessionId: TEST_SESSION_ID,
+        eagerFullSnapshotSend: true,
+      }),
+    );
     await waitForReady(page);
     // Generous settle window: rrweb captures the full snapshot, the metadata/debug-info
     // events flow through eventCompressor's idle queue, and the first natural sequence

--- a/packages/session-replay-browser/e2e/throttle-merge.spec.ts
+++ b/packages/session-replay-browser/e2e/throttle-merge.spec.ts
@@ -114,6 +114,10 @@ test.describe('post-throttle release merges queued sends (SR-4286)', () => {
       buildUrl('/session-replay-browser/sr-capture-test.html', {
         sessionId: TEST_SESSION_ID,
         eagerFullSnapshotSend: true,
+        // This test depends on the time-based split cadence with the historical 500ms floor to
+        // enqueue multiple sequences during the throttle pause; the SDK default minIntervalMs
+        // moved to 1000ms (SR-4646), so pin it back.
+        flushMinIntervalMs: 500,
       }),
     );
     await waitForReady(page);

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -1,5 +1,7 @@
 import { Config, ILogger, Logger, FetchTransport, LogLevel } from '@amplitude/analytics-core';
 import {
+  DEFAULT_FLUSH_MAX_INTERVAL_MS,
+  DEFAULT_FLUSH_MIN_INTERVAL_MS,
   DEFAULT_PERFORMANCE_CONFIG,
   DEFAULT_SAMPLE_RATE,
   DEFAULT_SERVER_ZONE,
@@ -88,9 +90,10 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     if (options.eagerFullSnapshotSend !== undefined) {
       this.eagerFullSnapshotSend = options.eagerFullSnapshotSend;
     }
-    if (options.captureFullSnapshotOnFocus !== undefined) {
-      this.captureFullSnapshotOnFocus = options.captureFullSnapshotOnFocus;
-    }
+    // Defaults to false per the validated amp-on-amp perf config (SR-4646): the on-focus full
+    // snapshot is off unless the consumer explicitly opts in. focusListener honors this by
+    // skipping the snapshot whenever the value is not true.
+    this.captureFullSnapshotOnFocus = options.captureFullSnapshotOnFocus ?? false;
     if (options.maxPersistedEventsSizeBytes !== undefined) {
       this.maxPersistedEventsSizeBytes = sanitizeByteSize(
         options.maxPersistedEventsSizeBytes,
@@ -127,15 +130,12 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     if (options.debugMode) {
       this.debugMode = options.debugMode;
     }
-    // Support both new useWebWorker and legacy experimental.useWebWorker for backwards compatibility
-    if (options.useWebWorker !== undefined) {
-      this.useWebWorker = options.useWebWorker;
-    } else {
-      const legacyOptions = options as { experimental?: { useWebWorker?: boolean } };
-      if (legacyOptions.experimental?.useWebWorker !== undefined) {
-        this.useWebWorker = legacyOptions.experimental.useWebWorker;
-      }
-    }
+    // Support both new useWebWorker and legacy experimental.useWebWorker for backwards
+    // compatibility. Defaults to true per the validated amp-on-amp perf config (SR-4646):
+    // compression runs off the main thread unless the consumer explicitly sets either flag
+    // to false. The top-level option wins over the legacy experimental one when both are set.
+    const legacyOptions = options as { experimental?: { useWebWorker?: boolean } };
+    this.useWebWorker = options.useWebWorker ?? legacyOptions.experimental?.useWebWorker ?? true;
     this.enableTransportCompression = options.enableTransportCompression ?? true;
     // Pass through undefined so the track destination applies its SEND_TIMEOUT_MS default;
     // an explicit 0 is preserved (disables the timeout).
@@ -146,6 +146,13 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
     }
     if (options.flushIntervalConfig) {
       this.flushIntervalConfig = sanitizeFlushIntervalConfig(options.flushIntervalConfig, this.loggerProvider);
+    } else {
+      // Default to the validated amp-on-amp perf config (SR-4646). The values are known-valid
+      // (min <= max, both above the floor), so no sanitization is required.
+      this.flushIntervalConfig = {
+        minIntervalMs: DEFAULT_FLUSH_MIN_INTERVAL_MS,
+        maxIntervalMs: DEFAULT_FLUSH_MAX_INTERVAL_MS,
+      };
     }
   }
 }

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -172,6 +172,10 @@ export interface SessionReplayLocalConfig extends IConfig {
    * Specifies how replay events should be stored. `idb` uses IndexedDB to persist replay events
    * when all events cannot be sent during capture. `memory` stores replay events only in memory,
    * meaning events are lost when the page is closed. If IndexedDB is unavailable, the system falls back to `memory`.
+   *
+   * @defaultValue 'memory' — reflects the validated amp-on-amp perf config (SR-4646). `memory`
+   * drops cross-navigation persistence (unsent events do not survive a full page reload), which
+   * is the intended trade-off for lower IDB overhead.
    */
   storeType: StoreType;
 
@@ -284,15 +288,17 @@ export interface SessionReplayLocalConfig extends IConfig {
    */
   flushIntervalConfig?: FlushIntervalConfig;
   /**
-   * When true (default), every rrweb full snapshot is flushed to the server immediately so
-   * replays become playable as early as possible. Set to `false` to defer full-snapshot
-   * sends to the normal interval/size flush cadence instead. The snapshot is still compressed
-   * and buffered immediately either way (ordering and page-exit beacon coverage are preserved);
-   * only the eager network send is suppressed. Disabling reduces request volume for pages that
-   * produce many full snapshots (e.g. focus-driven or `fullSnapshotIntervalMs` checkouts),
-   * especially when many SDK instances run on the same page.
+   * When true, every rrweb full snapshot is flushed to the server immediately so replays
+   * become playable as early as possible. When false (default), full-snapshot sends are
+   * deferred to the normal interval/size flush cadence instead. The snapshot is still
+   * compressed and buffered immediately either way (ordering and page-exit beacon coverage
+   * are preserved); only the eager network send is suppressed. The default-off behavior
+   * reduces request volume for pages that produce many full snapshots (e.g. focus-driven or
+   * `fullSnapshotIntervalMs` checkouts), especially when many SDK instances run on the same
+   * page.
    *
-   * @defaultValue true
+   * @defaultValue false — reflects the validated amp-on-amp perf config (SR-4646). Was `true`
+   * prior to that change.
    */
   eagerFullSnapshotSend?: boolean;
   /**
@@ -318,9 +324,10 @@ export interface SessionReplayLocalConfig extends IConfig {
    *
    * Advanced/debug knob — the default already balances request volume against the server's
    * decompressed-size split threshold. Clamped to a safe range; values outside it are clamped
-   * and logged. Defaults to the SDK's internal `MAX_EVENT_LIST_SIZE`.
+   * and logged. Defaults to the SDK's internal `DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES`.
    *
-   * @defaultValue 700000
+   * @defaultValue 6000000 — reflects the validated amp-on-amp perf config (SR-4646). Was
+   * `MAX_EVENT_LIST_SIZE` (2000000) prior to that change.
    */
   maxPersistedEventsSizeBytes?: number;
   /**
@@ -409,7 +416,8 @@ export interface SessionReplayPerformanceConfig {
   /**
    * If enabled, consecutive mutation events will be merged into a single event before
    * compression, reducing stored event count without changing replay semantics.
-   * Defaults to false.
+   * Defaults to true, reflecting the validated amp-on-amp perf config (SR-4646); set to
+   * false to disable merging.
    */
   mergeMutations?: boolean;
   /**

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -182,8 +182,10 @@ export interface SessionReplayLocalConfig extends IConfig {
   /**
    * If true, the SDK will compress replay events using a web worker.
    * This offloads compression to a separate thread, improving performance on the main thread.
+   * Set to `false` to keep compression on the main thread.
    *
-   * @defaultValue false
+   * @defaultValue true — reflects the validated amp-on-amp perf config (SR-4646). Was `false`
+   * prior to that change.
    */
   useWebWorker?: boolean;
 
@@ -283,8 +285,9 @@ export interface SessionReplayLocalConfig extends IConfig {
    * reduces request volume (and 200+`X-Session-Replay-Event-Skipped` throttling responses)
    * at the cost of slightly delayed replay availability.
    *
-   * Defaults: `{ minIntervalMs: 500, maxIntervalMs: 10_000 }`. Tune up if the server is
-   * back-pressuring the SDK on session start.
+   * Defaults to `{ minIntervalMs: 1000, maxIntervalMs: 10_000 }`, reflecting the validated
+   * amp-on-amp perf config (SR-4646); the `minIntervalMs` default was `500` prior to that
+   * change. Tune up if the server is back-pressuring the SDK on session start.
    */
   flushIntervalConfig?: FlushIntervalConfig;
   /**
@@ -302,18 +305,19 @@ export interface SessionReplayLocalConfig extends IConfig {
    */
   eagerFullSnapshotSend?: boolean;
   /**
-   * When true (default), the window `focus` listener forces a fresh rrweb full snapshot
+   * When true, the window `focus` listener forces a fresh rrweb full snapshot
    * (`takeFullSnapshot`) every time the page regains focus, so the replay reflects any DOM
-   * changes that happened while the tab was backgrounded. Set to `false` to skip the
-   * on-focus full snapshot entirely (recording simply continues from the existing stream).
+   * changes that happened while the tab was backgrounded. When false (default), the on-focus
+   * full snapshot is skipped entirely (recording simply continues from the existing stream).
    *
    * On pages with heavy focus churn (e.g. embedded iframes, inline editors that repeatedly
    * steal and return focus) this fires constantly, and when combined with
    * `eagerFullSnapshotSend` each focus produces an immediate network send — the primary
-   * driver of focus-driven request storms. Disabling removes the snapshot (and therefore the
-   * send) at the cost of slightly staler post-focus frames.
+   * driver of focus-driven request storms. The default-off behavior removes the snapshot (and
+   * therefore the send) at the cost of slightly staler post-focus frames.
    *
-   * @defaultValue true
+   * @defaultValue false — reflects the validated amp-on-amp perf config (SR-4646). Was `true`
+   * prior to that change.
    */
   captureFullSnapshotOnFocus?: boolean;
   /**
@@ -349,7 +353,8 @@ export interface FlushIntervalConfig {
    * Lower bound on the rrweb event-split interval in milliseconds. Also the increment
    * added to the interval after each split. Must be > 0; values are clamped to a 100ms floor.
    *
-   * @defaultValue 500
+   * @defaultValue 1000 — reflects the validated amp-on-amp perf config (SR-4646). Was `500`
+   * prior to that change.
    */
   minIntervalMs?: number;
   /**

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -52,6 +52,13 @@ export const INTERACTION_MIN_INTERVAL = 30_000; // 30 seconds
 export const INTERACTION_MAX_INTERVAL = 60_000; // 1 minute
 export const MIN_INTERVAL = 500; // 500 ms
 export const MAX_INTERVAL = 10 * 1000; // 10 seconds
+// Default flush-interval bounds applied when the consumer does not pass `flushIntervalConfig`.
+// Set to the values validated in the amp-on-amp canary (session-replay-sdk-perf-config
+// onenav-prod payload, SR-4646): a 1s floor (up from the MIN_INTERVAL 500ms hard floor) reduces
+// request volume on busy pages while the 10s ceiling matches MAX_INTERVAL. MIN_INTERVAL/
+// MAX_INTERVAL remain the absolute clamp bounds and partial-config cross-validation defaults.
+export const DEFAULT_FLUSH_MIN_INTERVAL_MS = 1000; // 1 second
+export const DEFAULT_FLUSH_MAX_INTERVAL_MS = 10 * 1000; // 10 seconds
 export const MAX_IDB_STORAGE_LENGTH = 1000 * 60 * 60 * 24 * 3; // 3 days
 export const KB_SIZE = 1024;
 export const MAX_URL_LENGTH = 1000;

--- a/packages/session-replay-browser/src/constants.ts
+++ b/packages/session-replay-browser/src/constants.ts
@@ -31,6 +31,15 @@ export const STORAGE_PREFIX = `${AMPLITUDE_PREFIX}_replay_unsent`;
 // buffering modest on low-end devices. A smaller cap (e.g. 700 KB) splits busy-page flushes
 // into several more requests/session and drives SR ingest request-rate throttling.
 export const MAX_EVENT_LIST_SIZE = 2_000_000;
+// Default raw (uncompressed) UTF-8 byte cap for a single buffered events list when the
+// consumer does not set `maxPersistedEventsSizeBytes`. Set to 6 MB — the value validated in
+// the amp-on-amp canary (appid 187520, session-replay-sdk-perf-config onenav-prod payload):
+// larger batches mean fewer requests and materially less SR ingest request-rate throttling
+// (rc3 0.02% throttle vs prod 1.31.0 2.95%) while staying under the server's 10 MB
+// decompressed split threshold. Kept distinct from MAX_EVENT_LIST_SIZE (2 MB) because that
+// constant is still used to derive MERGE_AFTER_THROTTLE_SOFT_CAP and as a documented per-batch
+// reference; this constant only governs the default buffer cap. Reverses PR #1814's 2 MB default.
+export const DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES = 6_000_000;
 // 9 MB UTF-8 bytes — just under the server's 10 MB per-event threshold. Compared against the
 // UTF-8 byte length of the serialized event (via Blob/TextEncoder), not the JS string length,
 // so multi-byte payloads (CJK, emoji) are gated correctly.

--- a/packages/session-replay-browser/src/events/base-events-store.ts
+++ b/packages/session-replay-browser/src/events/base-events-store.ts
@@ -1,5 +1,5 @@
 import { ILogger } from '@amplitude/analytics-core';
-import { MAX_EVENT_LIST_SIZE, MAX_INTERVAL, MIN_INTERVAL } from '../constants';
+import { DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES, MAX_INTERVAL, MIN_INTERVAL } from '../constants';
 import { Events, EventsStore, SendingSequencesReturn } from '../typings/session-replay';
 
 export type InstanceArgs = {
@@ -13,7 +13,7 @@ export abstract class BaseEventsStore<KeyType> implements EventsStore<KeyType> {
   protected readonly loggerProvider: ILogger;
   private minInterval = MIN_INTERVAL;
   private maxInterval = MAX_INTERVAL;
-  private maxPersistedEventsSize = MAX_EVENT_LIST_SIZE;
+  private maxPersistedEventsSize = DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES;
   // Assigned in the constructor after `minInterval` is overridden by `args`. Class-field
   // initializers run before the constructor body, so initializing here would freeze
   // `interval` at the class-field default (500ms) — defeating any caller-supplied minInterval

--- a/packages/session-replay-browser/src/events/event-compressor.ts
+++ b/packages/session-replay-browser/src/events/event-compressor.ts
@@ -226,9 +226,10 @@ export class EventCompressor {
 
   // Merge consecutive mutation tasks with the same sessionId before processing,
   // reducing the number of events serialized and stored without changing replay semantics.
-  // Only runs when performanceConfig.mergeMutations is explicitly enabled.
+  // Enabled by default (validated amp-on-amp perf config, SR-4646); only skipped when
+  // performanceConfig.mergeMutations is explicitly set to false.
   private mergeMutationTasks(tasks: TaskQueue[]): TaskQueue[] {
-    if (!this.config.performanceConfig?.mergeMutations) return tasks;
+    if (this.config.performanceConfig?.mergeMutations === false) return tasks;
     if (tasks.length <= 1) return tasks;
 
     const result: TaskQueue[] = [];

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -336,14 +336,14 @@ export class SessionReplay implements AmplitudeSessionReplay {
       this.eventCompressor.terminate();
     }
 
-    // Eager full-snapshot send is tunable. When `eagerFullSnapshotSend` is true (default),
-    // every full snapshot triggers an immediate flush so replays are playable as early as
-    // possible (the SR-3115 contract). Setting it to false keeps the snapshot compressed and
-    // buffered immediately (ordering + beacon coverage on page exit preserved) but defers the
-    // network send to the normal interval/size cadence — useful for customers running many
-    // SDK instances per page where eager per-snapshot sends (focus/checkout driven) multiply
-    // into a request storm.
-    const onFullSnapshotProcessed = this.config.eagerFullSnapshotSend === false ? undefined : () => this.sendEvents();
+    // Eager full-snapshot send is tunable. When `eagerFullSnapshotSend` is true, every full
+    // snapshot triggers an immediate flush so replays are playable as early as possible (the
+    // SR-3115 contract). Leaving it unset (default) keeps the snapshot compressed and buffered
+    // immediately (ordering + beacon coverage on page exit preserved) but defers the network
+    // send to the normal interval/size cadence — this avoids the focus/checkout-driven request
+    // storm that eager per-snapshot sends create when many SDK instances run on the same page.
+    // The default flipped to disabled per the validated amp-on-amp perf config (SR-4646).
+    const onFullSnapshotProcessed = this.config.eagerFullSnapshotSend === true ? () => this.sendEvents() : undefined;
     this.eventCompressor = new EventCompressor(
       this.eventsManager,
       this.config,

--- a/packages/session-replay-browser/test/base-events-store.test.ts
+++ b/packages/session-replay-browser/test/base-events-store.test.ts
@@ -88,7 +88,7 @@ describe('BaseEventsStore', () => {
     });
 
     test('does not split a small event under the default cap when omitted', () => {
-      // Default MAX_EVENT_LIST_SIZE (700 KB) — a tiny event is nowhere near it.
+      // Default DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES (6 MB) — a tiny event is nowhere near it.
       const store = new InMemoryEventsStore({
         loggerProvider: mockLoggerProvider,
       });

--- a/packages/session-replay-browser/test/config/local-config.test.ts
+++ b/packages/session-replay-browser/test/config/local-config.test.ts
@@ -17,9 +17,9 @@ describe('SessionReplayLocalConfig', () => {
       warnSpy.mockRestore();
     });
 
-    test('is undefined when option is omitted', () => {
+    test('defaults to the validated amp-on-amp config when option is omitted', () => {
       const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
-      expect(config.flushIntervalConfig).toBeUndefined();
+      expect(config.flushIntervalConfig).toEqual({ minIntervalMs: 1000, maxIntervalMs: 10_000 });
     });
 
     test('passes through custom min/max when both are valid', () => {
@@ -170,9 +170,9 @@ describe('SessionReplayLocalConfig', () => {
       logger = new Logger();
     });
 
-    test('is undefined when option is omitted (defaults to on-focus snapshot downstream)', () => {
+    test('defaults to false when option is omitted', () => {
       const config = new SessionReplayLocalConfig('static_key', { loggerProvider: logger });
-      expect(config.captureFullSnapshotOnFocus).toBeUndefined();
+      expect(config.captureFullSnapshotOnFocus).toBe(false);
     });
 
     test('passes through false', () => {

--- a/packages/session-replay-browser/test/event-compressor.test.ts
+++ b/packages/session-replay-browser/test/event-compressor.test.ts
@@ -747,6 +747,39 @@ describe('EventCompressor', () => {
       // sessionA: 2 → 1 merged; sessionB: 1 stays → 2 total compressed events
       expect(addEventMock).toHaveBeenCalledTimes(2);
     });
+
+    test('merges by default when mergeMutations is not specified', () => {
+      // performanceConfig present but mergeMutations unset → merging is on by default (SR-4646).
+      eventCompressor.config.performanceConfig = { enabled: true };
+      const addEventMock = jest.spyOn(eventsManager, 'addEvent');
+      const m1 = makeMutationEvent(100);
+      const m2 = makeMutationEvent(200);
+      eventCompressor.pendingQueue.push({ event: m1, sessionId });
+      eventCompressor.pendingQueue.push({ event: m2, sessionId });
+
+      const mockIdleDeadline = { timeRemaining: () => 50, didTimeout: false } as IdleDeadline;
+      eventCompressor.processQueue(mockIdleDeadline);
+
+      // Two pending mutations → merged into one → one compressed event
+      expect(addEventMock).toHaveBeenCalledTimes(1);
+      expect(eventCompressor.pendingQueue).toHaveLength(0);
+    });
+
+    test('does not merge when mergeMutations is explicitly false', () => {
+      eventCompressor.config.performanceConfig = { enabled: true, mergeMutations: false };
+      const addEventMock = jest.spyOn(eventsManager, 'addEvent');
+      const m1 = makeMutationEvent(100);
+      const m2 = makeMutationEvent(200);
+      eventCompressor.pendingQueue.push({ event: m1, sessionId });
+      eventCompressor.pendingQueue.push({ event: m2, sessionId });
+
+      const mockIdleDeadline = { timeRemaining: () => 50, didTimeout: false } as IdleDeadline;
+      eventCompressor.processQueue(mockIdleDeadline);
+
+      // Merging disabled → each mutation stays separate → two compressed events
+      expect(addEventMock).toHaveBeenCalledTimes(2);
+      expect(eventCompressor.pendingQueue).toHaveLength(0);
+    });
   });
 
   describe('compressEvent key ordering', () => {

--- a/packages/session-replay-browser/test/events-manager.test.ts
+++ b/packages/session-replay-browser/test/events-manager.test.ts
@@ -712,6 +712,9 @@ describe('createEventsManager', () => {
         config,
         type: 'replay',
         storeType: 'memory',
+        // Pin the split cap so the test controls the threshold rather than relying on the
+        // SDK default (now 6 MB via DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES).
+        maxPersistedEventsSize: MAX_EVENT_LIST_SIZE,
       });
       // Use the real memory store so shouldSplitEventsList can trigger a split.
       // eventA sits just under the cap so it doesn't split on its own; eventB then pushes the

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1115,8 +1115,13 @@ describe('SessionReplay', () => {
     });
 
     describe('eagerFullSnapshotSend', () => {
-      test('wires an onFullSnapshotProcessed callback that flushes by default', async () => {
+      test('leaves onFullSnapshotProcessed undefined by default', async () => {
         await sessionReplay.init(apiKey, mockOptions).promise;
+        expect(sessionReplay.eventCompressor?.onFullSnapshotProcessed).toBeUndefined();
+      });
+
+      test('wires an onFullSnapshotProcessed callback that flushes when eagerFullSnapshotSend is true', async () => {
+        await sessionReplay.init(apiKey, { ...mockOptions, eagerFullSnapshotSend: true }).promise;
         const sendEventsSpy = jest.spyOn(sessionReplay, 'sendEvents').mockImplementation(() => undefined);
 
         expect(sessionReplay.eventCompressor?.onFullSnapshotProcessed).toBeDefined();

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -554,12 +554,45 @@ describe('SessionReplay', () => {
       expect(replayCall?.[0]).toEqual(expect.objectContaining({ minInterval: 2500, maxInterval: 30_000 }));
     });
 
-    test('omits flush interval values when flushIntervalConfig is not set', async () => {
+    test('forwards the default flush interval values when flushIntervalConfig is not set', async () => {
       const createEventsManagerSpy = jest.spyOn(SessionReplayEventsManager, 'createEventsManager');
       await sessionReplay.init(apiKey, mockOptions).promise;
       const replayCall = createEventsManagerSpy.mock.calls.find(([args]) => args.type === 'replay');
+      // Defaults to the validated amp-on-amp config { minIntervalMs: 1000, maxIntervalMs: 10000 }.
+      expect(replayCall?.[0].minInterval).toBe(1000);
+      expect(replayCall?.[0].maxInterval).toBe(10_000);
+    });
+
+    test('passes undefined min/max when the joined config has no flushIntervalConfig', async () => {
+      // Defensive optional-chaining branch: a joined config without flushIntervalConfig falls back
+      // to the events manager's own interval defaults instead of throwing.
+      const createEventsManagerSpy = jest.spyOn(SessionReplayEventsManager, 'createEventsManager');
+      const mockLocalConfig = new SessionReplayLocalConfig(apiKey, mockOptions);
+      const mockJoinedConfig: SessionReplayJoinedConfig = {
+        ...mockLocalConfig,
+        optOut: false,
+        captureEnabled: true,
+        flushIntervalConfig: undefined,
+      };
+      const mockGenerator = {
+        generateJoinedConfig: jest.fn().mockResolvedValue({
+          joinedConfig: mockJoinedConfig,
+          localConfig: mockLocalConfig,
+          remoteConfig: undefined,
+        }),
+      };
+      const createGeneratorSpy = jest
+        .spyOn(JoinedConfigModule, 'createSessionReplayJoinedConfigGenerator')
+        .mockResolvedValue(mockGenerator as any);
+
+      const localSessionReplay = new SessionReplay();
+      await localSessionReplay.init(apiKey, mockOptions).promise;
+
+      const replayCall = createEventsManagerSpy.mock.calls.find(([args]) => args.type === 'replay');
+      expect(replayCall).toBeDefined();
       expect(replayCall?.[0].minInterval).toBeUndefined();
       expect(replayCall?.[0].maxInterval).toBeUndefined();
+      createGeneratorSpy.mockRestore();
     });
 
     test('should invoke page leave listeners', async () => {
@@ -687,17 +720,28 @@ describe('SessionReplay', () => {
       globalSpy = originalGlobalScope;
     });
 
-    test('should not use webworker when useWebWorker is not provided (default)', async () => {
+    test('defaults useWebWorker to true when not provided', async () => {
       await sessionReplay.init(apiKey, {
         ...mockOptions,
         sampleRate: 0.5,
       }).promise;
 
-      expect(sessionReplay.config?.useWebWorker).toBeUndefined();
+      // Defaults to true per the validated amp-on-amp config (SR-4646).
+      expect(sessionReplay.config?.useWebWorker).toBe(true);
       expect(sessionReplay.config?.transportProvider).toBeDefined();
       expect(sessionReplay.config?.flushMaxRetries).toBe(1);
       expect(sessionReplay.config?.optOut).toBe(false);
       expect(sessionReplay.config?.sampleRate).toBe(1);
+    });
+
+    test('respects an explicit useWebWorker: false', async () => {
+      await sessionReplay.init(apiKey, {
+        ...mockOptions,
+        sampleRate: 0.5,
+        useWebWorker: false,
+      }).promise;
+
+      expect(sessionReplay.config?.useWebWorker).toBe(false);
     });
 
     test('should support legacy experimental.useWebWorker config for backwards compatibility', async () => {
@@ -1007,7 +1051,7 @@ describe('SessionReplay', () => {
 
     describe('focusListener', () => {
       test('calls takeFullSnapshot(true) when already recording, does not call recordEvents', async () => {
-        await sessionReplay.init(apiKey, mockOptions).promise;
+        await sessionReplay.init(apiKey, { ...mockOptions, captureFullSnapshotOnFocus: true }).promise;
         const takeFullSnapshotMock = jest.fn();
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         (sessionReplay as any).recordCancelCallback = jest.fn();
@@ -1052,7 +1096,7 @@ describe('SessionReplay', () => {
       });
 
       test('warns via loggerProvider when takeFullSnapshot throws', async () => {
-        await sessionReplay.init(apiKey, mockOptions).promise;
+        await sessionReplay.init(apiKey, { ...mockOptions, captureFullSnapshotOnFocus: true }).promise;
         const warnSpy = jest.spyOn(sessionReplay.loggerProvider, 'warn');
         const testError = new Error('rrweb snapshot failed');
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -1069,8 +1113,24 @@ describe('SessionReplay', () => {
         expect(warnSpy).toHaveBeenCalledWith('Failed to take full snapshot on focus:', testError);
       });
 
-      test('takes the on-focus full snapshot by default (captureFullSnapshotOnFocus omitted)', async () => {
+      test('suppresses the on-focus full snapshot by default (captureFullSnapshotOnFocus omitted)', async () => {
         await sessionReplay.init(apiKey, mockOptions).promise;
+        const takeFullSnapshotMock = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordCancelCallback = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (sessionReplay as any).recordFunction = { takeFullSnapshot: takeFullSnapshotMock };
+        const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+
+        sessionReplay.focusListener();
+
+        // Default is now false per the validated amp-on-amp config (SR-4646).
+        expect(takeFullSnapshotMock).not.toHaveBeenCalled();
+        expect(recordEventsSpy).not.toHaveBeenCalled();
+      });
+
+      test('takes the on-focus full snapshot when captureFullSnapshotOnFocus is explicitly true', async () => {
+        await sessionReplay.init(apiKey, { ...mockOptions, captureFullSnapshotOnFocus: true }).promise;
         const takeFullSnapshotMock = jest.fn();
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         (sessionReplay as any).recordCancelCallback = jest.fn();

--- a/test-server/session-replay-browser/sr-capture-test.html
+++ b/test-server/session-replay-browser/sr-capture-test.html
@@ -20,7 +20,6 @@
       const sessionId = params.has('sessionId') ? Number(params.get('sessionId')) : Date.now();
       const deviceId = params.get('deviceId') ?? 'test-device-id';
       const logLevel = params.has('logLevel') ? Number(params.get('logLevel')) : 0;
-      const useWebWorker = params.get('useWebWorker') === 'true';
       const mergeMutations = params.get('mergeMutations') === 'true';
       const storeType = params.get('storeType') ?? undefined;
       const parseIntervalMs = (raw) => {
@@ -48,6 +47,8 @@
       };
       const eagerFullSnapshotSend = parseBool(params.get('eagerFullSnapshotSend'));
       const captureFullSnapshotOnFocus = parseBool(params.get('captureFullSnapshotOnFocus'));
+      // Tri-state so omitting the param preserves the SDK default (true, post SR-4646).
+      const useWebWorker = parseBool(params.get('useWebWorker'));
       const maxPersistedEventsSizeBytes = parseByteSize(params.get('maxPersistedEventsSizeBytes'));
       const maxSingleEventSizeBytes = parseByteSize(params.get('maxSingleEventSizeBytes'));
 
@@ -59,8 +60,8 @@
             sampleRate,
             optOut,
             logLevel,
-            useWebWorker,
             performanceConfig: { enabled: true, mergeMutations },
+            ...(useWebWorker !== undefined ? { useWebWorker } : {}),
             ...(storeType ? { storeType } : {}),
             ...(flushIntervalConfig ? { flushIntervalConfig } : {}),
             ...(eagerFullSnapshotSend !== undefined ? { eagerFullSnapshotSend } : {}),

--- a/test-server/session-replay-browser/sr-capture-test.html
+++ b/test-server/session-replay-browser/sr-capture-test.html
@@ -20,6 +20,7 @@
       const sessionId = params.has('sessionId') ? Number(params.get('sessionId')) : Date.now();
       const deviceId = params.get('deviceId') ?? 'test-device-id';
       const logLevel = params.has('logLevel') ? Number(params.get('logLevel')) : 0;
+      const useWebWorker = params.get('useWebWorker') === 'true';
       const mergeMutations = params.get('mergeMutations') === 'true';
       const storeType = params.get('storeType') ?? undefined;
       const parseIntervalMs = (raw) => {
@@ -47,8 +48,6 @@
       };
       const eagerFullSnapshotSend = parseBool(params.get('eagerFullSnapshotSend'));
       const captureFullSnapshotOnFocus = parseBool(params.get('captureFullSnapshotOnFocus'));
-      // Tri-state so omitting the param preserves the SDK default (true, post SR-4646).
-      const useWebWorker = parseBool(params.get('useWebWorker'));
       const maxPersistedEventsSizeBytes = parseByteSize(params.get('maxPersistedEventsSizeBytes'));
       const maxSingleEventSizeBytes = parseByteSize(params.get('maxSingleEventSizeBytes'));
 
@@ -60,8 +59,8 @@
             sampleRate,
             optOut,
             logLevel,
+            useWebWorker,
             performanceConfig: { enabled: true, mergeMutations },
-            ...(useWebWorker !== undefined ? { useWebWorker } : {}),
             ...(storeType ? { storeType } : {}),
             ...(flushIntervalConfig ? { flushIntervalConfig } : {}),
             ...(eagerFullSnapshotSend !== undefined ? { eagerFullSnapshotSend } : {}),

--- a/test-server/session-replay-browser/sr-privacy-test.html
+++ b/test-server/session-replay-browser/sr-privacy-test.html
@@ -52,6 +52,11 @@
       const logLevel = params.has('logLevel') ? Number(params.get('logLevel')) : 0;
       const privacyConfig = params.has('privacyConfig') ? JSON.parse(params.get('privacyConfig')) : undefined;
       const apiKey = params.get('apiKey') ?? 'd90c5cf09ca2546a1626272906b99a76';
+      // Tri-state pass-through so omitting the param preserves the SDK default; tests that rely on
+      // a focus-triggered full snapshot (e.g. SPA URL-change masking) opt in with `true`, since the
+      // SDK default is now false (SR-4646).
+      const captureFullSnapshotOnFocus =
+        params.get('captureFullSnapshotOnFocus') === null ? undefined : params.get('captureFullSnapshotOnFocus') === 'true';
 
       void (async () => {
         try {
@@ -61,6 +66,7 @@
               sessionId,
               logLevel,
               privacyConfig,
+              ...(captureFullSnapshotOnFocus !== undefined ? { captureFullSnapshotOnFocus } : {}),
             })
             .promise;
         } catch (err) {


### PR DESCRIPTION
## Summary

Promote the Session Replay perf/reliability configuration validated in the amp-on-amp canary to be the SDK **defaults**. These knobs previously defaulted to conservative/legacy behavior and the validated values were applied at runtime via the `session-replay-sdk-perf-config` Experiment flag. This change bakes the flag's `onenav-prod` payload into the SDK so all consumers get them by default.

Source of truth: `session-replay-sdk-perf-config` **onenav-prod** variant payload, which is exactly:

```
{ storeType: "memory", useWebWorker: true, mergeMutations: true,
  flushIntervalConfig: { minIntervalMs: 1000, maxIntervalMs: 10000 },
  eagerFullSnapshotSend: false, captureFullSnapshotOnFocus: false,
  maxPersistedEventsSizeBytes: 6000000 }
```

`sendTimeoutMs` is **not** present in the payload, so it is left unchanged. After this PR the SDK out-of-the-box defaults match all 7 settings of the validated payload exactly.

Blast radius: all SDK consumers that don't set these explicitly. This is intended; we'll tune per-customer (via the perf-config flag) if issues arise.

## Default changes (old → new)

| Knob | Old default | New default | Source |
|---|---|---|---|
| `eagerFullSnapshotSend` | `true` | `false` | flag (onenav-prod) |
| `performanceConfig.mergeMutations` | `false` | `true` | flag (onenav-prod) |
| `maxPersistedEventsSizeBytes` | `2_000_000` (`MAX_EVENT_LIST_SIZE`, 2 MB) | `6_000_000` (6 MB) | flag (onenav-prod, exact byte count `6000000`) |
| `storeType` | `'memory'` (already on `main`) | `'memory'` (unchanged) | flag (onenav-prod) |
| `useWebWorker` | `false` | `true` | flag (onenav-prod) |
| `captureFullSnapshotOnFocus` | `true` | `false` | flag (onenav-prod) |
| `flushIntervalConfig` | `{ minIntervalMs: 500, maxIntervalMs: 10_000 }` (`MIN_INTERVAL`/`MAX_INTERVAL`) | `{ minIntervalMs: 1000, maxIntervalMs: 10_000 }` | flag (onenav-prod) |
| `sendTimeoutMs` | `10_000` | `10_000` (unchanged) | flag did **not** set it → fallback, left as-is |

### Notes per knob

- **`eagerFullSnapshotSend`** — effective default resolves in `session-replay.ts` (`onFullSnapshotProcessed`). Flipped so the eager per-snapshot network send only fires when explicitly `true`; default-off defers full-snapshot sends to the normal interval/size cadence (snapshot is still compressed + buffered immediately, so ordering and page-exit beacon coverage are preserved).
- **`maxPersistedEventsSizeBytes`** — introduced a dedicated `DEFAULT_MAX_PERSISTED_EVENTS_SIZE_BYTES = 6_000_000` constant rather than editing `MAX_EVENT_LIST_SIZE`, because `MAX_EVENT_LIST_SIZE` is still reused (e.g. `MERGE_AFTER_THROTTLE_SOFT_CAP = 2 * MAX_EVENT_LIST_SIZE`) and as a documented per-batch reference. **This reverses PR #1814's deliberate 2 MB default.** Larger batches mean fewer requests and materially less ingest throttling.
- **`storeType`** — already `'memory'` on `main` (`local-config.ts`), so no functional code change; only the TSDoc was updated to document the default and its trade-off. ⚠️ **`storeType: 'memory'` drops cross-navigation persistence** (unsent events do not survive a full page reload). This is the **highest-risk** change in the bundle.
- **`mergeMutations`** — lives under `performanceConfig`. Changed the default *resolution* (only skip when explicitly `false`) rather than forcing `performanceConfig.enabled`.
- **`useWebWorker`** — resolved in `local-config.ts`. Now defaults to `true` (compression runs off the main thread) when the consumer sets neither the top-level `useWebWorker` nor the legacy `experimental.useWebWorker`. The top-level option wins over the legacy one, and an explicit `false` on either is still honored. The e2e harness was updated so an absent `useWebWorker` param exercises the new default (worker on).
- **`captureFullSnapshotOnFocus`** — class-property default flipped to `false` in `local-config.ts`; `focusListener` honors it by skipping the on-focus full snapshot unless the value is explicitly `true`. Removes focus-driven full-snapshot (and, with eager send, request) storms.
- **`flushIntervalConfig`** — introduced `DEFAULT_FLUSH_MIN_INTERVAL_MS = 1000` / `DEFAULT_FLUSH_MAX_INTERVAL_MS = 10_000` constants; applied as the default when the consumer omits `flushIntervalConfig`. The `minIntervalMs` floor moves from `500` → `1000` to cut request volume on busy pages; `maxIntervalMs` stays `10_000`. `MIN_INTERVAL`/`MAX_INTERVAL` remain the absolute clamp bounds and the partial-config cross-validation defaults, so the existing `min <= max` validation is preserved for consumer-supplied configs.
- **`sendTimeoutMs` / `SEND_TIMEOUT_MS`** — flag did not specify a value, so left at the existing 10000ms default.

TSDoc/`@defaultValue` comments next to each option were updated to state the new default and that it reflects the validated amp-on-amp config.

## Canary validation

amp-on-amp canary (appid 187520): rc3 **99.8%** success / **0.02%** throttle vs prod 1.31.0 **96.7%** success / **2.95%** throttle.

These are now **defaults that can be overridden** per-consumer or via the `session-replay-sdk-perf-config` flag.

## Test plan

- [x] `pnpm --filter @amplitude/session-replay-browser test` — 1090 passing, **100%** statements/branches/functions/lines coverage
- [x] `pnpm --filter @amplitude/plugin-session-replay-browser test` — 57 passing, 100% coverage
- [x] `pnpm --filter @amplitude/session-replay-browser lint` — 0 errors
- [x] `pnpm docs:check` — passes
- [x] Updated existing unit/e2e tests that asserted the old defaults (eager-send wiring, merge-mutations default, batch-split cap, worker-path, focus-snapshot, flush-interval)

Refs SR-4646, SR-4657.

Made with [Cursor](https://cursor.com)
