### PR TITLE
fix(session-replay-react-native): SRMaskView pointerEvents compiles across RN 0.73-0.88 (SDKRN-41)

### DIFF
--- a/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskView.kt
+++ b/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskView.kt
@@ -38,13 +38,16 @@ class SRMaskView(context: Context) : ReactViewGroup(context) {
     // Children are unaffected. This view is never created from a JS
     // pointerEvents prop, so nothing else writes this field.
     //
-    // Deliberately NO accessor override as belt-and-braces: the accessor's
-    // shape is not stable across RN versions (a Java getter through RN 0.78,
-    // a Kotlin `val pointerEvents` interface property from RN 0.79), so an
-    // override cannot compile against both. Instead the setter call here is
-    // re-asserted in onLayout below, which runs before any capture/touch can
-    // observe a recycled instance whose field was reset.
-    setPointerEvents(PointerEvents.BOX_NONE)
+    // CROSS-VERSION CONSTRAINT (do not "simplify" either way): ReactViewGroup
+    // is Java with getPointerEvents()/setPointerEvents() through RN 0.80 and
+    // a Kotlin `var pointerEvents` property from RN 0.81, so neither an
+    // accessor override (`override fun` vs `override var`) nor an explicit
+    // setPointerEvents(...) call compiles against both. Property-assignment
+    // syntax is the one shape that resolves on every version: Kotlin
+    // synthesizes the property from the Java accessor pair on <= 0.80 and
+    // binds the real property on 0.81+. Re-asserted in onLayout below so a
+    // recycling reset can never be observed by capture or touch.
+    pointerEvents = PointerEvents.BOX_NONE
   }
 
   // Children can be laid out after the host's own layout pass; re-widen then.
@@ -90,7 +93,7 @@ class SRMaskView(context: Context) : ReactViewGroup(context) {
     super.onLayout(changed, left, top, right, bottom)
     // Re-assert touch transparency in case a recycling path reset the field
     // (version-agnostic replacement for an accessor override; see init).
-    setPointerEvents(PointerEvents.BOX_NONE)
+    pointerEvents = PointerEvents.BOX_NONE
     expandBoundsToChildrenUnion()
   }
 

--- a/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskView.kt
+++ b/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskView.kt
@@ -3,7 +3,6 @@ package com.amplitude.sessionreplayreactnative.fabric
 import android.content.Context
 import android.view.View
 import com.amplitude.sessionreplayreactnative.SRMaskingRegistry
-import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.views.view.ReactViewGroup
 
 /**
@@ -38,16 +37,14 @@ class SRMaskView(context: Context) : ReactViewGroup(context) {
     // Children are unaffected. This view is never created from a JS
     // pointerEvents prop, so nothing else writes this field.
     //
-    // CROSS-VERSION CONSTRAINT (do not "simplify" either way): ReactViewGroup
-    // is Java with getPointerEvents()/setPointerEvents() through RN 0.80 and
-    // a Kotlin `var pointerEvents` property from RN 0.81, so neither an
-    // accessor override (`override fun` vs `override var`) nor an explicit
-    // setPointerEvents(...) call compiles against both. Property-assignment
-    // syntax is the one shape that resolves on every version: Kotlin
-    // synthesizes the property from the Java accessor pair on <= 0.80 and
-    // binds the real property on 0.81+. Re-asserted in onLayout below so a
-    // recycling reset can never be observed by capture or touch.
-    pointerEvents = PointerEvents.BOX_NONE
+    // CROSS-VERSION CONSTRAINT (do not "simplify" to a Kotlin call/assignment
+    // or an accessor override): pointerEvents has three incompatible
+    // source-level shapes across RN versions and no single Kotlin syntax
+    // compiles against all of them — see SRMaskViewPointerEvents.java, which
+    // resolves the ever-present bytecode setter instead. Re-asserted in
+    // onLayout below so a recycling reset can never be observed by capture
+    // or touch.
+    SRMaskViewPointerEvents.forceBoxNone(this)
   }
 
   // Children can be laid out after the host's own layout pass; re-widen then.
@@ -93,7 +90,7 @@ class SRMaskView(context: Context) : ReactViewGroup(context) {
     super.onLayout(changed, left, top, right, bottom)
     // Re-assert touch transparency in case a recycling path reset the field
     // (version-agnostic replacement for an accessor override; see init).
-    pointerEvents = PointerEvents.BOX_NONE
+    SRMaskViewPointerEvents.forceBoxNone(this)
     expandBoundsToChildrenUnion()
   }
 

--- a/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskView.kt
+++ b/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskView.kt
@@ -37,13 +37,15 @@ class SRMaskView(context: Context) : ReactViewGroup(context) {
     // can be targets) and lets misses fall through to views underneath.
     // Children are unaffected. This view is never created from a JS
     // pointerEvents prop, so nothing else writes this field.
+    //
+    // Deliberately NO accessor override as belt-and-braces: the accessor's
+    // shape is not stable across RN versions (a Java getter through RN 0.78,
+    // a Kotlin `val pointerEvents` interface property from RN 0.79), so an
+    // override cannot compile against both. Instead the setter call here is
+    // re-asserted in onLayout below, which runs before any capture/touch can
+    // observe a recycled instance whose field was reset.
     setPointerEvents(PointerEvents.BOX_NONE)
   }
-
-  // Belt-and-braces with the init{} setter: TouchTargetHelper consults this
-  // accessor, and it must stay BOX_NONE even if some future code path (e.g.
-  // view recycling's resetPointerEvents) rewrites the backing field.
-  override fun getPointerEvents(): PointerEvents = PointerEvents.BOX_NONE
 
   // Children can be laid out after the host's own layout pass; re-widen then.
   private val childLayoutChangeListener =
@@ -86,6 +88,9 @@ class SRMaskView(context: Context) : ReactViewGroup(context) {
   // onLayout is the hook that runs right after, where we can re-widen it.
   override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
     super.onLayout(changed, left, top, right, bottom)
+    // Re-assert touch transparency in case a recycling path reset the field
+    // (version-agnostic replacement for an accessor override; see init).
+    setPointerEvents(PointerEvents.BOX_NONE)
     expandBoundsToChildrenUnion()
   }
 

--- a/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskViewPointerEvents.java
+++ b/packages/session-replay-react-native/android/src/newarch/java/com/amplitude/sessionreplayreactnative/fabric/SRMaskViewPointerEvents.java
@@ -1,0 +1,36 @@
+package com.amplitude.sessionreplayreactnative.fabric;
+
+import com.facebook.react.uimanager.PointerEvents;
+import com.facebook.react.views.view.ReactViewGroup;
+
+/**
+ * Java on purpose. {@code pointerEvents} has THREE incompatible source-level
+ * shapes across React Native versions, so no single Kotlin syntax compiles
+ * against all of them:
+ *
+ * <ul>
+ *   <li>&le; ~0.77: Java interface + Java {@code ReactViewGroup} get/set pair
+ *       (Kotlin property syntax OK, setter call OK)</li>
+ *   <li>~0.78&ndash;0.80: Kotlin {@code ReactPointerEventsView} declares
+ *       {@code val pointerEvents} while {@code ReactViewGroup} is still Java —
+ *       Kotlin resolves assignment against the interface's {@code val} and
+ *       rejects it ({@code 'val' cannot be reassigned}); only an explicit
+ *       {@code setPointerEvents(...)} call compiles</li>
+ *   <li>0.81+: {@code ReactViewGroup} is Kotlin with {@code var pointerEvents} —
+ *       property syntax OK, but {@code setPointerEvents(...)} is an unresolved
+ *       reference from Kotlin source</li>
+ * </ul>
+ *
+ * The BYTECODE, however, has a {@code setPointerEvents(PointerEvents)} method
+ * in every era (the Java method through 0.80; the Kotlin-var-generated setter
+ * from 0.81, verified via javap of react-android AARs). Java source resolves
+ * against bytecode, so this shim compiles and works on every supported RN
+ * version.
+ */
+final class SRMaskViewPointerEvents {
+  private SRMaskViewPointerEvents() {}
+
+  static void forceBoxNone(ReactViewGroup view) {
+    view.setPointerEvents(PointerEvents.BOX_NONE);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a **publish blocker** for `@amplitude/session-replay-react-native` (SDKRN-41): the Fabric `SRMaskView`'s touch-transparency code (`pointerEvents = BOX_NONE`, shipped in #1866) does not compile on React Native ≥ 0.78 — New-Architecture consumers on newer RN cannot build the package at all.

Found by a cross-version compile/behavior sweep (RN 0.73 / 0.76 / 0.77.2 / 0.79.5 / 0.86.0 / 0.88-nightly, package installed via `npm pack` tarball into fresh apps).

## The problem: three incompatible ABI shapes

`pointerEvents` changed source-level shape twice as Meta Kotlinized the RN Android codebase, and **no single Kotlin syntax compiles against all three eras**:

| RN era | Shape | Kotlin property syntax | Kotlin `setPointerEvents(...)` call | `override fun getPointerEvents()` |
|---|---|---|---|---|
| ≤ ~0.77 | Java interface + Java `ReactViewGroup` get/set | ✅ (synthetic) | ✅ | ✅ |
| ~0.78–0.80 | Kotlin `ReactPointerEventsView` declares `val pointerEvents`; `ReactViewGroup` still Java | ❌ `'val' cannot be reassigned` | ✅ | ❌ overrides nothing |
| 0.81+ | Kotlin `ReactViewGroup` with `var pointerEvents` | ✅ | ❌ unresolved reference | ❌ (fun vs var) |

The first two fix attempts on this branch each cover two of the three eras (kept as commits for the archaeology; each was disproven empirically by the sweep).

## The fix: a bytecode-level Java shim

The **bytecode** has `setPointerEvents(PointerEvents)` in every era — the Java method through 0.80, the Kotlin-`var`-generated setter from 0.81 (verified via `javap` of the react-android 0.86 AAR). Java source resolves against bytecode, immune to Kotlin's property semantics. So:

- `SRMaskViewPointerEvents.java` — a ~10-line package-private shim: `view.setPointerEvents(PointerEvents.BOX_NONE)`
- `SRMaskView.kt` calls it from `init` and re-asserts in `onLayout` (covers recycling resets version-agnostically; replaces the unshippable accessor override)

## Verification

Stock tarball (no local patches), Android compile per version — with explicit verification that `compileDebugJavaWithJavac` executes and the shim `.class` lands in the library output on every new-arch lane:

| RN | Result |
|---|---|
| 0.73.11 old-arch | ✅ `assembleDebug` (newarch sources excluded; packaging sane) |
| 0.77.2 new-arch | ✅ compile (forced non-incremental) + **instrumented suite 16/16 on device** (incl. the BOX_NONE test) |
| 0.79.5 new-arch | ✅ compile + `assembleDebug`; separately: 5-min debug crash-stress + 12/12 taps-through-mask + masking verified in captured replay (iOS 0.79 also device-verified: ~9 min, ~8,700 stress commits, zero asserts) |
| 0.86.0 new-arch | ✅ compile + `assembleDebug` (device behavior verified with semantically identical code during the sweep) |
| 0.88.0-nightly | ✅ compile + `assembleDebug` |

iOS is untouched by this change (its analogue is the version-stable `hitTest` override).

Do NOT "simplify" the shim back into Kotlin — the constraint is documented in both files, and any Kotlin call/override/assignment shape breaks at least one supported RN era.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Android Fabric touch-targeting fix with unchanged intended behavior; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **publish blocker** where Fabric `SRMaskView` no longer compiled on React Native ≥ 0.78 because Kotlin cannot express `pointerEvents = BOX_NONE` consistently across RN’s three incompatible Android API shapes.
> 
> **`SRMaskViewPointerEvents.java`** is added as a small Java shim that calls `setPointerEvents(PointerEvents.BOX_NONE)` against bytecode that exists on all supported RN versions. **`SRMaskView.kt`** drops direct Kotlin `setPointerEvents` usage and the `getPointerEvents()` override, and instead calls `SRMaskViewPointerEvents.forceBoxNone(this)` in `init` and again in `onLayout` so touch transparency survives view recycling without version-specific overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c14be09c7faea945a9a0208fd33106746a8f7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->