### PR TITLE
fix(autocapture): use correct elementSelector remote config key

### DIFF
--- a/packages/element-selector/README.md
+++ b/packages/element-selector/README.md
@@ -56,9 +56,13 @@ const engine = createSelectorEngine(resolveSelectorConfig(remote, config.loggerP
   logger: config.loggerProvider,
 });
 
-config.remoteConfigClient.subscribe('elementSelector', 'all', (next) => {
-  engine.updateConfig(resolveSelectorConfig(next, config.loggerProvider));
-});
+config.remoteConfigClient.subscribe(
+  'configs.analyticsSDK.browserSDK.autocapture.elementSelector',
+  'all',
+  (next) => {
+    engine.updateConfig(resolveSelectorConfig(next, config.loggerProvider));
+  },
+);
 ```
 
 ### Chrome extension visual tagger

--- a/packages/plugin-autocapture-browser/src/element-selector-config.ts
+++ b/packages/plugin-autocapture-browser/src/element-selector-config.ts
@@ -3,11 +3,12 @@ import { ElementSelectorRemoteConfig } from '@amplitude/element-selector';
 import { DataExtractor } from './data-extractor';
 
 /**
- * Remote-config key for the element-selector engine payload. Mirrors the
- * `configs.analyticsSDK.pageActions` namespace autocapture already subscribes
- * to. The payload shape is `ElementSelectorRemoteConfig`.
+ * Remote-config key for the element-selector engine payload. Nested under the
+ * browser SDK autocapture namespace alongside other autocapture toggles
+ * (elementInteractions, frustrationInteractions, etc.). The payload shape is
+ * `ElementSelectorRemoteConfig`.
  */
-export const ELEMENT_SELECTOR_REMOTE_CONFIG_KEY = 'configs.analyticsSDK.elementSelector';
+export const ELEMENT_SELECTOR_REMOTE_CONFIG_KEY = 'configs.analyticsSDK.browserSDK.autocapture.elementSelector';
 
 /**
  * Subscribe a plugin's {@link DataExtractor} to element-selector remote config.

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin.test.ts
@@ -128,7 +128,11 @@ describe('frustrationPlugin', () => {
         instance,
       );
 
-      expect(subscribe).toHaveBeenCalledWith('configs.analyticsSDK.elementSelector', 'all', expect.any(Function));
+      expect(subscribe).toHaveBeenCalledWith(
+        'configs.analyticsSDK.browserSDK.autocapture.elementSelector',
+        'all',
+        expect.any(Function),
+      );
 
       await plugin?.teardown?.();
       expect(unsubscribe).toHaveBeenCalledWith('es-sub');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the remote config subscription key for the element-selector engine. Production config nests `elementSelector` under `configs.analyticsSDK.browserSDK.autocapture`, but the SDK was subscribing to `configs.analyticsSDK.elementSelector`, so `enabled: true` was never delivered and the engine stayed on the legacy cssPath algorithm.

## Changes

- Update `ELEMENT_SELECTOR_REMOTE_CONFIG_KEY` to `configs.analyticsSDK.browserSDK.autocapture.elementSelector`
- Update frustration-plugin test expectation
- Fix README example to match the real key path

## Test plan

- [x] `element-selector-config.test.ts` passes
- [x] `frustration-plugin.test.ts` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f38cc48-7e34-4534-8195-da73277e8c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f38cc48-7e34-4534-8195-da73277e8c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

