### PR TITLE
fix(react-native): configure :app first to avoid Android languageVersion crash (SDKRN-6)

### DIFF
--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -2,11 +2,17 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+// Gradle configures projects alphabetically, so this project sorts before ':app'.
+// If the app doesn't apply RN's 'com.facebook.react.rootproject' plugin, the RN gradle
+// plugin's jvmToolchain(17) sweep reaches this project after AGP has already finalized
+// its Java toolchain, failing with "property 'languageVersion' is final" (issue #1510).
+// Configuring ':app' first (as rootproject would) keeps the sweep ahead of finalization.
+if (findProject(':app') != null) {
+  evaluationDependsOn(':app')
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-
-
-def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"

--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -7,6 +7,7 @@ def isNewArchitectureEnabled() {
 // plugin's jvmToolchain(17) sweep reaches this project after AGP has already finalized
 // its Java toolchain, failing with "property 'languageVersion' is final" (issue #1510).
 // Configuring ':app' first (as rootproject would) keeps the sweep ahead of finalization.
+// When the app already applies that plugin, this block is a harmless no-op (both force ':app' first).
 if (findProject(':app') != null) {
   evaluationDependsOn(':app')
 }

--- a/packages/plugin-session-replay-react-native/android/build.gradle
+++ b/packages/plugin-session-replay-react-native/android/build.gradle
@@ -12,6 +12,7 @@ def isNewArchitectureEnabled() {
 // plugin's jvmToolchain(17) sweep reaches this project after AGP has already finalized
 // its Java toolchain, failing with "property 'languageVersion' is final" (issue #1510).
 // Configuring ':app' first (as rootproject would) keeps the sweep ahead of finalization.
+// When the app already applies that plugin, this block is a harmless no-op (both force ':app' first).
 if (findProject(':app') != null) {
   evaluationDependsOn(':app')
 }

--- a/packages/plugin-session-replay-react-native/android/build.gradle
+++ b/packages/plugin-session-replay-react-native/android/build.gradle
@@ -7,6 +7,15 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+// Gradle configures projects alphabetically, so this project sorts before ':app'.
+// If the app doesn't apply RN's 'com.facebook.react.rootproject' plugin, the RN gradle
+// plugin's jvmToolchain(17) sweep reaches this project after AGP has already finalized
+// its Java toolchain, failing with "property 'languageVersion' is final" (issue #1510).
+// Configuring ':app' first (as rootproject would) keeps the sweep ahead of finalization.
+if (findProject(':app') != null) {
+  evaluationDependsOn(':app')
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 

--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -9,6 +9,15 @@ def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
+// Gradle configures projects alphabetically, so this project sorts before ':app'.
+// If the app doesn't apply RN's 'com.facebook.react.rootproject' plugin, the RN gradle
+// plugin's jvmToolchain(17) sweep reaches this project after AGP has already finalized
+// its Java toolchain, failing with "property 'languageVersion' is final" (issue #1510).
+// Configuring ':app' first (as rootproject would) keeps the sweep ahead of finalization.
+if (findProject(':app') != null) {
+  evaluationDependsOn(':app')
+}
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 

--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -14,6 +14,7 @@ def isNewArchitectureEnabled() {
 // plugin's jvmToolchain(17) sweep reaches this project after AGP has already finalized
 // its Java toolchain, failing with "property 'languageVersion' is final" (issue #1510).
 // Configuring ':app' first (as rootproject would) keeps the sweep ahead of finalization.
+// When the app already applies that plugin, this block is a harmless no-op (both force ':app' first).
 if (findProject(':app') != null) {
   evaluationDependsOn(':app')
 }


### PR DESCRIPTION
## Summary

Fixes the Android build crash reported in amplitude/Amplitude-TypeScript#1510:

```
Failed to apply plugin 'com.facebook.react'.
> The value for property 'languageVersion' is final and cannot be changed any further.
```

### Root cause (in plain terms)

Gradle sets up each module in a build **one at a time, in alphabetical order by name**. Our library's module is `amplitude_analytics-react-native`, and the app is `app` — `am…` sorts before `ap…`, so **our module is set up first, the app second**.

When a module finishes its setup, the Android build tool (AGP) **freezes** part of its config — including a field called `languageVersion` (which just means "compile me with Java 17"). After that, writing to it throws, *even if you write the same value* (like `Object.freeze()` in JS).

The crash is then three steps:

1. Our module is set up first (alphabetical) → finishes → its config is **frozen**. 🧊
2. The app is set up. React Native then does a helpful sweep: loop over **every** module and set each to Java 17 so the whole build matches.
3. The sweep reaches our module and tries to write `languageVersion = 17` → but it's **already frozen** → 💥.

### Why this looks Amplitude-specific but isn't our code

1. The repro proved the crash happens with a library containing **nothing but** `com.android.library` + `kotlin-android` — no Amplitude code, no `com.facebook.react`, no codegen. So the community diagnosis in amplitude/Amplitude-TypeScript#1510 ("Amplitude's module applies the React plugin") is wrong about the mechanism; scenario S1 crashed without it.
2. Rename that same library from `:aaa_lib` to `:zzz_lib` (so it configures **after** `:app`) → no crash. The only necessary ingredients are: **Kotlin library + name sorting before** `:app`.
3. Virtually all popular RN libraries are `react-native-*`, `lottie-*`, `@sentry/*`, `@notifee/*`… all sort **after** `:app`. `@amplitude/*` is one of the very few that sorts **before** it — upstream even used our package as the canonical reproducer in [facebook/react-native#41306](<https://github.com/facebook/react-native/pull/41306>).

### The fix

Add a guarded `evaluationDependsOn(':app')` to each RN library's `android/build.gradle`, so `:app` is configured **first**. With the app going first, React Native's Java-17 sweep (which runs during the app's setup) reaches our module **before** it gets frozen — so the write lands and the build succeeds. This is the exact mechanism React Native's own `com.facebook.react.rootproject` plugin uses; we make it self-contained inside the SDK so it works even for apps missing that template protection.

```gradle
if (findProject(':app') != null) {
  evaluationDependsOn(':app')
}
```

### Why `:app` is enough

* **It's the React Native convention, essentially always.** The RN CLI generates the app in `android/app/`, which becomes the Gradle project `:app`. A differently-named app module is very rare and off the RN happy path.
* **RN's own official fix hardcodes** `:app` **too.** Their `com.facebook.react.rootproject` plugin literally runs `subproject.evaluationDependsOn(":app")`. Matching it means we cover exactly the cases RN itself supports.
* **The crash only happens when the app name sorts *after* ours.** The default `:app` does; names sorting *before* ours (e.g. `:aaaa`, `:abc`) make the app configure first, so they never hit the bug — the fix being a no-op there is fine.
* The `findProject(':app') != null` guard makes standalone/library-only builds (e.g. our own CI, where there is no `:app`) a safe no-op.

The one uncovered edge is a **custom** app-module name that *still* sorts after ours (e.g. `:mobile`) — the same limitation RN's own fix has. Not worth trading for a dependency on RN's internal `disableJavaVersionAlignment` flag unless we actually see it in the wild.

### Validation

Empirically reproduced and fixed with real Gradle at the exact failing versions (Gradle 8.14.3, AGP 8.12.0, Kotlin 2.1.20, RN 0.81.1, `newArchEnabled=true`):

<!-- linear:table-colwidths:400,400 -->
| Scenario | Crashes? |
| -- | -- |
| Lib = `com.android.library` + `kotlin-android` only, named `:aaa_lib` (before `:app`) | **Yes** |
| Same lib renamed `:zzz_lib` (after `:app`) | No |
| Lib also applies `com.facebook.react` + `react{}` (mirrors our SDK) | Yes (same error) |
| Lib pre-sets `kotlin { jvmToolchain(17) }` itself | **Yes** (finalized rejects even an equal value) |
| Lib adds `evaluationDependsOn(':app')` — **this fix** | **No** ✅ |

Applied to all three RN packages, which share the identical latent bug (all are `:amplitude_*` Kotlin libraries sorting before `:app`):

* `analytics-react-native` (also drops a dead `appProject` lookup)
* `session-replay-react-native`
* `plugin-session-replay-react-native`

### Notes

* Not new to RN 0.81 / Kotlin 2.1 / Gradle 9 — latent since **RN 0.73 (AGP 8.1)**; Kotlin version is irrelevant.

Fixes amplitude/Amplitude-TypeScript#1510  <br>Closes amplitude/Amplitude-TypeScript#1510

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

### CI coverage caveat

The only CI job that builds these Gradle files (`android-unit` in `rn-smoke.yml`) runs against `examples/react-native/app`, whose root `build.gradle` already applies `com.facebook.react.rootproject` — so the new guard is a harmless no-op there and CI would pass identically with or without this fix. There is currently **no automated regression protection**; correctness rests on the manual repro table above (real Gradle at the exact failing versions). A dedicated regression app (RN ≥0.81 / AGP ≥8.1, *without* the rootproject plugin) wired into CI is a sensible follow-up — our existing `expo-app` example is RN 0.71 (AGP 7.x), too old to exhibit the bug.