### PR TITLE
refactor(analytics-react-native): make sessions configurable as Autocapture option

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -152,6 +152,8 @@ export { NodeConfig, NodeOptions } from './types/config/node-config';
 // React Native
 export {
   ReactNativeConfig,
+  ReactNativeConfigAutocaptureBeta,
+  ReactNativeAutocaptureOptions,
   ReactNativeTrackingOptions,
   ReactNativeOptions,
   ReactNativeAttributionOptions,

--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -6,6 +6,12 @@ type HiddenOptions = 'apiKey' | 'lastEventId';
 
 export type ReactNativeOptions = Omit<Partial<ReactNativeConfig>, HiddenOptions>;
 
+export interface ReactNativeAutocaptureOptions {
+  sessions?: boolean;
+  // screenViews?: boolean;
+  // elementInteractions?
+}
+
 export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   trackingOptions: ReactNativeTrackingOptions;
   trackingSessionEvents?: boolean;
@@ -26,6 +32,11 @@ export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   sessionId?: number;
   sessionTimeout: number;
   userId?: string;
+}
+
+// TODO: Merge this into ReactNativeConfig once autocapture is GA
+export interface ReactNativeConfigAutocaptureBeta extends ReactNativeConfig {
+  autocapture?: boolean | ReactNativeAutocaptureOptions;
 }
 
 export interface ReactNativeAttributionOptions {

--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -14,6 +14,8 @@ import {
   FetchTransport,
 } from '@amplitude/analytics-core';
 
+import { ReactNativeAutocaptureOptions } from '@amplitude/analytics-core';
+
 import { LocalStorage } from './storage/local-storage';
 import RemnantDataMigration from './migration/remnant-data-migration';
 
@@ -62,6 +64,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
   sessionTimeout: number;
   trackingSessionEvents: boolean;
   trackingOptions: ReactNativeTrackingOptions;
+  autocapture?: ReactNativeAutocaptureOptions | boolean;
 
   // NOTE: These protected properties are used to cache values from async storage
   protected _deviceId?: string;
@@ -102,6 +105,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
     this.sessionTimeout = options?.sessionTimeout ?? defaultConfig.sessionTimeout;
     this.trackingOptions = options?.trackingOptions ?? defaultConfig.trackingOptions;
     this.trackingSessionEvents = options?.trackingSessionEvents ?? defaultConfig.trackingSessionEvents;
+    this.autocapture = options?.autocapture;
   }
 
   get deviceId() {

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -23,6 +23,7 @@ import {
   SpecialEventType,
   AnalyticsClient,
   OfflineDisabled,
+  ReactNativeAutocaptureOptions,
 } from '@amplitude/analytics-core';
 import { CampaignTracker } from './campaign/campaign-tracker';
 import { Context } from './plugins/context';
@@ -30,6 +31,7 @@ import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity
 import { useReactNativeConfig, createCookieStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
+import { ReactNativeConfigAutocaptureBeta } from '@amplitude/analytics-core';
 
 const START_SESSION_EVENT = 'session_start';
 const END_SESSION_EVENT = 'session_end';
@@ -42,6 +44,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
   // @ts-ignore
   config: ReactNativeConfig;
   userProperties: { [key: string]: any } | undefined;
+  autocapture: boolean | ReactNativeAutocaptureOptions = false;
 
   init(apiKey = '', userId?: string, options?: ReactNativeOptions) {
     return returnWrapper(this._init({ ...options, userId, apiKey }));
@@ -67,6 +70,10 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
       userId: options.userId ?? oldCookies.userId,
     });
     await super._init(reactNativeOptions);
+
+    if ('autocapture' in this.config) {
+      this.autocapture = (this.config as ReactNativeConfigAutocaptureBeta).autocapture ?? false;
+    }
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the
@@ -217,7 +224,10 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     this.config.sessionId = sessionId;
 
-    if (this.config.trackingSessionEvents) {
+    const trackSessionEvents = this.config.trackingSessionEvents ||
+      (typeof this.autocapture === 'object' && this.autocapture?.sessions === true) ||
+      this.autocapture === true;
+    if (trackSessionEvents) {
       this.config.loggerProvider?.log(`SESSION_END event: previousSessionId = ${previousSessionId ?? 'undefined'}`);
 
       if (previousSessionId !== undefined) {

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -927,4 +927,84 @@ describe('react-native-client', () => {
       });
     });
   });
+
+  describe('autocapture', () => {
+    let client: AmplitudeReactNative;
+    let trackSpy: jest.SpyInstance;
+
+    const sendResponse = {
+      status: Status.Success,
+      statusCode: 200,
+      body: {
+        eventsIngested: 1,
+        payloadSizeBytes: 1,
+        serverUploadTime: 1,
+      },
+    };
+
+    const initOptions = (autocapture: boolean | { sessions?: boolean }) => ({
+      autocapture,
+      transportProvider: {
+        send: jest.fn().mockResolvedValue(sendResponse),
+      },
+      ...attributionConfig,
+    });
+
+    describe('sessions', () => {
+      beforeEach(() => {
+        client = new AmplitudeReactNative();
+        trackSpy = jest.spyOn(client, 'track');
+      });
+
+      afterEach(() => {
+        trackSpy.mockClear();
+      });
+
+      describe('should track', () => {
+        test('when autocapture is true', async () => {
+          await client.init(API_KEY, undefined, initOptions(true)).promise;
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_start',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+          // Force a session change; track() does not start sessions while appState is active
+          client.setSessionId(client.config.sessionId! + 1);
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_end',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+        });
+
+        test('when autocapture is object and .sessions is true', async () => {
+          await client.init(API_KEY, undefined, initOptions({ sessions: true })).promise;
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_start',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+          // Force a session change; track() does not start sessions while appState is active
+          client.setSessionId(client.config.sessionId! + 1);
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_end',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+        });
+      });
+
+      describe('should not track', () => {
+        test('when autocapture is false', async () => {
+          await client.init(API_KEY, undefined, initOptions(false)).promise;
+          expect(trackSpy).not.toHaveBeenCalled();
+        });
+
+        test('when autocapture is object and .sessions is false', async () => {
+          await client.init(API_KEY, undefined, initOptions({ sessions: false })).promise;
+          expect(trackSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Summary

Analytics RN already supports tracking `session_start` and `session_end` via `config.trackingSessionEvents`. This adds a new property `config.autocapture` that mirrors Analytics Browser and supports `sessions`.

Autocapture is defined in a beta config that's hidden to users for now and will be unhidden once it's ready for GA.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config and event gating only; existing `trackingSessionEvents` behavior is unchanged when autocapture is off.
> 
> **Overview**
> Adds a **beta** `autocapture` option for React Native that aligns with the Browser SDK shape (`boolean` or `{ sessions?: boolean }`), exported via `ReactNativeAutocaptureOptions` and `ReactNativeConfigAutocaptureBeta` until GA.
> 
> `trackingSessionEvents` still works; **`session_start` / `session_end`** are also emitted when `autocapture === true` or `autocapture.sessions === true`. Init reads `autocapture` from config onto the client; the RN config class persists the option from init options.
> 
> New unit tests cover session autocapture on/off for boolean and object forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7dac29333bfdadfa8ca2b13ffe0a3e933aa5e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->