### PR TITLE
chore: add React Native E2E tests to publish workflow

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -4,6 +4,22 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: true
+  run-tests:
+    description: 'Whether to run unit tests'
+    required: false
+    default: 'true'
+  run-lint:
+    description: 'Whether to run lint'
+    required: false
+    default: 'true'
+  configure-git:
+    description: 'Whether to configure git user for versioning'
+    required: false
+    default: 'true'
+  configure-aws:
+    description: 'Whether to configure AWS credentials'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -29,16 +45,19 @@ runs:
       shell: bash
 
     - name: Test all packages
+      if: inputs.run-tests == 'true'
       run: |
         pnpm test
       shell: bash
 
     - name: Lint all packages
+      if: inputs.run-lint == 'true'
       run: |
         pnpm lint
       shell: bash
 
     - name: Configure Git User
+      if: inputs.configure-git == 'true'
       run: |
         git config --global user.name amplitude-sdk-dev
         git config --global user.email 249154226+amplitude-sdk-dev@users.noreply.github.com
@@ -46,8 +65,7 @@ runs:
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
-      if: github.event.inputs.releaseType != 'dry-run'
+      if: inputs.configure-aws == 'true' && github.event.inputs.releaseType != 'dry-run'
       with:
         role-to-assume: arn:aws:iam::358203115967:role/github-actions-role
         aws-region: us-west-2
-

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -89,11 +89,55 @@ jobs:
         with:
           amplitude-api-key: ${{ secrets.AMPLITUDE_API_KEY }}
 
+  e2e-react-native:
+    name: E2E Tests - React Native (${{ matrix.platform }}, newArch=${{ matrix.new-arch }})
+    runs-on: ${{ matrix.runs-on }}
+    needs: [authorize]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ios
+            new-arch: 'true'
+            runs-on: macos-14
+          - platform: ios
+            new-arch: 'false'
+            runs-on: macos-14
+          - platform: android
+            new-arch: 'true'
+            runs-on: ubuntu-latest
+          - platform: android
+            new-arch: 'false'
+            runs-on: ubuntu-latest
+    env:
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+
+    steps:
+      - name: Skip E2E for recovery publish
+        if: ${{ github.event.inputs.skipLernaVersion == 'true' }}
+        run: echo "Skipping E2E because skipLernaVersion is true"
+
+      - name: Check out git repository
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
+
+      - name: Run React Native E2E harness
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        uses: ./.github/actions/e2e-react-native
+        with:
+          platform: ${{ matrix.platform }}
+          new-arch: ${{ matrix.new-arch }}
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     environment: npm-release
-    needs: [authorize, e2e]
+    needs: [authorize, e2e, e2e-react-native]
     if: ${{ github.event.inputs.releaseType == 'release' }}
     permissions:
       id-token: write # Required for OIDC
@@ -221,7 +265,7 @@ jobs:
     name: Prerelease feature branch
     runs-on: ubuntu-latest
     environment: npm-release
-    needs: [authorize, e2e]
+    needs: [authorize, e2e, e2e-react-native]
     if: ${{ github.event.inputs.releaseType == 'prerelease' || github.event.inputs.releaseType == 'dry-run' }}
     permissions:
       id-token: write # Required for OIDC

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -83,6 +83,29 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Run E2E tests
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        uses: ./.github/actions/e2e-test
+        with:
+          amplitude-api-key: ${{ secrets.AMPLITUDE_API_KEY }}
+
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    needs: [authorize]
+
+    steps:
+      - name: Skip build and test for recovery publish
+        if: ${{ github.event.inputs.skipLernaVersion == 'true' }}
+        run: echo "Skipping build and test because skipLernaVersion is true"
+
+      - name: Check out git repository
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
+
       - name: Build and Test
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         uses: ./.github/actions/build-and-test
@@ -90,12 +113,6 @@ jobs:
           node-version: 20.x
           configure-git: 'false'
           configure-aws: 'false'
-
-      - name: Run E2E tests
-        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
-        uses: ./.github/actions/e2e-test
-        with:
-          amplitude-api-key: ${{ secrets.AMPLITUDE_API_KEY }}
 
   e2e-react-native:
     name: E2E Tests - React Native (${{ matrix.platform }}, newArch=${{ matrix.new-arch }})
@@ -145,7 +162,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     environment: npm-release
-    needs: [authorize, e2e, e2e-react-native]
+    needs: [authorize, build-and-test, e2e, e2e-react-native]
     if: ${{ github.event.inputs.releaseType == 'release' }}
     permissions:
       id-token: write # Required for OIDC
@@ -189,12 +206,14 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
-      - name: Build
+      # Normal releases already ran unit tests/lint in the build-and-test job.
+      # Recovery publishes (skipLernaVersion) skip that job, so run them here.
+      - name: ${{ github.event.inputs.skipLernaVersion == 'true' && 'Build and Test' || 'Build' }}
         uses: ./.github/actions/build-and-test
         with:
           node-version: ${{ matrix.node-version }}
-          run-tests: 'false'
-          run-lint: 'false'
+          run-tests: ${{ github.event.inputs.skipLernaVersion }}
+          run-lint: ${{ github.event.inputs.skipLernaVersion }}
 
       - name: Verify ref has not advanced since e2e checkout
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
@@ -275,7 +294,7 @@ jobs:
     name: Prerelease feature branch
     runs-on: ubuntu-latest
     environment: npm-release
-    needs: [authorize, e2e, e2e-react-native]
+    needs: [authorize, build-and-test, e2e, e2e-react-native]
     if: ${{ github.event.inputs.releaseType == 'prerelease' || github.event.inputs.releaseType == 'dry-run' }}
     permissions:
       id-token: write # Required for OIDC
@@ -309,12 +328,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Build
+      # Normal releases already ran unit tests/lint in the build-and-test job.
+      # Recovery publishes (skipLernaVersion) skip that job, so run them here.
+      - name: ${{ github.event.inputs.skipLernaVersion == 'true' && 'Build and Test' || 'Build' }}
         uses: ./.github/actions/build-and-test
         with:
           node-version: ${{ matrix.node-version }}
-          run-tests: 'false'
-          run-lint: 'false'
+          run-tests: ${{ github.event.inputs.skipLernaVersion }}
+          run-lint: ${{ github.event.inputs.skipLernaVersion }}
 
       # Keep alphanumeric characters and hyphens, remove other invalid characters
       # Examples:

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -83,6 +83,14 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Build and Test
+        if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
+        uses: ./.github/actions/build-and-test
+        with:
+          node-version: 20.x
+          configure-git: 'false'
+          configure-aws: 'false'
+
       - name: Run E2E tests
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
         uses: ./.github/actions/e2e-test
@@ -181,10 +189,12 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
-      - name: Build and Test
+      - name: Build
         uses: ./.github/actions/build-and-test
         with:
           node-version: ${{ matrix.node-version }}
+          run-tests: 'false'
+          run-lint: 'false'
 
       - name: Verify ref has not advanced since e2e checkout
         if: ${{ github.event.inputs.skipLernaVersion != 'true' }}
@@ -299,10 +309,12 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Build and Test
+      - name: Build
         uses: ./.github/actions/build-and-test
         with:
           node-version: ${{ matrix.node-version }}
+          run-tests: 'false'
+          run-lint: 'false'
 
       # Keep alphanumeric characters and hyphens, remove other invalid characters
       # Examples:

--- a/packages/plugin-stub-browser/src/stub-plugin.ts
+++ b/packages/plugin-stub-browser/src/stub-plugin.ts
@@ -4,7 +4,7 @@ import { PLUGIN_NAME } from './constants';
 
 export type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 
-export const COUNTER = 1; // increment this to test new releases
+export const COUNTER = 2; // increment this to test new releases
 
 export const stubPlugin = (): BrowserEnrichmentPlugin => {
   const setup: BrowserEnrichmentPlugin['setup'] = async (/*config, amplitude*/) => {

--- a/packages/plugin-stub-browser/src/stub-plugin.ts
+++ b/packages/plugin-stub-browser/src/stub-plugin.ts
@@ -4,6 +4,8 @@ import { PLUGIN_NAME } from './constants';
 
 export type BrowserEnrichmentPlugin = EnrichmentPlugin<BrowserClient, BrowserConfig>;
 
+export const COUNTER = 1; // increment this to test new releases
+
 export const stubPlugin = (): BrowserEnrichmentPlugin => {
   const setup: BrowserEnrichmentPlugin['setup'] = async (/*config, amplitude*/) => {
     // add logic here to setup any resources


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

1. adds React Native E2E tests into the E2E testing stage
2. moves "Build and Test" into E2E testing stage
3. in deploy stage, replace "Build and Test" with just "Build"

Tested via https://github.com/amplitude/Amplitude-TypeScript/actions/runs/29550428053

<img width="1275" height="724" alt="Screenshot 2026-07-16 at 7 39 10 PM" src="https://github.com/user-attachments/assets/ff6f6bfe-4269-40f2-a657-5fc855624285" />

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release gating and when tests run relative to npm publish; misconfigured `skipLernaVersion` or input wiring could skip checks or block releases, but no runtime SDK behavior changes except the stub counter.
> 
> **Overview**
> **Publish v2** now runs **unit build/test/lint** and **React Native E2E** (iOS/Android × new/old architecture) in parallel **before** deploy/prerelease, and both release paths **wait on** `build-and-test`, existing Playwright `e2e`, and the new `e2e-react-native` matrix. Recovery publishes (`skipLernaVersion`) still skip those pre-check jobs; deploy/prerelease then run full **build + test + lint** via the composite action.
> 
> The **`build-and-test`** composite action gains toggles for **tests**, **lint**, **git user**, and **AWS** setup, with test/lint/git/AWS steps gated by those inputs. Deploy/prerelease call it with **`run-tests` / `run-lint` only when** `skipLernaVersion` is true so normal releases avoid duplicating checks already run in the standalone job.
> 
> A **`COUNTER`** constant in `plugin-stub-browser` is bumped (release smoke-test helper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be37b4deeeaf0122467fc8848197d979297e686. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->