### PR TITLE
ci(publish-v2): use GitHub App token to push releases

### DIFF
--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -120,11 +120,21 @@ jobs:
               ;;
           esac
 
+      # Mint a short-lived GitHub App installation token. The app is on the branch
+      # ruleset bypass list, so it can push the lerna version commit + tags directly
+      # to the protected branch (a plain PAT/GITHUB_TOKEN is rejected by the ruleset).
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AMPLITUDE_DEV_EXP_APP_ID }}
+          private-key: ${{ secrets.AMPLITUDE_DEV_EXP_PRIVATE_KEY }}
+
       - name: Check out git repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PUBLISH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Build and Test
@@ -148,7 +158,7 @@ jobs:
           
           # Temporarily disable exit on error to capture output even when command fails
           set +e
-          OUTPUT=$(GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --create-release github 2>&1)
+          OUTPUT=$(GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:version -y --no-private --create-release github 2>&1)
           EXIT_CODE=$?
           set -e
           
@@ -174,7 +184,7 @@ jobs:
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Release to NPM
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish
+          GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:publish
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
@@ -231,12 +241,19 @@ jobs:
             exit 1
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AMPLITUDE_DEV_EXP_APP_ID }}
+          private-key: ${{ secrets.AMPLITUDE_DEV_EXP_PRIVATE_KEY }}
+
       - name: Check out git repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ steps.determine-branch.outputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PUBLISH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Build and Test
         uses: ./.github/actions/build-and-test
@@ -258,18 +275,18 @@ jobs:
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
+          GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
 
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
         run: |
-            GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+            GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
 
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Pre-release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
         run: |
-          GH_TOKEN=${{ secrets.GH_PUBLISH_TOKEN }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
+          GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 


### PR DESCRIPTION
## Why

The last `release` run on `publish-v2` left a **tagged-but-unpublished orphan commit**: lerna created the `chore(release): publish` commit + version tags and pushed the *tags*, but the push of the commit to the protected `main` branch was **rejected by branch protection**, so the version step failed and nothing reached npm. The six release tags pointed at a commit no branch contained.

A plain PAT / `GITHUB_TOKEN` can't push to the protected branch. The fix is to push as a **GitHub App that's on the branch-ruleset bypass list**.

## What

- Mint a short-lived installation token via `actions/create-github-app-token` (pinned to `v3.2.0`) in both the **deploy** and **prerelease** jobs.
- Use `steps.app-token.outputs.token` for `actions/checkout`, `lerna version` (`GH_TOKEN`), and the publish steps — replacing `GH_PUBLISH_TOKEN` everywhere.
- Token is minted from the `AMPLITUDE_DEV_EXP_APP_ID` / `AMPLITUDE_DEV_EXP_PRIVATE_KEY` `npm-release` environment secrets.

## Prerequisites (infra, done outside this PR)

- GitHub App installed on this repo with **Contents: write**.
- App added to the branch ruleset **bypass list** (mode: Always), and the legacy classic branch protection on `main` removed so the ruleset is authoritative.

## Notes

- `authorize` job still uses `GITHUB_TOKEN` for the read-only permission check — unchanged.
- The stale orphan tags from the failed run were already deleted from the remote, so a fresh full `release` run (`skipLernaVersion: false`) can re-version cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)