### PR TITLE
chore: update publish-v2 to use GITHUB_TOKEN over GH_PUBLISH_TOKEN

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PUBLISH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Build and Test
@@ -148,7 +148,7 @@ jobs:
           
           # Temporarily disable exit on error to capture output even when command fails
           set +e
-          OUTPUT=$(GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --create-release github 2>&1)
+          OUTPUT=$(GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version -y --no-private --create-release github 2>&1)
           EXIT_CODE=$?
           set -e
           
@@ -174,7 +174,7 @@ jobs:
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:publish
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
@@ -236,7 +236,7 @@ jobs:
         with:
           ref: ${{ steps.determine-branch.outputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PUBLISH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Test
         uses: ./.github/actions/build-and-test
@@ -258,18 +258,18 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
         run: |
-            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Pre-release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

(see title)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and prerelease jobs depend on `GITHUB_TOKEN` permissions for tagging and GitHub releases; if those are insufficient compared to the old PAT, publishes could fail until workflow permissions are adjusted.
> 
> **Overview**
> **Publish v2** no longer uses the custom `GH_PUBLISH_TOKEN` secret for GitHub API/git operations during release and prerelease.
> 
> All former `GH_PUBLISH_TOKEN` references in `.github/workflows/publish-v2.yml` are switched to the built-in **`GITHUB_TOKEN`**: checkout (deploy and prerelease), `pnpm deploy:version` / dry-run / prerelease versioning, and `pnpm deploy:publish` for release and prerelease. Behavior and steps are unchanged aside from which credential is passed as `GH_TOKEN` and to `actions/checkout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac0ab32936bb79c0b75d98f0065f7beb0945872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->