### PR TITLE
refactor(ci): use the shared setup action in the size-limit job

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '20'
+  install:
+    description: 'Whether to install workspace dependencies'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -23,5 +27,6 @@ runs:
         cache: 'pnpm'
 
     - name: Install project dependencies
+      if: inputs.install == 'true'
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Node and pnpm'
-description: 'Set up pnpm and Node.js with a pnpm cache, and install workspace dependencies'
+description: 'Set up pnpm and Node.js with a pnpm cache, optionally installing workspace dependencies'
 
 # Callers need their own actions/checkout step, since a local action is only
 # resolvable once the repository is on disk.

--- a/.github/workflows/ci-nx.yml
+++ b/.github/workflows/ci-nx.yml
@@ -65,22 +65,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Setup stays inline until ./.github/actions/setup-node-pnpm exists on the
-      # base branch. size-limit-action runs `git checkout -f <base>` to measure
-      # baseline sizes and never switches back, so the base branch is what's on
-      # disk when this job's post steps run, and a local composite action's post
-      # step fails if that branch doesn't carry it. Switch this job over once the
-      # action is on main — noting this workflow also runs for PRs into v1.x,
-      # which won't carry it.
-      # size-limit-action installs dependencies itself, so there is no install here.
-      - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-
-      - name: Setup Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      # size-limit-action installs dependencies itself, so install is skipped.
+      #
+      # This action must exist on the base branch: size-limit-action runs
+      # `git checkout -f <base>` to measure baseline sizes and never switches
+      # back, so the base branch is what's on disk when this job's post steps
+      # run. main carries it, and this workflow only exists on main.
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: 24
-          cache: 'pnpm'
+          install: 'false'
 
       - name: Restore Nx cache
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4


### PR DESCRIPTION
Follow-up to #1909.

Two similarly-named things below, kept distinct on purpose:
- **`check-size-limits`** — our job in `ci-nx.yml`. This is what changed.
- **`daniel-statsig/size-limit-action`** — the third-party action that job calls. Unchanged; nothing here modifies it.

## The change

`check-size-limits` now uses the shared `./.github/actions/setup-node-pnpm` instead of its own inline pnpm/Node steps:

```yaml
      - name: Setup Node and pnpm
        uses: ./.github/actions/setup-node-pnpm
        with:
          node-version: 24
          install: 'false'
```

All five jobs needing setup now use the action; no inline setup remains in either workflow.

Also restores the action's `install` input, which #1909 dropped once this job stopped being a caller. `size-limit-action` runs its own install, so the job passes `install: 'false'` — behaviour unchanged.

## Why #1909 couldn't do this

#1909 tried, and CI failed:

```
Can't find 'action.yml' under '.../.github/actions/setup-node-pnpm'.
Did you forget to run actions/checkout before running your local action?
```

Misleading message — checkout had run. `size-limit-action` does `git checkout -f <base>` to measure baseline sizes and never switches back, so the **base branch** is on disk by the time the job's post steps run. The setup action's post step (setup-node saving the pnpm cache) then couldn't find its own `action.yml`.

A bootstrap problem: the file wasn't on `main` yet. It is now, so the checkout no longer removes it.

## v1.x

#1909 flagged that this workflow also runs for PRs into `v1.x`, which won't carry the action, and might need a trigger filter. Unnecessary — `ci-nx.yml` only exists on `main`, so it never runs for those PRs. No `branches:` filter added.

## Verification

**Check Size Limits passes** — the first run where the base branch carries the action, which is exactly what #1909 couldn't test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
