### PR TITLE
fix(analytics-core): queued functions not being flushed when init not awaited

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -51,7 +51,9 @@ export class AmplitudeCore implements CoreClient, PluginHost {
     this.config = config;
     this.timeline.reset(this);
     this.timeline.loggerProvider = this.config.loggerProvider;
-    await this.runQueuedFunctions('q');
+    do {
+      await this.runQueuedFunctions('q');
+    } while (this.q.length > 0);
     this.isReady = true;
   }
 
@@ -69,6 +71,7 @@ export class AmplitudeCore implements CoreClient, PluginHost {
         await val;
       }
     }
+
     // Rerun queued functions if the queue has accrued more while awaiting promises
     if (this[queueName].length) {
       await this.runQueuedFunctions(queueName);

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -253,6 +253,36 @@ describe('core-client', () => {
       expect(_setOptOut).toHaveBeenCalledWith(true);
       expect(client.config.optOut).toBe(true);
     });
+
+    test('should flush queue items added after runQueuedFunctions returns before isReady', async () => {
+      // Covers the do-while in _init: work can land on q after runQueuedFunctions
+      // returns (e.g. a microtask) but before isReady is set.
+      const client = new AmplitudeCore();
+      const setup = jest.fn().mockResolvedValue(undefined);
+      const plugin: EnrichmentPlugin = {
+        name: 'late-plugin',
+        type: 'enrichment',
+        setup,
+        execute: jest.fn(),
+      };
+
+      let flushCount = 0;
+      const originalRunQueuedFunctions = client.runQueuedFunctions.bind(client);
+      jest.spyOn(client, 'runQueuedFunctions').mockImplementation(async (queueName) => {
+        await originalRunQueuedFunctions(queueName);
+        flushCount += 1;
+        if (flushCount === 1 && queueName === 'q') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+          (client as any).q.push(client._addPlugin.bind(client, plugin));
+        }
+      });
+
+      await (client as any)._init(useDefaultConfig());
+
+      expect(flushCount).toBeGreaterThanOrEqual(2);
+      expect(setup).toHaveBeenCalled();
+      expect(client.plugin('late-plugin')).toBeDefined();
+    });
   });
 
   describe('dispatchWithCallback', () => {

--- a/packages/analytics-node/test/node-client.test.ts
+++ b/packages/analytics-node/test/node-client.test.ts
@@ -1,6 +1,6 @@
 import { AmplitudeNode } from '../src/node-client';
 import * as core from '@amplitude/analytics-core';
-import { Status } from '@amplitude/analytics-core';
+import { EnrichmentPlugin, Event, Status } from '@amplitude/analytics-core';
 import * as Config from '../src/config';
 
 describe('node-client', () => {
@@ -30,6 +30,54 @@ describe('node-client', () => {
       await Promise.all([client.init(API_KEY), client.init(API_KEY), client.init(API_KEY)]);
       // NOTE: `useNodeConfig` is only called once despite multiple init calls
       expect(useNodeConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('add', () => {
+    test('should register enrichment plugin added immediately after init without awaiting', async () => {
+      const send = jest.fn().mockResolvedValue({
+        status: Status.Success,
+        statusCode: 200,
+        body: {
+          eventsIngested: 1,
+          payloadSizeBytes: 1,
+          serverUploadTime: 1,
+        },
+      });
+      const client = new AmplitudeNode();
+      const setup = jest.fn().mockResolvedValue(undefined);
+      const execute = jest.fn().mockImplementation((event: Event) =>
+        Promise.resolve({
+          ...event,
+          event_properties: {
+            ...event.event_properties,
+            source: 'my-app',
+          },
+        }),
+      );
+      const plugin: EnrichmentPlugin = {
+        name: 'my-plugin',
+        type: 'enrichment',
+        setup,
+        execute,
+      };
+
+      // Mirrors: init('API_KEY'); add(new MyPlugin()); track('test event');
+      // add() runs in the same sync turn as init()'s return, after q is flushed but
+      // before isReady is set — so the plugin is queued and then silently dropped.
+      const initPromise = client.init(API_KEY, {
+        flushIntervalMillis: 1000,
+        transportProvider: {
+          send,
+        },
+      }).promise;
+      Promise.resolve().then(() => client.add(plugin));
+      await client.track('test event').promise;
+      await initPromise;
+
+      expect(setup).toHaveBeenCalled();
+      expect(execute).toHaveBeenCalled();
+      expect(send).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client initialization ordering used by all SDKs; behavior change is intentional but could affect subtle timing during startup.
> 
> **Overview**
> Fixes a race where **`init()`** is not awaited and callers **`add()`** plugins (or other pre-ready APIs) in the same turn or via microtasks: work could land on **`q`** after **`runQueuedFunctions`** finished but before **`isReady`**, so it was never executed.
> 
> **`_init`** now loops with **`do { await runQueuedFunctions('q') } while (this.q.length > 0)`** so the pre-ready queue is drained before **`isReady = true`**. **`runQueuedFunctions`** also re-invokes itself when new entries appear on the queue while earlier items’ promises are still settling.
> 
> Adds regression tests in **analytics-core** and **analytics-node** for late-queued plugins during init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ce88f23b539c26f5c47f37b2e3f4515112f8e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->