### PR TITLE
refactor(plugin-network-capture-browser): change BodyCaptureRule import to "type"

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -110,7 +110,7 @@ export { Status } from './types/status';
 
 export { NetworkEventCallback, networkObserver } from './observers/network';
 export { NetworkRequestEvent, IRequestWrapper, JsonObject, JsonValue, JsonArray } from './network-request-event';
-export { NetworkTrackingOptions, NetworkCaptureRule } from './types/network-tracking';
+export { NetworkTrackingOptions, NetworkCaptureRule, BodyCaptureRule } from './types/network-tracking';
 export { SAFE_HEADERS, FORBIDDEN_HEADERS } from './types/constants';
 
 export { PageUrlEnrichmentOptions } from './types/page-url-enrichment';

--- a/packages/plugin-network-capture-browser/src/track-network-event.ts
+++ b/packages/plugin-network-capture-browser/src/track-network-event.ts
@@ -12,7 +12,7 @@ import {
 } from '@amplitude/analytics-core';
 import { AllWindowObservables, TimestampedEvent } from './network-capture-plugin';
 import { AMPLITUDE_NETWORK_REQUEST_EVENT, IS_HEADER_CAPTURE_EXPERIMENTAL } from './constants';
-import { BodyCaptureRule } from '@amplitude/analytics-core/lib/esm/types/network-tracking';
+import type { BodyCaptureRule } from '@amplitude/analytics-core';
 
 const DEFAULT_STATUS_CODE_RANGE = '500-599';
 


### PR DESCRIPTION
### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public export addition and import-path refactor with no logic changes.
> 
> **Overview**
> **`@amplitude/analytics-core`** now re-exports **`BodyCaptureRule`** alongside the other network-tracking types, so consumers can import it from the package entry instead of deep paths.
> 
> **`plugin-network-capture-browser`** updates **`track-network-event.ts`** to use `import type { BodyCaptureRule } from '@amplitude/analytics-core'`, replacing the previous `@amplitude/analytics-core/lib/esm/types/network-tracking` import. Runtime behavior is unchanged; only the import surface and type-only import style differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dee156973b68466597cac617f4e74d14835fe31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->