### PR TITLE
chore: use GITHUB_TOKEN for prerelease job in publish-v2 workflow

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -236,7 +236,7 @@ jobs:
         with:
           ref: ${{ steps.determine-branch.outputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PUBLISH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Test
         uses: ./.github/actions/build-and-test
@@ -258,18 +258,18 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
         run: |
-            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+            GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Pre-release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 


### PR DESCRIPTION
### Summary

Partially reverts #1846 for the **prerelease** job only. The prerelease job doesn't push version-bump commits to protected `main`, so it doesn't need the `GH_PUBLISH_TOKEN` branch-protection bypass PAT. Its checkout, dry-run version, prerelease version, and publish steps go back to `GITHUB_TOKEN`, unblocking the prerelease branch.

The `deploy` job keeps `GH_PUBLISH_TOKEN` (restored in #1846) since it must push to protected `main`.

This also addresses the Codex P1 feedback on #1846: the dry-run path no longer exposes the publish PAT to arbitrary-branch code.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No