### PR TITLE
chore(analytics-react-native): add integration tests for storage and network connectivity

### DIFF
--- a/packages/analytics-react-native-test/test/network/network-connectivity.harness.ts
+++ b/packages/analytics-react-native-test/test/network/network-connectivity.harness.ts
@@ -1,0 +1,136 @@
+/**
+ * On-device harness for offline queueing / reconnect flush.
+ *
+ * Runs on a real device/simulator (not Jest/Node).
+ * Requires react-native-harness + examples/react-native/app built and installed.
+ *
+ * Connectivity flips are simulated via DeviceEventEmitter (same bus NativeEventEmitter
+ * listens on). A custom transport captures what would be uploaded.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+import { describe, it, expect } from 'react-native-harness';
+import { DeviceEventEmitter } from 'react-native';
+import {
+  MemoryStorage,
+  STORAGE_PREFIX,
+  Status,
+  type Event,
+  type Payload,
+  type Response,
+  type Transport,
+} from '@amplitude/analytics-core';
+import { createInstance, Types } from '@amplitude/analytics-react-native';
+
+const API_KEY = 'dummyApiKey';
+const CONNECTIVITY_EVENT_NAME = 'AmplitudeNetworkConnectivityChanged';
+const STORAGE_KEY = `${STORAGE_PREFIX}_${API_KEY.substring(0, 10)}`;
+
+function emitConnectivity(isConnected: boolean) {
+  DeviceEventEmitter.emit(CONNECTIVITY_EVENT_NAME, { isConnected });
+}
+
+async function waitForQueuedEvents(
+  storage: MemoryStorage<Event[]>,
+  minCount: number,
+  timeoutMs = 3000,
+): Promise<Event[]> {
+  const started = Date.now();
+  while (Date.now() - started <= timeoutMs) {
+    const queued = (await storage.get(STORAGE_KEY)) ?? [];
+    if (queued.length >= minCount) {
+      return queued;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const queued = (await storage.get(STORAGE_KEY)) ?? [];
+  throw new Error(
+    `Timed out waiting for ${minCount} queued events; got ${queued.length}: ${queued
+      .map((e) => e.event_type)
+      .join(', ')}`,
+  );
+}
+
+async function waitForSentEvents(sentEvents: Event[], eventTypes: string[], timeoutMs = 5000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started <= timeoutMs) {
+    const types = sentEvents.map((e) => e.event_type);
+    if (eventTypes.every((type) => types.includes(type))) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(
+    `Timed out waiting for sent events [${eventTypes.join(', ')}]; got [${sentEvents
+      .map((e) => e.event_type)
+      .join(', ')}]`,
+  );
+}
+
+describe('network connectivity', () => {
+  it('queues offline events in storage and flushes them on reconnect', async () => {
+    const sentEvents: Event[] = [];
+    const transportProvider: Transport = {
+      send: async (_serverUrl: string, payload: Payload): Promise<Response> => {
+        sentEvents.push(...payload.events);
+        return {
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: payload.events.length,
+            payloadSizeBytes: 0,
+            serverUploadTime: 0,
+          },
+        };
+      },
+    };
+    const storageProvider = new MemoryStorage<Event[]>();
+
+    const client = createInstance();
+    await client.init(API_KEY, 'harness-user', {
+      transportProvider,
+      storageProvider,
+      flushQueueSize: 1,
+      flushIntervalMillis: 100,
+      logLevel: Types.LogLevel.None,
+      attribution: {
+        disabled: true,
+      },
+      autocapture: {
+        appLifecycles: false,
+        sessions: false,
+      },
+    } as any).promise;
+
+    // 1. Track while online — should upload immediately.
+    const onlineResult = await client.track('event_online_1').promise;
+    expect(onlineResult.code).toBe(200);
+    await waitForSentEvents(sentEvents, ['event_online_1']);
+
+    // 2. Simulate offline.
+    emitConnectivity(false);
+
+    // 3. Track while offline (promise resolves only after flush on reconnect).
+    void client.track('event_offline_2').promise;
+
+    // 4. Offline event should be persisted; nothing new sent yet.
+    const queued = await waitForQueuedEvents(storageProvider, 1);
+    expect(queued.some((e) => e.event_type === 'event_offline_2')).toBe(true);
+    expect(sentEvents.map((e) => e.event_type)).toEqual(['event_online_1']);
+
+    // 5. Go online again — connectivity plugin flushes the queue.
+    emitConnectivity(true);
+
+    // 6. Track a third event after reconnect.
+    void client.track('event_online_3').promise;
+
+    // 7. All three events should have been uploaded; storage should drain.
+    await waitForSentEvents(sentEvents, ['event_online_1', 'event_offline_2', 'event_online_3']);
+    const sentTypes = sentEvents.map((e) => e.event_type);
+    expect(sentTypes.includes('event_online_1')).toBe(true);
+    expect(sentTypes.includes('event_offline_2')).toBe(true);
+    expect(sentTypes.includes('event_online_3')).toBe(true);
+
+    const remaining = (await storageProvider.get(STORAGE_KEY)) ?? [];
+    expect(remaining).toEqual([]);
+  });
+});

--- a/packages/analytics-react-native-test/test/storage/custom-storage.harness.ts
+++ b/packages/analytics-react-native-test/test/storage/custom-storage.harness.ts
@@ -1,0 +1,131 @@
+/**
+ * On-device harness for custom in-memory storage with AsyncStorage unavailable.
+ *
+ * Runs on a real device/simulator (not Jest/Node).
+ * Requires react-native-harness + examples/react-native/app built and installed.
+ *
+ * The host app excludes RNCAsyncStorage from native autolinking (SDKRN-8).
+ * This test additionally forces AsyncStorage APIs to throw, then verifies the
+ * SDK still initializes and persists identity via custom MemoryStorage.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-argument,import/no-extraneous-dependencies, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment */
+import { describe, it, expect, afterEach } from 'react-native-harness';
+import { MemoryStorage, getCookieName, type Event, type UserSession } from '@amplitude/analytics-core';
+import { createInstance, Types } from '@amplitude/analytics-react-native';
+
+const API_KEY = 'dummyApiKey';
+const DEVICE_ID = 'custom-storage-device-id';
+const USER_ID = 'harness-custom-storage-user';
+
+type AsyncStorageLike = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+  clear: () => Promise<void>;
+};
+
+let restoreAsyncStorage: (() => void) | undefined;
+
+async function waitForStoredSessionId(
+  cookieStorage: MemoryStorage<UserSession>,
+  expectedSessionId: number,
+  timeoutMs = 2000,
+): Promise<UserSession> {
+  const key = getCookieName(API_KEY);
+  const started = Date.now();
+  while (Date.now() - started <= timeoutMs) {
+    const stored = await cookieStorage.get(key);
+    if (stored?.sessionId === expectedSessionId) {
+      return stored;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const stored = await cookieStorage.get(key);
+  throw new Error(
+    `Timed out waiting for sessionId ${expectedSessionId} in cookieStorage; got ${JSON.stringify(stored)}`,
+  );
+}
+
+/**
+ * Make AsyncStorage unusable before SDK init.
+ * - If the JS package loads, replace methods with throws.
+ * - If require itself throws (native module null), treat that as already blown up.
+ */
+function breakAsyncStorage(): void {
+  try {
+    const mod = require('@react-native-async-storage/async-storage');
+    const asyncStorage = (mod?.default ?? mod) as AsyncStorageLike | undefined;
+    if (!asyncStorage) {
+      return;
+    }
+
+    const originals = {
+      getItem: asyncStorage.getItem.bind(asyncStorage),
+      setItem: asyncStorage.setItem.bind(asyncStorage),
+      removeItem: asyncStorage.removeItem.bind(asyncStorage),
+      clear: asyncStorage.clear.bind(asyncStorage),
+    };
+    const boom = () => Promise.reject(new Error('NativeModule: AsyncStorage is null'));
+    asyncStorage.getItem = boom;
+    asyncStorage.setItem = boom;
+    asyncStorage.removeItem = boom;
+    asyncStorage.clear = boom;
+
+    restoreAsyncStorage = () => {
+      asyncStorage.getItem = originals.getItem;
+      asyncStorage.setItem = originals.setItem;
+      asyncStorage.removeItem = originals.removeItem;
+      asyncStorage.clear = originals.clear;
+    };
+  } catch {
+    // Package blows up on require when the native module is excluded — expected.
+    restoreAsyncStorage = undefined;
+  }
+}
+
+describe('custom memory storage', () => {
+  afterEach(() => {
+    restoreAsyncStorage?.();
+    restoreAsyncStorage = undefined;
+  });
+
+  it('sets device/session identity when AsyncStorage is broken and custom MemoryStorage is used', async () => {
+    breakAsyncStorage();
+
+    const cookieStorage = new MemoryStorage<UserSession>();
+    const storageProvider = new MemoryStorage<Event[]>();
+
+    const client = createInstance();
+    await client.init(API_KEY, USER_ID, {
+      deviceId: DEVICE_ID,
+      cookieStorage,
+      storageProvider,
+      flushQueueSize: 1,
+      logLevel: Types.LogLevel.None,
+      attribution: {
+        disabled: true,
+      },
+      migrateLegacyData: false,
+    } as any).promise;
+
+    expect(client.getUserId()).toBe(USER_ID);
+    expect(client.getDeviceId()).toBe(DEVICE_ID);
+
+    const sessionId = client.getSessionId();
+    expect(typeof sessionId).toBe('number');
+    expect(sessionId).toBeGreaterThan(0);
+
+    // updateStorage is fire-and-forget; wait for the initial write.
+    const stored = await waitForStoredSessionId(cookieStorage, sessionId!);
+    expect(stored.userId).toBe(USER_ID);
+    expect(stored.deviceId).toBe(DEVICE_ID);
+
+    const nextSessionId = sessionId! + 1;
+    client.setSessionId(nextSessionId);
+    expect(client.getSessionId()).toBe(nextSessionId);
+
+    const storedAfterSession = await waitForStoredSessionId(cookieStorage, nextSessionId);
+    expect(storedAfterSession.deviceId).toBe(DEVICE_ID);
+    expect(storedAfterSession.userId).toBe(USER_ID);
+  });
+});


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Enhances our React Native integration testing by testing offline/online connectivity and by testing that an alternative cookieStorage can be used when async-storage is not available.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no changes to the analytics SDK or production code paths.
> 
> **Overview**
> Adds **two on-device harness tests** under `packages/analytics-react-native-test` (react-native-harness, not Jest) to cover behaviors that need a real RN runtime.
> 
> **Network connectivity** (`network-connectivity.harness.ts`): Simulates online/offline via `DeviceEventEmitter` (`AmplitudeNetworkConnectivityChanged`), uses in-memory storage and a stub transport, and asserts that events upload while online, queue while offline, flush on reconnect, and clear the queue after upload.
> 
> **Custom storage** (`custom-storage.harness.ts`): Breaks or simulates missing `@react-native-async-storage/async-storage`, then initializes the SDK with `MemoryStorage` for events and cookie/session identity. Verifies user/device/session IDs and that session updates persist in custom `cookieStorage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006b2899e0163e27610c0ae2962cd60844959621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->