### PR TITLE
fix(ci): remediate Semgrep findings in GitHub Actions workflows

### DIFF
--- a/.github/actions/e2e-test/action.yml
+++ b/.github/actions/e2e-test/action.yml
@@ -45,17 +45,26 @@ runs:
 
     - name: Create .env file
       shell: bash
+      env:
+        VITE_AMPLITUDE_API_KEY: ${{ inputs.amplitude-api-key }}
+        VITE_AMPLITUDE_USER_ID: ${{ inputs.amplitude-user-id }}
       run: |
-        echo "VITE_AMPLITUDE_API_KEY=${{ inputs.amplitude-api-key }}" > .env
-        echo "VITE_AMPLITUDE_USER_ID=${{ inputs.amplitude-user-id }}" >> .env
+        printf 'VITE_AMPLITUDE_API_KEY=%s\n' "$VITE_AMPLITUDE_API_KEY" > .env
+        printf 'VITE_AMPLITUDE_USER_ID=%s\n' "$VITE_AMPLITUDE_USER_ID" >> .env
 
     - name: Start dev server
       shell: bash
+      env:
+        SERVER_PORT: ${{ inputs.server-port }}
       run: |
+        if ! [[ "$SERVER_PORT" =~ ^[0-9]+$ ]]; then
+          echo "Invalid server port: $SERVER_PORT"
+          exit 1
+        fi
         pnpm build:vite
-        pnpm start --port ${{ inputs.server-port }} &
+        pnpm start --port "$SERVER_PORT" &
         sleep 10
-        curl -f http://localhost:${{ inputs.server-port }} || exit 1
+        curl -f "http://localhost:$SERVER_PORT" || exit 1
 
     - name: Run Playwright tests
       shell: bash

--- a/.github/workflows/publish-v2.yml
+++ b/.github/workflows/publish-v2.yml
@@ -173,8 +173,9 @@ jobs:
 
     steps:
       - name: Validate protected branch
+        env:
+          REF: ${{ github.event.inputs.branch || github.ref_name }}
         run: |
-          REF="${{ github.event.inputs.branch || github.ref_name }}"
           case "$REF" in
             main)
               echo "✅ Branch check passed: main"
@@ -306,9 +307,15 @@ jobs:
     steps:
       - name: Determine branch to use
         id: determine-branch
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
-          if [ -n "${{ github.event.inputs.branch }}" ]; then
-            echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+          if [ -n "$BRANCH" ]; then
+            if ! git check-ref-format --branch "$BRANCH"; then
+              echo "Invalid branch name: $BRANCH"
+              exit 1
+            fi
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           else
             echo "❌ No branch specified. Please specify a branch to create pre-release from."
             exit 1
@@ -344,28 +351,39 @@ jobs:
       #   - fix_bug_123 -> fixbug123
       #   - user@company.com -> usercompanycom
       - name: Transform feature branch name
+        env:
+          BRANCH: ${{ steps.determine-branch.outputs.branch }}
         run: |
-          echo "PREID=$(echo '${{ steps.determine-branch.outputs.branch }}' | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
+          echo "PREID=$(echo "$BRANCH" | tr -cd '[:alnum:]-')" >> "$GITHUB_ENV"
 
       # Use --no-push to prevent pushing to remote
       # Version example: 1.0.0 -> 1.1.0-{preid}.0
       - name: Dry run pre-release version
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PREID: ${{ env.PREID }}
         run: |
-          GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:version:dry-run -y --preid ${{ env.PREID }}
+          pnpm deploy:version:dry-run -y --preid "$PREID"
 
       - name: Pre-release version
         if: ${{ github.event.inputs.releaseType == 'prerelease' && github.event.inputs.skipLernaVersion != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PREID: ${{ env.PREID }}
+          BRANCH: ${{ steps.determine-branch.outputs.branch }}
         run: |
-            GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:version -y --no-private --conventional-prerelease --preid ${{ env.PREID }} --allow-branch ${{ steps.determine-branch.outputs.branch }} --create-release github
+          pnpm deploy:version -y --no-private --conventional-prerelease --preid "$PREID" --allow-branch "$BRANCH" --create-release github
 
       # Publish to NPM (also uploads minified JS and source maps to S3)
       - name: Publish Pre-release to NPM
         if: ${{ github.event.inputs.releaseType == 'prerelease' }}
-        run: |
-          GH_TOKEN=${{ steps.app-token.outputs.token }} pnpm deploy:publish --no-git-checks --ignore-scripts --tag ${{ env.PREID }}
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PREID: ${{ env.PREID }}
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+        run: |
+          pnpm deploy:publish --no-git-checks --ignore-scripts --tag "$PREID"
 
       - name: Dry run publish release to NPM
         if: ${{ github.event.inputs.releaseType == 'dry-run' }}

--- a/.github/workflows/rn-smoke.yml
+++ b/.github/workflows/rn-smoke.yml
@@ -198,9 +198,23 @@ jobs:
         run: xcrun simctl install "$SIM_UDID" build/Build/Products/Release-iphonesimulator/app.app
 
       - name: Install Maestro
+        env:
+          MAESTRO_VERSION: '2.7.0'
+          MAESTRO_SHA256: 'a4ccab6b604617e7aef6db4f885666056eabe5cfa32befaa3bc994041b8fcbb5'
         run: |
-          curl -fsSL "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+          MAESTRO_DIR="$HOME/.maestro"
+          MAESTRO_TMP="$MAESTRO_DIR/tmp"
+          MAESTRO_ZIP="$MAESTRO_TMP/maestro.zip"
+          DOWNLOAD_URL="https://github.com/mobile-dev-inc/maestro/releases/download/cli-${MAESTRO_VERSION}/maestro.zip"
+          mkdir -p "$MAESTRO_TMP"
+          curl -fsSL "$DOWNLOAD_URL" -o "$MAESTRO_ZIP"
+          echo "$MAESTRO_SHA256  $MAESTRO_ZIP" | shasum -a 256 -c -
+          unzip -qo "$MAESTRO_ZIP" -d "$MAESTRO_TMP"
+          rm -rf "${MAESTRO_DIR}/lib" "${MAESTRO_DIR}/bin"
+          mkdir -p "$MAESTRO_DIR"
+          cp -rf "$MAESTRO_TMP/maestro/"* "$MAESTRO_DIR"
+          rm -rf "$MAESTRO_TMP/maestro" "$MAESTRO_ZIP"
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
       - name: Run Maestro smoke flow
         working-directory: ${{ env.APP_DIR }}


### PR DESCRIPTION
## Summary
- Fix script-injection Semgrep findings in `.github/actions/e2e-test/action.yml` and `.github/workflows/publish-v2.yml` by moving untrusted `${{ }}` values into step `env:` and quoting shell expansions
- Replace `curl | bash` Maestro install in `.github/workflows/rn-smoke.yml` with a pinned `2.7.0` release download and SHA-256 verification
- Linear: [FDE-408](https://linear.app/amplitude/issue/FDE-408/fix-semgrep-findings-in-github-actions-workflows)

## Test plan
- [ ] Confirm Semgrep no longer reports the five findings on these files
- [ ] Spot-check publish-v2 dry-run / prerelease path still accepts a valid branch input
- [ ] Confirm RN smoke Maestro install succeeds with checksum verification on a follow-up non-draft run (or after mark ready)


Made with [Cursor](https://cursor.com)