### PR TITLE
fix(analytics-core): catch uncaught errors when IndexedDB fails

### DIFF
--- a/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-storage.ts
@@ -149,8 +149,12 @@ export class DiagnosticsStorage implements IDiagnosticsStorage {
         resolve(db);
       };
 
-      request.onupgradeneeded = (event) => {
-        const db = (event.target as IDBOpenDBRequest).result;
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db) {
+          this.logger.debug('DiagnosticsStorage: Missing DB during upgrade.');
+          return;
+        }
         this.createTables(db);
       };
     });

--- a/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-storage.test.ts
@@ -188,6 +188,47 @@ describe('DiagnosticsStorage', () => {
       // Restore the original method
       indexedDB.open = originalOpen;
     });
+
+    test('should not throw when upgradeneeded fires without a DB result', () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalOpen = indexedDB.open;
+      const mockRequest = {
+        onerror: null as ((event: Event) => void) | null,
+        onsuccess: null as ((event: Event) => void) | null,
+        onupgradeneeded: null as (() => void) | null,
+        result: undefined as IDBDatabase | undefined,
+      };
+
+      indexedDB.open = jest.fn().mockReturnValue(mockRequest);
+
+      const openDBPromise = storage.openDB();
+      const createTablesSpy = jest.spyOn(storage, 'createTables');
+
+      expect(() => {
+        if (mockRequest.onupgradeneeded) {
+          mockRequest.onupgradeneeded();
+        }
+      }).not.toThrow();
+
+      expect(createTablesSpy).not.toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith('DiagnosticsStorage: Missing DB during upgrade.');
+
+      // Resolve open so the promise does not hang
+      if (mockRequest.onsuccess) {
+        mockRequest.result = {
+          onclose: null,
+          onerror: null,
+          close: jest.fn(),
+        } as unknown as IDBDatabase;
+        mockRequest.onsuccess(new Event('success'));
+      }
+
+      return openDBPromise.finally(() => {
+        createTablesSpy.mockRestore();
+        indexedDB.open = originalOpen;
+      });
+    });
   });
 
   describe('setTags', () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in optional diagnostics storage only; normal IndexedDB open paths are unchanged.
> 
> **Overview**
> Hardens **diagnostics IndexedDB** open logic when `onupgradeneeded` runs but `request.result` is absent (failed or broken IndexedDB), so the SDK does not throw during upgrade.
> 
> The `onupgradeneeded` handler now reads the DB from `request.result`, **bails out** with a debug log (`Missing DB during upgrade.`) instead of calling `createTables`, and a unit test covers the no-throw / no-`createTables` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2a418a489668de725048c9cb9dfe16f7b58bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->