### PR TITLE
refactor(analytics-react-native): support Network Tracking

### DIFF
--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -1,8 +1,11 @@
 import {Button, StyleSheet, Text, View} from 'react-native';
 import {useEffect} from 'react';
 import {identify, Identify, init, track, add, Types} from '@amplitude/analytics-react-native';
+import {networkCapturePlugin} from '@amplitude/plugin-network-capture-browser';
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import FetchNetworkTestScreen from './FetchNetworkTestScreen';
+
 
 const Stack = createNativeStackNavigator();
 
@@ -10,9 +13,26 @@ function HomeScreen({ navigation }) {
   return (
     <View style={styles.container}>
       <Text>Home Screen</Text>
-      <Button title="Online test" onPress={() => track('RN Expo Online Test')} />
-      <Button title="Offline test" onPress={() => track('RN Expo Offline Test')} />
-      <Button title="Go to Settings" onPress={() => navigation.navigate('Settings')} />
+      <Button accessibilityLabel="Online test label" title="Online test" onPress={() => track('RN Expo Online Test')} />
+      <Button accessibilityLabel="Offline test" title="Offline test" onPress={() => track('RN Expo Offline Test')} />
+      <Button accessibilityLabel="Go to Settings" title="Go to Settings" onPress={() => navigation.navigate('Settings')} />
+      <Button
+        accessibilityLabel="Fetch Network Test"
+        title="Fetch Network Test"
+        onPress={() => navigation.navigate('FetchNetworkTest')}
+      />
+      <Button accessibilityLabel="Make Network Request" title="Make Network Request" onPress={() => {
+        track('Making Network Request');
+        fetch('https://api.amplitude.com/2/asdf', {
+          method: 'POST',
+          body: JSON.stringify({
+            api_key: process.env.AMPLITUDE_API_KEY,
+            event: {
+              event_type: 'test',
+            },
+          }),
+        });
+      }} />
     </View>
   );
 }
@@ -31,9 +51,13 @@ export default function App() {
     (async () => {
         // AMPLITUDE_API_KEY is inlined at bundle time (see babel.config.js).
         await init(process.env.AMPLITUDE_API_KEY || 'YOUR_API_KEY', 'react-native-user-id', {
-          logLevel: Types.LogLevel.Debug,
+          logLevel: Types.LogLevel.Error,
           // autocapture: { } // <-- todo
         }).promise;
+        // Capture localhost traffic except Metro (8081) for the fetch network test screen.
+        add(networkCapturePlugin({
+          ignoreHosts: ['localhost:8081'],
+        }));
         track('expo-app/react-native/test-event');
         await identify(new Identify().set('react-native-test', 'yes')).promise;
     })();
@@ -43,6 +67,7 @@ export default function App() {
       <Stack.Navigator>
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Settings" component={SettingsScreen} />
+        <Stack.Screen name="FetchNetworkTest" component={FetchNetworkTestScreen} options={{title: 'Fetch Network Test'}} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/examples/react-native/expo-app/FetchNetworkTestScreen.tsx
+++ b/examples/react-native/expo-app/FetchNetworkTestScreen.tsx
@@ -1,0 +1,383 @@
+import {useEffect, useRef, useState} from 'react';
+import {Platform, ScrollView, StyleSheet, Text, View} from 'react-native';
+
+
+type FetchOptions = RequestInit;
+
+type FetchResult = {
+  res?: Response;
+  data?: unknown;
+  url: string;
+  options?: FetchOptions;
+  error?: Error;
+};
+
+type DisplayResult = {
+  url: string;
+  status: number | string;
+  statusText: string;
+  method: string;
+  data?: unknown;
+  error?: Error;
+  isError: boolean;
+};
+
+/**
+ * Resolve the host that can reach the Vite test server from this device.
+ * Prefer the Metro bundler host (already proven reachable), then explicit env override.
+ */
+function getTestServerHost(): string {
+  if (process.env.TEST_SERVER_HOST) {
+    return process.env.TEST_SERVER_HOST;
+  }
+  return Platform.OS === 'android' ? '10.0.2.2' : 'localhost';
+}
+
+const TEST_SERVER_HOST = getTestServerHost();
+const BASE_URL = `http://${TEST_SERVER_HOST}:5173`;
+
+function apiUrl(path: string): string {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+  return `${BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+function displayResultToItem(result: FetchResult): DisplayResult {
+  const error = result.error;
+  return {
+    url: result.url,
+    status: error ? 'Error' : result.res?.status ?? 'Error',
+    statusText: error ? error.name : result.res?.statusText ?? '',
+    method: result.options?.method || 'GET',
+    data: result.data,
+    error,
+    isError: Boolean(error),
+  };
+}
+
+function assert(result: FetchResult, expectedStatus: number): boolean {
+  if (result.error) {
+    if (expectedStatus !== 0) {
+      throw new Error(`Expected status code ${expectedStatus} but got error: ${result.error.message}`);
+    }
+    return true;
+  }
+
+  const res = result.res;
+  if (!(res instanceof Response)) {
+    throw new Error('Test failed to receive a Response object');
+  }
+
+  if (typeof res.status !== 'number') {
+    throw new Error('Response missing status code');
+  }
+
+  if (typeof res.statusText !== 'string') {
+    throw new Error('Response missing status text');
+  }
+
+  if (!(res.headers instanceof Headers)) {
+    throw new Error('Response missing headers');
+  }
+
+  if (res.status < 0 || res.status > 599) {
+    throw new Error(`Invalid status code: ${res.status}`);
+  }
+
+  if (res.status !== expectedStatus) {
+    throw new Error(`Expected status code ${expectedStatus} but got ${res.status}`);
+  }
+
+  if (['HEAD', 'OPTIONS'].includes(result.options?.method || '')) {
+    return true;
+  }
+
+  const contentType = res.headers.get('content-type');
+  if (!contentType && res.status !== 204 && res.status !== 304) {
+    throw new Error('Response missing content-type header');
+  }
+
+  // if (!res.body && res.status !== 204 && res.status !== 304) {
+  //   throw new Error('Response missing body');
+  // }
+
+  return true;
+}
+
+async function makeRequest(
+  url: string,
+  options: FetchOptions | undefined,
+  onResult: (item: DisplayResult) => void,
+): Promise<FetchResult> {
+  const resolvedUrl = apiUrl(url);
+  try {
+    const res = await fetch(resolvedUrl, options);
+    const contentType = res.headers.get('content-type') || '';
+    let data: unknown = null;
+
+    if (options?.method !== 'HEAD') {
+      data = contentType.includes('application/json') ? await res.json() : await res.text();
+    }
+
+    const result: FetchResult = {res, data, url: resolvedUrl, options};
+    onResult(displayResultToItem(result));
+    return result;
+  } catch (error) {
+    const fetchError = error instanceof Error ? error : new Error(String(error));
+    const result: FetchResult = {error: fetchError, url: resolvedUrl, options};
+    onResult(displayResultToItem(result));
+    return result;
+  }
+}
+
+async function runFetchNetworkTests(onResult: (item: DisplayResult) => void): Promise<string> {
+  let res: FetchResult;
+
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 10);
+
+  try {
+    const abortedRes = await fetch(apiUrl('/api/status/200'), {
+      method: 'POST',
+      body: 'This request will be aborted',
+      headers: {'Content-Type': 'text/plain'},
+      signal: controller.signal,
+    });
+    await abortedRes.text();
+  } catch (err) {
+    const abortError = err instanceof Error ? err : new Error(String(err));
+    console.error('Aborted request error:', abortError.name);
+  }
+
+  res = await makeRequest('/api/status/500', {method: 'POST', body: 'Hello', headers: {'Content-Type': 'text/plain'}}, onResult);
+  assert(res, 500);
+
+  res = await makeRequest(
+    '/api/status/501',
+    {
+      method: 'POST',
+      body: JSON.stringify({message: 'Hello', count: 42}),
+      headers: {'Content-Type': 'application/json'},
+    },
+    onResult,
+  );
+  assert(res, 501);
+
+  const formData = new FormData();
+  formData.append('text', 'Hello from FormData');
+  formData.append('file', new Blob(['Hello from Blob'], {type: 'text/plain'}));
+  
+  res = await makeRequest('/api/status/502', {method: 'POST', body: formData}, onResult);
+  assert(res, 502);
+
+  const params = new URLSearchParams();
+  params.append('param1', 'value1');
+  params.append('param2', 'value2');
+  res = await makeRequest('/api/status/503', {method: 'POST', body: params}, onResult);
+  assert(res, 503);
+
+  res = await makeRequest(
+    '/api/status/505',
+    {method: 'POST', body: new Blob(['Hello from Blob'], {type: 'text/plain'})},
+    onResult,
+  );
+  assert(res, 505);
+
+  // TODO: TextEncoder is not supported in React Native
+  res = await makeRequest('/api/status/506', {method: 'POST', body: 'hello world!'}, onResult);
+  assert(res, 506);
+
+  res = await makeRequest('/api/status/507', {method: 'GET'}, onResult);
+  assert(res, 507);
+
+  res = await makeRequest('/api/status/200', {method: 'GET'}, onResult);
+  assert(res, 200);
+
+  res = await makeRequest('/api/status/200', {method: 'HEAD'}, onResult);
+  assert(res, 200);
+
+  res = await makeRequest('/api/status/200', {method: 'OPTIONS'}, onResult);
+  assert(res, 200);
+
+  res = await makeRequest('/api/status/200', {method: 'DELETE'}, onResult);
+  assert(res, 200);
+
+  res = await makeRequest(
+    '/api/status/200',
+    {
+      method: 'PUT',
+      body: JSON.stringify({message: 'Update'}),
+      headers: {'Content-Type': 'application/json'},
+    },
+    onResult,
+  );
+  assert(res, 200);
+
+  res = await makeRequest('/api/test', {method: 'GET'}, onResult);
+  assert(res, 200);
+
+  res = await makeRequest('https://notrealdomain', undefined, onResult);
+  assert(res, 0);
+
+  res = await makeRequest('/api/status/200?sleep=5000', {method: 'GET'}, onResult);
+  assert(res, 200);
+
+  return 'All tests completed successfully!';
+}
+
+export default function FetchNetworkTestScreen() {
+  const [completionMessage, setCompletionMessage] = useState('Running tests...');
+  const [isComplete, setIsComplete] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [results, setResults] = useState<DisplayResult[]>([]);
+  const hasStarted = useRef(false);
+
+  useEffect(() => {
+    if (hasStarted.current) {
+      return;
+    }
+    hasStarted.current = true;
+
+    const timeoutId = setTimeout(async () => {
+      try {
+        const message = await runFetchNetworkTests((item) => {
+          setResults((current) => [...current, item]);
+        });
+        setIsComplete(true);
+        setIsSuccess(true);
+        setCompletionMessage(message);
+      } catch (error) {
+        const failureMessage = `Test failed: ${error instanceof Error ? error.message : String(error)}`;
+        setIsComplete(true);
+        setIsSuccess(false);
+        setCompletionMessage(failureMessage);
+        console.error(failureMessage);
+      }
+    }, 100);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <Text style={styles.title}>Fetch Network Tracking Test</Text>
+
+      <View
+        style={[
+          styles.completionIndicator,
+          isComplete && (isSuccess ? styles.completionSuccess : styles.completionFailure),
+        ]}
+      >
+        <Text
+          style={[
+            styles.completionText,
+            isComplete && (isSuccess ? styles.completionTextSuccess : styles.completionTextFailure),
+          ]}
+        >
+          {completionMessage}
+        </Text>
+      </View>
+
+      <Text style={styles.description}>
+        This tests the autocapture.networkTracking feature and the fetch API. It will make a series of
+        requests to various endpoints and display the results to verify that the fetch override is working.
+      </Text>
+
+      <Text style={styles.serverHint}>Test server: {BASE_URL}</Text>
+
+      {results.map((result, index) => (
+        <View
+          key={`${result.url}-${result.method}-${index}`}
+          style={[styles.resultItem, result.isError ? styles.resultError : styles.resultSuccess]}
+        >
+          <Text style={styles.resultUrl}>{result.url}</Text>
+          <Text style={styles.resultStatus}>
+            Status: {result.status} {result.statusText}
+          </Text>
+          <View style={styles.resultDetails}>
+            <Text style={styles.resultDetailsText}>
+              {`Method: ${result.method}`}
+              {result.data !== undefined && result.data !== null
+                ? `\nResponse: ${JSON.stringify(result.data, null, 2)}`
+                : ''}
+              {result.error ? `\nError: ${result.error.message}` : ''}
+            </Text>
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    padding: 16,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  completionIndicator: {
+    padding: 10,
+    marginVertical: 10,
+    borderRadius: 4,
+    backgroundColor: '#e3f2fd',
+  },
+  completionSuccess: {
+    backgroundColor: '#e8f5e9',
+  },
+  completionFailure: {
+    backgroundColor: '#ffebee',
+  },
+  completionText: {
+    color: '#1565c0',
+    fontWeight: '700',
+  },
+  completionTextSuccess: {
+    color: '#2e7d32',
+  },
+  completionTextFailure: {
+    color: '#c62828',
+  },
+  description: {
+    marginBottom: 12,
+    lineHeight: 20,
+  },
+  serverHint: {
+    marginBottom: 12,
+    fontFamily: Platform.select({ios: 'Menlo', android: 'monospace', default: 'monospace'}),
+    fontSize: 12,
+    color: '#555',
+  },
+  resultItem: {
+    marginVertical: 10,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    borderLeftWidth: 4,
+  },
+  resultSuccess: {
+    borderLeftColor: '#4CAF50',
+  },
+  resultError: {
+    borderLeftColor: '#f44336',
+  },
+  resultUrl: {
+    fontWeight: '700',
+  },
+  resultStatus: {
+    marginVertical: 5,
+  },
+  resultDetails: {
+    backgroundColor: '#f5f5f5',
+    padding: 10,
+    borderRadius: 4,
+  },
+  resultDetailsText: {
+    fontFamily: Platform.select({ios: 'Menlo', android: 'monospace', default: 'monospace'}),
+  },
+});

--- a/examples/react-native/expo-app/babel.config.js
+++ b/examples/react-native/expo-app/babel.config.js
@@ -7,7 +7,7 @@ module.exports = function (api) {
       // `export AMPLITUDE_API_KEY=…` before `pnpm run android` / `pnpm run ios`.
       [
         'transform-inline-environment-variables',
-        {include: ['AMPLITUDE_API_KEY']},
+        {include: ['AMPLITUDE_API_KEY', 'TEST_SERVER_HOST']},
       ],
     ],
   };

--- a/examples/react-native/expo-app/metro.config.js
+++ b/examples/react-native/expo-app/metro.config.js
@@ -14,6 +14,7 @@ config.watchFolders = [
   path.join(packagesRoot, 'analytics-react-native'),
   path.join(packagesRoot, 'analytics-core'),
   path.join(packagesRoot, 'plugin-page-view-tracking-browser'),
+  path.join(packagesRoot, 'plugin-network-capture-browser'),
 ];
 config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
 

--- a/examples/react-native/expo-app/package.json
+++ b/examples/react-native/expo-app/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-react-native": "workspace:*",
+    "@amplitude/plugin-network-capture-browser": "workspace:*",
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "~1.17.11",
     "@react-navigation/native": "^6.1.18",

--- a/examples/react-native/expo-app/pnpm-lock.yaml
+++ b/examples/react-native/expo-app/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@amplitude/analytics-react-native':
         specifier: workspace:*
         version: link:../../../packages/analytics-react-native
+      '@amplitude/plugin-network-capture-browser':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-network-capture-browser
       '@babel/runtime':
         specifier: ^7.20.0
         version: 7.28.6
@@ -246,6 +249,16 @@ importers:
         version: 0.20.4
 
   ../../../packages/analytics-types: {}
+
+  ../../../packages/element-selector:
+    dependencies:
+      tslib:
+        specifier: ^2.4.1
+        version: 2.8.1
+    devDependencies:
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
 
   ../../../packages/gtm-snippet:
     dependencies:
@@ -964,8 +977,8 @@ importers:
         specifier: workspace:*
         version: link:../analytics-core
       '@amplitude/engagement-browser':
-        specifier: ^1.0.3
-        version: 1.0.9
+        specifier: ^1.0.10
+        version: 1.0.10
       '@amplitude/plugin-experiment-browser':
         specifier: workspace:*
         version: link:../plugin-experiment-browser
@@ -977,12 +990,6 @@ importers:
         specifier: ^2.79.1
         version: 2.80.0
 
-  ../../../packages/utils-element-selector:
-    dependencies:
-      tslib:
-        specifier: ^2.4.1
-        version: 2.8.1
-
 packages:
 
   '@amplitude/analytics-connector@1.6.4':
@@ -991,11 +998,8 @@ packages:
   '@amplitude/analytics-types@1.4.0':
     resolution: {integrity: sha512-RiMPHBqdrJ8ktTqG+Wzj2htnN/PCG9jGZG0SXtTFnWwVvcAJYbYm55/nrP1TTyrx1OlLhvF2VG3lVUP/xGAU8w==}
 
-  '@amplitude/analytics-types@2.11.1':
-    resolution: {integrity: sha512-wFEgb0t99ly2uJKm5oZ28Lti0Kh5RecR5XBkwfUpDzn84IoCIZ8GJTsMw/nThu8FZFc7xFDA4UAt76zhZKrs9A==}
-
-  '@amplitude/engagement-browser@1.0.9':
-    resolution: {integrity: sha512-zvPr0L5aLlOS3nG8scIkEEDMVK2y3MaMbgjYhMfYruhMpfsC/U0apov22nEc1RRrTwve2awEXruPRKf1TysqrQ==}
+  '@amplitude/engagement-browser@1.0.10':
+    resolution: {integrity: sha512-sv8ei+Xy2qMs31lvW3bJCOZBg8LRuorAxlzM8fmh3FyVaRMbs5WyQGaWSfJ8y5tqmllJnLfbBS5R38Mv6G3h7w==}
 
   '@amplitude/eslint-plugin-amplitude@1.1.1':
     resolution: {integrity: sha512-zFobyNSMVHJ44aeBYdJ6aaPMmzmSKZlCTMbgsLGjswKkBVUbZeIAyc4n8s+USIM7+p7YG9MFXPDdkqFaHO1UHQ==}
@@ -1986,6 +1990,162 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -3633,6 +3793,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -6903,11 +7068,9 @@ snapshots:
 
   '@amplitude/analytics-types@1.4.0': {}
 
-  '@amplitude/analytics-types@2.11.1': {}
-
-  '@amplitude/engagement-browser@1.0.9':
+  '@amplitude/engagement-browser@1.0.10':
     dependencies:
-      '@amplitude/analytics-types': 2.11.1
+      '@amplitude/analytics-types': 1.4.0
 
   '@amplitude/eslint-plugin-amplitude@1.1.1':
     dependencies:
@@ -8265,6 +8428,84 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
@@ -10829,6 +11070,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -179,4 +179,4 @@ export { ExcludeInternalReferrersOptions, EXCLUDE_INTERNAL_REFERRERS_CONDITIONS 
 
 export { VideoObserver, State as VideoState, type VideoObserverParams } from './observers/video';
 export { EmbeddedVideoPlayer, type Vendor as VideoVendor } from './video-analytics/types';
-export { isChromeExtension } from './utils/environment';
+export { isChromeExtension, isReactNative } from './utils/environment';

--- a/packages/analytics-core/src/utils/environment.ts
+++ b/packages/analytics-core/src/utils/environment.ts
@@ -4,3 +4,8 @@ export function isChromeExtension(): boolean {
   const globalScope = getGlobalScope() as { chrome?: { runtime?: { id?: string } } };
   return typeof globalScope?.chrome?.runtime?.id === 'string';
 }
+
+export function isReactNative(): boolean {
+  const globalScope = getGlobalScope() as { navigator?: { product?: string } };
+  return globalScope?.navigator?.product === 'ReactNative';
+}

--- a/packages/analytics-core/test/utils/environment.test.ts
+++ b/packages/analytics-core/test/utils/environment.test.ts
@@ -40,3 +40,35 @@ describe('isChromeExtension', () => {
     expect(analyticsCoreModule.isChromeExtension()).toBe(true);
   });
 });
+
+describe('isReactNative', () => {
+  let getGlobalScopeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getGlobalScopeSpy = jest.spyOn(globalScopeModule, 'getGlobalScope');
+  });
+
+  afterEach(() => {
+    getGlobalScopeSpy.mockRestore();
+  });
+
+  test('returns false when globalScope is undefined', () => {
+    getGlobalScopeSpy.mockReturnValue(undefined);
+    expect(analyticsCoreModule.isReactNative()).toBe(false);
+  });
+
+  test('returns false when navigator is undefined', () => {
+    getGlobalScopeSpy.mockReturnValue({});
+    expect(analyticsCoreModule.isReactNative()).toBe(false);
+  });
+
+  test('returns false when navigator.product is not ReactNative', () => {
+    getGlobalScopeSpy.mockReturnValue({ navigator: { product: 'NotReactNative' } });
+    expect(analyticsCoreModule.isReactNative()).toBe(false);
+  });
+
+  test('returns true when navigator.product is ReactNative', () => {
+    getGlobalScopeSpy.mockReturnValue({ navigator: { product: 'ReactNative' } });
+    expect(analyticsCoreModule.isReactNative()).toBe(true);
+  });
+});

--- a/packages/plugin-network-capture-browser/package.json
+++ b/packages/plugin-network-capture-browser/package.json
@@ -23,6 +23,7 @@
     "build:es5": "tsc -p ./tsconfig.es5.json",
     "build:esm": "tsc -p ./tsconfig.esm.json",
     "watch": "tsc -p ./tsconfig.esm.json --watch",
+    "watch:es5": "tsc -p ./tsconfig.es5.json --watch",
     "clean": "rimraf node_modules lib coverage",
     "fix": "pnpm fix:eslint & pnpm fix:prettier",
     "fix:eslint": "eslint '{src,test}/**/*.ts' --fix",

--- a/packages/plugin-network-capture-browser/src/network-capture-plugin.ts
+++ b/packages/plugin-network-capture-browser/src/network-capture-plugin.ts
@@ -8,6 +8,7 @@ import {
   NetworkEventCallback,
   NetworkTrackingOptions,
   ILogger,
+  isReactNative,
 } from '@amplitude/analytics-core';
 import * as constants from './constants';
 import { Observable, Unsubscribable } from '@amplitude/analytics-core';
@@ -80,9 +81,12 @@ export const networkCapturePlugin = (options: NetworkTrackingOptions = {}): Brow
     };
   };
 
+  // TODO: remove this when ready to ship React Native network tracking
+  const BLOCK_REACT_NATIVE = true;
+
   const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
-    /* istanbul ignore if */
-    if (typeof document === 'undefined') {
+    /* istanbul ignore next */
+    if (typeof document === 'undefined' && (!isReactNative() || BLOCK_REACT_NATIVE)) {
       return;
     }
 

--- a/packages/plugin-network-capture-browser/src/track-network-event.ts
+++ b/packages/plugin-network-capture-browser/src/track-network-event.ts
@@ -78,7 +78,22 @@ function isCaptureRuleMatch(
   return true;
 }
 
-function parseUrl(url: string | undefined) {
+export function parseUrlFromString(href: string) {
+  const hashIndex = href.indexOf('#');
+  const fragment = hashIndex >= 0 ? href.slice(hashIndex + 1) : '';
+  const urlWithoutHash = hashIndex >= 0 ? href.slice(0, hashIndex) : href;
+
+  const queryIndex = urlWithoutHash.indexOf('?');
+  const query = queryIndex >= 0 ? urlWithoutHash.slice(queryIndex + 1) : '';
+  const hrefWithoutQueryOrHash = queryIndex >= 0 ? urlWithoutHash.slice(0, queryIndex) : urlWithoutHash;
+
+  const authorityMatch = hrefWithoutQueryOrHash.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]+)/i);
+  const host = authorityMatch?.[1] ?? '';
+
+  return { query, fragment, href, hrefWithoutQueryOrHash, host };
+}
+
+export function parseUrl(url: string | undefined) {
   if (!url) {
     return;
   }
@@ -94,9 +109,14 @@ function parseUrl(url: string | undefined) {
     urlObj.search = '';
     const hrefWithoutQueryOrHash = urlObj.href;
     return { query, fragment, href, hrefWithoutQueryOrHash, host };
-  } catch (e) {
-    /* istanbul ignore next */
-    return;
+  } catch {
+    try {
+      // if global URL is not available, parse the URL from the string
+      return parseUrlFromString(url);
+    } catch {
+      /* istanbul ignore next */
+      return;
+    }
   }
 }
 

--- a/packages/plugin-network-capture-browser/test/autocapture-plugin/track-network-event.test.ts
+++ b/packages/plugin-network-capture-browser/test/autocapture-plugin/track-network-event.test.ts
@@ -21,6 +21,7 @@ import {
   logNetworkAnalyticsEvent,
   NetworkAnalyticsEvent,
   parseHeaderCaptureRule,
+  parseUrlFromString,
   shouldTrackNetworkEvent,
 } from '../../src/track-network-event';
 import { BrowserEnrichmentPlugin, networkCapturePlugin } from '../../src/network-capture-plugin';
@@ -328,6 +329,91 @@ describe('track-network-event', () => {
         return call[0] === AMPLITUDE_NETWORK_REQUEST_EVENT;
       });
       expect(networkEventCall).toBeUndefined();
+    });
+  });
+
+  describe('shouldTrackNetworkEvent with React Native URL polyfill', () => {
+    const originalURL = global.URL;
+
+    afterEach(() => {
+      global.URL = originalURL;
+    });
+
+    test('parses host and query when URL.host is not implemented', () => {
+      class ReactNativeURL {
+        _url: string;
+
+        constructor(url: string) {
+          this._url = url.endsWith('/') ? url : `${url}/`;
+        }
+
+        get href() {
+          return this._url;
+        }
+
+        get host() {
+          throw new Error('URL.host is not implemented');
+        }
+
+        get searchParams() {
+          return { toString: () => '' };
+        }
+      }
+
+      global.URL = ReactNativeURL as unknown as typeof URL;
+
+      networkEvent.url = 'http://10.0.2.2:5173/api/test?foo=bar';
+      localConfig.networkTrackingOptions = {
+        captureRules: [{ hosts: ['10.0.2.2:5173'], statusCodeRange: '200-299' }],
+      };
+
+      expect(shouldTrackNetworkEvent(networkEvent, localConfig.networkTrackingOptions)).toBe(true);
+    });
+  });
+
+  describe('parseUrlFromString()', () => {
+    test('parses plain URL', () => {
+      const url = parseUrlFromString('http://10.0.2.2:5173/api/test');
+      expect(url).toEqual({
+        href: 'http://10.0.2.2:5173/api/test',
+        hrefWithoutQueryOrHash: 'http://10.0.2.2:5173/api/test',
+        host: '10.0.2.2:5173',
+        query: '',
+        fragment: '',
+      });
+    });
+
+    test('parses host and query when URL.host is not implemented', () => {
+      const url = parseUrlFromString('http://10.0.2.2:5173/api/test?foo=bar');
+      expect(url).toEqual({
+        href: 'http://10.0.2.2:5173/api/test?foo=bar',
+        hrefWithoutQueryOrHash: 'http://10.0.2.2:5173/api/test',
+        host: '10.0.2.2:5173',
+        query: 'foo=bar',
+        fragment: '',
+      });
+    });
+
+    test('parses hash fragments', () => {
+      const url = parseUrlFromString('http://10.0.2.2:5173/api/test?foo=bar#hash');
+      expect(url).toEqual({
+        href: 'http://10.0.2.2:5173/api/test?foo=bar#hash',
+        hrefWithoutQueryOrHash: 'http://10.0.2.2:5173/api/test',
+        host: '10.0.2.2:5173',
+        query: 'foo=bar',
+        fragment: 'hash',
+      });
+    });
+
+    test('parses relative URL', () => {
+      const url = parseUrlFromString('/api/test');
+      expect(url).toEqual({
+        href: '/api/test',
+        hrefWithoutQueryOrHash: '/api/test',
+        host: '',
+        query: '',
+        fragment: '',
+      });
     });
   });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -126,7 +126,8 @@ export default defineConfig({
     alias: amplitudeAliases
   },
   server: {
-    host: process.env.SSH ? 'local.website.com' : undefined,
+    // Listen on all interfaces so simulators/emulators/devices can reach the mock API.
+    host: process.env.SSH ? 'local.website.com' : true,
     https: process.env.SSH ? {
       key: fs.readFileSync(path.resolve(process.env.HOME, 'certs/local-website/key.pem')),
       cert: fs.readFileSync(path.resolve(process.env.HOME, 'certs/local-website/cert.pem')),


### PR DESCRIPTION
### Summary
* Fix plugin-network-capture to make it work in React Native
  * Added a "parseUrlFromString" function as fallback to when the native URL isn't available or doesn't work
  * Added an environment check for "isReactNative" so that network capture plugin can be used in RN
  * Temporarily blocking the plugin though until we've adequately tested it
* Add test app in React Native to test the network calls

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared network-capture filtering/parsing used on web and introduces a RN setup path that will intercept fetch once `BLOCK_REACT_NATIVE` is flipped; mis-parsed hosts or premature enablement could change which requests get autocaptured.
> 
> **Overview**
> Prepares **network tracking** to run outside the browser by exporting **`isReactNative()`** from analytics-core and teaching the network-capture plugin to allow setup when `document` is missing on React Native (still gated behind **`BLOCK_REACT_NATIVE = true`** until release).
> 
> **URL parsing** now falls back to string-based **`parseUrlFromString`** when the platform `URL` implementation throws or lacks `host` (common on RN), with unit tests for that path.
> 
> **Expo example app** wires in `@amplitude/plugin-network-capture-browser`, adds a **Fetch Network Test** screen that drives fetch against the Vite mock API (`TEST_SERVER_HOST`, Android `10.0.2.2`), and includes experimental **touch** tracking via `AmplitudeWrapper`. Metro/babel and the root Vite server are updated so devices/emulators can reach the test server on all interfaces.
> 
> Minor example tweaks: bare RN app touch wrapper logging; expo init log level **Error**; plugin **`watch:es5`** script; lockfile churn from workspace links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ab0e274532ed71336300ed716ff14c22a0b07e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->