### PR TITLE
feat(session-replay-react-native): add New Architecture support

### DIFF
--- a/packages/session-replay-react-native/README.md
+++ b/packages/session-replay-react-native/README.md
@@ -8,6 +8,19 @@ Amplitude Session Replay for React Native
 npm install @amplitude/session-replay-react-native
 ```
 
+## React Native New Architecture
+
+This SDK supports both the New Architecture (Bridgeless / TurboModules) and the
+legacy architecture. On the New Architecture the native module is exposed as a
+TurboModule; on the legacy architecture it continues to work as a standard bridge
+module. No configuration is required — the correct implementation is selected
+automatically based on how your app is built.
+
+`peerDependencies` are intentionally left unconstrained (`react-native: "*"`) so
+the SDK keeps working on older React Native versions on the legacy architecture.
+The TurboModule code path is compiled only when the New Architecture is enabled,
+which itself requires React Native 0.74 or newer.
+
 ## Usage
 
 ### Session Replay React Native Standalone SDK

--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -42,6 +42,18 @@ android {
     }
   }
 
+  // New Arch compiles src/newarch (codegen spec + BaseReactPackage); Old Arch
+  // compiles src/oldarch (hand-written spec + plain ReactPackage).
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += ['src/newarch/java']
+      } else {
+        java.srcDirs += ['src/oldarch/java']
+      }
+    }
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
@@ -82,4 +94,14 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}
+
+// Codegen for the TurboModule spec (New Architecture only). Generates
+// NativeAmpSessionReplaySpec from src/specs/NativeAmpSessionReplay.ts.
+if (isNewArchitectureEnabled()) {
+  react {
+    jsRootDir = file("../src/specs/")
+    libraryName = "AmpSessionReplaySpec"
+    codegenJavaPackageName = "com.amplitude.sessionreplayreactnative"
+  }
 }

--- a/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
+++ b/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
@@ -7,23 +7,24 @@ import com.amplitude.common.Logger
 import com.amplitude.common.android.LogcatLogger
 import com.amplitude.core.ServerZone
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.bridge.ReadableMap
 
+// `@ReactMethod` is required on the legacy architecture and ignored on the new
+// one, so it stays on the overrides below.
 class SessionReplayReactNativeModule(private val reactContext: ReactApplicationContext) :
-  ReactContextBaseJavaModule(reactContext) {
+  SessionReplayReactNativeSpec(reactContext) {
   private lateinit var sessionReplay: SessionReplay
 
   override fun getName(): String {
-    return "AMPNativeSessionReplay"
+    return NAME
   }
 
   @ReactMethod
-  fun setup(config: ReadableMap, promise: Promise) {
+  override fun setup(config: ReadableMap, promise: Promise) {
     try {
       val apiKey = config.getString("apiKey") ?: throw IllegalArgumentException("apiKey is required")
       val deviceId = config.getString("deviceId")
@@ -88,7 +89,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun setSessionId(sessionId: Double, promise: Promise) {
+  override fun setSessionId(sessionId: Double, promise: Promise) {
     try {
       sessionReplay.setSessionId(sessionId.toLong())
       promise.resolve(null)
@@ -98,7 +99,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun setDeviceId(deviceId: String?, promise: Promise) {
+  override fun setDeviceId(deviceId: String?, promise: Promise) {
     try {
       sessionReplay.setDeviceId(deviceId ?: "")
       promise.resolve(null)
@@ -108,7 +109,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun getSessionId(promise: Promise) {
+  override fun getSessionId(promise: Promise) {
     try {
       promise.resolve(sessionReplay.getSessionId().toDouble())
     } catch (e: Exception) {
@@ -117,7 +118,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun getSessionReplayProperties(promise: Promise) {
+  override fun getSessionReplayProperties(promise: Promise) {
     try {
       val properties: Map<String, Any> = sessionReplay.getSessionReplayProperties()
       val map: WritableMap = WritableNativeMap()
@@ -141,7 +142,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
   
   @ReactMethod
-  fun start(promise: Promise) {
+  override fun start(promise: Promise) {
     try {
       sessionReplay.start()
       promise.resolve(null)
@@ -151,7 +152,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun stop(promise: Promise) {
+  override fun stop(promise: Promise) {
     try {
       sessionReplay.stop()
       promise.resolve(null)
@@ -161,7 +162,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun flush(promise: Promise) {
+  override fun flush(promise: Promise) {
     try {
       sessionReplay.flush()
       promise.resolve(null)
@@ -179,5 +180,9 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
     if (::sessionReplay.isInitialized) {
       sessionReplay.shutdown()
     }
+  }
+
+  companion object {
+    const val NAME = "AMPNativeSessionReplay"
   }
 }

--- a/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativePackage.kt
+++ b/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativePackage.kt
@@ -1,0 +1,40 @@
+package com.amplitude.sessionreplayreactnative
+
+import com.facebook.react.BaseReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
+import com.facebook.react.uimanager.ViewManager
+
+// BaseReactPackage (RN >= 0.74) registers the module as a TurboModule. It lives in
+// the newarch source set so it is compiled only when the New Architecture is
+// enabled; legacy-arch apps on older RN never reference it.
+class SessionReplayReactNativePackage : BaseReactPackage() {
+  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+    return if (name == SessionReplayReactNativeModule.NAME) {
+      SessionReplayReactNativeModule(reactContext)
+    } else {
+      null
+    }
+  }
+
+  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+    return ReactModuleInfoProvider {
+      mapOf(
+        SessionReplayReactNativeModule.NAME to ReactModuleInfo(
+          SessionReplayReactNativeModule.NAME, // name
+          SessionReplayReactNativeModule.NAME, // className
+          false, // canOverrideExistingModule
+          false, // needsEagerInit
+          false, // isCxxModule
+          true, // isTurboModule
+        ),
+      )
+    }
+  }
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+    return listOf(SessionReplayReactNativeViewManager())
+  }
+}

--- a/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
+++ b/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
@@ -1,0 +1,7 @@
+package com.amplitude.sessionreplayreactnative
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+// Codegen-generated base (from src/specs/NativeAmpSessionReplay.ts); makes the module a TurboModule.
+abstract class SessionReplayReactNativeSpec(reactContext: ReactApplicationContext) :
+  NativeAmpSessionReplaySpec(reactContext)

--- a/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativePackage.kt
+++ b/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativePackage.kt
@@ -5,7 +5,8 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
-
+// Plain ReactPackage using only APIs present in every supported RN version, so
+// older legacy-arch apps keep building unchanged (no peerDependencies floor).
 class SessionReplayReactNativePackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
     return listOf(SessionReplayReactNativeModule(reactContext))

--- a/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
+++ b/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
@@ -1,0 +1,20 @@
+package com.amplitude.sessionreplayreactnative
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReadableMap
+
+// Legacy-arch counterpart of the codegen spec: same method signatures so the
+// module's `override`s compile against both bases.
+abstract class SessionReplayReactNativeSpec(reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
+  abstract fun setup(config: ReadableMap, promise: Promise)
+  abstract fun setSessionId(sessionId: Double, promise: Promise)
+  abstract fun setDeviceId(deviceId: String?, promise: Promise)
+  abstract fun getSessionId(promise: Promise)
+  abstract fun getSessionReplayProperties(promise: Promise)
+  abstract fun start(promise: Promise)
+  abstract fun stop(promise: Promise)
+  abstract fun flush(promise: Promise)
+}

--- a/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
+++ b/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
@@ -19,3 +19,23 @@ RCT_EXTERN_METHOD(start:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReject
 RCT_EXTERN_METHOD(stop:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+// Bind the Swift module to the codegen TurboModule interface. A named category is
+// required because a Swift class cannot gain protocol conformance via an anonymous
+// class extension.
+#import <AmpSessionReplaySpec/AmpSessionReplaySpec.h>
+
+@interface AMPNativeSessionReplay (TurboModule) <RCTTurboModule>
+@end
+
+@implementation AMPNativeSessionReplay (TurboModule)
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeAmpSessionReplaySpecJSI>(params);
+}
+
+@end
+#endif

--- a/packages/session-replay-react-native/package.json
+++ b/packages/session-replay-react-native/package.json
@@ -78,6 +78,14 @@
     "react": "*",
     "react-native": "*"
   },
+  "codegenConfig": {
+    "name": "AmpSessionReplaySpec",
+    "type": "modules",
+    "jsSrcsDir": "src/specs",
+    "android": {
+      "javaPackageName": "com.amplitude.sessionreplayreactnative"
+    }
+  },
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",

--- a/packages/session-replay-react-native/src/native-module.ts
+++ b/packages/session-replay-react-native/src/native-module.ts
@@ -1,4 +1,5 @@
-import { NativeModules, Platform } from 'react-native';
+import { Platform } from 'react-native';
+import SessionReplaySpec from './specs/NativeAmpSessionReplay';
 
 const LINKING_ERROR =
   `The package '@amplitude/session-replay-react-native' doesn't seem to be linked. Make sure: \n\n` +
@@ -6,16 +7,21 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
-export const NativeSessionReplay = NativeModules.AMPNativeSessionReplay
-  ? (NativeModules.AMPNativeSessionReplay as NativeSessionReplaySpec)
-  : (new Proxy(
-      {},
-      {
-        get() {
-          throw new Error(LINKING_ERROR);
-        },
+// JS callers use the rich, hand-written types below for full type safety; the
+// codegen `Spec` is intentionally loose (`UnsafeObject`) at the native boundary.
+// The spec resolves the native module via `TurboModuleRegistry.get` (both
+// architectures). When the module isn't linked it resolves to null, so we fall
+// back to a proxy that throws a descriptive linking error on first use rather
+// than crashing app startup at import time.
+export const NativeSessionReplay = (SessionReplaySpec ??
+  new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(LINKING_ERROR);
       },
-    ) as NativeSessionReplaySpec);
+    },
+  )) as unknown as NativeSessionReplaySpec;
 
 /**
  * Configuration interface for setting up the native iOS and Android session replay modules.

--- a/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
+++ b/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
@@ -1,0 +1,29 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+// The codegen types live in a Flow-typed file that eslint-plugin-import cannot parse.
+// eslint-disable-next-line import/namespace
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+
+// Codegen TurboModule spec for the imperative Session Replay module.
+//
+// The config crosses the bridge as an untyped object: the native side already
+// reads a ReadableMap / NSDictionary, and app-boundary type safety lives in the
+// public `SessionReplayConfig`. See native-module.ts for the typed facade that
+// JS callers actually use.
+export interface Spec extends TurboModule {
+  setup(config: UnsafeObject): Promise<void>;
+  setSessionId(sessionId: number): Promise<void>;
+  setDeviceId(deviceId: string | null): Promise<void>;
+  getSessionId(): Promise<number>;
+  getSessionReplayProperties(): Promise<UnsafeObject>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  flush(): Promise<void>;
+}
+
+// Use non-enforcing `get` (returns null when the native module isn't linked)
+// so importing the package never crashes app startup. The typed facade in
+// native-module.ts throws a friendly linking error lazily on first use instead.
+// Works on both architectures: JSI on the New Architecture, legacy NativeModules
+// fallback on the old one.
+export default TurboModuleRegistry.get<Spec>('AMPNativeSessionReplay');

--- a/packages/session-replay-react-native/test/__mocks__/react-native.ts
+++ b/packages/session-replay-react-native/test/__mocks__/react-native.ts
@@ -1,15 +1,24 @@
 // __mocks__/react-native.ts
+const ampNativeSessionReplay = {
+  setup: jest.fn().mockResolvedValue(undefined),
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  flush: jest.fn().mockResolvedValue(undefined),
+  getSessionId: jest.fn().mockResolvedValue(12345),
+  getSessionReplayProperties: jest.fn().mockResolvedValue({ replayId: 'test-id' }),
+  setDeviceId: jest.fn().mockResolvedValue(undefined),
+  setSessionId: jest.fn().mockResolvedValue(undefined),
+};
+
+// Resolve on both architectures: NativeModules (old arch) and TurboModuleRegistry
+// (new arch) return the same module instance.
 export const NativeModules = {
-  AMPNativeSessionReplay: {
-    setup: jest.fn().mockResolvedValue(undefined),
-    start: jest.fn().mockResolvedValue(undefined),
-    stop: jest.fn().mockResolvedValue(undefined),
-    flush: jest.fn().mockResolvedValue(undefined),
-    getSessionId: jest.fn().mockResolvedValue(12345),
-    getSessionReplayProperties: jest.fn().mockResolvedValue({ replayId: 'test-id' }),
-    setDeviceId: jest.fn().mockResolvedValue(undefined),
-    setSessionId: jest.fn().mockResolvedValue(undefined),
-  },
+  AMPNativeSessionReplay: ampNativeSessionReplay,
+};
+
+export const TurboModuleRegistry = {
+  get: jest.fn(() => ampNativeSessionReplay),
+  getEnforcing: jest.fn(() => ampNativeSessionReplay),
 };
 
 export const Platform = {


### PR DESCRIPTION
### Summary

Adds React Native **New Architecture (TurboModule)** support to `@amplitude/session-replay-react-native`, while keeping the legacy bridge fully working. The existing Swift/Kotlin Session Replay implementation is unchanged — this PR is a thin, additive compatibility layer around it:

- **JS**: a Codegen TurboModule spec (`src/specs/NativeAmpSessionReplay.ts`) + `codegenConfig`. The rich, hand-written types stay in `native-module.ts`; the spec is intentionally loose (`UnsafeObject`) at the bridge boundary. Resolution via `TurboModuleRegistry.getEnforcing` works on both architectures.
- **iOS**: keep `RCT_EXTERN_MODULE` for the legacy bridge; add the TurboModule conformance only under `#ifdef RCT_NEW_ARCH_ENABLED`.
- **Android**: dual source sets — `oldarch` keeps a plain `ReactPackage` (only APIs present in every supported RN version), `newarch` uses `BaseReactPackage` and is compiled solely when `newArchEnabled=true`.

**Backward compatibility:** old-architecture consumers are unaffected (no peer-dependency floor raised; explicit handling for RN < 0.71 retained on both platforms). The New Architecture path effectively requires **RN ≥ 0.74** (Android `BaseReactPackage`).

**Why it's safe:** new-arch code is gated behind `#ifdef` / source-set switches, so it is never referenced by legacy-arch builds. No Session Replay capture logic changed.

**Out of scope (intentional):** this PR does **not** add native field masking — `secureTextEntry` in the example only hides characters on screen; masking is a follow-up PR.

**Verification:** built and ran the example app across all four combinations — iOS (old + new arch) and Android (old + new arch). In every case the SDK initializes and `getSessionReplayProperties()` returns a live session. On the New Architecture the app reports `TurboModule: true · Fabric: true`. Android logcat confirms the full replay pipeline (full + incremental snapshots with real bitmap content, and `rrweb` event uploads to Amplitude), attributed to the run's derived `deviceId`. The example app was expanded to a multi-screen harness (Home/Form/Gallery/WebView) to generate non-trivial replay frames.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the native module is registered and resolved on both platforms; mis-gating or codegen wiring could break linking or New Arch builds, though session replay capture logic is untouched.
> 
> **Overview**
> Adds **React Native New Architecture** support for `@amplitude/session-replay-react-native` while keeping the legacy bridge path unchanged. Consumers still use the same public JS API; the native module is resolved through a **Codegen TurboModule spec** instead of `NativeModules` directly.
> 
> On **JavaScript**, a new `src/specs/NativeAmpSessionReplay.ts` spec plus `codegenConfig` in `package.json` define the native contract. `native-module.ts` now loads the module via `TurboModuleRegistry.get` (with a lazy proxy when linking fails), and the hand-written types in `native-module.ts` remain what app code uses.
> 
> On **Android**, Gradle switches between `src/oldarch` (plain `ReactPackage` + hand-written `SessionReplayReactNativeSpec` base) and `src/newarch` (`BaseReactPackage`, TurboModule metadata, codegen `NativeAmpSessionReplaySpec`) when `newArchEnabled` is true. The shared `SessionReplayReactNativeModule` now extends the architecture-specific spec base and `override`s bridge methods; Session Replay capture logic is not modified.
> 
> On **iOS**, legacy `RCT_EXTERN_MODULE` stays as-is; under `RCT_NEW_ARCH_ENABLED`, `AMPNativeSessionReplay.mm` adds TurboModule conformance wired to the codegen JSI class.
> 
> README documents dual-arch behavior and unconstrained `react-native` peers; Jest mocks mock both `NativeModules` and `TurboModuleRegistry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513777592141050ccfe684d0c642cbb564b8dd0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->