### PR TITLE
feat(analytics-browser): enable event property attribution by default (SDKW-27)

### DIFF
--- a/packages/analytics-browser-test/test/web-attribution.test.ts
+++ b/packages/analytics-browser-test/test/web-attribution.test.ts
@@ -18,7 +18,11 @@ import {
 
 describe('Web attribution', () => {
   const defaultTracking = {
-    attribution: true,
+    // These tests cover user-property (web) attribution; event-property attribution is on by
+    // default, so disable it here to keep the assertions focused on the user-property flow.
+    attribution: {
+      trackingMethod: 'userProperty' as const,
+    },
     fileDownloads: false,
     formInteractions: false,
     pageViews: true,
@@ -153,6 +157,7 @@ describe('Web attribution', () => {
           defaultTracking: {
             ...defaultTracking,
             attribution: {
+              trackingMethod: 'userProperty',
               excludeReferrers: [referrerDomain],
             },
           },
@@ -356,6 +361,7 @@ describe('Web attribution', () => {
           defaultTracking: {
             ...defaultTracking,
             attribution: {
+              trackingMethod: 'userProperty',
               resetSessionOnNewCampaign: true,
             },
           },
@@ -377,6 +383,7 @@ describe('Web attribution', () => {
             defaultTracking: {
               ...defaultTracking,
               attribution: {
+                trackingMethod: 'userProperty',
                 resetSessionOnNewCampaign: true,
               },
             },
@@ -502,6 +509,7 @@ describe('Web attribution', () => {
           defaultTracking: {
             ...defaultTracking,
             attribution: {
+              trackingMethod: 'userProperty',
               excludeReferrers: [referring_domain],
             },
             sessions: true,
@@ -634,6 +642,7 @@ describe('Web attribution', () => {
           defaultTracking: {
             ...defaultTracking,
             attribution: {
+              trackingMethod: 'userProperty',
               resetSessionOnNewCampaign: true,
             },
             sessions: true,

--- a/packages/analytics-browser/src/attribution/tracking-methods.ts
+++ b/packages/analytics-browser/src/attribution/tracking-methods.ts
@@ -10,7 +10,7 @@ const isTrackingMethod = (value: unknown): value is TrackingMethod =>
  * The default tracking methods used when no valid method is configured. Both run by default and
  * are independent.
  */
-export const DEFAULT_TRACKING_METHODS: readonly TrackingMethod[] = [
+const DEFAULT_TRACKING_METHODS: readonly TrackingMethod[] = [
   USER_PROPERTY_TRACKING_METHOD,
   EVENT_PROPERTY_TRACKING_METHOD,
 ];

--- a/packages/analytics-browser/src/attribution/tracking-methods.ts
+++ b/packages/analytics-browser/src/attribution/tracking-methods.ts
@@ -10,7 +10,7 @@ const isTrackingMethod = (value: unknown): value is TrackingMethod =>
  * The default tracking methods used when no valid method is configured. Both run by default and
  * are independent.
  */
-export const DEFAULT_TRACKING_METHODS: TrackingMethod[] = [
+export const DEFAULT_TRACKING_METHODS: readonly TrackingMethod[] = [
   USER_PROPERTY_TRACKING_METHOD,
   EVENT_PROPERTY_TRACKING_METHOD,
 ];

--- a/packages/analytics-browser/src/attribution/tracking-methods.ts
+++ b/packages/analytics-browser/src/attribution/tracking-methods.ts
@@ -7,15 +7,24 @@ const isTrackingMethod = (value: unknown): value is TrackingMethod =>
   value === USER_PROPERTY_TRACKING_METHOD || value === EVENT_PROPERTY_TRACKING_METHOD;
 
 /**
+ * The default tracking methods used when no valid method is configured. Both run by default and
+ * are independent.
+ */
+export const DEFAULT_TRACKING_METHODS: TrackingMethod[] = [
+  USER_PROPERTY_TRACKING_METHOD,
+  EVENT_PROPERTY_TRACKING_METHOD,
+];
+
+/**
  * Normalizes attribution tracking methods from runtime config, drops unsupported values,
- * and falls back to the legacy default when nothing valid is provided.
+ * and falls back to the default methods when nothing valid is provided.
  */
 export const normalizeTrackingMethod = (trackingMethod?: unknown): TrackingMethod[] => {
   const normalized = [
     ...new Set((Array.isArray(trackingMethod) ? trackingMethod : [trackingMethod]).filter(isTrackingMethod)),
   ];
 
-  return normalized.length > 0 ? normalized : [USER_PROPERTY_TRACKING_METHOD];
+  return normalized.length > 0 ? normalized : [...DEFAULT_TRACKING_METHODS];
 };
 
 export const hasTrackingMethod = (options: AttributionOptions, trackingMethod: TrackingMethod) =>

--- a/packages/analytics-browser/test/attribution/tracking-methods.test.ts
+++ b/packages/analytics-browser/test/attribution/tracking-methods.test.ts
@@ -8,8 +8,8 @@ import {
 } from '../../src/attribution/tracking-methods';
 
 describe('tracking-methods', () => {
-  test('should default to user property tracking', () => {
-    expect(normalizeTrackingMethod()).toEqual([USER_PROPERTY_TRACKING_METHOD]);
+  test('should default to both user property and event property tracking', () => {
+    expect(normalizeTrackingMethod()).toEqual([USER_PROPERTY_TRACKING_METHOD, EVENT_PROPERTY_TRACKING_METHOD]);
   });
 
   test('should normalize and dedupe tracking methods', () => {
@@ -28,9 +28,15 @@ describe('tracking-methods', () => {
     ).toEqual([USER_PROPERTY_TRACKING_METHOD, EVENT_PROPERTY_TRACKING_METHOD]);
   });
 
-  test('should fall back to user property tracking when runtime input is invalid', () => {
-    expect(normalizeTrackingMethod('event_property')).toEqual([USER_PROPERTY_TRACKING_METHOD]);
-    expect(normalizeTrackingMethod([123, false, null])).toEqual([USER_PROPERTY_TRACKING_METHOD]);
+  test('should fall back to the default tracking methods when runtime input is invalid', () => {
+    expect(normalizeTrackingMethod('event_property')).toEqual([
+      USER_PROPERTY_TRACKING_METHOD,
+      EVENT_PROPERTY_TRACKING_METHOD,
+    ]);
+    expect(normalizeTrackingMethod([123, false, null])).toEqual([
+      USER_PROPERTY_TRACKING_METHOD,
+      EVENT_PROPERTY_TRACKING_METHOD,
+    ]);
   });
 
   test('should detect enabled tracking methods', () => {
@@ -45,11 +51,12 @@ describe('tracking-methods', () => {
     expect(options.fallbackAttributionEvent).toBe(true);
   });
 
-  test('should enable user property tracking by default', () => {
+  test('should enable both user property and event property tracking by default', () => {
     const options = {};
 
     expect(hasTrackingMethod(options, USER_PROPERTY_TRACKING_METHOD)).toBe(true);
+    expect(hasTrackingMethod(options, EVENT_PROPERTY_TRACKING_METHOD)).toBe(true);
     expect(isUserPropertyAttributionEnabled(options)).toBe(true);
-    expect(isEventPropertyAttributionEnabled(options)).toBe(false);
+    expect(isEventPropertyAttributionEnabled(options)).toBe(true);
   });
 });

--- a/packages/analytics-browser/test/browser-client.test.ts
+++ b/packages/analytics-browser/test/browser-client.test.ts
@@ -1063,6 +1063,27 @@ describe('browser-client', () => {
       );
     });
 
+    test('should add both attribution plugins by default when no tracking method is configured', async () => {
+      jest.spyOn(core.CampaignParser.prototype, 'parse').mockResolvedValue({
+        ...core.BASE_CAMPAIGN,
+        utm_source: 'amp-test',
+      });
+      const eventPropertyTrackingPlugin = jest.spyOn(eventPropertyTracking, 'eventPropertyTrackingPlugin');
+      const webAttributionInit = jest.spyOn(WebAttribution.prototype, 'init');
+
+      await client.init(apiKey, userId, {
+        fetchRemoteConfig: false,
+        defaultTracking: {
+          attribution: {},
+          pageViews: false,
+          sessions: false,
+        },
+      }).promise;
+
+      expect(webAttributionInit).toHaveBeenCalledTimes(1);
+      expect(eventPropertyTrackingPlugin).toHaveBeenCalledTimes(1);
+    });
+
     test('should enrich same-tick track calls with the latest campaign after pushState', async () => {
       jest
         .spyOn(core.CampaignParser.prototype, 'parse')

--- a/packages/analytics-core/src/types/config/browser-config.ts
+++ b/packages/analytics-core/src/types/config/browser-config.ts
@@ -271,8 +271,7 @@ export interface AttributionOptions {
    * When multiple methods are provided, each enabled method runs independently and their behaviors are combined.
    * For example, `['userProperty', 'eventProperty']` updates user properties and also attaches campaign params
    * to event properties.
-   * @experimental this feature is experimental and may not be stable
-   * @defaultValue `"userProperty"`
+   * @defaultValue `["userProperty", "eventProperty"]`
    */
   trackingMethod?: TrackingMethod | TrackingMethod[];
   /**
@@ -280,7 +279,6 @@ export interface AttributionOptions {
    * such as on page load and SPA URL changes.
    * Applies only to `eventProperty` tracking.
    * Ignored by `userProperty` tracking.
-   * @experimental this feature is experimental and may not be stable
    * @defaultValue `false`
    */
   fallbackAttributionEvent?: boolean;


### PR DESCRIPTION
## Summary

Moves the Browser SDK's event property-based attribution tracking out of the experimental tag and enables it by default, per [SDKW-27](https://linear.app/amplitude/issue/SDKW-27/move-event-property-based-attribution-tracking-out-of-experimental-and).

Previously this feature was gated behind an experimental `trackingMethod: 'eventProperty'` opt-in. It is now a stable, default-on capability so campaign params are attached to event properties automatically.

## Changes

- **Remove experimental tags** from `trackingMethod` and `fallbackAttributionEvent` in `AttributionOptions` (`analytics-core`).
- **Change the default tracking method** from `["userProperty"]` to `["userProperty", "eventProperty"]` (`normalizeTrackingMethod` in `analytics-browser`). Extracted into a `DEFAULT_TRACKING_METHODS` constant. Both methods run independently and combine.
- **Update JSDoc** `@defaultValue` for `trackingMethod`.
- **Update tests** asserting the old default.

## Backward compatibility

Explicit user configuration is still honored. Users who opted into a specific method (e.g. `trackingMethod: 'userProperty'` or `'eventProperty'`) keep exactly their configured behavior — the new default only applies when nothing valid is configured. Existing default users keep their user-property attribution and additionally gain event-property attribution.

## Testing

- `analytics-browser`: 511 tests pass, 100% coverage
- `analytics-core`: 815 tests pass, 100% coverage
- `plugin-event-property-attribution-browser`: 12 tests pass, 100% coverage
- Lint clean on changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on event-property attribution changes emitted event payloads and plugin wiring for integrators who relied on implicit user-property-only behavior; explicit `trackingMethod` overrides remain unchanged.
> 
> **Overview**
> **Event-property attribution is now on by default** alongside user-property attribution when attribution is enabled and no valid `trackingMethod` is set. `normalizeTrackingMethod` falls back to both methods via a new `DEFAULT_TRACKING_METHODS` constant instead of only `userProperty`.
> 
> **Public config docs** in `AttributionOptions` drop the experimental label on `trackingMethod` and document `@defaultValue` as `["userProperty", "eventProperty"]` (the experimental tag on `fallbackAttributionEvent` is also removed in the diff).
> 
> **Tests** expect the dual default, assert init registers **both** web attribution and the event-property plugin when `attribution: {}`, and pin integration web-attribution scenarios to `trackingMethod: 'userProperty'` so assertions stay focused on user-property behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c72d4a8d164258b99cd3716719a3b1fb3c06da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->