### PR TITLE
fix(analytics-browser): tolerate nullish querySelectorAll in mutation observers

### DIFF
--- a/packages/analytics-browser/src/plugins/file-download-tracking.ts
+++ b/packages/analytics-browser/src/plugins/file-download-tracking.ts
@@ -86,11 +86,21 @@ export const fileDownloadTracking = (): EnrichmentPlugin => {
         observer = new MutationObserver((mutations) => {
           mutations.forEach((mutation) => {
             mutation.addedNodes.forEach((node) => {
-              if (node.nodeName === 'A') {
-                addFileDownloadListener(node as HTMLAnchorElement);
-              }
-              if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
-                Array.from(node.querySelectorAll('a') as HTMLAnchorElement[]).map(addFileDownloadListener);
+              // Registration of one node must not abort registration of the rest of the batch, otherwise
+              // links appended after a malformed node are silently never tracked.
+              try {
+                if (node.nodeName === 'A') {
+                  addFileDownloadListener(node as HTMLAnchorElement);
+                }
+                if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+                  // Some environments patch querySelectorAll to return a nullish value, so the return type
+                  // is widened to reflect what may actually arrive at runtime.
+                  const queryableNode = node as Element;
+                  const links: NodeListOf<HTMLAnchorElement> | null | undefined = queryableNode.querySelectorAll('a');
+                  links?.forEach(addFileDownloadListener);
+                }
+              } catch (error) {
+                config.loggerProvider.warn(`Failed to track file downloads for an added node: ${String(error)}`);
               }
             });
           });

--- a/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
+++ b/packages/analytics-browser/src/plugins/form-interaction-tracking.ts
@@ -131,17 +131,27 @@ export const formInteractionTracking = (): EnrichmentPlugin => {
       const forms = Array.from(document.getElementsByTagName('form'));
       forms.forEach(addFormInteractionListener);
 
-      // Adds listener to anchor tags added after initial load
+      // Adds listener to form tags added after initial load
       /* istanbul ignore else */
       if (typeof MutationObserver !== 'undefined') {
         observer = new MutationObserver((mutations) => {
           mutations.forEach((mutation) => {
             mutation.addedNodes.forEach((node) => {
-              if (node.nodeName === 'FORM') {
-                addFormInteractionListener(node as HTMLFormElement);
-              }
-              if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
-                Array.from(node.querySelectorAll('form') as HTMLFormElement[]).map(addFormInteractionListener);
+              // Registration of one node must not abort registration of the rest of the batch, otherwise
+              // forms appended after a malformed node are silently never tracked.
+              try {
+                if (node.nodeName === 'FORM') {
+                  addFormInteractionListener(node as HTMLFormElement);
+                }
+                if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
+                  // Some environments patch querySelectorAll to return a nullish value, so the return type
+                  // is widened to reflect what may actually arrive at runtime.
+                  const queryableNode = node as Element;
+                  const forms: NodeListOf<HTMLFormElement> | null | undefined = queryableNode.querySelectorAll('form');
+                  forms?.forEach(addFormInteractionListener);
+                }
+              } catch (error) {
+                config.loggerProvider.warn(`Failed to track form interactions for an added node: ${String(error)}`);
               }
             });
           });

--- a/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/file-download-tracking.test.ts
@@ -142,6 +142,110 @@ describe('fileDownloadTracking', () => {
     });
   });
 
+  describe('malformed added nodes', () => {
+    const createLinkInWrapper = (id: string) => {
+      const link = document.createElement('a');
+      link.setAttribute('id', id);
+      link.setAttribute('href', `https://analytics.amplitude.com/files/${id}.pdf`);
+      link.text = `${id}-text`;
+
+      const wrapper = document.createElement('div');
+      wrapper.appendChild(link);
+
+      return { link, wrapper };
+    };
+
+    const expectedEventProperties = (id: string) => ({
+      [FILE_EXTENSION]: 'pdf',
+      [FILE_NAME]: `/files/${id}.pdf`,
+      [LINK_ID]: id,
+      [LINK_TEXT]: `${id}-text`,
+      [LINK_URL]: `https://analytics.amplitude.com/files/${id}.pdf`,
+    });
+
+    test('should track links added after a node whose querySelectorAll returns a nullish value', async () => {
+      // setup
+      const config = createConfigurationMock();
+      const plugin = fileDownloadTracking();
+      await plugin.setup?.(config, amplitude);
+      window.dispatchEvent(new Event('load'));
+
+      const early = createLinkInWrapper('early-link-id');
+      const late = createLinkInWrapper('late-link-id');
+
+      // simulate an environment that patches querySelectorAll to return a nullish value
+      const poisoned = document.createElement('div');
+      Object.defineProperty(poisoned, 'querySelectorAll', {
+        value: () => undefined,
+        configurable: true,
+      });
+
+      // append all three in a single mutation batch, with the poisoned node between the two links
+      document.body.append(early.wrapper, poisoned, late.wrapper);
+
+      // allow mutation observer to execute and event listeners to be attached
+      await new Promise((r) => r(undefined)); // basically, await next clock tick
+      early.link.dispatchEvent(new Event('click'));
+      late.link.dispatchEvent(new Event('click'));
+
+      // assert the link appended after the poisoned node was still registered
+      expect(amplitude.track).toHaveBeenCalledTimes(2);
+      expect(amplitude.track).toHaveBeenNthCalledWith(
+        1,
+        '[Amplitude] File Downloaded',
+        expectedEventProperties('early-link-id'),
+      );
+      expect(amplitude.track).toHaveBeenNthCalledWith(
+        2,
+        '[Amplitude] File Downloaded',
+        expectedEventProperties('late-link-id'),
+      );
+
+      await plugin.teardown?.();
+      [early.wrapper, poisoned, late.wrapper].forEach((node) => node.remove());
+    });
+
+    test('should log a warning and track links added after a node whose querySelectorAll throws', async () => {
+      // setup
+      const config = createConfigurationMock();
+      const warnSpy = jest.spyOn(config.loggerProvider, 'warn');
+      const plugin = fileDownloadTracking();
+      await plugin.setup?.(config, amplitude);
+      window.dispatchEvent(new Event('load'));
+
+      const late = createLinkInWrapper('late-link-id');
+
+      const throwing = document.createElement('div');
+      Object.defineProperty(throwing, 'querySelectorAll', {
+        value: () => {
+          throw new TypeError('querySelectorAll is not available');
+        },
+        configurable: true,
+      });
+
+      // append both in a single mutation batch, with the throwing node first
+      document.body.append(throwing, late.wrapper);
+
+      // allow mutation observer to execute and event listeners to be attached
+      await new Promise((r) => r(undefined)); // basically, await next clock tick
+      late.link.dispatchEvent(new Event('click'));
+
+      // assert the failure was logged rather than escaping the observer callback
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to track file downloads for an added node'));
+
+      // assert the link appended after the throwing node was still registered
+      expect(amplitude.track).toHaveBeenCalledTimes(1);
+      expect(amplitude.track).toHaveBeenNthCalledWith(
+        1,
+        '[Amplitude] File Downloaded',
+        expectedEventProperties('late-link-id'),
+      );
+
+      await plugin.teardown?.();
+      [throwing, late.wrapper].forEach((node) => node.remove());
+    });
+  });
+
   test('should track file download event when the plugin is added after window load', async () => {
     // setup
     document.getElementById('my-link-id')?.setAttribute('href', 'https://analytics.amplitude.com/files/my-file.pdf');

--- a/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
+++ b/packages/analytics-browser/test/plugins/form-interaction-tracking.test.ts
@@ -264,6 +264,104 @@ describe('formInteractionTracking', () => {
     expect(amplitude.track).toHaveBeenCalledTimes(1);
   });
 
+  describe('malformed added nodes', () => {
+    const createFormInWrapper = (id: string) => {
+      const form = document.createElement('form');
+      form.setAttribute('id', id);
+      form.setAttribute('name', `${id}-name`);
+      form.setAttribute('action', '/submit');
+
+      const wrapper = document.createElement('div');
+      wrapper.appendChild(form);
+
+      return { form, wrapper };
+    };
+
+    test('should track forms added after a node whose querySelectorAll returns a nullish value', async () => {
+      // setup
+      const config = createConfigurationMock();
+      const plugin = formInteractionTracking();
+      await plugin.setup?.(config, amplitude);
+      window.dispatchEvent(new Event('load'));
+
+      const early = createFormInWrapper('early-form-id');
+      const late = createFormInWrapper('late-form-id');
+
+      // simulate an environment that patches querySelectorAll to return a nullish value
+      const poisoned = document.createElement('div');
+      Object.defineProperty(poisoned, 'querySelectorAll', {
+        value: () => undefined,
+        configurable: true,
+      });
+
+      // append all three in a single mutation batch, with the poisoned node between the two forms
+      document.body.append(early.wrapper, poisoned, late.wrapper);
+
+      // allow mutation observer to execute and event listeners to be attached
+      await new Promise((r) => r(undefined)); // basically, await next clock tick
+      early.form.dispatchEvent(new Event('change'));
+      late.form.dispatchEvent(new Event('change'));
+
+      // assert the form appended after the poisoned node was still registered
+      expect(amplitude.track).toHaveBeenCalledTimes(2);
+      expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
+        [FORM_ID]: 'early-form-id',
+        [FORM_NAME]: 'early-form-id-name',
+        [FORM_DESTINATION]: 'http://localhost/submit',
+      });
+      expect(amplitude.track).toHaveBeenNthCalledWith(2, '[Amplitude] Form Started', {
+        [FORM_ID]: 'late-form-id',
+        [FORM_NAME]: 'late-form-id-name',
+        [FORM_DESTINATION]: 'http://localhost/submit',
+      });
+
+      await plugin.teardown?.();
+      [early.wrapper, poisoned, late.wrapper].forEach((node) => node.remove());
+    });
+
+    test('should log a warning and track forms added after a node whose querySelectorAll throws', async () => {
+      // setup
+      const config = createConfigurationMock();
+      const warnSpy = jest.spyOn(config.loggerProvider, 'warn');
+      const plugin = formInteractionTracking();
+      await plugin.setup?.(config, amplitude);
+      window.dispatchEvent(new Event('load'));
+
+      const late = createFormInWrapper('late-form-id');
+
+      const throwing = document.createElement('div');
+      Object.defineProperty(throwing, 'querySelectorAll', {
+        value: () => {
+          throw new TypeError('querySelectorAll is not available');
+        },
+        configurable: true,
+      });
+
+      // append both in a single mutation batch, with the throwing node first
+      document.body.append(throwing, late.wrapper);
+
+      // allow mutation observer to execute and event listeners to be attached
+      await new Promise((r) => r(undefined)); // basically, await next clock tick
+      late.form.dispatchEvent(new Event('change'));
+
+      // assert the failure was logged rather than escaping the observer callback
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to track form interactions for an added node'),
+      );
+
+      // assert the form appended after the throwing node was still registered
+      expect(amplitude.track).toHaveBeenCalledTimes(1);
+      expect(amplitude.track).toHaveBeenNthCalledWith(1, '[Amplitude] Form Started', {
+        [FORM_ID]: 'late-form-id',
+        [FORM_NAME]: 'late-form-id-name',
+        [FORM_DESTINATION]: 'http://localhost/submit',
+      });
+
+      await plugin.teardown?.();
+      [throwing, late.wrapper].forEach((node) => node.remove());
+    });
+  });
+
   test('should track form_start and form_submit events on change and submit', async () => {
     // setup
     const config = createConfigurationMock();


### PR DESCRIPTION
### Summary

Fixes amplitude/Amplitude-TypeScript#1918

`formInteractionTracking` and `fileDownloadTracking` guard that an added node's `querySelectorAll` **exists and is callable**, but not that its **return value** is iterable:

```ts
if ('querySelectorAll' in node && typeof node.querySelectorAll === 'function') {
  Array.from(node.querySelectorAll('form') as HTMLFormElement[]).map(addFormInteractionListener);
}
```

When a patched `querySelectorAll` returns a nullish value, `Array.from` throws. Because the throw happens inside nested `forEach` callbacks, it aborts iteration of both `mutation.addedNodes` and the outer `mutations` array, then escapes the `MutationObserver` callback as an **unhandled** error. Two consequences:

1. **Silent, partial data loss.** Every form/link appended after the offending node in the same mutation batch is never registered, so `Form Started` / `Form Submitted` / `File Downloaded` never fire for those elements. The observer survives for later batches, so the loss is invisible — it looks like users simply didn't interact.
2. **An unhandled** `TypeError` attributed to the host page's bundle.

Per amplitude/Amplitude-TypeScript#1918, production RUM shows **642 occurrences over 30 days across 21 browser/OS combinations**, all `handling: unhandled`, with retained occurrences dating to 2024-10-24. The `as HTMLFormElement[]` cast is what kept the compiler from flagging the nullish case — `querySelectorAll` returns a `NodeList`, not an array.

`file-download-tracking.ts` had the byte-identical pattern for anchor tags and failed the same way, so both are fixed here.

### Changes

Per node, in both plugins:

* **Guard the return value** before iterating.
* **Drop the unsound casts** (`as HTMLFormElement[]` / `as HTMLAnchorElement[]`). The node is narrowed to `Element` so `querySelectorAll('form')` resolves to `NodeListOf<HTMLFormElement>` via the tag-name overload, and the result is annotated `| null | undefined` — a sound widening that admits the type lies at runtime, rather than a narrowing cast that hides it. No `any` is reintroduced, which matters because `no-unsafe-*` is active in `src/`.
* **Wrap the per-node body in** `try`**/**`catch` that logs via `config.loggerProvider.warn`, so one malformed node cannot abort registration for the rest of the batch. This addresses the silent-data-loss half independently of this specific nullish case — e.g. a hostile node whose `querySelectorAll` throws outright.
* `Array.from` is no longer needed: `querySelectorAll` returns a static `NodeList`, so there is nothing to snapshot, and `NodeList.forEach` is already relied on for `mutation.addedNodes` in these same callbacks.

Also corrects a copy-paste comment in the form plugin ("anchor tags" → "form tags") on the block being rewritten.

### Tests

Four regression tests, two per plugin, in the existing suites:

* **nullish return** — a node whose `querySelectorAll` returns `undefined`, appended *between* two wrapped elements in a single mutation batch; asserts the later element is still registered and tracked.
* **batch continuation on throw** — a node whose `querySelectorAll` throws; asserts the warning is logged and the element appended after it is still registered.

Verified these are genuine regression tests: with the `src` changes stashed, exactly these **4 fail** (with the production error, `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))` at `Array.from`) and the 24 pre-existing tests pass. With the fix, all 28 pass, and both changed files stay at **100% statements/branches/functions/lines** — no new `istanbul ignore` needed.

### Out of scope

`querySelectUniqueElements` in `plugin-autocapture-browser/src/helpers.ts` has the same guard-existence-but-not-return-value gap, but it is **unreachable**: no production module imports it (only its own test does) and it is not re-exported from that package's `index.ts`. Fixing it would mean a second package release with no user-facing effect; the more appropriate follow-up is deleting it, which `pnpm lint:deps` / knip territory covers better than this PR.

### Checklist

- [X] Does your PR title have the correct [title format](<https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions>)?
- Does your PR have a breaking change?: No — behavior is unchanged for conforming DOM nodes; previously-throwing nodes are now skipped with a warning.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

> < />!NOTE< /> **Low Risk**  <br>Defensive bugfix in analytics DOM observers; behavior is unchanged for normal nodes and only adds resilience plus warning logs.
>
> **Overview**  <br>Fixes silent data loss in `fileDownloadTracking` and `formInteractionTracking` when a dynamically added node's `querySelectorAll` returns nullish or throws.
>
> Previously, `Array.from(node.querySelectorAll(...))` inside nested `forEach` callbacks aborted the entire mutation batch on failure, so later links/forms were never registered. Per-node processing is now wrapped in `try`/`catch` (with a warn log), nullish returns are guarded via optional chaining, and unsound casts are dropped. Regression tests cover both the nullish-return and throw cases.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 35eadf0345ab59ac9864e5a79664082a95c51051. Configure [here](<https://www.cursor.com/dashboard/bugbot>).