### PR TITLE
revert: restore GH_PUBLISH_TOKEN in publish-v2 workflow (#1833)

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PUBLISH_TOKEN }}
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Build and Test
@@ -148,7 +148,7 @@ jobs:
           
           # Temporarily disable exit on error to capture output even when command fails
           set +e
-          OUTPUT=$(GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version -y --no-private --create-release github 2>&1)
+          OUTPUT=$(GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --create-release github 2>&1)
           EXIT_CODE=$?
           set -e
           
@@ -174,7 +174,7 @@ jobs:
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:publish
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
@@ -236,7 +236,7 @@ jobs:
         with:
           ref: ${{ steps.determine-branch.outputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PUBLISH_TOKEN }}
 
       - name: Build and Test
         uses: ./.github/actions/build-and-test
@@ -258,18 +258,18 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: |
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
         run: |
-            GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Pre-release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 


### PR DESCRIPTION
### Summary

Reverts the token swap from #1833, restoring `GH_PUBLISH_TOKEN` in the Publish v2.x workflow.

The default `GITHUB_TOKEN` authenticates as `github-actions[bot]`, which GitHub does not expose as a selectable branch-protection bypass actor. As a result, `lerna version`'s `git push --follow-tags origin main` was rejected on protected `main` (GH006 — "Changes must be made through a pull request"), breaking the release. Restoring `GH_PUBLISH_TOKEN` unblocks Publish v2.x.

This is the exact inverse of #1833: the 6 token references it changed (the `deploy` checkout, `deploy:version`, `deploy:publish`, and the prerelease checkout/version/publish steps) revert from `GITHUB_TOKEN` back to `GH_PUBLISH_TOKEN`. The `authorize` job's permission check is left untouched.

The longer-term security alternatives (GitHub App with bypass, PR-based release, or a fine-grained PAT) are tracked in the issue.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
