### PR TITLE
feat(session-replay-browser): custom transport hooks for authenticated proxies (SR-4497)

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -41,7 +41,14 @@ export {
   MIN_GZIP_UPLOAD_BODY_SIZE_BYTES,
 } from './transports/gzip';
 
-export { RemoteConfigClient, IRemoteConfigClient, RemoteConfig, Source } from './remote-config/remote-config';
+export {
+  RemoteConfigClient,
+  IRemoteConfigClient,
+  RemoteConfig,
+  Source,
+  RemoteConfigFetchRequest,
+  RemoteConfigCustomFetch,
+} from './remote-config/remote-config';
 
 export { LogLevel } from './types/loglevel';
 export { AMPLITUDE_PREFIX, STORAGE_PREFIX } from './types/constants';

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -42,6 +42,35 @@ export interface RemoteConfigFetchRequest {
  */
 export type RemoteConfigCustomFetch = (request: RemoteConfigFetchRequest) => Promise<Response>;
 
+/**
+ * Settles with `promise`, but rejects with an AbortError when `signal` fires. The request-timeout
+ * signal is handed to customFetch, but a transport that ignores it would block the await (and the
+ * retry loop) indefinitely; racing the abort guarantees the client-side timeout always applies.
+ * The transport's own promise keeps running — we can't cancel it — we just stop awaiting it.
+ */
+function abortableFetch(promise: Promise<Response>, signal: AbortSignal): Promise<Response> {
+  return new Promise<Response>((resolve, reject) => {
+    const onAbort = () => {
+      // Match how a native aborted fetch rejects (name 'AbortError') so fetch()'s catch logs it
+      // as a timeout; either way the loop retries since the abort doesn't clear shouldRetry.
+      const err = new Error('Remote config custom fetch aborted by timeout');
+      err.name = 'AbortError';
+      reject(err);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 export const US_SERVER_URL = 'https://sr-client-cfg.amplitude.com/config';
 export const EU_SERVER_URL = 'https://sr-client-cfg.eu.amplitude.com/config';
 export const DEFAULT_MAX_RETRIES = 3;
@@ -378,8 +407,14 @@ export class RemoteConfigClient implements IRemoteConfigClient {
         const headers: Record<string, string> = { Accept: '*/*' };
         // When a custom transport is configured, hand it the fully-formed request and let it own
         // the network call; otherwise use the built-in fetch. Retry/response handling is identical.
+        // The built-in fetch cancels directly on the signal; the custom transport can't be
+        // cancelled, so race it against the abort (abortableFetch) to enforce the timeout even if
+        // the transport ignores the signal — otherwise a hung transport would block every retry.
         const res = this.customFetch
-          ? await this.customFetch({ url, method: 'GET', headers, signal: abortController.signal })
+          ? await abortableFetch(
+              this.customFetch({ url, method: 'GET', headers, signal: abortController.signal }),
+              abortController.signal,
+            )
           : await fetch(url, {
               method: 'GET',
               headers,

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -386,8 +386,13 @@ export class RemoteConfigClient implements IRemoteConfigClient {
               signal: abortController.signal,
             });
 
+        // Treat a 2xx status as success even when `res.ok` is absent. A custom transport may return
+        // a Response-like object that sets `status`/`text()`/`json()` but not `ok` (e.g. an axios
+        // adapter); falling back to the status range keeps the config path consistent with the
+        // event-upload path while still honoring native fetch's `ok`.
+        const isSuccess = res.ok || (res.status >= 200 && res.status < 300);
         // Handle unsuccessful fetch
-        if (!res.ok) {
+        if (!isSuccess) {
           const body = await res.text();
           this.logger.debug(`Remote config client fetch with retry time ${retries} failed with ${res.status}: ${body}`);
 

--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -22,6 +22,26 @@ export type DeliveryMode = 'all' | { timeout: number };
  */
 export type Source = 'cache' | 'remote';
 
+/**
+ * The fully-formed remote-config request handed to a custom transport. Consumers that need to
+ * own the network call (e.g. to attach auth headers and route through a proxy) supply a
+ * {@link RemoteConfigCustomFetch} via the client constructor; the client builds this request
+ * (resolved URL, headers, abort signal) and the callback executes it.
+ */
+export interface RemoteConfigFetchRequest {
+  url: string;
+  method: 'GET';
+  headers: Record<string, string>;
+  /** Abort signal the client uses to enforce the fetch timeout; honor it in your fetch call. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Custom transport for the remote-config fetch. Must return a `Response`. Retry/backoff stays
+ * in the client around this callback, so it is invoked once per attempt.
+ */
+export type RemoteConfigCustomFetch = (request: RemoteConfigFetchRequest) => Promise<Response>;
+
 export const US_SERVER_URL = 'https://sr-client-cfg.amplitude.com/config';
 export const EU_SERVER_URL = 'https://sr-client-cfg.eu.amplitude.com/config';
 export const DEFAULT_MAX_RETRIES = 3;
@@ -128,12 +148,22 @@ export class RemoteConfigClient implements IRemoteConfigClient {
   fetchPromise: Promise<RemoteConfigInfo> | null = null;
   // Used to skip periodic updateConfigs calls when API key is invalid.
   isLastFetchInvalidApiKey = false;
+  // Optional custom transport. When provided, it replaces the internal fetch for the config GET
+  // (e.g. to attach auth and route through a proxy). Retry stays in the client around it.
+  readonly customFetch?: RemoteConfigCustomFetch;
 
-  constructor(apiKey: string, logger: ILogger, serverZone: ServerZoneType = 'US', serverUrl?: string) {
+  constructor(
+    apiKey: string,
+    logger: ILogger,
+    serverZone: ServerZoneType = 'US',
+    serverUrl?: string,
+    customFetch?: RemoteConfigCustomFetch,
+  ) {
     this.apiKey = apiKey;
     this.serverUrl = serverUrl || (serverZone === 'US' ? US_SERVER_URL : EU_SERVER_URL);
     this.logger = logger;
     this.storage = new RemoteConfigLocalStorage(apiKey, logger);
+    this.customFetch = customFetch;
   }
 
   subscribe(key: string | undefined, deliveryMode: DeliveryMode, callback: RemoteConfigCallback): string {
@@ -344,13 +374,17 @@ export class RemoteConfigClient implements IRemoteConfigClient {
       const timeoutId = setTimeout(() => abortController.abort(), timeout);
 
       try {
-        const res = await fetch(this.getUrlParams(), {
-          method: 'GET',
-          headers: {
-            Accept: '*/*',
-          },
-          signal: abortController.signal,
-        });
+        const url = this.getUrlParams();
+        const headers: Record<string, string> = { Accept: '*/*' };
+        // When a custom transport is configured, hand it the fully-formed request and let it own
+        // the network call; otherwise use the built-in fetch. Retry/response handling is identical.
+        const res = this.customFetch
+          ? await this.customFetch({ url, method: 'GET', headers, signal: abortController.signal })
+          : await fetch(url, {
+              method: 'GET',
+              headers,
+              signal: abortController.signal,
+            });
 
         // Handle unsuccessful fetch
         if (!res.ok) {

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -1112,6 +1112,52 @@ describe('RemoteConfigClient', () => {
     });
   });
 
+  describe('customFetch (custom transport)', () => {
+    test('invokes the custom transport with a fully-formed request instead of fetch', async () => {
+      global.fetch = jest.fn();
+      const customFetch = jest.fn(
+        (_request: { url: string; method: string; headers: Record<string, string>; signal?: AbortSignal }) =>
+          Promise.resolve({ ok: true, json: () => Promise.resolve({ key: 'value' }) } as Response),
+      );
+      const customClient = new RemoteConfigClient(mockApiKey, mockLogger, 'US', undefined, customFetch);
+
+      const result = await customClient.fetch();
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      const request = customFetch.mock.calls[0][0];
+      expect(request.method).toBe('GET');
+      expect(request.url).toContain('/config/test-api-key');
+      expect(request.headers.Accept).toBe('*/*');
+      expect(request.signal).toBeInstanceOf(AbortSignal);
+      expect(result.remoteConfig).toEqual({ key: 'value' });
+    });
+
+    test('falls back to the built-in fetch when no custom transport is provided', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve({ key: 'value' }) } as Response),
+      );
+      const result = await client.fetch();
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(result.remoteConfig).toEqual({ key: 'value' });
+    });
+
+    test('retry stays in the client around the custom transport (5xx then 200)', async () => {
+      global.fetch = jest.fn();
+      const customFetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 500, text: () => Promise.resolve('err') } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ key: 'value' }) } as Response);
+      const customClient = new RemoteConfigClient(mockApiKey, mockLogger, 'US', undefined, customFetch);
+
+      const result = await customClient.fetch(2);
+
+      expect(customFetch).toHaveBeenCalledTimes(2);
+      expect(result.remoteConfig).toEqual({ key: 'value' });
+    });
+  });
+
   describe('getUrlParams', () => {
     test('should generate correct US URL', () => {
       const expectedUrl = `https://sr-client-cfg.amplitude.com/config/test-api-key?config_group=browser`;

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -1156,6 +1156,32 @@ describe('RemoteConfigClient', () => {
       expect(customFetch).toHaveBeenCalledTimes(2);
       expect(result.remoteConfig).toEqual({ key: 'value' });
     });
+
+    test('aborts a hung custom transport on timeout and retries instead of blocking forever', async () => {
+      global.fetch = jest.fn();
+      // Never-settling transport that ignores the abort signal. The client-side timeout must
+      // still reject the await so the retry loop proceeds rather than hanging indefinitely.
+      const customFetch = jest.fn(() => new Promise<Response>(() => undefined));
+      const customClient = new RemoteConfigClient(mockApiKey, mockLogger, 'US', undefined, customFetch);
+
+      // Returning at all (rather than hanging the test) proves the timeout aborted each hung
+      // attempt; both retries ran and the loop gave up with a null config.
+      const result = await customClient.fetch(2, 40);
+
+      expect(customFetch).toHaveBeenCalledTimes(2);
+      expect(result.remoteConfig).toBeNull();
+    });
+
+    test('surfaces a rejected custom transport through the retry loop', async () => {
+      global.fetch = jest.fn();
+      const customFetch = jest.fn().mockRejectedValue(new Error('network down'));
+      const customClient = new RemoteConfigClient(mockApiKey, mockLogger, 'US', undefined, customFetch);
+
+      const result = await customClient.fetch(1);
+
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(result.remoteConfig).toBeNull();
+    });
   });
 
   describe('getUrlParams', () => {

--- a/packages/plugin-session-replay-browser/src/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/session-replay.ts
@@ -114,6 +114,8 @@ export class SessionReplayPlugin implements EnrichmentPlugin<BrowserClient, Brow
         maxPersistedEventsSizeBytes: this.options.maxPersistedEventsSizeBytes,
         maxSingleEventSizeBytes: this.options.maxSingleEventSizeBytes,
         sendTimeoutMs: this.options.sendTimeoutMs,
+        handleSendEvents: this.options.handleSendEvents,
+        handleFetchConfig: this.options.handleFetchConfig,
       };
 
       await this.sessionReplay.init(config.apiKey, this.srInitOptions).promise;

--- a/packages/plugin-session-replay-browser/src/typings/session-replay.ts
+++ b/packages/plugin-session-replay-browser/src/typings/session-replay.ts
@@ -1,6 +1,8 @@
 import { Event } from '@amplitude/analytics-core';
 import {
   StoreType,
+  type SessionReplaySendEventsHandler,
+  type SessionReplayFetchConfigHandler,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type SessionReplayOptions as StandaloneSessionReplayOptions, // used for documentation
 } from '@amplitude/session-replay-browser';
@@ -216,4 +218,15 @@ export interface SessionReplayOptions {
    * @see {@link StandaloneSessionReplayOptions.sendTimeoutMs}
    */
   sendTimeoutMs?: number;
+  /**
+   * Optional custom transport for replay event uploads. Use to attach custom auth (e.g. a JWT
+   * `Authorization` header) and route through an authenticated proxy.
+   * @see {@link StandaloneSessionReplayOptions.handleSendEvents}
+   */
+  handleSendEvents?: SessionReplaySendEventsHandler;
+  /**
+   * Optional custom transport for the remote-config fetch.
+   * @see {@link StandaloneSessionReplayOptions.handleFetchConfig}
+   */
+  handleFetchConfig?: SessionReplayFetchConfigHandler;
 }

--- a/packages/session-replay-browser/README.md
+++ b/packages/session-replay-browser/README.md
@@ -106,6 +106,209 @@ sessionReplay.shutdown()
 |`useWebWorker`|`boolean`|No|`false`|If true, the SDK will compress replay events using a web worker. This offloads compression to a separate thread, improving performance on the main thread.|
 |`crossOriginIframes.enabled`|`boolean`|No|`false`|Enables cross-origin iframe recording. Must be set to `true` on both the parent page and each child iframe page. See [Cross-Origin Iframe Recording](#cross-origin-iframe-recording).|
 |`crossOriginIframes.coordinateChildren`|`boolean`|No|`true`|When `true`, the parent SDK automatically sends start/stop signals to child iframes via `postMessage`. Set to `false` to manage child recording lifecycle yourself.|
+|`handleSendEvents`|`function`|No|`undefined`|Custom transport for replay event uploads. Lets you fully own the outbound HTTP call (e.g. to attach a JWT `Authorization` header and route through an authenticated proxy) while the SDK keeps batching, retry and serialization. See [Custom Transport](#custom-transport-authenticated-proxies--jwt).|
+|`handleFetchConfig`|`function`|No|`undefined`|Custom transport for the remote-config fetch. Same contract as `handleSendEvents`, for the config GET. See [Custom Transport](#custom-transport-authenticated-proxies--jwt).|
+
+## Custom Transport (authenticated proxies / JWT)
+
+By default the SDK sends replay events and fetches remote config with its own internal `fetch`.
+If your environment requires custom request logic on every outbound call — for example a JWT
+`Authorization` header validated by your own proxy before forwarding to Amplitude — provide the
+`handleSendEvents` and/or `handleFetchConfig` callbacks. The SDK hands each callback a
+fully-formed request and the callback's only job is to execute it and return the `Response`. The
+SDK keeps everything else: URL resolution (including `trackServerUrl` / `configServerUrl`),
+batching, retry/backoff, serialization, compression, and error handling.
+
+```ts
+import * as sessionReplay from '@amplitude/session-replay-browser';
+import type { SendEventsRequest, FetchConfigRequest } from '@amplitude/session-replay-browser';
+
+sessionReplay.init(API_KEY, {
+  deviceId,
+  sessionId,
+  // Optional: point at your proxy. The resolved URL is passed into the callbacks.
+  trackServerUrl: 'https://my-proxy.example.com/sr-events',
+  configServerUrl: 'https://my-proxy.example.com/sr-config',
+
+  handleSendEvents: async ({ url, method, headers, body, keepalive }: SendEventsRequest) => {
+    return fetch(url, {
+      method,
+      // Spread the SDK headers so you don't drop Content-Encoding etc., then add your auth.
+      headers: { ...headers, Authorization: `Bearer ${getJwt()}` },
+      body,
+      keepalive, // forward this so page-exit batches survive unload
+    });
+  },
+
+  handleFetchConfig: async ({ url, method, headers, signal }: FetchConfigRequest) => {
+    return fetch(url, {
+      method,
+      headers: { ...headers, Authorization: `Bearer ${getJwt()}` },
+      signal, // honor the SDK's fetch-timeout abort signal
+    });
+  },
+});
+```
+
+For a cookie-authenticated proxy, omit the `Authorization` header and add `credentials: 'include'`
+instead — the shape is otherwise identical.
+
+### Wiring it up for your integration
+
+The two callbacks are the same no matter how you install Session Replay — only *where you pass them
+in* changes. The example above is the **standalone** SDK. If you use the analytics plugin or the
+unified SDK, drop the same `handleSendEvents` / `handleFetchConfig` into your existing init instead:
+
+**Plugin — `@amplitude/plugin-session-replay-browser`** (alongside `@amplitude/analytics-browser`):
+
+```ts
+import * as amplitude from '@amplitude/analytics-browser';
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
+
+amplitude.add(
+  sessionReplayPlugin({
+    sampleRate: 1,
+    trackServerUrl: 'https://my-proxy.example.com/sr-events',
+    configServerUrl: 'https://my-proxy.example.com/sr-config',
+    handleSendEvents: async ({ url, method, headers, body, keepalive }) =>
+      fetch(url, { method, headers: { ...headers, Authorization: `Bearer ${getJwt()}` }, body, keepalive }),
+    handleFetchConfig: async ({ url, method, headers, signal }) =>
+      fetch(url, { method, headers: { ...headers, Authorization: `Bearer ${getJwt()}` }, signal }),
+  }),
+);
+amplitude.init(API_KEY);
+```
+
+**Unified — `@amplitude/unified`** (the callbacks go under the `sessionReplay` block):
+
+```ts
+import { initAll } from '@amplitude/unified';
+
+initAll(API_KEY, {
+  sessionReplay: {
+    sampleRate: 1,
+    trackServerUrl: 'https://my-proxy.example.com/sr-events',
+    configServerUrl: 'https://my-proxy.example.com/sr-config',
+    handleSendEvents: async ({ url, method, headers, body, keepalive }) =>
+      fetch(url, { method, headers: { ...headers, Authorization: `Bearer ${getJwt()}` }, body, keepalive }),
+    handleFetchConfig: async ({ url, method, headers, signal }) =>
+      fetch(url, { method, headers: { ...headers, Authorization: `Bearer ${getJwt()}` }, signal }),
+  },
+});
+```
+
+Everything else in this section — the contract, the proxy-side requirements, web-worker support —
+applies identically across all three.
+
+### Contract
+
+What the SDK guarantees to your callback:
+
+- It passes a fully-formed request (resolved URL, default headers, serialized body). Your only job
+  is to execute it and return a `Response`.
+- It calls the callback **once per logical request attempt**. Retry/backoff is handled by the SDK
+  *around* the callback, so do not implement your own retry.
+- Non-2xx responses and thrown errors / rejected promises are surfaced to the SDK's existing retry
+  and logging logic, exactly as the built-in path treats them.
+
+What the SDK requires from your callback:
+
+- It MUST return a `Response` (or a Response-like object with `ok`, `status`, `text()`).
+- It MUST NOT change the semantics of the SDK-supplied body. Forward it unchanged — when transport
+  compression is active, `body` is a gzipped `Uint8Array` and `headers` already includes
+  `Content-Encoding: gzip`, so keep them together (don't drop that header while forwarding the
+  compressed body, or the payload won't decode server-side).
+
+### Notes
+
+- **You own auth, not Amplitude.** Amplitude never validates your JWT; authentication happens in
+  your proxy, which forwards the (re-authenticated) request to Amplitude.
+- **Web Worker mode is supported.** When `useWebWorker: true`, the SDK keeps compressing off the
+  main thread and delegates only the network call back to the main thread to run your callback.
+- **Page exit.** On unload the SDK normally uses `navigator.sendBeacon`, which can't carry custom
+  headers. When `handleSendEvents` is set, the SDK instead routes the final batch through your
+  callback with `keepalive: true`, so the exit batch is still authenticated.
+- **Covers all outbound traffic.** When `handleSendEvents` is set it is used for every outbound
+  Session Replay request: replay event uploads, the page-exit beacon, and interaction/scroll
+  beacons (these otherwise send via `navigator.sendBeacon` and would not carry your auth). So no
+  Session Replay request leaves the page unauthenticated.
+
+### Implementing the proxy side
+
+The callbacks above are only half the story — they get the request out of the browser with your
+auth attached. The other half is **your proxy**, which has to check that auth and then forward the
+request on to Amplitude. You build and run this proxy; Amplitude doesn't provide one, and you don't
+need us to stand up any new endpoint. Here's everything you need to get it right.
+
+#### Where to forward to
+
+Your proxy forwards to Amplitude's existing public Session Replay endpoints — the same ones the SDK
+would have hit directly. Pick the row that matches your project's data region:
+
+| What | US | EU |
+| ---- | -- | -- |
+| Replay events (the `POST` from `handleSendEvents`) | `https://api-sr.amplitude.com/sessions/v2/track` | `https://api-sr.eu.amplitude.com/sessions/v2/track` |
+| Remote config (the `GET` from `handleFetchConfig`) | `https://sr-client-cfg.amplitude.com/config` | `https://sr-client-cfg.eu.amplitude.com/config` |
+
+So the round trip is just: **browser → your proxy → Amplitude → your proxy → browser.** Your proxy
+sits in the middle, checks the JWT, and relays everything else through.
+
+#### What your proxy needs to do
+
+1. **Validate your auth, then strip it.** Read the JWT (or whatever you attached in the callback),
+   verify it however your security team wants, and reject the request if it's bad. Don't pass your
+   JWT on to Amplitude — Amplitude doesn't know what it is and doesn't need it.
+
+2. **Keep the path and query string exactly as-is.** The SDK builds URLs like
+   `…/sessions/v2/track?device_id=…&session_id=…&type=replay` and
+   `…/config/<apiKey>?config_group=browser`. Those query params matter — forward them unchanged.
+   Don't drop or rewrite them.
+
+3. **Forward the body untouched, and keep `Content-Encoding`.** The replay body is usually gzipped,
+   and the request carries a `Content-Encoding: gzip` header to say so. Pass the bytes through
+   exactly as received and keep that header on. If you decompress, re-compress, or drop the header,
+   Amplitude won't be able to read the payload.
+
+4. **Make sure Amplitude can still see your API key.** This is the one that trips people up — see
+   below.
+
+#### The API-key gotcha (read this one)
+
+Amplitude identifies your project from your **Amplitude API key**, which the SDK puts in the
+`Authorization: Bearer <amplitudeApiKey>` header. If your callback does the obvious thing and
+*overwrites* that header with your JWT, the API key is gone by the time the request leaves the
+browser — and Amplitude will reject the forwarded request because it can't tell which project it
+belongs to.
+
+Two ways to handle it. **We recommend the second one** — it's simpler and harder to get wrong:
+
+- **Option A — your proxy puts the API key back.** Your callback overwrites `Authorization` with
+  the JWT; your proxy validates the JWT and then swaps `Authorization` back to
+  `Bearer <amplitudeApiKey>` before forwarding. Works, but your proxy now has to know your Amplitude
+  API key.
+
+- **Option B (recommended) — send the JWT in a different header.** Leave the SDK's `Authorization`
+  header alone and put your JWT somewhere else, e.g. `X-Customer-Auth`. Your proxy checks that
+  header, strips it, and forwards everything else (including the untouched `Authorization`) straight
+  through. Your proxy never has to know or handle the Amplitude API key.
+
+  ```ts
+  handleSendEvents: async ({ url, method, headers, body, keepalive }) =>
+    fetch(url, {
+      method,
+      // Don't overwrite Authorization — add the JWT under your own header instead.
+      headers: { ...headers, 'X-Customer-Auth': await getJwt() },
+      body,
+      keepalive,
+    }),
+  ```
+
+#### Quick sanity check
+
+Once your proxy is up, do a quick end-to-end test: load a page with the SDK pointed at your proxy,
+interact a bit, and confirm (a) your proxy logs show the JWT arriving and getting validated, and
+(b) replays actually show up in Amplitude. If replays don't land, it's almost always one of the four
+points above — most often the API-key header (gotcha above) or a dropped `Content-Encoding`.
 
 ## Cross-Origin Iframe Recording
 

--- a/packages/session-replay-browser/e2e/trc-url-rule.spec.ts
+++ b/packages/session-replay-browser/e2e/trc-url-rule.spec.ts
@@ -182,10 +182,21 @@ test.describe('TRC URL rule — happy path', () => {
     expect(String(propsAfter[SR_PROPERTY_KEY])).toContain(`/${TEST_SESSION_ID}`);
 
     await page.evaluate(() => window.dispatchEvent(new Event('blur')));
-    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
-    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
 
-    expect(getBodies().length).toBeGreaterThan(0);
+    // The full snapshot is captured asynchronously after targeting flips recording on, so a
+    // single flush can run before any rrweb event has been queued and deliver nothing. Poll:
+    // flush repeatedly until a batch actually reaches the track API (or time out). This removes
+    // the snapshot-vs-flush race that made this assertion flaky (it fails ~2/3 attempts even on
+    // main); flush(false) is a no-op when the queue is empty, so re-driving it is safe.
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+          return getBodies().length;
+        },
+        { timeout: 10_000 },
+      )
+      .toBeGreaterThan(0);
   });
 });
 

--- a/packages/session-replay-browser/src/beacon-transport.ts
+++ b/packages/session-replay-browser/src/beacon-transport.ts
@@ -1,5 +1,5 @@
-import { getGlobalScope } from '@amplitude/analytics-core';
-import { SessionReplayJoinedConfig } from './config/types';
+import { getGlobalScope, ILogger } from '@amplitude/analytics-core';
+import { SessionReplayJoinedConfig, SessionReplaySendEventsHandler } from './config/types';
 import { SessionReplayDestinationSessionMetadata } from './typings/session-replay';
 import { getServerUrl } from './helpers';
 
@@ -27,6 +27,10 @@ export class BeaconTransport<T> {
   private readonly basePageUrl: string;
   private readonly context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>;
   private readonly apiKey: string;
+  // Optional custom transport. When set, interaction beacons go through it (a keepalive fetch
+  // that can carry custom auth) instead of navigator.sendBeacon/XHR, which cannot set headers.
+  private readonly handleSendEvents?: SessionReplaySendEventsHandler;
+  private readonly loggerProvider?: ILogger;
 
   constructor(context: Omit<SessionReplayDestinationSessionMetadata, 'deviceId'>, config: SessionReplayJoinedConfig) {
     const globalScope = getGlobalScope();
@@ -56,10 +60,46 @@ export class BeaconTransport<T> {
     this.basePageUrl = getServerUrl(config.serverZone, config.trackServerUrl);
     this.apiKey = config.apiKey;
     this.context = context;
+    this.handleSendEvents = config.handleSendEvents;
+    this.loggerProvider = config.loggerProvider;
   }
 
   send(deviceId: string, payload: T) {
     const { sessionId, type } = this.context;
+
+    // Custom-transport path: navigator.sendBeacon/XHR cannot attach custom headers, so an
+    // interaction beacon would otherwise leave unauthenticated and be rejected by an
+    // authenticating proxy. When handleSendEvents is set, route the beacon through it instead —
+    // a keepalive fetch (survives page unload) that carries the customer's auth. Mirrors the
+    // replay page-exit path: api_key goes in the Authorization header, not the URL.
+    if (this.handleSendEvents) {
+      const params = new URLSearchParams({
+        device_id: deviceId,
+        session_id: String(sessionId),
+        type: String(type),
+      });
+      const url = `${this.basePageUrl}?${params.toString()}`;
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+        Authorization: `Bearer ${this.apiKey}`,
+      };
+      try {
+        void this.handleSendEvents({
+          url,
+          method: 'POST',
+          headers,
+          body: JSON.stringify(payload),
+          keepalive: true,
+        }).catch((e) => {
+          this.loggerProvider?.warn('Custom transport failed to send session replay interaction beacon:', e);
+        });
+      } catch (e) {
+        this.loggerProvider?.warn('Custom transport threw while sending session replay interaction beacon:', e);
+      }
+      return;
+    }
+
     const urlParams = new URLSearchParams({
       device_id: deviceId,
       session_id: String(sessionId),

--- a/packages/session-replay-browser/src/config/joined-config.ts
+++ b/packages/session-replay-browser/src/config/joined-config.ts
@@ -292,6 +292,9 @@ export const createSessionReplayJoinedConfigGenerator = async (apiKey: string, o
     localConfig.loggerProvider,
     localConfig.serverZone,
     options.configServerUrl,
+    // Custom transport for the config GET. SR's FetchConfigRequest is structurally compatible
+    // with RemoteConfigFetchRequest, so the customer's handleFetchConfig drops straight in.
+    options.handleFetchConfig,
   );
 
   return new SessionReplayJoinedConfigGenerator(remoteConfigClient, localConfig);

--- a/packages/session-replay-browser/src/config/local-config.ts
+++ b/packages/session-replay-browser/src/config/local-config.ts
@@ -19,6 +19,8 @@ import {
   PrivacyConfig,
   SessionReplayPerformanceConfig,
   SessionReplayVersion,
+  SessionReplaySendEventsHandler,
+  SessionReplayFetchConfigHandler,
 } from './types';
 import { SafeLoggerProvider } from '../logger';
 import { validateUGCFilterRules } from '../helpers';
@@ -57,6 +59,8 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
   captureFullSnapshotOnFocus?: boolean;
   maxPersistedEventsSizeBytes?: number;
   maxSingleEventSizeBytes?: number;
+  handleSendEvents?: SessionReplaySendEventsHandler;
+  handleFetchConfig?: SessionReplayFetchConfigHandler;
 
   constructor(apiKey: string, options: SessionReplayOptions) {
     const defaultConfig = getDefaultConfig();
@@ -154,6 +158,8 @@ export class SessionReplayLocalConfig extends Config implements ISessionReplayLo
         maxIntervalMs: DEFAULT_FLUSH_MAX_INTERVAL_MS,
       };
     }
+    this.handleSendEvents = options.handleSendEvents;
+    this.handleFetchConfig = options.handleFetchConfig;
   }
 }
 

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -92,6 +92,68 @@ export type UGCFilterRule = {
   replacement: string;
 };
 
+/**
+ * The fully-formed request the SDK hands to a custom `handleSendEvents` transport when
+ * uploading recorded replay events. The callback's only job is to execute this request and
+ * return the resulting `Response`; the SDK owns batching, retry, serialization and error
+ * handling around it.
+ */
+export interface SendEventsRequest {
+  /** The resolved track URL (respects `trackServerUrl`) including query params. */
+  url: string;
+  method: 'POST';
+  /**
+   * SDK-supplied default headers. When the body was gzipped, this includes
+   * `Content-Encoding: gzip` — drop it only if you also stop forwarding the gzipped body,
+   * otherwise the payload will not decode server-side.
+   */
+  headers: Record<string, string>;
+  /**
+   * The serialized payload, ready to send. A gzipped `Uint8Array` when transport compression
+   * is active, otherwise the raw JSON string. Forward it unchanged — do not re-serialize.
+   *
+   * Typed as `string | Uint8Array` (not the broader `BodyInit`) because the body must be
+   * structured-cloneable to cross `postMessage` in web-worker mode; `Blob`/`FormData`/
+   * `ReadableStream` are not, and the SDK never produces them here.
+   */
+  body: string | Uint8Array;
+  /**
+   * Whether the built-in path would set `keepalive` on this request. `true` for page-exit
+   * sends (so the request survives unload) and for small in-session batches. Forward it to
+   * your `fetch` call — i.e. `fetch(url, { method, headers, body, keepalive })` — so exit-time
+   * batches are not dropped when the page is tearing down.
+   */
+  keepalive: boolean;
+}
+
+/**
+ * The fully-formed request the SDK hands to a custom `handleFetchConfig` transport when
+ * fetching remote configuration.
+ */
+export interface FetchConfigRequest {
+  /** The resolved config URL (respects `configServerUrl`) including query params. */
+  url: string;
+  method: 'GET';
+  /** SDK-supplied default headers. */
+  headers: Record<string, string>;
+  /** Abort signal the SDK uses to enforce the remote-config fetch timeout. Honor it in your fetch. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Custom transport for replay event uploads. Invoked by the SDK in place of its internal
+ * `fetch`. Must return a `Response` (or Response-like with `ok`, `status`, `text()`). Called
+ * once per logical request attempt — retry is handled by the SDK around the callback, so do
+ * not implement your own retry. Thrown errors / rejected promises are surfaced to the SDK's
+ * existing retry logic.
+ */
+export type SessionReplaySendEventsHandler = (request: SendEventsRequest) => Promise<Response>;
+
+/**
+ * Custom transport for remote-config fetches. Same contract as {@link SessionReplaySendEventsHandler}.
+ */
+export type SessionReplayFetchConfigHandler = (request: FetchConfigRequest) => Promise<Response>;
+
 export interface CrossOriginIframesConfig {
   enabled: boolean;
   /**
@@ -346,6 +408,21 @@ export interface SessionReplayLocalConfig extends IConfig {
    * @defaultValue 9000000
    */
   maxSingleEventSizeBytes?: number;
+  /**
+   * Optional custom transport for replay event uploads. When provided, the SDK invokes this
+   * callback in place of its internal `fetch` for every event-upload attempt, passing a
+   * fully-formed {@link SendEventsRequest} (resolved URL, headers, serialized body). The SDK
+   * still owns batching, retry, serialization and error handling. Use it to attach custom
+   * auth (e.g. a JWT `Authorization` header) and route through an authenticated proxy.
+   *
+   * Works alongside `trackServerUrl`: the URL passed to the callback already respects it.
+   */
+  handleSendEvents?: SessionReplaySendEventsHandler;
+  /**
+   * Optional custom transport for the remote-config fetch. Same contract as `handleSendEvents`
+   * but for the config GET. The URL passed to the callback already respects `configServerUrl`.
+   */
+  handleFetchConfig?: SessionReplayFetchConfigHandler;
 }
 
 export interface FlushIntervalConfig {

--- a/packages/session-replay-browser/src/index.ts
+++ b/packages/session-replay-browser/src/index.ts
@@ -11,3 +11,9 @@ export const {
 export { SessionReplayOptions, StoreType } from './typings/session-replay';
 export { SafeLoggerProvider } from './logger';
 export { AmplitudeSessionReplay } from './typings/session-replay';
+export {
+  SendEventsRequest,
+  FetchConfigRequest,
+  SessionReplaySendEventsHandler,
+  SessionReplayFetchConfigHandler,
+} from './config/types';

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -688,9 +688,18 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       // 'fetch-request' when useCustomTransport (= !!this.handleSendEvents) was true. The
       // built-in fetch is a defensive fallback for the impossible case so we never accidentally
       // drop a delegated send; it is not a supported "run without a transport" path.
-      const res = this.handleSendEvents
-        ? await this.handleSendEvents({ url, method, headers, body, keepalive })
-        : await fetch(url, { method, headers, body, keepalive });
+      let res: Response;
+      if (this.handleSendEvents) {
+        res = await this.handleSendEvents({ url, method, headers, body, keepalive });
+      } else {
+        // Defensive only: the worker emits 'fetch-request' solely when useCustomTransport is set,
+        // so this branch shouldn't be reachable. Warn so a regression that delegates without a
+        // transport is diagnosable rather than silently routing to the built-in fetch.
+        this.loggerProvider.warn(
+          'Delegated session replay fetch received without a custom transport configured; falling back to built-in fetch.',
+        );
+        res = await fetch(url, { method, headers, body, keepalive });
+      }
       const status = res.status;
       let skipHeader: string | null = null;
       let responseBody = '';

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -81,6 +81,34 @@ const MAX_KILLED_SESSIONS = 256;
 // cap only guards the pathological case of a wedged worker that never replies at all.
 const MAX_TIMED_OUT_WORKER_REQUESTS = 256;
 
+// Settles with `promise`, but rejects early with an AbortError when `signal` fires. Used to apply
+// the send timeout to a custom transport whose own promise can't be cancelled: a hung transport
+// then surfaces as a retryable timeout (matching the built-in fetch and worker delegation paths)
+// instead of blocking the serial flush loop. The transport's promise keeps running; we just stop
+// awaiting it. `signal` is always supplied with the send-timeout controller's signal.
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      // Match how browsers reject an aborted fetch (DOMException 'AbortError'); sendOnMainThread's
+      // catch keys off the name to route it through the retry budget rather than failing fatally.
+      const err = new Error('Custom session replay transport aborted by send timeout');
+      err.name = 'AbortError';
+      reject(err);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrackDestination {
   loggerProvider: ILogger;
   storageKey = '';
@@ -807,10 +835,16 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       try {
         // When a custom transport is configured, hand it the fully-formed request and let it own
         // the network call (e.g. to attach a JWT and route through a proxy). Otherwise use the
-        // built-in fetch. Retry/response handling below is identical for both paths. The custom
-        // transport owns its own timeout; controller.signal only aborts the built-in fetch.
+        // built-in fetch. Retry/response handling below is identical for both paths. The built-in
+        // fetch cancels directly on controller.signal; the custom callback can't be cancelled, so
+        // we race it against the abort — a hung/never-settling transport then rejects with an
+        // AbortError (retryable, like the worker delegation path) instead of blocking the serial
+        // flush loop forever. The callback's own promise keeps running; we just stop awaiting it.
         res = this.handleSendEvents
-          ? await this.handleSendEvents({ url: serverUrl, method: 'POST', headers, body, keepalive })
+          ? await abortable(
+              this.handleSendEvents({ url: serverUrl, method: 'POST', headers, body, keepalive }),
+              controller.signal,
+            )
           : await fetch(serverUrl, options);
       } finally {
         // Clear on success and on error alike so a settled request never leaves an armed

--- a/packages/session-replay-browser/src/track-destination.ts
+++ b/packages/session-replay-browser/src/track-destination.ts
@@ -28,6 +28,7 @@ import {
   SEND_TIMEOUT_MS,
 } from './constants';
 import { gzipJson } from './utils/gzip';
+import { SessionReplaySendEventsHandler } from './config/types';
 
 interface WorkerCompleteMessage {
   type: 'complete';
@@ -47,7 +48,24 @@ interface WorkerPayloadTooLargeMessage {
   id: string;
   isWaf: boolean;
 }
-type WorkerMessage = WorkerCompleteMessage | WorkerLogMessage | WorkerPayloadTooLargeMessage;
+// Worker asks the main thread to run the custom transport for one network attempt (the
+// callback can't cross postMessage, so it lives on the main thread). Replied to with a
+// 'fetch-response' message posted back into the worker.
+interface WorkerFetchRequestMessage {
+  type: 'fetch-request';
+  requestId: string;
+  url: string;
+  method: 'POST';
+  headers: Record<string, string>;
+  // string | Uint8Array (not BodyInit) so it stays structured-cloneable across postMessage.
+  body: string | Uint8Array;
+  keepalive: boolean;
+}
+type WorkerMessage =
+  | WorkerCompleteMessage
+  | WorkerLogMessage
+  | WorkerPayloadTooLargeMessage
+  | WorkerFetchRequestMessage;
 
 export type PayloadBatcher = ({ version, events }: { version: number; events: string[] }) => {
   version: number;
@@ -108,6 +126,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
   // transition-only gating — so a sustained throttle scenario doesn't spam logs every cycle.
   private mergeLogFiredThisPause = false;
   private killedSessions = new Set<string | number>();
+  // Optional customer-supplied transport. When set, it replaces the internal fetch for every
+  // event-upload attempt; retry/response handling stays where it is, so the callback sits
+  // below retry and is invoked once per attempt.
+  private handleSendEvents?: SessionReplaySendEventsHandler;
 
   constructor({
     trackServerUrl,
@@ -116,6 +138,7 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     workerScript,
     enableTransportCompression,
     sendTimeoutMs,
+    handleSendEvents,
   }: {
     trackServerUrl?: string;
     loggerProvider: ILogger;
@@ -123,12 +146,14 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
     workerScript?: string;
     enableTransportCompression?: boolean;
     sendTimeoutMs?: number;
+    handleSendEvents?: SessionReplaySendEventsHandler;
   }) {
     this.loggerProvider = loggerProvider;
     this.payloadBatcher = payloadBatcher ? payloadBatcher : (payload) => payload;
     this.trackServerUrl = trackServerUrl;
     this.enableTransportCompression = enableTransportCompression ?? true;
     this.sendTimeoutMs = sendTimeoutMs ?? SEND_TIMEOUT_MS;
+    this.handleSendEvents = handleSendEvents;
 
     if (workerScript) {
       try {
@@ -203,6 +228,15 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
                 this.completeRequest({ context: timedOut });
               }
             }
+          } else if (msg.type === 'fetch-request') {
+            // Worker is delegating one network attempt to the custom transport (which lives on
+            // the main thread). Run it and post the result back into the worker's retry loop.
+            // Guard the fire-and-forget call: if posting the result back fails (e.g. the worker
+            // was terminated mid-flight), surface it to the logger instead of leaving an
+            // unhandled rejection.
+            void this.handleDelegatedFetch(worker, msg).catch((e) => {
+              loggerProvider.warn('Failed to handle delegated session replay fetch:', e);
+            });
           }
         };
         this.worker = worker;
@@ -283,6 +317,40 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       );
     }
     if (trimmedEvents.length === 0) {
+      return;
+    }
+    // Custom-transport page-exit path: navigator.sendBeacon cannot carry custom headers, so a
+    // JWT customer's exit batch would go out unauthenticated and be rejected by their proxy.
+    // Instead, route it through the callback with keepalive (which survives unload AND carries
+    // headers). Mirrors the main-send request shape: Authorization header + device_id/session_id/
+    // type params (api_key is NOT placed in the URL, unlike the legacy beacon path below).
+    if (this.handleSendEvents) {
+      const exitParams = new URLSearchParams({
+        device_id: deviceId,
+        session_id: String(sessionId),
+        type: 'replay',
+      });
+      const exitUrl = `${getServerUrl(serverZone, this.trackServerUrl)}?${exitParams.toString()}`;
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+        Authorization: `Bearer ${apiKey}`,
+      };
+      this.loggerProvider.debug(
+        `Routing session replay exit batch (${trimmedEvents.length} events) through custom transport for session id ${sessionId}.`,
+      );
+      try {
+        // Fire-and-forget: we cannot await during unload. The request is well under 64 KB
+        // (trimmed above) and keepalive: true is requested so it survives page teardown.
+        void this.handleSendEvents({ url: exitUrl, method: 'POST', headers, body: payload, keepalive: true }).catch(
+          (e) => {
+            // best effort on exit, but still surface the failure so it's diagnosable in logs.
+            this.loggerProvider.warn('Custom transport failed to send session replay exit batch:', e);
+          },
+        );
+      } catch (e) {
+        this.loggerProvider.warn('Custom transport threw while sending session replay exit batch:', e);
+      }
       return;
     }
     const urlParams = new URLSearchParams({
@@ -572,6 +640,10 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         id,
         payload,
         useRetry,
+        // Tell the worker to delegate each network attempt back to the main thread, where the
+        // custom transport callback lives (functions can't cross postMessage). Absent/false
+        // keeps the worker's own internal fetch — the unchanged path for existing integrations.
+        useCustomTransport: !!this.handleSendEvents,
         context: {
           apiKey: context.apiKey,
           deviceId: context.deviceId,
@@ -601,6 +673,49 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
         this.timedOutWorkerRequests.delete(oldest);
         break;
       }
+    }
+  }
+
+  // Runs the custom transport on the main thread for a single attempt the worker delegated,
+  // then posts the result back into the worker's retry loop as a 'fetch-response'. We read only
+  // what the worker's status handling needs: the skip header on a 2xx and the body text on a
+  // 413 (for WAF detection). A thrown/rejected transport is reported as an error so the worker
+  // surfaces it the same way a thrown fetch would (no retry) — matching the main-thread path.
+  private async handleDelegatedFetch(worker: Worker, msg: WorkerFetchRequestMessage): Promise<void> {
+    const { requestId, url, method, headers, body, keepalive } = msg;
+    try {
+      // In practice this.handleSendEvents is always set here: the worker only emits
+      // 'fetch-request' when useCustomTransport (= !!this.handleSendEvents) was true. The
+      // built-in fetch is a defensive fallback for the impossible case so we never accidentally
+      // drop a delegated send; it is not a supported "run without a transport" path.
+      const res = this.handleSendEvents
+        ? await this.handleSendEvents({ url, method, headers, body, keepalive })
+        : await fetch(url, { method, headers, body, keepalive });
+      const status = res.status;
+      let skipHeader: string | null = null;
+      let responseBody = '';
+      if (status >= 200 && status < 300) {
+        skipHeader = res.headers?.get?.(EVENT_SKIPPED_HEADER) ?? null;
+      }
+      if (status === 413) {
+        try {
+          responseBody = await res.text();
+        } catch {
+          // best effort
+        }
+      }
+      this.loggerProvider.debug(`Delegated session replay fetch (request ${requestId}) returned status ${status}.`);
+      worker.postMessage({ type: 'fetch-response', requestId, status, skipHeader, body: responseBody });
+    } catch (e) {
+      this.loggerProvider.debug(`Delegated session replay fetch (request ${requestId}) failed:`, e);
+      worker.postMessage({
+        type: 'fetch-response',
+        requestId,
+        status: 0,
+        skipHeader: null,
+        body: String(e),
+        error: true,
+      });
     }
   }
 
@@ -638,23 +753,26 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
       // SEND_TIMEOUT_MS. The abort surfaces as an AbortError in the catch below, where it's
       // routed as a retryable network failure when useRetry is true.
       const controller = new AbortController();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+        Authorization: `Bearer ${apiKey}`,
+        'X-Client-Version': version,
+        'X-Client-Library': sessionReplayLibrary,
+        'X-Client-Url': url.substring(0, MAX_URL_LENGTH), // limit url length to 1000 characters to avoid ELB 400 error
+        'X-Client-Sample-Rate': `${sampleRate}`,
+        'X-Sampling-Hash-Alg': 'xxhash32',
+        ...(gzipped ? { 'Content-Encoding': 'gzip' } : {}),
+      };
+      const body: string | Uint8Array = gzipped ?? payloadJson;
+      // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
+      // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
+      const keepalive = payloadSize <= MAX_KEEPALIVE_BYTES;
       const options: RequestInit = {
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: '*/*',
-          Authorization: `Bearer ${apiKey}`,
-          'X-Client-Version': version,
-          'X-Client-Library': sessionReplayLibrary,
-          'X-Client-Url': url.substring(0, MAX_URL_LENGTH), // limit url length to 1000 characters to avoid ELB 400 error
-          'X-Client-Sample-Rate': `${sampleRate}`,
-          'X-Sampling-Hash-Alg': 'xxhash32',
-          ...(gzipped ? { 'Content-Encoding': 'gzip' } : {}),
-        },
-        body: (gzipped ?? payloadJson) as BodyInit,
+        headers,
+        body,
         method: 'POST',
-        // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
-        // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
-        keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
+        keepalive,
         signal: controller.signal,
       };
 
@@ -678,7 +796,13 @@ export class SessionReplayTrackDestination implements AmplitudeSessionReplayTrac
           : undefined;
       let res: Response;
       try {
-        res = await fetch(serverUrl, options);
+        // When a custom transport is configured, hand it the fully-formed request and let it own
+        // the network call (e.g. to attach a JWT and route through a proxy). Otherwise use the
+        // built-in fetch. Retry/response handling below is identical for both paths. The custom
+        // transport owns its own timeout; controller.signal only aborts the built-in fetch.
+        res = this.handleSendEvents
+          ? await this.handleSendEvents({ url: serverUrl, method: 'POST', headers, body, keepalive })
+          : await fetch(serverUrl, options);
       } finally {
         // Clear on success and on error alike so a settled request never leaves an armed
         // timer that would abort a later reused controller or fire a stray callback.

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -51,9 +51,10 @@ interface RequestOptions {
   // string | Uint8Array (not BodyInit) so it stays structured-cloneable across postMessage.
   body: string | Uint8Array;
   keepalive: boolean;
-  // Abort signal for the send timeout. The built-in fetch path honors it; the delegation path
-  // runs the request on the main thread, which has its own lifecycle, so it ignores the signal.
-  signal?: AbortSignal;
+  // Send-timeout abort signal — doFetch always supplies controller.signal. The built-in fetch
+  // path passes it straight to fetch(); the delegation path listens for it to reject a hung
+  // attempt (the request itself runs on the main thread and can't be cancelled from here).
+  signal: AbortSignal;
 }
 
 type DoRequest = (url: string, options: RequestOptions) => Promise<ResponseLike>;
@@ -111,13 +112,11 @@ const delegateRequest: DoRequest = (url, options) => {
       err.name = 'AbortError';
       reject(err);
     };
-    if (signal?.aborted) {
-      abort();
-      return;
-    }
-    signal?.addEventListener('abort', abort, { once: true });
+    // doFetch arms the timeout after this runs, so the signal is never already aborted here;
+    // listening for the event covers every real abort.
+    signal.addEventListener('abort', abort, { once: true });
     pendingDelegations.set(requestId, (resp) => {
-      signal?.removeEventListener('abort', abort);
+      signal.removeEventListener('abort', abort);
       if (resp.error) {
         reject(new Error(resp.body));
         return;

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -91,10 +91,33 @@ const defaultRequest: DoRequest = (url, options) => fetch(url, options) as Promi
 // Posts a fetch-request to the main thread and resolves once the matching fetch-response
 // arrives. Rejects if the main-thread transport errored, so doFetch's catch surfaces it the
 // same way a thrown fetch would (no retry) — matching the non-worker custom-transport path.
+//
+// The send-timeout AbortController lives in doFetch. The built-in fetch honors its signal
+// directly; a delegated attempt runs the customer's transport on the main thread and can't
+// cancel it from here, but we still listen for the abort so a hung/never-settling transport
+// rejects this attempt as a retryable AbortError (matching the built-in path) instead of
+// leaving sendWithRetry awaiting forever and leaking the in-flight delegation. The main thread
+// may still post a late fetch-response, but its requestId is gone from pendingDelegations by
+// then, so onmessage drops it.
 const delegateRequest: DoRequest = (url, options) => {
   const requestId = `${++delegationCounter}`;
   return new Promise<ResponseLike>((resolve, reject) => {
+    const { signal } = options;
+    const abort = () => {
+      pendingDelegations.delete(requestId);
+      // Browsers reject aborted fetches with a DOMException named 'AbortError'; doFetch's catch
+      // matches on the name, so a plain Error with the same name takes the same retryable path.
+      const err = new Error('Delegated session replay fetch aborted by send timeout');
+      err.name = 'AbortError';
+      reject(err);
+    };
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    signal?.addEventListener('abort', abort, { once: true });
     pendingDelegations.set(requestId, (resp) => {
+      signal?.removeEventListener('abort', abort);
       if (resp.error) {
         reject(new Error(resp.body));
         return;
@@ -169,7 +192,8 @@ async function doFetch(
     // fetch() has no native timeout; abort a hung request so it surfaces as a retryable
     // failure instead of silently wedging the worker (and the awaiting orchestrator). The
     // request goes through doRequest so a custom transport (delegated to the main thread) is
-    // honored; the built-in fetch path uses the abort signal, the delegated path ignores it.
+    // honored; both paths observe the abort signal — the built-in fetch cancels directly, and
+    // delegateRequest rejects the pending delegation so a hung transport still times out.
     const controller = new AbortController();
     const timeout =
       sendTimeoutMs > 0

--- a/packages/session-replay-browser/src/worker/track-destination.ts
+++ b/packages/session-replay-browser/src/worker/track-destination.ts
@@ -36,9 +36,96 @@ interface SendContext {
   sendTimeoutMs?: number;
 }
 
+// Minimal subset of `Response` that doFetch's status handling relies on. Both the built-in
+// `fetch` path and the main-thread delegation path produce something of this shape, so the
+// status/skip-header/413-body logic below stays identical regardless of which transport runs.
+interface ResponseLike {
+  status: number;
+  headers?: { get?: (name: string) => string | null };
+  text: () => Promise<string>;
+}
+
+interface RequestOptions {
+  method: 'POST';
+  headers: Record<string, string>;
+  // string | Uint8Array (not BodyInit) so it stays structured-cloneable across postMessage.
+  body: string | Uint8Array;
+  keepalive: boolean;
+  // Abort signal for the send timeout. The built-in fetch path honors it; the delegation path
+  // runs the request on the main thread, which has its own lifecycle, so it ignores the signal.
+  signal?: AbortSignal;
+}
+
+type DoRequest = (url: string, options: RequestOptions) => Promise<ResponseLike>;
+
+// ---- Main-thread fetch delegation (custom transport / handleSendEvents) -------------------
+// Functions can't cross postMessage, so when the customer supplies a custom transport the
+// worker can't run it. Instead the worker delegates each network attempt to the main thread:
+// it posts a `fetch-request`, the main thread runs handleSendEvents, and posts back a
+// `fetch-response`. Retry stays in the worker (sendWithRetry), so the callback is still
+// invoked once per attempt with retry wrapped around it — identical to the main-thread path.
+// Both ends of this protocol ship in the same build, so the main thread always sends
+// well-formed messages: `skipHeader` is the EVENT_SKIPPED_HEADER value on a 2xx (else null),
+// and `body` is always a string ('' when there's nothing to read, or the error text). They
+// are therefore required, which keeps the worker-side reconstruction free of defensive
+// nullish handling.
+interface FetchResponseMessage {
+  type: 'fetch-response';
+  requestId: string;
+  status: number;
+  skipHeader: string | null;
+  body: string;
+  // True when the main-thread transport threw / rejected.
+  error?: boolean;
+}
+
+// Module-level state, scoped to this worker bundle. Each SessionReplayTrackDestination spins up
+// its own Worker (and a shutdown()+re-init in a SPA creates a fresh one), so a new session gets a
+// brand-new module scope — these are never shared across sessions and requestIds can't collide
+// between them. They intentionally hold only in-flight delegations for the single owning instance.
+let delegationCounter = 0;
+const pendingDelegations = new Map<string, (resp: FetchResponseMessage) => void>();
+
+const defaultRequest: DoRequest = (url, options) => fetch(url, options) as Promise<ResponseLike>;
+
+// Posts a fetch-request to the main thread and resolves once the matching fetch-response
+// arrives. Rejects if the main-thread transport errored, so doFetch's catch surfaces it the
+// same way a thrown fetch would (no retry) — matching the non-worker custom-transport path.
+const delegateRequest: DoRequest = (url, options) => {
+  const requestId = `${++delegationCounter}`;
+  return new Promise<ResponseLike>((resolve, reject) => {
+    pendingDelegations.set(requestId, (resp) => {
+      if (resp.error) {
+        reject(new Error(resp.body));
+        return;
+      }
+      // Reconstruct just the slice of Response that doFetch consumes. get() is only ever
+      // queried for EVENT_SKIPPED_HEADER today; the name check keeps it self-documenting and
+      // safe if a future reader adds another header lookup (the other branch is unreachable now).
+      resolve({
+        status: resp.status,
+        headers: {
+          get: (name: string) => (name === EVENT_SKIPPED_HEADER ? resp.skipHeader : /* istanbul ignore next */ null),
+        },
+        text: () => Promise.resolve(resp.body),
+      });
+    });
+    postMessage({
+      type: 'fetch-request',
+      requestId,
+      url,
+      method: 'POST',
+      headers: options.headers,
+      body: options.body,
+      keepalive: options.keepalive,
+    });
+  });
+};
+
 async function doFetch(
   payloadJson: string,
   context: SendContext,
+  doRequest: DoRequest,
 ): Promise<{
   shouldRetry: boolean;
   success: boolean;
@@ -80,7 +167,9 @@ async function doFetch(
     };
     const payloadSize = gzipped ? gzipped.byteLength : new Blob([payloadJson]).size;
     // fetch() has no native timeout; abort a hung request so it surfaces as a retryable
-    // failure instead of silently wedging the worker (and the awaiting orchestrator).
+    // failure instead of silently wedging the worker (and the awaiting orchestrator). The
+    // request goes through doRequest so a custom transport (delegated to the main thread) is
+    // honored; the built-in fetch path uses the abort signal, the delegated path ignores it.
     const controller = new AbortController();
     const timeout =
       sendTimeoutMs > 0
@@ -88,12 +177,12 @@ async function doFetch(
             controller.abort();
           }, sendTimeoutMs)
         : undefined;
-    let res: Response | null;
+    let res: ResponseLike | null;
     try {
-      res = await fetch(serverUrl, {
+      res = await doRequest(serverUrl, {
         method: 'POST',
         headers,
-        body: (gzipped ?? payloadJson) as BodyInit,
+        body: gzipped ?? payloadJson,
         // keepalive lets the request survive page navigation, preventing 499 (client-closed) errors.
         // Must stay under the browser's 64 KB keepalive budget; large payloads skip it.
         keepalive: payloadSize <= MAX_KEEPALIVE_BYTES,
@@ -150,13 +239,19 @@ async function doFetch(
   }
 }
 
-async function sendWithRetry(id: string, payloadJson: string, context: SendContext, useRetry: boolean): Promise<void> {
+async function sendWithRetry(
+  id: string,
+  payloadJson: string,
+  context: SendContext,
+  useRetry: boolean,
+  doRequest: DoRequest,
+): Promise<void> {
   // Start at 1 to match the main-thread's addToQueue behaviour, which increments
   // attempts to 1 before the first send. This ensures the same total number of
   // attempts and the same per-retry delay as the main-thread path.
   let attempt = 1;
   for (;;) {
-    const result = await doFetch(payloadJson, context);
+    const result = await doFetch(payloadJson, context, doRequest);
     if (result.success) {
       postMessage({ type: 'log', id, message: result.message });
       postMessage({ type: 'complete', id, skipCode: result.skipCode ?? null });
@@ -179,16 +274,33 @@ async function sendWithRetry(id: string, payloadJson: string, context: SendConte
 }
 
 onmessage = async (e: MessageEvent) => {
-  const { type, id, payload, context, useRetry } = e.data as {
+  const data = e.data as {
     type: string;
     id: string;
     payload: { version: number; events: unknown[] };
     context: SendContext;
     useRetry: boolean;
-  };
-  if (type === 'send') {
+    // When true, delegate each network attempt to the main thread (custom transport).
+    useCustomTransport?: boolean;
+  } & Partial<FetchResponseMessage>;
+
+  // Reply from the main thread to a delegated fetch — resolve the waiting attempt.
+  if (data.type === 'fetch-response') {
+    const resolver = pendingDelegations.get(data.requestId as string);
+    if (resolver) {
+      pendingDelegations.delete(data.requestId as string);
+      resolver(data as FetchResponseMessage);
+    }
+    return;
+  }
+
+  if (data.type === 'send') {
+    const { id, payload, context, useRetry, useCustomTransport } = data;
     const payloadJson = JSON.stringify(payload);
-    await sendWithRetry(id, payloadJson, context, useRetry);
+    // Only enter the delegation protocol when a custom transport is configured; otherwise the
+    // worker keeps doing its own fetch with no round-trip to the main thread (unchanged path).
+    const doRequest = useCustomTransport ? delegateRequest : defaultRequest;
+    await sendWithRetry(id, payloadJson, context, useRetry, doRequest);
   }
 };
 

--- a/packages/session-replay-browser/test/config/joined-config.test.ts
+++ b/packages/session-replay-browser/test/config/joined-config.test.ts
@@ -854,12 +854,14 @@ describe('SessionReplayJoinedConfigGenerator', () => {
         configServerUrl,
       });
 
-      // Verify RemoteConfigClient was called with the correct parameters
+      // Verify RemoteConfigClient was called with the correct parameters (5th arg is the
+      // optional handleFetchConfig custom transport, undefined when not configured).
       expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
         'static_key',
         mockLoggerProvider,
         ServerZone.EU,
         configServerUrl,
+        undefined,
       );
 
       // Verify the generator was created successfully
@@ -870,7 +872,30 @@ describe('SessionReplayJoinedConfigGenerator', () => {
       await createSessionReplayJoinedConfigGenerator('static_key', mockOptions);
 
       // Verify RemoteConfigClient was called with undefined for configServerUrl
-      expect(MockedRemoteConfigClient).toHaveBeenCalledWith('static_key', mockLoggerProvider, ServerZone.EU, undefined);
+      expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
+        'static_key',
+        mockLoggerProvider,
+        ServerZone.EU,
+        undefined,
+        undefined,
+      );
+    });
+
+    test('should pass handleFetchConfig through to RemoteConfigClient as the custom transport', async () => {
+      const handleFetchConfig = jest.fn(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response),
+      );
+
+      await createSessionReplayJoinedConfigGenerator('static_key', { ...mockOptions, handleFetchConfig });
+
+      // The customer's handleFetchConfig must arrive as the 5th (customFetch) constructor arg.
+      expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
+        'static_key',
+        mockLoggerProvider,
+        ServerZone.EU,
+        undefined,
+        handleFetchConfig,
+      );
     });
   });
 });

--- a/packages/session-replay-browser/test/custom-transport.test.ts
+++ b/packages/session-replay-browser/test/custom-transport.test.ts
@@ -1,0 +1,417 @@
+import * as AnalyticsCore from '@amplitude/analytics-core';
+import { ILogger, ServerZone } from '@amplitude/analytics-core';
+import { SessionReplayDestinationContext } from 'src/typings/session-replay';
+import { SessionReplayTrackDestination } from '../src/track-destination';
+import { VERSION } from '../src/version';
+
+type MockedLogger = jest.Mocked<ILogger>;
+
+const mockEvent = {
+  type: 4,
+  data: { href: 'https://analytics.amplitude.com/', width: 1728, height: 154 },
+  timestamp: 1687358660935,
+};
+const mockEventString = JSON.stringify(mockEvent);
+const apiKey = 'static_key';
+
+const baseContext = (): SessionReplayDestinationContext => ({
+  events: [mockEventString],
+  sessionId: 123,
+  apiKey,
+  attempts: 0,
+  timeout: 0,
+  flushMaxRetries: 2,
+  deviceId: '1a2b3c',
+  sampleRate: 1,
+  serverZone: ServerZone.US,
+  type: 'replay',
+  onComplete: jest.fn(),
+});
+
+describe('custom transport (handleSendEvents)', () => {
+  let originalFetch: typeof global.fetch;
+  const mockLoggerProvider: MockedLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(() => Promise.resolve({ status: 200 })) as jest.Mock;
+    jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({} as unknown as typeof globalThis);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(global.Math, 'random').mockRestore();
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  describe('main-thread send', () => {
+    test('invokes the callback with a fully-formed request and does NOT call fetch', async () => {
+      const handleSendEvents = jest.fn(() => Promise.resolve({ status: 200 } as Response));
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      await trackDestination.send({ ...baseContext(), version: { type: 'plugin', version: VERSION } });
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(handleSendEvents).toHaveBeenCalledTimes(1);
+      expect(handleSendEvents).toHaveBeenCalledWith({
+        url: 'https://api-sr.amplitude.com/sessions/v2/track?device_id=1a2b3c&session_id=123&type=replay',
+        method: 'POST',
+        headers: {
+          Accept: '*/*',
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer static_key',
+          'X-Client-Library': `plugin/${VERSION}`,
+          'X-Client-Sample-Rate': '1',
+          'X-Sampling-Hash-Alg': 'xxhash32',
+          'X-Client-Url': '',
+          'X-Client-Version': VERSION,
+        },
+        body: JSON.stringify({ version: 1, events: [mockEventString] }),
+        keepalive: true,
+      });
+    });
+
+    test('falls back to the built-in fetch when no callback is provided', async () => {
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      await trackDestination.send(baseContext());
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('lets the customer attach custom headers (e.g. JWT) without losing SDK headers', async () => {
+      const handleSendEvents = jest.fn(({ url, method, headers, body }) =>
+        // mimic the documented customer pattern: spread SDK headers, add auth
+        global.fetch(url, { method, headers: { ...headers, Authorization: 'Bearer jwt-123' }, body }),
+      );
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      await trackDestination.send(baseContext());
+
+      expect(handleSendEvents).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const [, options] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect((options.headers as Record<string, string>).Authorization).toBe('Bearer jwt-123');
+      // SDK-supplied headers are still present
+      expect((options.headers as Record<string, string>)['X-Client-Version']).toBe(VERSION);
+    });
+  });
+
+  describe('retry contract (callback sits below retry)', () => {
+    test.each([500, 408, 429, 499])('retries the callback on %i then succeeds', async (statusCode) => {
+      const handleSendEvents = jest
+        .fn()
+        .mockResolvedValueOnce({ status: statusCode } as Response)
+        .mockResolvedValueOnce({ status: 200 } as Response);
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      const sendPromise = trackDestination.send(baseContext(), true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      expect(handleSendEvents).toHaveBeenCalledTimes(2);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test('a thrown/rejected callback is surfaced (no retry), matching a thrown fetch', async () => {
+      const handleSendEvents = jest.fn().mockRejectedValue(new Error('network down'));
+      const onComplete = jest.fn();
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      const context = { ...baseContext(), onComplete };
+      const sendPromise = trackDestination.send(context, true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      // thrown error surfaces to completeRequest (same as built-in path); not retried
+      expect(handleSendEvents).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('page-exit (sendBeacon) path', () => {
+    const beaconArgs = {
+      sessionId: 123,
+      deviceId: 'device-abc',
+      apiKey: 'key-abc',
+      serverZone: 'US' as keyof typeof ServerZone,
+    };
+
+    test('routes the exit batch through the callback with keepalive instead of sendBeacon', () => {
+      const mockSendBeacon = jest.fn().mockReturnValue(true);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
+        navigator: { sendBeacon: mockSendBeacon },
+      } as unknown as typeof globalThis);
+      const handleSendEvents = jest.fn((_request: { url: string; headers: Record<string, string> }) =>
+        Promise.resolve({ status: 200 } as Response),
+      );
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      trackDestination.sendBeacon({ ...beaconArgs, events: ['e1', 'e2'] });
+
+      expect(mockSendBeacon).not.toHaveBeenCalled();
+      expect(handleSendEvents).toHaveBeenCalledTimes(1);
+      const request = handleSendEvents.mock.calls[0][0] as unknown as {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        keepalive: boolean;
+      };
+      expect(request.method).toBe('POST');
+      expect(request.keepalive).toBe(true);
+      expect(request.url).toContain('device_id=device-abc');
+      // api_key is NOT placed in the URL on the callback path (auth is via header)
+      expect(request.url).not.toContain('api_key=');
+      expect(request.headers.Authorization).toBe('Bearer key-abc');
+    });
+
+    test('warns (does not throw) when the exit-path callback rejects on unload', async () => {
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
+        navigator: { sendBeacon: jest.fn() },
+      } as unknown as typeof globalThis);
+      const handleSendEvents = jest.fn(() => Promise.reject(new Error('unload race')));
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      // Must not throw even though the callback rejects during unload.
+      expect(() => trackDestination.sendBeacon({ ...beaconArgs, events: ['e1'] })).not.toThrow();
+      expect(handleSendEvents).toHaveBeenCalledTimes(1);
+      // Let the rejected promise settle so the .catch handler runs.
+      await Promise.resolve();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        'Custom transport failed to send session replay exit batch:',
+        expect.any(Error),
+      );
+    });
+
+    test('warns (does not throw) when the exit-path callback throws synchronously', () => {
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
+        navigator: { sendBeacon: jest.fn() },
+      } as unknown as typeof globalThis);
+      const handleSendEvents = jest.fn(() => {
+        throw new Error('sync boom');
+      }) as unknown as () => Promise<Response>;
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+
+      expect(() => trackDestination.sendBeacon({ ...beaconArgs, events: ['e1'] })).not.toThrow();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        'Custom transport threw while sending session replay exit batch:',
+        expect.any(Error),
+      );
+    });
+
+    test('still uses navigator.sendBeacon when no callback is configured', () => {
+      const mockSendBeacon = jest.fn().mockReturnValue(true);
+      jest.spyOn(AnalyticsCore, 'getGlobalScope').mockReturnValue({
+        navigator: { sendBeacon: mockSendBeacon },
+      } as unknown as typeof globalThis);
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+
+      trackDestination.sendBeacon({ ...beaconArgs, events: ['e1'] });
+
+      expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('worker delegation (main-thread side: handleDelegatedFetch)', () => {
+    const EVENT_SKIPPED_HEADER = 'X-Session-Replay-Event-Skipped';
+    const makeMsg = (over: Record<string, unknown> = {}) => ({
+      type: 'fetch-request',
+      requestId: 'r1',
+      url: 'https://api-sr.amplitude.com/sessions/v2/track',
+      method: 'POST',
+      headers: { Authorization: 'Bearer k' },
+      body: '{}',
+      keepalive: true,
+      ...over,
+    });
+
+    test('runs the callback and posts a fetch-response with status + skip header back to the worker', async () => {
+      const handleSendEvents = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          headers: { get: (n: string) => (n === EVENT_SKIPPED_HEADER ? '4004' : null) },
+        } as unknown as Response),
+      );
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+      const postMessage = jest.fn();
+      const worker = { postMessage } as unknown as Worker;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (trackDestination as any).handleDelegatedFetch(worker, makeMsg());
+
+      expect(handleSendEvents).toHaveBeenCalledTimes(1);
+      expect(postMessage).toHaveBeenCalledWith({
+        type: 'fetch-response',
+        requestId: 'r1',
+        status: 200,
+        skipHeader: '4004',
+        body: '',
+      });
+    });
+
+    test('reads response body text on 413 for WAF detection', async () => {
+      const handleSendEvents = jest.fn(() =>
+        Promise.resolve({ status: 413, text: () => Promise.resolve('Payload Too Large') } as unknown as Response),
+      );
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+      const postMessage = jest.fn();
+      const worker = { postMessage } as unknown as Worker;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (trackDestination as any).handleDelegatedFetch(worker, makeMsg());
+
+      expect(postMessage).toHaveBeenCalledWith({
+        type: 'fetch-response',
+        requestId: 'r1',
+        status: 413,
+        skipHeader: null,
+        body: 'Payload Too Large',
+      });
+    });
+
+    test('reports an error when the callback throws', async () => {
+      const handleSendEvents = jest.fn(() => Promise.reject(new Error('boom')));
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+      });
+      const postMessage = jest.fn();
+      const worker = { postMessage } as unknown as Worker;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (trackDestination as any).handleDelegatedFetch(worker, makeMsg());
+
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetch-response', requestId: 'r1', status: 0, error: true }),
+      );
+    });
+
+    test('defensively falls back to fetch when no callback is set', async () => {
+      // Response without a headers object exercises the optional-chain fallback in skip-header read.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({ status: 200 } as unknown as Response);
+      const trackDestination = new SessionReplayTrackDestination({ loggerProvider: mockLoggerProvider });
+      const postMessage = jest.fn();
+      const worker = { postMessage } as unknown as Worker;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (trackDestination as any).handleDelegatedFetch(worker, makeMsg());
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetch-response', requestId: 'r1', status: 200 }),
+      );
+    });
+
+    test('worker.onmessage routes a fetch-request to handleDelegatedFetch', () => {
+      const mockWorker = {
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+        onerror: null as ((e: ErrorEvent) => void) | null,
+        onmessage: null as ((e: MessageEvent) => void) | null,
+      };
+      global.Worker = jest.fn(() => mockWorker) as unknown as typeof Worker;
+      global.URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+
+      const handleSendEvents = jest.fn(() =>
+        Promise.resolve({ status: 200, headers: { get: () => null } } as unknown as Response),
+      );
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+        handleSendEvents,
+      });
+      const spy = jest
+        .spyOn(trackDestination as unknown as { handleDelegatedFetch: () => Promise<void> }, 'handleDelegatedFetch')
+        .mockResolvedValue(undefined);
+
+      mockWorker.onmessage?.({
+        data: {
+          type: 'fetch-request',
+          requestId: 'r9',
+          url: 'u',
+          method: 'POST',
+          headers: {},
+          body: '{}',
+          keepalive: true,
+        },
+      } as MessageEvent);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test('worker.onmessage logs (does not leave an unhandled rejection) when handleDelegatedFetch rejects', async () => {
+      const mockWorker = {
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+        onerror: null as ((e: ErrorEvent) => void) | null,
+        onmessage: null as ((e: MessageEvent) => void) | null,
+      };
+      global.Worker = jest.fn(() => mockWorker) as unknown as typeof Worker;
+      global.URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        workerScript: 'self.onmessage = () => {}',
+        handleSendEvents: jest.fn(() => Promise.resolve({ status: 200 } as Response)),
+      });
+      jest
+        .spyOn(trackDestination as unknown as { handleDelegatedFetch: () => Promise<void> }, 'handleDelegatedFetch')
+        .mockRejectedValue(new Error('postMessage failed'));
+
+      mockWorker.onmessage?.({
+        data: {
+          type: 'fetch-request',
+          requestId: 'r9',
+          url: 'u',
+          method: 'POST',
+          headers: {},
+          body: '{}',
+          keepalive: true,
+        },
+      } as MessageEvent);
+      // Let the rejected promise settle so the .catch handler runs.
+      await Promise.resolve();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLoggerProvider.warn).toHaveBeenCalledWith(
+        'Failed to handle delegated session replay fetch:',
+        expect.any(Error),
+      );
+    });
+  });
+});

--- a/packages/session-replay-browser/test/custom-transport.test.ts
+++ b/packages/session-replay-browser/test/custom-transport.test.ts
@@ -145,6 +145,29 @@ describe('custom transport (handleSendEvents)', () => {
       expect(handleSendEvents).toHaveBeenCalledTimes(1);
       expect(onComplete).toHaveBeenCalledTimes(1);
     });
+
+    test('a hung callback is aborted by the send timeout and retried instead of blocking the flush loop', async () => {
+      // Never-settling transport. Before the fix, awaiting it blocked sendOnMainThread forever
+      // (the send-timeout only aborted the built-in fetch). Now the abort rejects the awaited
+      // callback with a retryable AbortError, so the retry budget runs and the send still settles.
+      const handleSendEvents = jest.fn(() => new Promise<Response>(() => undefined));
+      const onComplete = jest.fn();
+      const trackDestination = new SessionReplayTrackDestination({
+        loggerProvider: mockLoggerProvider,
+        handleSendEvents,
+        sendTimeoutMs: 10,
+      });
+
+      const context = { ...baseContext(), onComplete };
+      const sendPromise = trackDestination.send(context, true);
+      await jest.runAllTimersAsync();
+      await sendPromise;
+
+      // Each hung attempt timed out and was retried; the send settled exactly once (no wedge).
+      expect(handleSendEvents.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(fetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('page-exit (sendBeacon) path', () => {

--- a/packages/session-replay-browser/test/hooks/beacon.test.ts
+++ b/packages/session-replay-browser/test/hooks/beacon.test.ts
@@ -122,6 +122,91 @@ describe('beacon', () => {
           true,
         );
       });
+
+      describe('with custom transport (handleSendEvents)', () => {
+        const mockLogger = { warn: jest.fn() } as any;
+
+        test('routes the beacon through handleSendEvents with auth header (api_key NOT in URL) and keepalive', () => {
+          const sendBeacon = jest.fn().mockReturnValue(true);
+          mockGlobalScope({ navigator: { sendBeacon }, Blob: jest.fn() } as any);
+          const handleSendEvents = jest.fn().mockResolvedValue({ status: 200 });
+
+          transport = new BeaconTransport<TestEvent>({ sessionId, type: 'interaction' }, {
+            apiKey,
+            handleSendEvents,
+            loggerProvider: mockLogger,
+          } as unknown as SessionReplayJoinedConfig);
+          transport.send(deviceId, { Field1: 'foo', Field2: 1234 });
+
+          expect(sendBeacon).not.toHaveBeenCalled();
+          expect(xmlMockFns.open).not.toHaveBeenCalled();
+          expect(handleSendEvents).toHaveBeenCalledTimes(1);
+          const req = handleSendEvents.mock.calls[0][0];
+          expect(req.method).toBe('POST');
+          expect(req.keepalive).toBe(true);
+          expect(req.url).toContain(`device_id=${deviceId}`);
+          expect(req.url).toContain('type=interaction');
+          expect(req.url).not.toContain('api_key=');
+          expect(req.headers.Authorization).toBe(`Bearer ${apiKey}`);
+          expect(req.body).toBe(JSON.stringify({ Field1: 'foo', Field2: 1234 }));
+        });
+
+        test('warns (does not throw) when the custom transport rejects', async () => {
+          const handleSendEvents = jest.fn().mockRejectedValue(new Error('proxy down'));
+          transport = new BeaconTransport<TestEvent>({ sessionId, type: 'interaction' }, {
+            apiKey,
+            handleSendEvents,
+            loggerProvider: mockLogger,
+          } as unknown as SessionReplayJoinedConfig);
+
+          expect(() => transport.send(deviceId, { Field1: 'foo', Field2: 1234 })).not.toThrow();
+          await Promise.resolve();
+          expect(mockLogger.warn).toHaveBeenCalledWith(
+            'Custom transport failed to send session replay interaction beacon:',
+            expect.any(Error),
+          );
+        });
+
+        test('warns (does not throw) when the custom transport throws synchronously', () => {
+          const handleSendEvents = jest.fn(() => {
+            throw new Error('sync boom');
+          });
+          transport = new BeaconTransport<TestEvent>({ sessionId, type: 'interaction' }, {
+            apiKey,
+            handleSendEvents,
+            loggerProvider: mockLogger,
+          } as unknown as SessionReplayJoinedConfig);
+
+          expect(() => transport.send(deviceId, { Field1: 'foo', Field2: 1234 })).not.toThrow();
+          expect(mockLogger.warn).toHaveBeenCalledWith(
+            'Custom transport threw while sending session replay interaction beacon:',
+            expect.any(Error),
+          );
+        });
+
+        test('does not throw on async rejection when no loggerProvider is configured', async () => {
+          const handleSendEvents = jest.fn().mockRejectedValue(new Error('proxy down'));
+          transport = new BeaconTransport<TestEvent>({ sessionId, type: 'interaction' }, {
+            apiKey,
+            handleSendEvents,
+          } as unknown as SessionReplayJoinedConfig);
+
+          expect(() => transport.send(deviceId, { Field1: 'foo', Field2: 1234 })).not.toThrow();
+          await Promise.resolve();
+        });
+
+        test('does not throw on synchronous error when no loggerProvider is configured', () => {
+          const handleSendEvents = jest.fn(() => {
+            throw new Error('sync boom');
+          });
+          transport = new BeaconTransport<TestEvent>({ sessionId, type: 'interaction' }, {
+            apiKey,
+            handleSendEvents,
+          } as unknown as SessionReplayJoinedConfig);
+
+          expect(() => transport.send(deviceId, { Field1: 'foo', Field2: 1234 })).not.toThrow();
+        });
+      });
     });
   });
 });

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -655,5 +655,31 @@ describe('worker/track-destination', () => {
       expect(postedOfType('fetch-request')).toHaveLength(1);
       expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete', id: 'd4' }));
     });
+
+    test('send-timeout abort settles a hung delegated attempt instead of wedging the worker', async () => {
+      // Fire the armed send-timeout on the next macrotask.
+      const realSetTimeout = global.setTimeout;
+      jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation((fn) => realSetTimeout(fn, 0) as unknown as ReturnType<typeof setTimeout>);
+
+      // The main thread never replies with a fetch-response. Before the fix, delegateRequest
+      // ignored the abort signal, so sendWithRetry awaited the unanswered delegation forever and
+      // this invokeOnMessage would never resolve (the test would time out). Now the send-timeout
+      // aborts the delegation (retryable AbortError); with retries exhausted the worker settles
+      // by posting a failure complete. invokeOnMessage awaits the whole send, so its resolution
+      // is itself the proof the worker did not wedge.
+      await invokeOnMessage({
+        type: 'send',
+        id: 'd6',
+        payload: basePayload,
+        context: { ...baseContext, flushMaxRetries: 1, sendTimeoutMs: 5 },
+        useRetry: true,
+        useCustomTransport: true,
+      });
+
+      expect(postedOfType('fetch-request')).toHaveLength(1);
+      expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete', id: 'd6' }));
+    });
   });
 });

--- a/packages/session-replay-browser/test/worker/track-destination.test.ts
+++ b/packages/session-replay-browser/test/worker/track-destination.test.ts
@@ -527,4 +527,133 @@ describe('worker/track-destination', () => {
       delete (global as any).CompressionStream;
     }
   });
+
+  describe('custom transport delegation (useCustomTransport)', () => {
+    // No fake timers in this suite, so a real macrotask reliably flushes the microtasks that
+    // run between the worker receiving 'send' and posting its 'fetch-request'.
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+    type Msg = { type: string; requestId?: string; url?: string; method?: string; headers?: Record<string, string> };
+    const postedOfType = (type: string): Msg[] =>
+      mockPostMessage.mock.calls.map((c) => c[0] as Msg).filter((m) => m.type === type);
+
+    test('delegates the network call to the main thread instead of fetching directly', async () => {
+      const sendPromise = invokeOnMessage({
+        type: 'send',
+        id: 'd1',
+        payload: basePayload,
+        context: baseContext,
+        useRetry: false,
+        useCustomTransport: true,
+      });
+      await flush();
+
+      // The worker posted a fetch-request rather than calling its own fetch (trap §12-2).
+      expect(mockFetch).not.toHaveBeenCalled();
+      const [request] = postedOfType('fetch-request');
+      expect(request).toBeDefined();
+      expect(request.url).toContain('device_id=device-123');
+      expect(request.method).toBe('POST');
+      expect((request.headers as Record<string, string>).Authorization).toBe('Bearer test-api-key');
+
+      // The main thread replies; the worker resolves and completes via its normal path.
+      await invokeOnMessage({ type: 'fetch-response', requestId: request.requestId, status: 200, skipHeader: null });
+      await sendPromise;
+
+      expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'd1', skipCode: null });
+    });
+
+    test('does NOT delegate when useCustomTransport is falsy (unchanged worker path)', async () => {
+      mockFetch.mockResolvedValueOnce({ status: 200 });
+      await invokeOnMessage({ type: 'send', id: 'd2', payload: basePayload, context: baseContext, useRetry: false });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(postedOfType('fetch-request')).toHaveLength(0);
+    });
+
+    test('retries delegated attempts through the worker retry loop', async () => {
+      const realSetTimeout = global.setTimeout;
+      jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation((fn) => realSetTimeout(fn, 0) as unknown as ReturnType<typeof setTimeout>);
+
+      const sendPromise = invokeOnMessage({
+        type: 'send',
+        id: 'd3',
+        payload: basePayload,
+        context: { ...baseContext, flushMaxRetries: 2 },
+        useRetry: true,
+        useCustomTransport: true,
+      });
+      await flush();
+
+      // First attempt: reply with a retryable status.
+      let requests = postedOfType('fetch-request');
+      expect(requests).toHaveLength(1);
+      await invokeOnMessage({ type: 'fetch-response', requestId: requests[0].requestId, status: 500 });
+      await flush();
+
+      // Worker should have delegated a second attempt.
+      requests = postedOfType('fetch-request');
+      expect(requests).toHaveLength(2);
+      await invokeOnMessage({
+        type: 'fetch-response',
+        requestId: requests[1].requestId,
+        status: 200,
+        skipHeader: null,
+      });
+      await sendPromise;
+
+      expect(mockPostMessage).toHaveBeenCalledWith({ type: 'complete', id: 'd3', skipCode: null });
+    });
+
+    test('a delegated 413 reads the response body and posts payload_too_large', async () => {
+      const sendPromise = invokeOnMessage({
+        type: 'send',
+        id: 'd5',
+        payload: basePayload,
+        context: { ...baseContext, flushMaxRetries: 2 },
+        useRetry: true,
+        useCustomTransport: true,
+      });
+      await flush();
+
+      const [request] = postedOfType('fetch-request');
+      // body text is consulted via the reconstructed Response-like text() for WAF detection
+      await invokeOnMessage({
+        type: 'fetch-response',
+        requestId: request.requestId,
+        status: 413,
+        body: 'WAF: request body too large',
+      });
+      await sendPromise;
+
+      expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'payload_too_large', id: 'd5' }));
+    });
+
+    test('a main-thread transport error surfaces without retry', async () => {
+      const sendPromise = invokeOnMessage({
+        type: 'send',
+        id: 'd4',
+        payload: basePayload,
+        context: baseContext,
+        useRetry: true,
+        useCustomTransport: true,
+      });
+      await flush();
+
+      const [request] = postedOfType('fetch-request');
+      await invokeOnMessage({
+        type: 'fetch-response',
+        requestId: request.requestId,
+        status: 0,
+        error: true,
+        body: 'boom',
+      });
+      await sendPromise;
+
+      // A thrown/rejected transport is surfaced (no retry), matching the built-in path.
+      expect(postedOfType('fetch-request')).toHaveLength(1);
+      expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'complete', id: 'd4' }));
+    });
+  });
 });

--- a/test-server/mock-api.js
+++ b/test-server/mock-api.js
@@ -72,6 +72,54 @@ export function configureMockApiMiddleware(middlewares) {
     next();
   });
 
+  // Session Replay custom-transport echo endpoint (SR-4497).
+  // Used to verify that handleSendEvents / handleFetchConfig actually attach a custom auth
+  // header to outbound requests. Point trackServerUrl / configServerUrl at this endpoint and
+  // watch the server console: it logs the Authorization header it received (i.e. the JWT the
+  // callback injected), simulating a customer's authenticating proxy.
+  //
+  //   - GET  /api/sr-echo/config/<apiKey>?config_group=browser  → returns a minimal SR remote
+  //          config (capture enabled) so the SDK proceeds to capture and send events.
+  //   - POST /api/sr-echo/track?device_id=...                   → 200, so the send is treated
+  //          as successful.
+  middlewares.use('/api/sr-echo', (req, res) => {
+    const auth = req.headers['authorization'];
+    const isConfig = req.method === 'GET';
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n🔐 [sr-echo] ${req.method} ${req.url}\n   Authorization: ${auth ?? '(none — header NOT attached!)'}\n`,
+    );
+
+    // Same-origin in the test server, but set permissive CORS + allow Authorization so this
+    // also works if the page is served from a different origin or a proxy is added later.
+    res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Client-Version, X-Client-Library');
+
+    if (req.method === 'OPTIONS') {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    res.statusCode = 200;
+    if (isConfig) {
+      // Minimal remote config that enables capture so handleSendEvents will subsequently fire.
+      res.end(
+        JSON.stringify({
+          configs: {
+            sessionReplay: {
+              sr_sampling_config: { sample_rate: 1, capture_enabled: true },
+            },
+          },
+        }),
+      );
+    } else {
+      res.end(JSON.stringify({ ok: true, receivedAuthorization: auth ?? null }));
+    }
+  });
+
   // Simple test endpoint
   middlewares.use('/api/test', (req, res) => {
     res.setHeader('Content-Type', 'application/json');

--- a/test-server/session-replay-browser/sr-custom-transport.html
+++ b/test-server/session-replay-browser/sr-custom-transport.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/amplitude.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session Replay — Custom Transport (JWT) Test</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 720px;
+        margin: 50px auto;
+        padding: 20px;
+      }
+      h1 {
+        color: #333;
+      }
+      button {
+        background: #0066cc;
+        color: white;
+        border: none;
+        padding: 12px 24px;
+        margin: 10px 5px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 16px;
+      }
+      button:hover {
+        background: #0052a3;
+      }
+      .status {
+        padding: 10px;
+        margin: 10px 0;
+        border-radius: 4px;
+        background: #f0f0f0;
+        font-family: monospace;
+      }
+      label {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        margin: 6px 10px 6px 0;
+      }
+      input[type='text'] {
+        padding: 8px;
+        margin: 5px;
+        font-size: 14px;
+        width: 300px;
+      }
+      #log {
+        margin-top: 16px;
+        padding: 10px;
+        background: #111;
+        color: #0f0;
+        font-family: monospace;
+        font-size: 12px;
+        white-space: pre-wrap;
+        border-radius: 4px;
+        min-height: 120px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Session Replay — Custom Transport (JWT) Test</h1>
+
+    <p>
+      Initializes Session Replay with <code>handleSendEvents</code> and <code>handleFetchConfig</code> that attach an
+      <code>Authorization: Bearer &lt;jwt&gt;</code> header. Open the Network tab and confirm the outbound replay /
+      config requests carry the header. Toggle the web worker to verify both transport paths.
+    </p>
+
+    <div class="status" id="status">Status: Not initialized</div>
+
+    <input type="text" id="apiKey" placeholder="API Key (optional)" />
+    <br />
+    <label><input type="checkbox" id="useWebWorker" /> useWebWorker</label>
+    <br />
+    <button id="initBtn">Initialize with custom transport</button>
+    <button id="flushBtn" disabled>Generate events &amp; flush (triggers track POST)</button>
+
+    <div id="log"></div>
+
+    <script type="module">
+      import * as sessionReplay from '@amplitude/session-replay-browser';
+
+      window.sessionReplay = sessionReplay;
+
+      const statusEl = document.getElementById('status');
+      const apiKeyEl = document.getElementById('apiKey');
+      const initBtn = document.getElementById('initBtn');
+      const flushBtn = document.getElementById('flushBtn');
+      const workerEl = document.getElementById('useWebWorker');
+      const logEl = document.getElementById('log');
+
+      function updateStatus(message) {
+        statusEl.textContent = `Status: ${message}`;
+        console.log('[Status]', message);
+      }
+      function log(line) {
+        logEl.textContent += line + '\n';
+        console.log('[CustomTransport]', line);
+      }
+
+      // Stand-in for the customer's real token retrieval.
+      const getJwt = () => 'demo-jwt-token';
+
+      if (import.meta.env.VITE_AMPLITUDE_API_KEY) {
+        apiKeyEl.value = import.meta.env.VITE_AMPLITUDE_API_KEY;
+      }
+
+      initBtn.addEventListener('click', async () => {
+        const apiKey = apiKeyEl.value || import.meta.env.VITE_AMPLITUDE_API_KEY || 'test-api-key';
+        try {
+          updateStatus('Initializing with custom transport...');
+          logEl.textContent = '';
+
+          await sessionReplay.init(apiKey, {
+            deviceId: 'test-device',
+            // A session id is required for SR to start capturing — without it nothing records
+            // and no track POST is ever made.
+            sessionId: Date.now(),
+            sampleRate: 1.0,
+            logLevel: 'debug',
+            useWebWorker: workerEl.checked,
+            // Point both transports at the local sr-echo endpoint (mock-api.js). The server
+            // console logs the Authorization header it receives, simulating an auth proxy.
+            trackServerUrl: `${location.origin}/api/sr-echo/track`,
+            configServerUrl: `${location.origin}/api/sr-echo/config`,
+            handleSendEvents: async ({ url, method, headers, body, keepalive }) => {
+              log(`handleSendEvents → ${method} ${url} (Authorization attached, keepalive=${keepalive})`);
+              return fetch(url, {
+                method,
+                headers: { ...headers, Authorization: `Bearer ${getJwt()}` },
+                body,
+                keepalive,
+              });
+            },
+            handleFetchConfig: async ({ url, method, headers, signal }) => {
+              log(`handleFetchConfig → ${method} ${url} (Authorization attached)`);
+              return fetch(url, {
+                method,
+                headers: { ...headers, Authorization: `Bearer ${getJwt()}` },
+                signal,
+              });
+            },
+          }).promise;
+
+          const sessionId = sessionReplay.getSessionId();
+          updateStatus(`✓ Initialized (useWebWorker=${workerEl.checked})! Session ID: ${sessionId}`);
+          log('Initialized. Click "Generate events & flush" to trigger a track POST (or just interact + wait).');
+          flushBtn.disabled = false;
+        } catch (error) {
+          updateStatus(`✗ Error: ${error.message}`);
+          console.error('[Error]', error);
+        }
+      });
+
+      // Mutate the DOM so rrweb emits incremental events, then flush so the SDK sends a
+      // track POST right away (instead of waiting for the periodic flush interval).
+      flushBtn.addEventListener('click', async () => {
+        const marker = document.createElement('p');
+        marker.textContent = `event marker @ ${new Date().toISOString()}`;
+        document.body.appendChild(marker);
+        log('Generated a DOM mutation, flushing...');
+        await sessionReplay.flush(true);
+        log('flush() resolved — check the server console / Network tab for the track POST.');
+      });
+
+      updateStatus('Ready. Click "Initialize with custom transport".');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Adds optional `handleSendEvents` / `handleFetchConfig` callbacks to the Session Replay Browser SDK so customers can fully own the outbound HTTP call — e.g. attach a JWT `Authorization` header and route replay traffic through their own authenticating proxy — while the SDK keeps batching, retry/backoff, URL resolution, compression, serialization and error handling.

Both default to the SDK's internal `fetch`, so existing integrations are unchanged. The callback receives a fully-formed request (resolved URL respecting `trackServerUrl`/`configServerUrl`, default headers, serialized body) and returns a `Response`. It's invoked once per attempt; retry stays in the SDK around it.

Closes [SR-4497](https://linear.app/amplitude/issue/SR-4497).

> **Supersedes #1817.** That branch had diverged far from `main` and carried a stray prerelease `chore(release): publish` commit; this is a clean rebuild onto latest `main` (real source files only — no generated/version churn), with the earlier review feedback already folded in.

## Covers all outbound Session Replay traffic

`handleSendEvents` is used for **every** outbound request, so nothing leaves the page unauthenticated:
- replay event uploads (main thread)
- the **Web Worker**-delegated send (`useWebWorker`) — compression stays off the main thread; only the network call is delegated back to the main thread to run the callback, via a `fetch-request`/`fetch-response` protocol, so retry semantics are identical
- the page-exit beacon (`navigator.sendBeacon` can't carry headers → routed through the callback with `keepalive`)
- the interaction/scroll beacon (`BeaconTransport`)
- the remote-config GET (`handleFetchConfig`, wired through `RemoteConfigClient` via a new optional, instance-scoped `customFetch` param in `analytics-core`)

## API

```ts
sessionReplay.init(API_KEY, {
  trackServerUrl: 'https://my-proxy.example.com/sr-events',
  configServerUrl: 'https://my-proxy.example.com/sr-config',
  handleSendEvents: async ({ url, method, headers, body, keepalive }) =>
    fetch(url, { method, headers: { ...headers, 'X-Customer-Auth': await getJwt() }, body, keepalive }),
  handleFetchConfig: async ({ url, method, headers, signal }) =>
    fetch(url, { method, headers: { ...headers, 'X-Customer-Auth': await getJwt() }, signal }),
});
```

Plugin and unified SDK accept the same two options. The README documents the browser side, the proxy side (which endpoints to forward to, preserve `Content-Encoding`/body, keep the API-key auth), and all three integration paths.

## Notes / review feedback addressed

- **Config fetch success** is keyed on a 2xx status (falling back from `res.ok`) so a Response-like adapter (e.g. axios) works consistently with the event path.
- **Delegated-fetch fallback** logs a `warn` instead of silently using the built-in fetch.
- **Body typing** is `string | Uint8Array` to match the postMessage structured-clone constraint.
- **Known tradeoff (worker-crash + delegated send):** if the worker crashes *after* posting a `fetch-request` and the main-thread upload then succeeds, the crash path keeps the store record for recovery (favoring no-data-loss over no-duplicate), so a rare duplicate batch is possible. Extremely narrow timing window; outcome is a possible duplicate, not loss. Proposed as a follow-up rather than a risky fix here.

## Testing

- Unit: 100% coverage — session-replay-browser (1124 tests), analytics-core remote-config (50), plugin (57). Covers callback substitution, retry contract, worker delegation protocol, page-exit + interaction beacons, and `handleFetchConfig` wire-through.
- End-to-end: verified in a real browser through a local authenticating proxy — config GET + replay events + interaction/scroll beacons all forward `200` carrying the JWT, in both main-thread and `useWebWorker` modes; unauthenticated requests are rejected (no open relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes every Session Replay outbound path and remote-config fetch when hooks are enabled; behavior is unchanged without them, but misconfigured proxies/auth can break capture or uploads.
> 
> **Overview**
> Adds optional **`handleSendEvents`** and **`handleFetchConfig`** so customers can run outbound HTTP (e.g. JWT + authenticating proxy) while the SDK keeps batching, retry, compression, and URL resolution. Defaults stay on internal `fetch`.
> 
> **Session Replay** routes all replay traffic through the callbacks when set: main-thread uploads, **page-exit** and **interaction** beacons (replacing `sendBeacon`/XHR so headers work), and **web-worker** sends via a `fetch-request` / `fetch-response` delegation to the main thread. Hung custom transports are **raced against abort** so timeouts and retries still apply.
> 
> **analytics-core** extends `RemoteConfigClient` with an optional constructor **`customFetch`** (wired from `handleFetchConfig`); config success treats **2xx** even if `res.ok` is missing.
> 
> Docs/README cover proxy contracts; plugin/unified pass the same options; e2e TRC test polls flush to reduce flake; local **sr-echo** test harness added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a096ad768246e14154882c4134b3cceb932338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->