### PR TITLE
refactor(analytics-react-native): create Autocapture API (beta) with Sessions + AppState

### DIFF
--- a/.github/actions/e2e-react-native/action.yml
+++ b/.github/actions/e2e-react-native/action.yml
@@ -12,7 +12,7 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '20'
+    default: '22'
   force-rebuild:
     description: 'Force rebuild of the host app binary (true/false)'
     required: false

--- a/examples/react-native/app/android/gradle.properties
+++ b/examples/react-native/app/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -21,8 +21,8 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+# Disabled: jetifying hermes/react AARs OOMs in CI; all deps are already AndroidX.
+android.enableJetifier=false
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -51,8 +51,11 @@ export default function App() {
     (async () => {
         // AMPLITUDE_API_KEY is inlined at bundle time (see babel.config.js).
         await init(process.env.AMPLITUDE_API_KEY || 'YOUR_API_KEY', 'react-native-user-id', {
-          logLevel: Types.LogLevel.Error,
-          // autocapture: { } // <-- todo
+          logLevel: Types.LogLevel.Debug,
+          autocapture: {
+            sessions: true,
+            appLifecycles: true,
+          } // <-- todo
         }).promise;
         // Capture localhost traffic except Metro (8081) for the fetch network test screen.
         add(networkCapturePlugin({

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -152,6 +152,8 @@ export { NodeConfig, NodeOptions } from './types/config/node-config';
 // React Native
 export {
   ReactNativeConfig,
+  ReactNativeConfigAutocaptureBeta,
+  ReactNativeAutocaptureOptions,
   ReactNativeTrackingOptions,
   ReactNativeOptions,
   ReactNativeAttributionOptions,

--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -6,8 +6,10 @@ type HiddenOptions = 'apiKey' | 'lastEventId';
 
 export type ReactNativeOptions = Omit<Partial<ReactNativeConfig>, HiddenOptions>;
 
+/* @experimental this config is experimental pending GA of React Native autocapture */
 export interface ReactNativeAutocaptureOptions {
   sessions?: boolean;
+  appLifecycles?: boolean;
   // screenViews?: boolean;
   // elementInteractions?
 }
@@ -36,6 +38,7 @@ export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
 
 // TODO: Merge this into ReactNativeConfig once autocapture is GA
 export interface ReactNativeConfigAutocaptureBeta extends ReactNativeConfig {
+  /* @experimental this config is experimental pending GA of React Native autocapture */
   autocapture?: boolean | ReactNativeAutocaptureOptions;
 }
 

--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -6,6 +6,12 @@ type HiddenOptions = 'apiKey' | 'lastEventId';
 
 export type ReactNativeOptions = Omit<Partial<ReactNativeConfig>, HiddenOptions>;
 
+export interface ReactNativeAutocaptureOptions {
+  sessions?: boolean;
+  // screenViews?: boolean;
+  // elementInteractions?
+}
+
 export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   trackingOptions: ReactNativeTrackingOptions;
   trackingSessionEvents?: boolean;
@@ -26,6 +32,11 @@ export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   sessionId?: number;
   sessionTimeout: number;
   userId?: string;
+}
+
+// TODO: Merge this into ReactNativeConfig once autocapture is GA
+export interface ReactNativeConfigAutocaptureBeta extends ReactNativeConfig {
+  autocapture?: boolean | ReactNativeAutocaptureOptions;
 }
 
 export interface ReactNativeAttributionOptions {

--- a/packages/analytics-react-native-test/scripts/run-harness-android.mjs
+++ b/packages/analytics-react-native-test/scripts/run-harness-android.mjs
@@ -38,11 +38,19 @@ const buildApk = () => {
   console.log(
     `Building Android debug APK (${arch.label}, -PnewArchEnabled=${arch.gradleFlag})...`,
   );
+  // CI emulators are x86_64; building all ABIs inflates memory/time for no gain.
+  const architectures =
+    process.env.REACT_NATIVE_ARCHITECTURES ||
+    (process.env.CI ? 'x86_64' : undefined);
+
   run(
     './gradlew',
     [
       ':app:assembleDebug',
       `-PnewArchEnabled=${arch.gradleFlag}`,
+      ...(architectures
+        ? [`-PreactNativeArchitectures=${architectures}`]
+        : []),
       '--console=plain',
     ],
     {

--- a/packages/analytics-react-native-test/test/autocapture/app-state.harness.ts
+++ b/packages/analytics-react-native-test/test/autocapture/app-state.harness.ts
@@ -1,0 +1,74 @@
+/**
+ * On-device harness for autocapture app lifecycle events.
+ *
+ * Runs on a real device/simulator (not Jest/Node).
+ * Requires react-native-harness + examples/react-native/app built and installed.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { describe, it, expect, beforeEach, afterEach } from 'react-native-harness';
+import { DeviceEventEmitter } from 'react-native';
+import { createInstance, Types } from '@amplitude/analytics-react-native';
+import { createEventCapture, EventCapture } from '../helpers/event-capture';
+
+const API_KEY = 'dummyApiKey';
+let client: Types.ReactNativeClient;
+
+/** RN AppState listens on RCTDeviceEventEmitter for `{ app_state }` payloads. */
+function emitAppState(state: 'active' | 'background' | 'inactive') {
+  DeviceEventEmitter.emit('appStateDidChange', { app_state: state });
+}
+
+describe('autocapture.appState', () => {
+  let capture: EventCapture;
+  let openedOnInit: string | undefined;
+
+  beforeEach(async () => {
+    client = createInstance();
+    capture = createEventCapture();
+    client.add(capture.plugin);
+
+    await client.init(API_KEY, 'harness-user', {
+      flushQueueSize: 1,
+      logLevel: Types.LogLevel.None,
+      attribution: {
+        disabled: true,
+      },
+      autocapture: {
+        appLifecycles: true,
+        sessions: false,
+      },
+    } as any).promise;
+
+    // Cold start emits Application Opened when already active. Wait for it to land
+    // in the capture plugin before clearing — otherwise it races into later tests.
+    await capture.waitForEvents(1);
+    openedOnInit = capture.events[0]?.event_type;
+    capture.clear();
+  });
+
+  afterEach(() => {
+    capture.clear();
+  });
+
+  it('tracks Application Opened on init when app is already active', () => {
+    expect(openedOnInit).toBe('[Amplitude] Application Opened');
+  });
+
+  it('tracks Application Backgrounded and Opened for background → active', async () => {
+    emitAppState('background');
+    emitAppState('active');
+
+    await capture.waitForEvents(2);
+    expect(capture.events[0]?.event_type).toBe('[Amplitude] Application Backgrounded');
+    expect(capture.events[1]?.event_type).toBe('[Amplitude] Application Opened');
+  });
+
+  it('does not track Application Opened for inactive → active (e.g. Control Center)', async () => {
+    emitAppState('inactive');
+    emitAppState('active');
+
+    // Give the runtime a beat; no lifecycle events should arrive.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(capture.events.map((e) => e.event_type)).toEqual([]);
+  });
+});

--- a/packages/analytics-react-native-test/test/autocapture/session.harness.ts
+++ b/packages/analytics-react-native-test/test/autocapture/session.harness.ts
@@ -1,0 +1,61 @@
+/**
+ * On-device harness for autocapture session_start / session_end.
+ *
+ * Runs on a real device/simulator (not Jest/Node).
+ * Requires react-native-harness + examples/react-native/app built and installed.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { describe, it, expect, beforeEach, afterEach } from 'react-native-harness';
+import { createInstance, Types } from '@amplitude/analytics-react-native';
+import { createEventCapture, EventCapture } from '../helpers/event-capture';
+
+const API_KEY = 'dummyApiKey';
+let client: Types.ReactNativeClient;
+
+describe('autocapture.sessions', () => {
+  let capture: EventCapture;
+
+  beforeEach(async () => {
+    client = createInstance();
+    capture = createEventCapture();
+
+    // Queue plugin before init so it is registered in core _init and sees session_start.
+    client.add(capture.plugin);
+
+    await client.init(API_KEY, 'harness-user', {
+      flushQueueSize: 1,
+      logLevel: Types.LogLevel.None,
+      attribution: {
+        disabled: true,
+      },
+      autocapture: {
+        appLifecycles: false,
+        sessions: true,
+      },
+    } as any).promise;
+
+    await capture.waitForEvents(1);
+  });
+
+  afterEach(() => {
+    capture.clear();
+  });
+
+  it('captures session_start and session rotation', async () => {
+    const { events, waitForEvents } = capture;
+    expect(events[0]?.event_type).toBe('session_start');
+
+    // force a session change.
+    const previousSessionId = client.getSessionId();
+    expect(typeof previousSessionId).toBe('number');
+    client.setSessionId(previousSessionId! + 1);
+
+    await waitForEvents(3);
+    expect(events[1]?.event_type).toBe('session_end');
+    expect(events[2]?.event_type).toBe('session_start');
+
+    await client.track('test_event').promise;
+    await waitForEvents(4);
+    expect(events[3]?.event_type).toBe('test_event');
+  });
+});

--- a/packages/analytics-react-native-test/test/helpers/event-capture.ts
+++ b/packages/analytics-react-native-test/test/helpers/event-capture.ts
@@ -1,0 +1,61 @@
+import { Types } from '@amplitude/analytics-react-native';
+
+export type EventCapture = {
+  events: Types.Event[];
+  /** Enrichment plugin that appends each processed event to `events`. */
+  plugin: {
+    name: string;
+    type: 'enrichment';
+    setup: () => Promise<void>;
+    execute: (event: Types.Event) => Promise<Types.Event>;
+  };
+  waitForEvents: (count: number, timeoutMs?: number) => Promise<void>;
+  clear: () => void;
+};
+
+/**
+ * Captures SDK events via an enrichment plugin.
+ * Add `plugin` before init (queued) so early events like session_start are seen.
+ */
+export function createEventCapture(name = 'event-capture'): EventCapture {
+  const events: Types.Event[] = [];
+
+  return {
+    events,
+    plugin: {
+      name,
+      type: 'enrichment',
+      setup: async () => undefined,
+      execute: async (event: Types.Event) => {
+        events.push(event);
+        return event;
+      },
+    },
+    waitForEvents(count: number, timeoutMs = 3000): Promise<void> {
+      return new Promise((resolve, reject) => {
+        const started = Date.now();
+        const tick = () => {
+          if (events.length >= count) {
+            resolve();
+            return;
+          }
+          if (Date.now() - started > timeoutMs) {
+            reject(
+              new Error(
+                `Timed out waiting for ${count} events; got ${events.length}: ${events
+                  .map((e) => e.event_type)
+                  .join(', ')}`,
+              ),
+            );
+            return;
+          }
+          setTimeout(tick, 10);
+        };
+        tick();
+      });
+    },
+    clear() {
+      events.length = 0;
+    },
+  };
+}

--- a/packages/analytics-react-native-test/test/smoke.harness.ts
+++ b/packages/analytics-react-native-test/test/smoke.harness.ts
@@ -6,7 +6,7 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { describe, it, expect } from 'react-native-harness';
-import { AppState, Platform, DeviceEventEmitter } from 'react-native';
+import { Platform } from 'react-native';
 import { createInstance, Types } from '@amplitude/analytics-react-native';
 
 const API_KEY = '17fcb31e58fc138462fd64bfe7add49e'; // TODO: Remove hardcoded key
@@ -15,25 +15,7 @@ describe('@amplitude/analytics-react-native harness smoke', () => {
   it('runs on ios or android', () => {
     expect(Platform.OS).toMatch(/^(ios|android)$/);
   });
-
-  it('simulate AppState change', async () => {
-    const seen: string[] = [];
-    const sub = AppState.addEventListener('change', (state) => {
-      seen.push(state);
-    });
-    DeviceEventEmitter.emit('appStateDidChange', {
-      app_state: 'background',
-    });
-    expect(AppState.currentState).toBe('background');
-    expect(seen).toContain('background');
-    // restore if needed
-    DeviceEventEmitter.emit('appStateDidChange', {
-      app_state: 'active',
-    });
-    expect(AppState.currentState).toBe('active');
-    sub.remove();
-  });
-
+  
   it('initializes and tracks an event', async () => {
     const client = createInstance();
     await client.init(API_KEY, 'harness-user', {

--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -14,6 +14,8 @@ import {
   FetchTransport,
 } from '@amplitude/analytics-core';
 
+import { ReactNativeAutocaptureOptions } from '@amplitude/analytics-core';
+
 import { LocalStorage } from './storage/local-storage';
 import RemnantDataMigration from './migration/remnant-data-migration';
 
@@ -62,6 +64,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
   sessionTimeout: number;
   trackingSessionEvents: boolean;
   trackingOptions: ReactNativeTrackingOptions;
+  autocapture?: ReactNativeAutocaptureOptions | boolean;
 
   // NOTE: These protected properties are used to cache values from async storage
   protected _deviceId?: string;
@@ -102,6 +105,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
     this.sessionTimeout = options?.sessionTimeout ?? defaultConfig.sessionTimeout;
     this.trackingOptions = options?.trackingOptions ?? defaultConfig.trackingOptions;
     this.trackingSessionEvents = options?.trackingSessionEvents ?? defaultConfig.trackingSessionEvents;
+    this.autocapture = options?.autocapture;
   }
 
   get deviceId() {

--- a/packages/analytics-react-native/src/config.ts
+++ b/packages/analytics-react-native/src/config.ts
@@ -12,9 +12,9 @@ import {
   getCookieName,
   getQueryParams,
   FetchTransport,
+  ReactNativeConfigAutocaptureBeta,
+  ReactNativeAutocaptureOptions,
 } from '@amplitude/analytics-core';
-
-import { ReactNativeAutocaptureOptions } from '@amplitude/analytics-core';
 
 import { LocalStorage } from './storage/local-storage';
 import RemnantDataMigration from './migration/remnant-data-migration';
@@ -105,7 +105,7 @@ export class ReactNativeConfig extends Config implements IReactNativeConfig {
     this.sessionTimeout = options?.sessionTimeout ?? defaultConfig.sessionTimeout;
     this.trackingOptions = options?.trackingOptions ?? defaultConfig.trackingOptions;
     this.trackingSessionEvents = options?.trackingSessionEvents ?? defaultConfig.trackingSessionEvents;
-    this.autocapture = options?.autocapture;
+    this.autocapture = (options as ReactNativeConfigAutocaptureBeta)?.autocapture;
   }
 
   get deviceId() {

--- a/packages/analytics-react-native/src/migration/remnant-data-migration.ts
+++ b/packages/analytics-react-native/src/migration/remnant-data-migration.ts
@@ -1,6 +1,5 @@
 import { NativeModules } from 'react-native';
-import { Event, ILogger, Storage, UserSession } from '@amplitude/analytics-core';
-import { STORAGE_PREFIX } from '@amplitude/analytics-core';
+import { Event, ILogger, Storage, UserSession, STORAGE_PREFIX } from '@amplitude/analytics-core';
 
 type LegacyEventKind = 'event' | 'identify' | 'interceptedIdentify';
 

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -23,6 +23,7 @@ import {
   SpecialEventType,
   AnalyticsClient,
   OfflineDisabled,
+  ReactNativeAutocaptureOptions,
 } from '@amplitude/analytics-core';
 import { CampaignTracker } from './campaign/campaign-tracker';
 import { Context } from './plugins/context';
@@ -30,6 +31,7 @@ import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity
 import { useReactNativeConfig, createCookieStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
+import { ReactNativeConfigAutocaptureBeta } from '@amplitude/analytics-core';
 
 const START_SESSION_EVENT = 'session_start';
 const END_SESSION_EVENT = 'session_end';
@@ -42,6 +44,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
   // @ts-ignore
   config: ReactNativeConfig;
   userProperties: { [key: string]: any } | undefined;
+  autocapture: boolean | ReactNativeAutocaptureOptions = false;
 
   init(apiKey = '', userId?: string, options?: ReactNativeOptions) {
     return returnWrapper(this._init({ ...options, userId, apiKey }));
@@ -67,6 +70,10 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
       userId: options.userId ?? oldCookies.userId,
     });
     await super._init(reactNativeOptions);
+
+    if ('autocapture' in this.config) {
+      this.autocapture = (this.config as ReactNativeConfigAutocaptureBeta).autocapture ?? false;
+    }
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the
@@ -217,7 +224,10 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     this.config.sessionId = sessionId;
 
-    if (this.config.trackingSessionEvents) {
+    const trackSessionEvents = this.config.trackingSessionEvents ||
+      (typeof this.autocapture === 'object' && this.autocapture?.sessions === true) ||
+      this.autocapture === true;
+    if (trackSessionEvents) {
       this.config.loggerProvider?.log(`SESSION_END event: previousSessionId = ${previousSessionId ?? 'undefined'}`);
 
       if (previousSessionId !== undefined) {

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -24,6 +24,7 @@ import {
   AnalyticsClient,
   OfflineDisabled,
   ReactNativeAutocaptureOptions,
+  ReactNativeConfigAutocaptureBeta,
 } from '@amplitude/analytics-core';
 import { CampaignTracker } from './campaign/campaign-tracker';
 import { Context } from './plugins/context';
@@ -31,20 +32,25 @@ import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity
 import { useReactNativeConfig, createCookieStorage } from './config';
 import { parseOldCookies } from './cookie-migration';
 import { isNative } from './utils/platform';
-import { ReactNativeConfigAutocaptureBeta } from '@amplitude/analytics-core';
 
 const START_SESSION_EVENT = 'session_start';
 const END_SESSION_EVENT = 'session_end';
 
 export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeClient, AnalyticsClient {
   appState: AppStateStatus = 'background';
+  /**
+   * True after a transition into `background` until the next `active`.
+   * Used so Application Opened only pairs with Application Backgrounded
+   * (e.g. skip iOS inactive→active from Control Center overlays).
+   */
+  private wasBackgrounded = false;
   private appStateChangeHandler: NativeEventSubscription | undefined;
   explicitSessionId: number | undefined;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   config: ReactNativeConfig;
   userProperties: { [key: string]: any } | undefined;
-  autocapture: boolean | ReactNativeAutocaptureOptions = false;
+  autocapture: ReactNativeAutocaptureOptions | null = null;
 
   init(apiKey = '', userId?: string, options?: ReactNativeOptions) {
     return returnWrapper(this._init({ ...options, userId, apiKey }));
@@ -71,10 +77,20 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     });
     await super._init(reactNativeOptions);
 
-    // Step 2.1: parse autocapture config
-    if ('autocapture' in this.config) {
-      this.autocapture = (this.config as ReactNativeConfigAutocaptureBeta).autocapture ?? false;
+    // Step 2.1: parse autocapture config (always reset so re-init clears prior flags)
+    const autocaptureConfig = (this.config as ReactNativeConfigAutocaptureBeta).autocapture;
+    if (autocaptureConfig === true) {
+      this.autocapture = {
+        appLifecycles: true,
+        sessions: true,
+      };
+    } else if (autocaptureConfig && typeof autocaptureConfig === 'object') {
+      this.autocapture = autocaptureConfig;
+    } else {
+      this.autocapture = null;
     }
+    // Drop any background seen before this init so Opened cannot fire unpaired.
+    this.wasBackgrounded = false;
 
     // Set up the analytics connector to integrate with the experiment SDK.
     // Send events from the experiment SDK and forward identifies to the
@@ -108,7 +124,15 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     this.initializing = false;
 
-    // Step 5: Track attributions
+    // Step 5: autocapture
+
+    // Step 5.1: track Application Opened when already foregrounded at init (cold start).
+    // Do not await — track().promise waits on flush/network and would block init.
+    if (this.autocapture?.appLifecycles === true && this.appState === 'active') {
+      this.track('[Amplitude] Application Opened');
+    }
+
+    // Step 5.2: run attribution strategy
     await this.runAttributionStrategy(options.attribution, isNewSession);
 
     // Step 6: Run queued functions
@@ -225,10 +249,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     this.config.sessionId = sessionId;
 
-    const trackSessionEvents = this.config.trackingSessionEvents ||
-      (typeof this.autocapture === 'object' && this.autocapture?.sessions === true) ||
-      this.autocapture === true;
-    if (trackSessionEvents) {
+    if (this.config.trackingSessionEvents || this.autocapture?.sessions) {
       this.config.loggerProvider?.log(`SESSION_END event: previousSessionId = ${previousSessionId ?? 'undefined'}`);
 
       if (previousSessionId !== undefined) {
@@ -335,11 +356,21 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
       } else {
         this.exitForeground(timestamp);
       }
+      if (nextAppState == 'background' && this.autocapture?.appLifecycles === true) {
+        // Only remember background when we also emit Backgrounded, so Opened stays paired.
+        this.wasBackgrounded = true;
+        this.track('[Amplitude] Application Backgrounded');
+      }
     }
   };
 
   private enterForeground(timestamp: number) {
     this.config.loggerProvider?.log('App Activated');
+    // Only emit Application Opened after a real background (not inactive→active).
+    if (this.autocapture?.appLifecycles === true && this.wasBackgrounded) {
+      this.track('[Amplitude] Application Opened');
+    }
+    this.wasBackgrounded = false;
     return this.startNewSessionIfNeeded(timestamp);
   }
 

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -71,6 +71,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     });
     await super._init(reactNativeOptions);
 
+    // Step 2.1: parse autocapture config
     if ('autocapture' in this.config) {
       this.autocapture = (this.config as ReactNativeConfigAutocaptureBeta).autocapture ?? false;
     }

--- a/packages/analytics-react-native/test/helpers/default.ts
+++ b/packages/analytics-react-native/test/helpers/default.ts
@@ -1,5 +1,9 @@
-import { MemoryStorage } from '@amplitude/analytics-core';
-import { ReactNativeConfig as IReactNativeConfig, ReactNativeOptions, UserSession } from '@amplitude/analytics-core';
+import {
+  MemoryStorage,
+  ReactNativeConfig as IReactNativeConfig,
+  ReactNativeOptions,
+  UserSession,
+} from '@amplitude/analytics-core';
 
 import { ReactNativeConfig } from '../../src/config';
 

--- a/packages/analytics-react-native/test/migration/remnant-data-migration.test.ts
+++ b/packages/analytics-react-native/test/migration/remnant-data-migration.test.ts
@@ -1,7 +1,8 @@
 import { NativeModules } from 'react-native';
 import { AmplitudeReactNative } from '../../src/react-native-client';
-import { Logger, MemoryStorage } from '@amplitude/analytics-core';
 import {
+  Logger,
+  MemoryStorage,
   Event,
   LogLevel,
   UserSession,

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -927,4 +927,84 @@ describe('react-native-client', () => {
       });
     });
   });
+
+  describe('autocapture', () => {
+    let client: AmplitudeReactNative;
+    let trackSpy: jest.SpyInstance;
+
+    const sendResponse = {
+      status: Status.Success,
+      statusCode: 200,
+      body: {
+        eventsIngested: 1,
+        payloadSizeBytes: 1,
+        serverUploadTime: 1,
+      },
+    };
+
+    const initOptions = (autocapture: boolean | { sessions?: boolean }) => ({
+      autocapture,
+      transportProvider: {
+        send: jest.fn().mockResolvedValue(sendResponse),
+      },
+      ...attributionConfig,
+    });
+
+    describe('sessions', () => {
+      beforeEach(() => {
+        client = new AmplitudeReactNative();
+        trackSpy = jest.spyOn(client, 'track');
+      });
+
+      afterEach(() => {
+        trackSpy.mockClear();
+      });
+
+      describe('should track', () => {
+        test('when autocapture is true', async () => {
+          await client.init(API_KEY, undefined, initOptions(true)).promise;
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_start',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+          // Force a session change; track() does not start sessions while appState is active
+          client.setSessionId(client.config.sessionId! + 1);
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_end',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+        });
+
+        test('when autocapture is object and .sessions is true', async () => {
+          await client.init(API_KEY, undefined, initOptions({ sessions: true })).promise;
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_start',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+          // Force a session change; track() does not start sessions while appState is active
+          client.setSessionId(client.config.sessionId! + 1);
+          expect(trackSpy).toHaveBeenCalledWith({
+            event_type: 'session_end',
+            time: expect.any(Number),
+            session_id: expect.any(Number),
+          });
+        });
+      });
+
+      describe('should not track', () => {
+        test('when autocapture is false', async () => {
+          await client.init(API_KEY, undefined, initOptions(false)).promise;
+          expect(trackSpy).not.toHaveBeenCalled();
+        });
+
+        test('when autocapture is object and .sessions is false', async () => {
+          await client.init(API_KEY, undefined, initOptions({ sessions: false })).promise;
+          expect(trackSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
 });

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -8,6 +8,7 @@ import {
   getAnalyticsConnector,
   getCookieName as getStorageKey,
 } from '@amplitude/analytics-core';
+import { AppState } from 'react-native';
 import { isWeb } from '../src/utils/platform';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Config from '../src/config';
@@ -942,7 +943,7 @@ describe('react-native-client', () => {
       },
     };
 
-    const initOptions = (autocapture: boolean | { sessions?: boolean }) => ({
+    const initOptions = (autocapture: boolean | { sessions?: boolean; appLifecycles?: boolean }) => ({
       autocapture,
       transportProvider: {
         send: jest.fn().mockResolvedValue(sendResponse),
@@ -1004,6 +1005,109 @@ describe('react-native-client', () => {
           await client.init(API_KEY, undefined, initOptions({ sessions: false })).promise;
           expect(trackSpy).not.toHaveBeenCalled();
         });
+      });
+    });
+
+    describe('appLifecycles', () => {
+      const originalAppState = AppState.currentState;
+
+      beforeEach(() => {
+        client = new AmplitudeReactNative();
+        trackSpy = jest.spyOn(client, 'track');
+        AppState.currentState = 'active';
+      });
+
+      afterEach(() => {
+        trackSpy.mockClear();
+        AppState.currentState = originalAppState;
+      });
+
+      test('should track Application Opened on init when app is already active', async () => {
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: true })).promise;
+        expect(trackSpy).toHaveBeenCalledWith('[Amplitude] Application Opened');
+      });
+
+      test('should not track Application Opened on init when app is background', async () => {
+        AppState.currentState = 'background';
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: true })).promise;
+        expect(trackSpy).not.toHaveBeenCalledWith('[Amplitude] Application Opened');
+      });
+
+      test('should track appLifecycles when it is enabled', async () => {
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: true })).promise;
+        trackSpy.mockClear();
+        (client as any).handleAppStateChange('background');
+        expect(trackSpy).toHaveBeenCalledWith('[Amplitude] Application Backgrounded');
+        (client as any).handleAppStateChange('active');
+        expect(trackSpy).toHaveBeenCalledWith('[Amplitude] Application Opened');
+      });
+
+      test('should track Application Opened after background → inactive → active', async () => {
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: true })).promise;
+        trackSpy.mockClear();
+        (client as any).handleAppStateChange('background');
+        (client as any).handleAppStateChange('inactive');
+        (client as any).handleAppStateChange('active');
+        expect(trackSpy).toHaveBeenCalledWith('[Amplitude] Application Backgrounded');
+        expect(trackSpy).toHaveBeenCalledWith('[Amplitude] Application Opened');
+      });
+
+      test('should not track Application Opened on inactive → active without background', async () => {
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: true })).promise;
+        // App is typically active after init; simulate iOS overlay (Control Center).
+        (client as any).appState = 'active';
+        (client as any).wasBackgrounded = false;
+        trackSpy.mockClear();
+
+        (client as any).handleAppStateChange('inactive');
+        (client as any).handleAppStateChange('active');
+
+        expect(trackSpy).not.toHaveBeenCalledWith('[Amplitude] Application Backgrounded');
+        expect(trackSpy).not.toHaveBeenCalledWith('[Amplitude] Application Opened');
+      });
+
+      test('should not track Application Opened after re-init when background happened with appLifecycles off', async () => {
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: false })).promise;
+        (client as any).handleAppStateChange('background');
+        expect(trackSpy).not.toHaveBeenCalledWith('[Amplitude] Application Backgrounded');
+
+        AppState.currentState = 'background';
+        await client.init(API_KEY, undefined, initOptions({ appLifecycles: true })).promise;
+        trackSpy.mockClear();
+        (client as any).appState = 'background';
+        (client as any).handleAppStateChange('active');
+
+        expect(trackSpy).not.toHaveBeenCalledWith('[Amplitude] Application Opened');
+      });
+    });
+
+    describe('re-init', () => {
+      beforeEach(() => {
+        client = new AmplitudeReactNative();
+        trackSpy = jest.spyOn(client, 'track');
+      });
+
+      afterEach(() => {
+        trackSpy.mockClear();
+      });
+
+      test('should clear previous autocapture flags when re-init omits or disables autocapture', async () => {
+        await client.init(API_KEY, undefined, initOptions({ sessions: true, appLifecycles: true })).promise;
+        expect(client.autocapture).toEqual({ sessions: true, appLifecycles: true });
+
+        await client.init(API_KEY, undefined, initOptions(false)).promise;
+        expect(client.autocapture).toBeNull();
+
+        await client.init(API_KEY, undefined, initOptions({ sessions: true, appLifecycles: true })).promise;
+        expect(client.autocapture).toEqual({ sessions: true, appLifecycles: true });
+
+        await client.init(API_KEY, undefined, {
+          transportProvider: {
+            send: jest.fn().mockResolvedValue(sendResponse),
+          },
+          ...attributionConfig,
+        }).promise;
+        expect(client.autocapture).toBeNull();
       });
     });
   });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default event volume and session semantics for adopters who enable autocapture, and touches init/AppState handling in the core RN client; opt-in and well-tested but affects analytics behavior when turned on.
> 
> **Overview**
> Adds an **experimental** React Native `autocapture` init option (boolean or `{ sessions?, appLifecycles? }`), typed in `@amplitude/analytics-core` as `ReactNativeConfigAutocaptureBeta` and wired through RN config.
> 
> When enabled, **`sessions`** emits `session_start` / `session_end` the same way as `trackingSessionEvents`. **`appLifecycles`** tracks `[Amplitude] Application Opened` on cold start (if already active) and pairs **Backgrounded** / **Opened** on real background→foreground transitions, skipping spurious **Opened** on inactive→active (e.g. Control Center). Re-init clears prior autocapture flags.
> 
> Coverage includes Jest tests, on-device harness specs (`session.harness`, `app-state.harness`) with an event-capture enrichment helper, and the Expo sample turns on autocapture. CI/Android harness tweaks: default Node **22**, Gradle heap **4GB**, **Jetifier off**, and **x86_64-only** APK builds in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d249d6ca0b7dd9fb533f32aad188e6df6580ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->