### PR TITLE
fix(session-replay): no-op setSessionId when session id unchanged

### DIFF
--- a/packages/session-replay-browser/e2e/set-session-id.spec.ts
+++ b/packages/session-replay-browser/e2e/set-session-id.spec.ts
@@ -1,13 +1,12 @@
-import { test, expect, Route } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import {
-  SR_API_SUCCESS,
   TEST_SESSION_ID,
   SNAPSHOT_SETTLE_MS,
   remoteConfigRecording,
   mockRemoteConfig,
   buildUrl,
   waitForReady,
-  readRouteBody,
+  captureTrackRequests,
   flushRecording,
 } from './helpers';
 
@@ -43,21 +42,14 @@ function countFullSnapshots(bodies: string[]): number {
 test.describe('setSessionId no-op (SR2-3635)', () => {
   test('redundant setSessionId does not restart rrweb capture', async ({ page }) => {
     await mockRemoteConfig(page, remoteConfigRecording);
-
-    const rawBodies: string[] = [];
-    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
-      rawBodies.push(readRouteBody(route));
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
-    });
-
-    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+    const { getBodies } = await captureTrackRequests(page);
 
     await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
     await waitForReady(page);
-    await requestPromise;
+    await flushRecording(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
-    expect(countFullSnapshots(rawBodies)).toBe(1);
+    expect(countFullSnapshots(getBodies())).toBe(1);
 
     // Poll-style redundant calls (hour-bucket pattern) must not stop/restart rrweb.
     await page.evaluate(async (sessionId) => {
@@ -70,26 +62,19 @@ test.describe('setSessionId no-op (SR2-3635)', () => {
     await page.click('#test-button');
     await flushRecording(page);
 
-    expect(countFullSnapshots(rawBodies)).toBe(1);
+    expect(countFullSnapshots(getBodies())).toBe(1);
   });
 
   test('session id change still restarts recording', async ({ page }) => {
     await mockRemoteConfig(page, remoteConfigRecording);
-
-    const rawBodies: string[] = [];
-    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
-      rawBodies.push(readRouteBody(route));
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
-    });
-
-    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+    const { getBodies } = await captureTrackRequests(page);
 
     await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
     await waitForReady(page);
-    await requestPromise;
+    await flushRecording(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
-    expect(countFullSnapshots(rawBodies)).toBe(1);
+    expect(countFullSnapshots(getBodies())).toBe(1);
 
     const nextSessionId = TEST_SESSION_ID + 3_600_000;
     await page.evaluate(async (sessionId) => {
@@ -100,7 +85,7 @@ test.describe('setSessionId no-op (SR2-3635)', () => {
     await flushRecording(page);
     await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
-    expect(countFullSnapshots(rawBodies)).toBeGreaterThanOrEqual(2);
+    expect(countFullSnapshots(getBodies())).toBeGreaterThanOrEqual(2);
     const currentSessionId = await page.evaluate((): number | string | undefined => {
       return (
         window as { sessionReplay?: { getSessionId: () => number | string | undefined } }

--- a/packages/session-replay-browser/e2e/set-session-id.spec.ts
+++ b/packages/session-replay-browser/e2e/set-session-id.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, Route } from '@playwright/test';
+import {
+  SR_API_SUCCESS,
+  TEST_SESSION_ID,
+  SNAPSHOT_SETTLE_MS,
+  remoteConfigRecording,
+  mockRemoteConfig,
+  buildUrl,
+  waitForReady,
+  readRouteBody,
+  flushRecording,
+} from './helpers';
+
+const EVENT_FULL_SNAPSHOT = 2;
+
+function decodeAllEvents(rawBody: string): Array<Record<string, unknown>> {
+  if (!rawBody) return [];
+  let payload: { events?: unknown[] };
+  try {
+    payload = JSON.parse(rawBody) as { events?: unknown[] };
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(payload.events)) return [];
+  const results: Array<Record<string, unknown>> = [];
+  for (const eventStr of payload.events) {
+    if (typeof eventStr !== 'string') continue;
+    try {
+      results.push(JSON.parse(eventStr) as Record<string, unknown>);
+    } catch {
+      // skip unparseable events
+    }
+  }
+  return results;
+}
+
+function countFullSnapshots(bodies: string[]): number {
+  return bodies.flatMap((b) => decodeAllEvents(b)).filter((e) => e['type'] === EVENT_FULL_SNAPSHOT).length;
+}
+
+// ─── setSessionId no-op (SR2-3635) ───────────────────────────────────────────
+
+test.describe('setSessionId no-op (SR2-3635)', () => {
+  test('redundant setSessionId does not restart rrweb capture', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    const rawBodies: string[] = [];
+    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+      rawBodies.push(readRouteBody(route));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+
+    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await requestPromise;
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    expect(countFullSnapshots(rawBodies)).toBe(1);
+
+    // Poll-style redundant calls (hour-bucket pattern) must not stop/restart rrweb.
+    await page.evaluate(async (sessionId) => {
+      const sr = (window as any).sessionReplay;
+      await sr.setSessionId(sessionId).promise;
+      await sr.setSessionId(sessionId).promise;
+      await sr.setSessionId(sessionId).promise;
+    }, TEST_SESSION_ID);
+
+    await page.click('#test-button');
+    await flushRecording(page);
+
+    expect(countFullSnapshots(rawBodies)).toBe(1);
+  });
+
+  test('session id change still restarts recording', async ({ page }) => {
+    await mockRemoteConfig(page, remoteConfigRecording);
+
+    const rawBodies: string[] = [];
+    await page.route('https://api-sr.amplitude.com/**', async (route: Route) => {
+      rawBodies.push(readRouteBody(route));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SR_API_SUCCESS) });
+    });
+
+    const requestPromise = page.waitForRequest('https://api-sr.amplitude.com/**', { timeout: 10_000 });
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await requestPromise;
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    expect(countFullSnapshots(rawBodies)).toBe(1);
+
+    const nextSessionId = TEST_SESSION_ID + 3_600_000;
+    await page.evaluate(async (sessionId) => {
+      await (window as any).sessionReplay.setSessionId(sessionId).promise;
+    }, nextSessionId);
+
+    await page.click('#test-button');
+    await flushRecording(page);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    expect(countFullSnapshots(rawBodies)).toBeGreaterThanOrEqual(2);
+    const currentSessionId = await page.evaluate((): number | string | undefined => {
+      return (
+        window as { sessionReplay?: { getSessionId: () => number | string | undefined } }
+      ).sessionReplay?.getSessionId();
+    });
+    expect(currentSessionId).toBe(nextSessionId);
+  });
+});

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -418,6 +418,11 @@ export class SessionReplay implements AmplitudeSessionReplay {
   ) {
     const previousSessionId = this.identifiers?.sessionId;
     const currentDeviceId = this.getDeviceId();
+    // Standalone SDK callers may poll setSessionId with a stable bucket id (e.g. hour-aligned
+    // timestamps) and only need a no-op when the bucket hasn't rolled. Without this guard,
+    // the rest of asyncSetSessionId still runs: sendEvents, targeting reset, config refetch,
+    // and recordEvents (stop + restart rrweb). Proceed when deviceId changes or
+    // userProperties are passed so targeting can re-evaluate on Identify.
     if (
       previousSessionId !== undefined &&
       previousSessionId === sessionId &&

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -422,12 +422,12 @@ export class SessionReplay implements AmplitudeSessionReplay {
     // timestamps) and only need a no-op when the bucket hasn't rolled. Without this guard,
     // the rest of asyncSetSessionId still runs: sendEvents, targeting reset, config refetch,
     // and recordEvents (stop + restart rrweb). Proceed when deviceId changes or
-    // userProperties are passed so targeting can re-evaluate on Identify.
+    // non-empty userProperties are passed so targeting can re-evaluate on Identify.
     if (
       previousSessionId !== undefined &&
       previousSessionId === sessionId &&
       (deviceId === undefined || deviceId === currentDeviceId) &&
-      !options?.userProperties
+      (options?.userProperties === undefined || Object.keys(options.userProperties).length === 0)
     ) {
       return;
     }

--- a/packages/session-replay-browser/src/session-replay.ts
+++ b/packages/session-replay-browser/src/session-replay.ts
@@ -416,12 +416,21 @@ export class SessionReplay implements AmplitudeSessionReplay {
     deviceId?: string,
     options?: { userProperties?: { [key: string]: any } },
   ) {
+    const previousSessionId = this.identifiers?.sessionId;
+    const currentDeviceId = this.getDeviceId();
+    if (
+      previousSessionId !== undefined &&
+      previousSessionId === sessionId &&
+      (deviceId === undefined || deviceId === currentDeviceId) &&
+      !options?.userProperties
+    ) {
+      return;
+    }
+
     // Invalidate any in-flight URL-change re-evaluations from the previous session.
     this.latestUrlChangeTargetingEvaluationId++;
     this.sessionTargetingMatch = false;
     this.lastShouldRecordDecision = undefined; // Reset targeting decision for new session
-
-    const previousSessionId = this.identifiers && this.identifiers.sessionId;
     if (previousSessionId) {
       this.sendEvents(previousSessionId);
     }

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1492,6 +1492,10 @@ describe('SessionReplay', () => {
       (sessionReplay as any).hasEmittedGateDecision = true;
       (sessionReplay as any).suppressedSendCount = 7;
 
+      const sendEventsSpy = jest.spyOn(sessionReplay, 'sendEvents');
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents').mockResolvedValue(undefined);
+      const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+
       // Caller passes the current sessionId redundantly — must NOT restart the gate clock.
       await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c');
 
@@ -1500,6 +1504,42 @@ describe('SessionReplay', () => {
       // Per-session gate state must also be preserved.
       expect((sessionReplay as any).hasEmittedGateDecision).toBe(true);
       expect((sessionReplay as any).suppressedSendCount).toBe(7);
+      expect(sendEventsSpy).not.toHaveBeenCalled();
+      expect(recordEventsSpy).not.toHaveBeenCalled();
+      expect(evaluateTargetingAndCaptureSpy).not.toHaveBeenCalled();
+    });
+
+    test('still proceeds when sessionId is unchanged but deviceId changes', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const sendEventsSpy = jest.spyOn(sessionReplay, 'sendEvents');
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents').mockResolvedValue(undefined);
+
+      await (sessionReplay as any).asyncSetSessionId(123, 'new-device-id');
+
+      expect(sessionReplay.identifiers?.deviceId).toBe('new-device-id');
+      expect(sendEventsSpy).toHaveBeenCalledWith(123);
+      expect(recordEventsSpy).toHaveBeenCalled();
+    });
+
+    test('no-ops redundant setSessionId without sendEvents, recordEvents, or targeting reset', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      if (!sessionReplay.joinedConfigGenerator) throw new Error('init');
+
+      const sendEventsSpy = jest.spyOn(sessionReplay, 'sendEvents');
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+      const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+      const generateJoinedConfigSpy = jest.spyOn(sessionReplay.joinedConfigGenerator, 'generateJoinedConfig');
+      const priorTargetingMatch = sessionReplay.sessionTargetingMatch;
+      const priorUrlEvaluationId = (sessionReplay as any).latestUrlChangeTargetingEvaluationId;
+
+      await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c');
+
+      expect(sendEventsSpy).not.toHaveBeenCalled();
+      expect(recordEventsSpy).not.toHaveBeenCalled();
+      expect(evaluateTargetingAndCaptureSpy).not.toHaveBeenCalled();
+      expect(generateJoinedConfigSpy).not.toHaveBeenCalled();
+      expect(sessionReplay.sessionTargetingMatch).toBe(priorTargetingMatch);
+      expect((sessionReplay as any).latestUrlChangeTargetingEvaluationId).toBe(priorUrlEvaluationId);
     });
 
     test('drops previous-session beacon buffer ONLY on real session change', async () => {

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1567,6 +1567,20 @@ describe('SessionReplay', () => {
       expect((sessionReplay as any).latestUrlChangeTargetingEvaluationId).toBe(priorUrlEvaluationId);
     });
 
+    test('no-ops when sessionId unchanged and userProperties is an empty object', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      const sendEventsSpy = jest.spyOn(sessionReplay, 'sendEvents');
+      const recordEventsSpy = jest.spyOn(sessionReplay, 'recordEvents');
+      const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+
+      await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c', { userProperties: {} });
+
+      expect(sendEventsSpy).not.toHaveBeenCalled();
+      expect(recordEventsSpy).not.toHaveBeenCalled();
+      expect(evaluateTargetingAndCaptureSpy).not.toHaveBeenCalled();
+    });
+
     test('still proceeds when sessionId and deviceId unchanged but userProperties provided', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
 

--- a/packages/session-replay-browser/test/session-replay.test.ts
+++ b/packages/session-replay-browser/test/session-replay.test.ts
@@ -1521,6 +1521,31 @@ describe('SessionReplay', () => {
       expect(recordEventsSpy).toHaveBeenCalled();
     });
 
+    test('still re-evaluates targeting when same sessionId has new userProperties', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+      const mockConfigWithTargeting = new SessionReplayLocalConfig(apiKey, mockOptions);
+      (mockConfigWithTargeting as SessionReplayJoinedConfig).targetingConfig = {
+        key: 'sr_targeting_config',
+        variants: { on: { key: 'on' }, off: { key: 'off' } },
+        segments: [],
+      };
+      jest.spyOn(sessionReplay.joinedConfigGenerator!, 'generateJoinedConfig').mockResolvedValue({
+        joinedConfig: mockConfigWithTargeting,
+        localConfig: mockConfigWithTargeting,
+        remoteConfig: undefined,
+      });
+      const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+      const userProperties = { plan: 'enterprise' };
+
+      await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c', { userProperties });
+
+      expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith(
+        { userProperties, page: { url: 'http://localhost' } },
+        false,
+        true,
+      );
+    });
+
     test('no-ops redundant setSessionId without sendEvents, recordEvents, or targeting reset', async () => {
       await sessionReplay.init(apiKey, mockOptions).promise;
       if (!sessionReplay.joinedConfigGenerator) throw new Error('init');
@@ -1540,6 +1565,33 @@ describe('SessionReplay', () => {
       expect(generateJoinedConfigSpy).not.toHaveBeenCalled();
       expect(sessionReplay.sessionTargetingMatch).toBe(priorTargetingMatch);
       expect((sessionReplay as any).latestUrlChangeTargetingEvaluationId).toBe(priorUrlEvaluationId);
+    });
+
+    test('still proceeds when sessionId and deviceId unchanged but userProperties provided', async () => {
+      await sessionReplay.init(apiKey, mockOptions).promise;
+
+      const mockConfigWithTargeting = new SessionReplayLocalConfig(apiKey, mockOptions);
+      (mockConfigWithTargeting as SessionReplayJoinedConfig).targetingConfig = {
+        key: 'sr_targeting_config',
+        variants: { on: { key: 'on' }, off: { key: 'off' } },
+        segments: [],
+      };
+      jest.spyOn(sessionReplay.joinedConfigGenerator!, 'generateJoinedConfig').mockResolvedValue({
+        joinedConfig: mockConfigWithTargeting,
+        localConfig: mockConfigWithTargeting,
+        remoteConfig: undefined,
+      });
+
+      const evaluateTargetingAndCaptureSpy = jest.spyOn(sessionReplay, 'evaluateTargetingAndCapture');
+      const userProperties = { plan: 'enterprise' };
+
+      await (sessionReplay as any).asyncSetSessionId(123, '1a2b3c', { userProperties });
+
+      expect(evaluateTargetingAndCaptureSpy).toHaveBeenCalledWith(
+        { userProperties, page: { url: 'http://localhost' } },
+        false,
+        true,
+      );
     });
 
     test('drops previous-session beacon buffer ONLY on real session change', async () => {


### PR DESCRIPTION
## Summary
- Early-return asyncSetSessionId when sessionId and deviceId are unchanged, avoiding spurious sendEvents/recordEvents/targeting resets.
- Verified: `pnpm --filter @amplitude/session-replay-browser test -- session-replay.test.ts` (288 passed)

Linear: https://linear.app/amplitude/issue/SR2-3635

Made with [Cursor](https://cursor.com)