### PR TITLE
feat(session-replay-browser): apply body masking rules in SR network logging

### DIFF
--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -164,6 +164,7 @@ export { Observable, asyncMap, merge, multicast, Unsubscribable } from './utils/
 
 export { InstanceProxy } from './types/proxy';
 export { safeJsonStringify } from './utils/safe-stringify';
+export { pruneJson } from './utils/json-query';
 
 // Messenger (cross-window communication)
 export type { BaseWindowMessenger, ActionHandler } from './messenger/base-window-messenger';

--- a/packages/analytics-core/test/index.test.ts
+++ b/packages/analytics-core/test/index.test.ts
@@ -76,6 +76,7 @@ import {
   AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL,
   EXCLUDE_INTERNAL_REFERRERS_CONDITIONS,
   omitUndefined,
+  pruneJson,
 } from '../src/index';
 
 describe('index', () => {
@@ -171,6 +172,7 @@ describe('index', () => {
     expect(typeof AMPLITUDE_BACKGROUND_CAPTURE_SCRIPT_URL).toBe('string');
     expect(typeof EXCLUDE_INTERNAL_REFERRERS_CONDITIONS).toBe('object');
     expect(typeof omitUndefined).toBe('function');
+    expect(typeof pruneJson).toBe('function');
   });
 
   describe('EXCLUDE_INTERNAL_REFERRERS_CONDITIONS export', () => {

--- a/packages/session-replay-browser/e2e/capture.spec.ts
+++ b/packages/session-replay-browser/e2e/capture.spec.ts
@@ -21,7 +21,22 @@ const remoteConfigNotRecording = {
 /**
  * Remote config with network logging and opt-in body capture enabled.
  */
-function remoteConfigWithNetworkBody(opts: { request?: boolean; response?: boolean; maxBodySizeBytes?: number } = {}) {
+type BodyCaptureRemoteConfig =
+  | boolean
+  | {
+      allowlist?: string[];
+      excludelist?: string[];
+      blocklist?: string[];
+    };
+
+function remoteConfigWithNetworkBody(
+  opts: {
+    request?: BodyCaptureRemoteConfig;
+    response?: BodyCaptureRemoteConfig;
+    maxBodySizeBytes?: number;
+  } = {},
+) {
+  const { request = true, response = true, maxBodySizeBytes } = opts;
   return {
     configs: {
       sessionReplay: {
@@ -29,7 +44,11 @@ function remoteConfigWithNetworkBody(opts: { request?: boolean; response?: boole
         sr_logging_config: {
           network: {
             enabled: true,
-            body: { request: true, response: true, ...opts },
+            body: {
+              request,
+              response,
+              ...(maxBodySizeBytes !== undefined ? { maxBodySizeBytes } : {}),
+            },
           },
         },
       },
@@ -831,6 +850,118 @@ test.describe('network body capture', () => {
   });
 });
 
+// ─── Network body masking ─────────────────────────────────────────────────────
+
+test.describe('network body masking', () => {
+  test('applies excludelist to request bodies', async ({ page }) => {
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithNetworkBody({
+        request: { excludelist: ['/password'] },
+        response: false,
+      }),
+    );
+    const getFetchEvents = await mockTrackApiWithCapture(page);
+    await page.route(`${TEST_FETCH_ORIGIN}/**`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+    );
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await waitForNetworkObservers(page);
+
+    await page.evaluate(
+      (url) =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username: 'alice', password: 'secret' }),
+        }),
+      `${TEST_FETCH_ORIGIN}/login`,
+    );
+    await page.waitForTimeout(200);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    const evt = getFetchEvents().find((e) => String(e.url).includes(TEST_FETCH_ORIGIN));
+    expect(evt).toBeDefined();
+    expect(evt!.requestBody).toBe('{"username":"alice"}');
+  });
+
+  test('applies allowlist to request bodies', async ({ page }) => {
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithNetworkBody({
+        request: { allowlist: ['/id'] },
+        response: false,
+      }),
+    );
+    const getFetchEvents = await mockTrackApiWithCapture(page);
+    await page.route(`${TEST_FETCH_ORIGIN}/**`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+    );
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await waitForNetworkObservers(page);
+
+    await page.evaluate(
+      (url) =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: 1, email: 'secret@example.com' }),
+        }),
+      `${TEST_FETCH_ORIGIN}/profile`,
+    );
+    await page.waitForTimeout(200);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    const evt = getFetchEvents().find((e) => String(e.url).includes(TEST_FETCH_ORIGIN));
+    expect(evt).toBeDefined();
+    expect(evt!.requestBody).toBe('{"id":1}');
+  });
+
+  test('honors deprecated blocklist alias on response bodies', async ({ page }) => {
+    await mockRemoteConfig(
+      page,
+      remoteConfigWithNetworkBody({
+        request: false,
+        response: { blocklist: ['/token'] },
+      }),
+    );
+    const getFetchEvents = await mockTrackApiWithCapture(page);
+    await page.route(`${TEST_FETCH_ORIGIN}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: 'alice', token: 'secret-token' }),
+      }),
+    );
+
+    await page.goto(buildUrl('/session-replay-browser/sr-capture-test.html', { sessionId: TEST_SESSION_ID }));
+    await waitForReady(page);
+    await waitForNetworkObservers(page);
+
+    await page.evaluate((url) => fetch(url), `${TEST_FETCH_ORIGIN}/session`);
+    await page.waitForTimeout(200);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await page.evaluate(() => (window as any).sessionReplay.flush(false) as Promise<void>);
+    await page.waitForTimeout(SNAPSHOT_SETTLE_MS);
+
+    const evt = getFetchEvents().find((e) => String(e.url).includes(TEST_FETCH_ORIGIN));
+    expect(evt).toBeDefined();
+    expect(evt!.responseBody).toBe('{"user":"alice"}');
+    expect(evt!.responseBodyStatus).toBe('captured');
+  });
+});
+
 // ─── Attribute masking ────────────────────────────────────────────────────────
 
 test.describe('attribute masking', () => {
@@ -1558,18 +1689,18 @@ test.describe('retry behavior', () => {
         }
       });
 
-    // The retry path is exercised via the eager initial send; the SDK eager default is now
-    // false (SR-4646), so opt in so the first (failing) request is made.
-    await page.goto(
-      buildUrl('/session-replay-browser/sr-capture-test.html', {
-        sessionId: TEST_SESSION_ID,
-        eagerFullSnapshotSend: true,
-      }),
-    );
-    await waitForReady(page);
-    await retryPromise;
+      // The retry path is exercised via the eager initial send; the SDK eager default is now
+      // false (SR-4646), so opt in so the first (failing) request is made.
+      await page.goto(
+        buildUrl('/session-replay-browser/sr-capture-test.html', {
+          sessionId: TEST_SESSION_ID,
+          eagerFullSnapshotSend: true,
+        }),
+      );
+      await waitForReady(page);
+      await retryPromise;
 
-    expect(callCount).toBeGreaterThanOrEqual(2);
+      expect(callCount).toBeGreaterThanOrEqual(2);
       expect(receivedBodies.length).toBeGreaterThan(0);
     });
 

--- a/packages/session-replay-browser/src/config/types.ts
+++ b/packages/session-replay-browser/src/config/types.ts
@@ -1,6 +1,7 @@
 import { IConfig, LogLevel, ILogger } from '@amplitude/analytics-core';
 import { StoreType, ConsoleLogLevel } from '../typings/session-replay';
 import { TargetingFlag } from '@amplitude/targeting';
+import type { BodyCaptureRuleConfig } from '../network-body-capture';
 
 export interface SamplingConfig {
   sample_rate: number;
@@ -26,8 +27,8 @@ export interface LoggingConfig {
   network?: {
     enabled: boolean;
     body?: {
-      request?: boolean;
-      response?: boolean;
+      request?: BodyCaptureRuleConfig;
+      response?: BodyCaptureRuleConfig;
       maxBodySizeBytes?: number;
     };
   };

--- a/packages/session-replay-browser/src/network-body-capture.ts
+++ b/packages/session-replay-browser/src/network-body-capture.ts
@@ -5,6 +5,8 @@ export type BodyCaptureRuleConfig =
   | {
       enabled?: boolean;
       allowlist?: string[];
+      /** @deprecated use excludelist */
+      blocklist?: string[];
       excludelist?: string[];
     };
 
@@ -24,7 +26,7 @@ export const getBodyMaskingLists = (
   if (typeof config === 'object' && config !== null) {
     return {
       allowlist: config.allowlist ?? [],
-      excludelist: config.excludelist ?? [],
+      excludelist: config.excludelist || config.blocklist || [],
     };
   }
   return { allowlist: [], excludelist: [] };

--- a/packages/session-replay-browser/src/network-body-capture.ts
+++ b/packages/session-replay-browser/src/network-body-capture.ts
@@ -1,0 +1,58 @@
+import { pruneJson } from '@amplitude/analytics-core';
+
+export type BodyCaptureRuleConfig =
+  | boolean
+  | {
+      enabled?: boolean;
+      allowlist?: string[];
+      excludelist?: string[];
+    };
+
+export const isBodyCaptureEnabled = (config: BodyCaptureRuleConfig | undefined): boolean => {
+  if (config === undefined) {
+    return false;
+  }
+  if (typeof config === 'boolean') {
+    return config;
+  }
+  return config.enabled !== false;
+};
+
+export const getBodyMaskingLists = (
+  config: BodyCaptureRuleConfig | undefined,
+): { allowlist: string[]; excludelist: string[] } => {
+  if (typeof config === 'object' && config !== null) {
+    return {
+      allowlist: config.allowlist ?? [],
+      excludelist: config.excludelist ?? [],
+    };
+  }
+  return { allowlist: [], excludelist: [] };
+};
+
+export const applyBodyMasking = (serialized: string, allowlist: string[], excludelist: string[]): string => {
+  if (allowlist.length === 0 && excludelist.length === 0) {
+    return serialized;
+  }
+
+  const effectiveAllowlist = allowlist.length > 0 ? allowlist : ['/**'];
+
+  try {
+    const json = JSON.parse(serialized) as Record<string, unknown>;
+    pruneJson(json, effectiveAllowlist, excludelist);
+    return JSON.stringify(json);
+  } catch {
+    return serialized;
+  }
+};
+
+export const captureSerializedBody = (
+  serialized: string,
+  config: BodyCaptureRuleConfig | undefined,
+  maxBytes: number,
+  truncate: (value: string, max: number) => { value: string; truncated: boolean },
+): { value: string; truncated: boolean } => {
+  const { allowlist, excludelist } = getBodyMaskingLists(config);
+  const masked = applyBodyMasking(serialized, allowlist, excludelist);
+  return truncate(masked, maxBytes);
+};

--- a/packages/session-replay-browser/src/observers.ts
+++ b/packages/session-replay-browser/src/observers.ts
@@ -1,5 +1,7 @@
 import { getGlobalScope } from '@amplitude/analytics-core';
 
+import { type BodyCaptureRuleConfig, captureSerializedBody, isBodyCaptureEnabled } from './network-body-capture';
+
 export type ResponseBodyStatus = 'captured' | 'truncated' | 'skipped_binary' | 'error';
 
 export interface NetworkRequestEvent {
@@ -23,8 +25,8 @@ export interface NetworkRequestEvent {
 export type NetworkEventCallback = (event: NetworkRequestEvent) => void;
 
 export interface NetworkBodyConfig {
-  request?: boolean;
-  response?: boolean;
+  request?: BodyCaptureRuleConfig;
+  response?: BodyCaptureRuleConfig;
   maxBodySizeBytes?: number;
 }
 
@@ -122,11 +124,16 @@ export class NetworkObservers {
 
       // Capture request body if configured
       const bodyConfig = this.networkConfig?.body;
-      if (bodyConfig?.request) {
+      if (bodyConfig && isBodyCaptureEnabled(bodyConfig.request)) {
         const serialized = serializeRequestBody(init?.body);
         if (serialized !== undefined) {
           const maxBytes = bodyConfig.maxBodySizeBytes ?? DEFAULT_MAX_BODY_SIZE_BYTES;
-          requestEvent.requestBody = truncateToByteLimit(serialized, maxBytes).value;
+          requestEvent.requestBody = captureSerializedBody(
+            serialized,
+            bodyConfig.request,
+            maxBytes,
+            truncateToByteLimit,
+          ).value;
         }
       }
 
@@ -144,7 +151,7 @@ export class NetworkObservers {
         });
         requestEvent.responseHeaders = headers;
 
-        if (bodyConfig?.response) {
+        if (bodyConfig && isBodyCaptureEnabled(bodyConfig.response)) {
           const contentType = headers['content-type'] || null;
           if (isBinaryContentType(contentType)) {
             requestEvent.responseBodyStatus = 'skipped_binary';
@@ -155,7 +162,12 @@ export class NetworkObservers {
             cloned.text().then(
               (text) => {
                 const maxBytes = bodyConfig.maxBodySizeBytes ?? DEFAULT_MAX_BODY_SIZE_BYTES;
-                const { value, truncated } = truncateToByteLimit(text, maxBytes);
+                const { value, truncated } = captureSerializedBody(
+                  text,
+                  bodyConfig.response,
+                  maxBytes,
+                  truncateToByteLimit,
+                );
                 requestEvent.responseBody = value;
                 requestEvent.responseBodyStatus = truncated ? 'truncated' : 'captured';
                 this.notifyEvent(requestEvent);

--- a/packages/session-replay-browser/test/network-body-capture.test.ts
+++ b/packages/session-replay-browser/test/network-body-capture.test.ts
@@ -1,0 +1,80 @@
+import {
+  applyBodyMasking,
+  captureSerializedBody,
+  getBodyMaskingLists,
+  isBodyCaptureEnabled,
+} from '../src/network-body-capture';
+
+describe('network-body-capture', () => {
+  describe('isBodyCaptureEnabled', () => {
+    it('returns false for undefined and false', () => {
+      expect(isBodyCaptureEnabled(undefined)).toBe(false);
+      expect(isBodyCaptureEnabled(false)).toBe(false);
+    });
+
+    it('returns true for boolean true and object configs', () => {
+      expect(isBodyCaptureEnabled(true)).toBe(true);
+      expect(isBodyCaptureEnabled({ allowlist: ['/user/id'] })).toBe(true);
+    });
+
+    it('returns false when enabled is false', () => {
+      expect(isBodyCaptureEnabled({ allowlist: ['/user/id'], enabled: false })).toBe(false);
+    });
+  });
+
+  describe('applyBodyMasking', () => {
+    it('returns full body when no lists are configured', () => {
+      const body = '{"email":"secret@example.com","id":1}';
+      expect(applyBodyMasking(body, [], [])).toBe(body);
+    });
+
+    it('excludes nested fields when only excludelist is set', () => {
+      const body = '{"variables":{"input":{"customer":{"email":"secret@example.com"}}},"id":1}';
+      const result = applyBodyMasking(body, [], ['/variables/input/customer/email']);
+      expect(JSON.parse(result)).toEqual({ id: 1 });
+    });
+
+    it('keeps only allowlisted fields', () => {
+      const body = '{"email":"secret@example.com","id":1}';
+      const result = applyBodyMasking(body, ['/id'], []);
+      expect(JSON.parse(result)).toEqual({ id: 1 });
+    });
+
+    it('returns non-JSON bodies unchanged when masking is configured', () => {
+      const body = 'not-json';
+      expect(applyBodyMasking(body, [], ['/password'])).toBe(body);
+    });
+  });
+
+  describe('captureSerializedBody', () => {
+    it('masks then truncates serialized bodies', () => {
+      const truncate = jest.fn((value: string) => ({ value: value.slice(0, 5), truncated: true }));
+      const result = captureSerializedBody(
+        '{"password":"secret","id":1}',
+        { excludelist: ['/password'] },
+        10,
+        truncate,
+      );
+
+      expect(truncate).toHaveBeenCalledWith('{"id":1}', 10);
+      expect(result).toEqual({ value: '{"id"', truncated: true });
+    });
+  });
+
+  describe('getBodyMaskingLists', () => {
+    it('returns empty lists for boolean configs', () => {
+      expect(getBodyMaskingLists(true)).toEqual({ allowlist: [], excludelist: [] });
+    });
+
+    it('returns configured lists for object configs', () => {
+      expect(getBodyMaskingLists({ allowlist: ['/id'], excludelist: ['/password'] })).toEqual({
+        allowlist: ['/id'],
+        excludelist: ['/password'],
+      });
+      expect(getBodyMaskingLists({ allowlist: ['/id'] })).toEqual({
+        allowlist: ['/id'],
+        excludelist: [],
+      });
+    });
+  });
+});

--- a/packages/session-replay-browser/test/network-body-capture.test.ts
+++ b/packages/session-replay-browser/test/network-body-capture.test.ts
@@ -76,5 +76,25 @@ describe('network-body-capture', () => {
         excludelist: [],
       });
     });
+
+    it('uses blocklist when excludelist is undefined', () => {
+      expect(getBodyMaskingLists({ allowlist: ['/id'], blocklist: ['/password'] })).toEqual({
+        allowlist: ['/id'],
+        excludelist: ['/password'],
+      });
+    });
+
+    it('prefers excludelist over blocklist', () => {
+      expect(
+        getBodyMaskingLists({
+          allowlist: ['/id'],
+          excludelist: ['/password'],
+          blocklist: ['/ignore-me'],
+        }),
+      ).toEqual({
+        allowlist: ['/id'],
+        excludelist: ['/password'],
+      });
+    });
   });
 });

--- a/packages/session-replay-browser/test/observers.test.ts
+++ b/packages/session-replay-browser/test/observers.test.ts
@@ -158,6 +158,29 @@ describe('NetworkObservers', () => {
       expect(events[0].requestBody).toBe('{"key":"value"}');
     });
 
+    it('should apply excludelist masking to JSON request bodies', async () => {
+      const mockResponse = {
+        status: 200,
+        headers: { forEach: jest.fn() },
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+      networkObservers.start(callback, {
+        enabled: true,
+        body: {
+          request: {
+            excludelist: ['/password'],
+          },
+        },
+      });
+
+      await globalScope.fetch('https://api.example.com/data', {
+        method: 'POST',
+        body: '{"username":"alice","password":"secret"}',
+      });
+
+      expect(JSON.parse(events[0].requestBody!)).toEqual({ username: 'alice' });
+    });
+
     it('should capture URLSearchParams request body', async () => {
       const mockResponse = {
         status: 200,


### PR DESCRIPTION
## Summary
- Apply allowlist/excludelist JSON pointer masking to `fetch-request` bodies captured via `sr_logging_config`, matching autocapture network tracking semantics.
- Export `pruneJson` from `@amplitude/analytics-core` for shared masking logic.
- Pairs with https://github.com/amplitude/javascript/pull/136906 (SR logging settings UI).

## Test plan
- [x] `pnpm test` in `packages/session-replay-browser` (100% coverage)
- [ ] Verify masked request/response bodies in SR console after UI + SDK ship together


Made with [Cursor](https://cursor.com)