### PR TITLE
use local variables

### DIFF
--- a/examples/react-native/expo-app/App.tsx
+++ b/examples/react-native/expo-app/App.tsx
@@ -1,7 +1,6 @@
 import {Button, StyleSheet, Text, View} from 'react-native';
 import {useEffect} from 'react';
 import {identify, Identify, init, track, add, Types, trackScreenViewOnNavigationStateChange} from '@amplitude/analytics-react-native';
-import {networkCapturePlugin} from '@amplitude/plugin-network-capture-browser';
 import { NavigationContainer, useNavigationContainerRef } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import FetchNetworkTestScreen from './FetchNetworkTestScreen';
@@ -59,9 +58,7 @@ export default function App() {
           autocapture: {
             screenViews: true,
             elementInteractions: true,
-            networkTracking: {
-              ignoreHosts: ['http://localhost:8081'],
-            },
+            networkTracking: false,
             appLifecycles: true,
             sessions: true,
           },

--- a/examples/react-native/expo-app/babel.config.js
+++ b/examples/react-native/expo-app/babel.config.js
@@ -3,13 +3,13 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      '@amplitude/babel-plugin-autocapture-transformer',
       // Inlines AMPLITUDE_API_KEY from the shell environment at bundle time.
       // `export AMPLITUDE_API_KEY=…` before `pnpm run android` / `pnpm run ios`.
       [
         'transform-inline-environment-variables',
         {include: ['AMPLITUDE_API_KEY', 'TEST_SERVER_HOST']},
       ],
+      '@amplitude/babel-plugin-autocapture-transformer',
     ],
   };
 };

--- a/examples/react-native/expo-app/package.json
+++ b/examples/react-native/expo-app/package.json
@@ -9,8 +9,8 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "workspace:*",
-    "@amplitude/plugin-network-capture-browser": "workspace:*",
+    "@amplitude/analytics-react-native": "1.6.8",
+    "@amplitude/babel-plugin-autocapture-transformer": "0.1.1",
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "~1.17.11",
     "@react-navigation/native": "^6.1.18",

--- a/examples/react-native/expo-app/pnpm-lock.yaml
+++ b/examples/react-native/expo-app/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@amplitude/analytics-react-native':
-        specifier: workspace:*
-        version: link:../../../packages/analytics-react-native
-      '@amplitude/plugin-network-capture-browser':
-        specifier: workspace:*
-        version: link:../../../packages/plugin-network-capture-browser
+        specifier: 1.6.8
+        version: 1.6.8(react-native@0.71.14(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0))(react@18.2.0)
+      '@amplitude/babel-plugin-autocapture-transformer':
+        specifier: 0.1.1
+        version: 0.1.1(@babel/core@7.28.6)
       '@babel/runtime':
         specifier: ^7.20.0
         version: 7.28.6
@@ -57,9 +57,6 @@ importers:
         specifier: 0.18.10
         version: 0.18.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
-      '@amplitude/babel-plugin-autocapture-transformer':
-        specifier: workspace:*
-        version: link:../../../packages/babel-plugin-autocapture-transformer
       '@babel/core':
         specifier: ^7.20.5
         version: 7.28.6
@@ -1084,8 +1081,22 @@ packages:
   '@amplitude/analytics-connector@1.6.4':
     resolution: {integrity: sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==}
 
+  '@amplitude/analytics-core@2.54.1':
+    resolution: {integrity: sha512-VMpcIPw7MBM9glKwTZivMiPeUSysY06LZr0Rsdl35szJqKIl3JAuVPR8UnRyYOxqDUZfkOPIm9w1+3E/NNtWVw==}
+
+  '@amplitude/analytics-react-native@1.6.8':
+    resolution: {integrity: sha512-s/n5yKLcoobuj4u62D4M8VJGXOPrGR6RrnFfN5gO0uzDPQJNEeSoFDO6k4mPygMEox6MLVBfCXKt9Zk1xbujMA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   '@amplitude/analytics-types@1.4.0':
     resolution: {integrity: sha512-RiMPHBqdrJ8ktTqG+Wzj2htnN/PCG9jGZG0SXtTFnWwVvcAJYbYm55/nrP1TTyrx1OlLhvF2VG3lVUP/xGAU8w==}
+
+  '@amplitude/babel-plugin-autocapture-transformer@0.1.1':
+    resolution: {integrity: sha512-rCrvYpZ170noIqmNxR/T2Z3D1yZ1k7hbw+IK1w7A9PeoS2hWfKfraJdH81YstGRAXZ4oXkkh20gbe30PR5Q+LQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@amplitude/engagement-browser@1.0.10':
     resolution: {integrity: sha512-sv8ei+Xy2qMs31lvW3bJCOZBg8LRuorAxlzM8fmh3FyVaRMbs5WyQGaWSfJ8y5tqmllJnLfbBS5R38Mv6G3h7w==}
@@ -1101,6 +1112,9 @@ packages:
 
   '@amplitude/experiment-js-client@1.21.1':
     resolution: {integrity: sha512-chE/4qQG/5Cgl93Wqj1NEdgOL5LkqySLlfk1EN0f+7bJa52HpkGFALA2FeCNYf31Z5CglEeKX6dUMgL7y33SIw==}
+
+  '@amplitude/plugin-network-capture-browser@1.10.12':
+    resolution: {integrity: sha512-FYdyMhPoToBL1GslOd7QjLctdhaL24sLKNGgXtYNVE8PiJNbmGNHWxf4Tr/CZ69uAuByXzo3Nvc0fGHpRIXiiQ==}
 
   '@amplitude/rrdom@2.1.0':
     resolution: {integrity: sha512-2dAtxXL02usBV2CSOnScLd3WoVqWaeiGpxN8LuXJ0r/NpLJkW1k876v2tRKAz5NrxPwSdjihsMmwCIXHpJhHfA==}
@@ -8367,7 +8381,30 @@ snapshots:
 
   '@amplitude/analytics-connector@1.6.4': {}
 
+  '@amplitude/analytics-core@2.54.1':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@types/zen-observable': 0.8.3
+      safe-json-stringify: 1.2.0
+      tslib: 2.8.1
+      zen-observable: 0.10.0
+
+  '@amplitude/analytics-react-native@1.6.8(react-native@0.71.14(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@amplitude/analytics-core': 2.54.1
+      '@amplitude/plugin-network-capture-browser': 1.10.12
+      '@amplitude/ua-parser-js': 0.7.33
+      '@react-native-async-storage/async-storage': 1.17.12(react-native@0.71.14(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0))
+      react: 18.2.0
+      react-native: 0.71.14(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0)
+      tslib: 2.8.1
+
   '@amplitude/analytics-types@1.4.0': {}
+
+  '@amplitude/babel-plugin-autocapture-transformer@0.1.1(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      tslib: 2.8.1
 
   '@amplitude/engagement-browser@1.0.10':
     dependencies:
@@ -8394,6 +8431,11 @@ snapshots:
       '@amplitude/ua-parser-js': 0.7.33
       base64-js: 1.5.1
       unfetch: 4.1.0
+
+  '@amplitude/plugin-network-capture-browser@1.10.12':
+    dependencies:
+      '@amplitude/analytics-core': 2.54.1
+      tslib: 2.8.1
 
   '@amplitude/rrdom@2.1.0':
     dependencies:

--- a/examples/react-native/expo-app/pnpm-workspace.yaml
+++ b/examples/react-native/expo-app/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - '.'
   - '../../../packages/*'
+
+# allow @amplitude/babel-plugin-autocapture-transformer to be installed without 3 day delay
+minimumReleaseAgeExclude:
+  - '@amplitude/*'


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only dependency and config changes; no production SDK or library code modified.
> 
> **Overview**
> The **expo-app** example no longer depends on monorepo `workspace:*` links for `@amplitude/analytics-react-native` and the network-capture plugin. It pins **`@amplitude/analytics-react-native@1.6.8`** and **`@amplitude/babel-plugin-autocapture-transformer@0.1.1`** from npm, with an updated **`pnpm-lock.yaml`** reflecting the published dependency tree (including transitive `@amplitude/plugin-network-capture-browser`).
> 
> **`App.tsx`** drops the explicit network-capture plugin import and sets **`autocapture.networkTracking`** to **`false`** instead of a config object with `ignoreHosts`. **`babel.config.js`** runs **`transform-inline-environment-variables`** before the autocapture Babel plugin so env vars are inlined in the right order.
> 
> **`pnpm-workspace.yaml`** adds **`minimumReleaseAgeExclude`** for **`@amplitude/*`** so those scoped packages can install without pnpm’s minimum release age delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19b447f48f11d74e98f0c313978d49f80037e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->