### PR TITLE
fix(analytics-core): bump background capture version to 1.0.3

### DIFF
--- a/packages/analytics-core/src/messenger/constants.ts
+++ b/packages/analytics-core/src/messenger/constants.ts
@@ -9,4 +9,4 @@ export const AMPLITUDE_ORIGINS_MAP: Record<string, string> = {
 };
 
 // Background capture script URL (shared between autocapture and session-replay)
-export const AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL = 'https://cdn.amplitude.com/libs/background-capture-1.0.1.js.gz';
+export const AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL = 'https://cdn.amplitude.com/libs/background-capture-1.0.2.js.gz';

--- a/packages/analytics-core/src/messenger/constants.ts
+++ b/packages/analytics-core/src/messenger/constants.ts
@@ -9,4 +9,4 @@ export const AMPLITUDE_ORIGINS_MAP: Record<string, string> = {
 };
 
 // Background capture script URL (shared between autocapture and session-replay)
-export const AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL = 'https://cdn.amplitude.com/libs/background-capture-1.0.2.js.gz';
+export const AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL = 'https://cdn.amplitude.com/libs/background-capture-1.0.3.js.gz';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Updates `AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL` from `background-capture-1.0.1.js.gz` to `background-capture-1.0.3.js.gz`. This constant is shared by autocapture and session replay when loading the background capture script from the CDN.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<details>
<summary>AI Prompt</summary>

We've bumped our background-capture script to 1.0.2. Make a draft PR that changes the version

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e922be8-4986-4164-9678-7396f092e6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e922be8-4986-4164-9678-7396f092e6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

