### PR TITLE
feat(plugin-web-vitals-browser): add "flush" method

### DIFF
--- a/packages/plugin-web-vitals-browser/src/web-vitals-plugin.ts
+++ b/packages/plugin-web-vitals-browser/src/web-vitals-plugin.ts
@@ -52,11 +52,16 @@ function processMetric(metric: Metric) {
   };
 }
 
-export const webVitalsPlugin = (): BrowserEnrichmentPlugin => {
+export type WebVitalsPlugin = BrowserEnrichmentPlugin & {
+  flushWebVitals: (() => void) | undefined;
+};
+
+export const webVitalsPlugin = (): WebVitalsPlugin => {
   let visibilityListener: ((this: Document, ev: Event) => void) | null = null;
   const globalScope = getGlobalScope();
   const doc = globalScope?.document;
   const location = globalScope?.location;
+  let flushWebVitals: (() => void) | undefined = undefined;
   const setup: BrowserEnrichmentPlugin['setup'] = async (config, amplitude) => {
     if (doc === undefined) {
       return;
@@ -90,9 +95,14 @@ export const webVitalsPlugin = (): BrowserEnrichmentPlugin => {
       webVitalsPayload['[Amplitude] TTFB'] = processMetric(metric);
     });
 
+    flushWebVitals = () => {
+      amplitude.track(WEB_VITALS_EVENT_NAME, webVitalsPayload);
+    };
+
     visibilityListener = () => {
       if (doc.visibilityState === 'hidden' && visibilityListener) {
-        amplitude.track(WEB_VITALS_EVENT_NAME, webVitalsPayload);
+        /* istanbul ignore next */
+        flushWebVitals?.();
         doc.removeEventListener('visibilitychange', visibilityListener);
         visibilityListener = null;
       }
@@ -114,6 +124,7 @@ export const webVitalsPlugin = (): BrowserEnrichmentPlugin => {
   return {
     name: PLUGIN_NAME,
     type: 'enrichment',
+    flushWebVitals,
     setup,
     execute,
     teardown,

--- a/packages/plugin-web-vitals-browser/test/web-vitals-plugin.test.ts
+++ b/packages/plugin-web-vitals-browser/test/web-vitals-plugin.test.ts
@@ -192,4 +192,19 @@ describe('webVitalsPlugin', () => {
     const result = await plugin?.execute?.(event);
     expect(result).toBe(event);
   });
+
+  describe('flushWebVitals', () => {
+    it('should be able to flush web vitals manually', async () => {
+      const plugin = webVitalsPlugin();
+      await plugin?.setup?.(config, amplitude);
+      (plugin.flushWebVitals as () => void)();
+      expect(amplitude.track).toHaveBeenCalledWith(WEB_VITALS_EVENT_NAME, expect.any(Object));
+    });
+
+    it('should be undefined if not setup', async () => {
+      const plugin = webVitalsPlugin();
+      plugin?.flushWebVitals?.();
+      expect(plugin?.flushWebVitals).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive analytics API with shared flush logic; no auth or data-model changes, and default autocapture behavior is unchanged unless callers invoke flush manually.
> 
> **Overview**
> Adds a **`flushWebVitals`** hook on the web vitals enrichment plugin so integrators can send the accumulated Web Vitals payload on demand, not only when the page becomes hidden.
> 
> After `setup`, `flushWebVitals` tracks the same `WEB_VITALS_EVENT_NAME` event the visibility listener used; that path now delegates to `flushWebVitals?.()` instead of calling `amplitude.track` inline. The plugin return type is **`WebVitalsPlugin`**, with `flushWebVitals` exposed via a getter and **`undefined`** until setup runs (when `document` is missing, flush stays unavailable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b28a72cf788844084e590903803b1d9f319eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->