### PR TITLE
chore: make DX codeowners of amplitude-typescript

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,9 @@
 #
 # More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# All packages
+* @amplitude/dx
+
 # Session Replay Packages (Browser)
 # Owned by the Session Replay SDK team
 /packages/session-replay-browser/ @amplitude/session-replay-sdk


### PR DESCRIPTION
Added code owner for all packages to the CODEOWNERS file.

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates GitHub review routing in CODEOWNERS; no application or runtime code changes.
> 
> **Overview**
> Adds a repository-wide default owner so **@amplitude/dx** is requested on PRs that touch any path.
> 
> The new catch-all rule `* @amplitude/dx` sits above the existing Session Replay package entries; those narrower paths still route to **@amplitude/session-replay-sdk** where they match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fbaa04027074376b4af43d6e59884ad0af4913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->