### PR TITLE
refactor(analytics-core): add cb to runQueuedFunction

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -51,13 +51,10 @@ export class AmplitudeCore implements CoreClient, PluginHost {
     this.config = config;
     this.timeline.reset(this);
     this.timeline.loggerProvider = this.config.loggerProvider;
-    do {
-      await this.runQueuedFunctions('q');
-    } while (this.q.length > 0);
-    this.isReady = true;
+    await this.runQueuedFunctions('q', () => (this.isReady = true));
   }
 
-  async runQueuedFunctions(queueName: 'q' | 'dispatchQ') {
+  async runQueuedFunctions(queueName: 'q' | 'dispatchQ', onQueueEmpty?: () => void) {
     const queuedFunctions = this[queueName];
     this[queueName] = [];
     for (const queuedFunction of queuedFunctions) {
@@ -74,7 +71,9 @@ export class AmplitudeCore implements CoreClient, PluginHost {
 
     // Rerun queued functions if the queue has accrued more while awaiting promises
     if (this[queueName].length) {
-      await this.runQueuedFunctions(queueName);
+      await this.runQueuedFunctions(queueName, onQueueEmpty);
+    } else {
+      onQueueEmpty?.();
     }
   }
 

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -254,34 +254,22 @@ describe('core-client', () => {
       expect(client.config.optOut).toBe(true);
     });
 
-    test('should flush queue items added after runQueuedFunctions returns before isReady', async () => {
-      // Covers the do-while in _init: work can land on q after runQueuedFunctions
-      // returns (e.g. a microtask) but before isReady is set.
+    test('should call onQueueEmpty when the queue finishes empty', async () => {
       const client = new AmplitudeCore();
-      const setup = jest.fn().mockResolvedValue(undefined);
-      const plugin: EnrichmentPlugin = {
-        name: 'late-plugin',
-        type: 'enrichment',
-        setup,
-        execute: jest.fn(),
-      };
+      const onQueueEmpty = jest.fn();
 
-      let flushCount = 0;
-      const originalRunQueuedFunctions = client.runQueuedFunctions.bind(client);
-      jest.spyOn(client, 'runQueuedFunctions').mockImplementation(async (queueName) => {
-        await originalRunQueuedFunctions(queueName);
-        flushCount += 1;
-        if (flushCount === 1 && queueName === 'q') {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-          (client as any).q.push(client._addPlugin.bind(client, plugin));
-        }
-      });
+      await client.runQueuedFunctions('q', onQueueEmpty);
+
+      expect(onQueueEmpty).toHaveBeenCalledTimes(1);
+    });
+
+    test('should set isReady via onQueueEmpty after init queue empties', async () => {
+      const client = new AmplitudeCore();
+      expect(client.isReady).toBe(false);
 
       await (client as any)._init(useDefaultConfig());
 
-      expect(flushCount).toBeGreaterThanOrEqual(2);
-      expect(setup).toHaveBeenCalled();
-      expect(client.plugin('late-plugin')).toBeDefined();
+      expect(client.isReady).toBe(true);
     });
   });
 

--- a/packages/analytics-node/test/node-client.test.ts
+++ b/packages/analytics-node/test/node-client.test.ts
@@ -71,7 +71,7 @@ describe('node-client', () => {
           send,
         },
       }).promise;
-      Promise.resolve().then(() => client.add(plugin));
+      client.add(plugin);
       await client.track('test event').promise;
       await initPromise;
 


### PR DESCRIPTION
### Summary

This is a refinement on the previous PR. 

The previous implementation worked like this:

```
do {
  await this.runQueuedFunction();
} while (this.q.length > 0);

runQueuedFunction() {
  // flush queue
  if (this.q.length > 0) runQueuedFunction
}
```

Thinking about this some more, this works, but seems redundant to have both the caller and the function itself to be checking for the queue to be empty and then calling it again when it's not empty.

This PR tweaks it so that it adds a callback to `runQueuedFunction` that is invoked as soon as the queue is empty, which resolves the original problem.

```
await this.runQueuedFunction('q', () => this.isReady = true);

runQueuedFunction(queue, onQueueEmpty) {
  // flush queue
  if (this.q.length > 0) runQueuedFunction
  else onQueueEmpty?.();
}
```

(Also, changed the test from `Promise.resolve().then(() => client.add(plugin));` to `client.add(plugin)` because when it was the former, it was sometimes passing even when reverted to it's previous broken form)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client initialization ordering used by all SDKs; behavior change is intentional but could affect timing-sensitive init/add/track sequences.
> 
> **Overview**
> **Init readiness** no longer uses a `do/while` around `runQueuedFunctions` in `_init`. A single `await runQueuedFunctions('q', () => (this.isReady = true))` sets **`isReady` only after the init queue is fully drained**, including any items added while earlier queued work was awaiting promises.
> 
> `runQueuedFunctions` gains an optional **`onQueueEmpty`** callback, invoked once when recursion finishes and the queue is empty (and passed through on re-entrant calls). That centralizes “queue is done” handling instead of duplicating empty-queue checks in the caller.
> 
> Tests were adjusted to cover the callback and `_init` → `isReady` behavior, and the node client test now calls **`add(plugin)` synchronously** after `init()` (replacing `Promise.resolve().then(...)`) so regressions in the init/add race are easier to catch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f9c67c862ee6036c6fd14571695a68e44e3d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->