### PR TITLE
fix(analytics-core): drop events with an empty event type before upload

### DIFF
--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -11,7 +11,7 @@ import {
 } from './types/event/event';
 import { IIdentify, OrderedIdentifyOperations } from './identify';
 import { IRevenue } from './revenue';
-import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from './types/messages';
+import { CLIENT_NOT_INITIALIZED, EMPTY_EVENT_TYPE_MESSAGE, OPT_OUT_MESSAGE } from './types/messages';
 import { Timeline } from './timeline';
 import {
   createGroupEvent,
@@ -237,6 +237,14 @@ export class AmplitudeCore implements CoreClient, PluginHost {
       // skip event processing if opt out
       if (this.config.optOut) {
         return buildResult(event, 0, OPT_OUT_MESSAGE);
+      }
+
+      // The event server 400s a blank event type, which also forces the rest of its
+      // upload batch to be retried, so drop it before it ever reaches a destination.
+      const eventType: unknown = event.event_type;
+      if (typeof eventType !== 'string' || eventType.trim().length === 0) {
+        this.config.loggerProvider.warn(EMPTY_EVENT_TYPE_MESSAGE);
+        return buildResult(event, 0, EMPTY_EVENT_TYPE_MESSAGE);
       }
 
       if (event.event_type === SpecialEventType.IDENTIFY) {

--- a/packages/analytics-core/src/core-client.ts
+++ b/packages/analytics-core/src/core-client.ts
@@ -243,7 +243,7 @@ export class AmplitudeCore implements CoreClient, PluginHost {
       // upload batch to be retried, so drop it before it ever reaches a destination.
       const eventType: unknown = event.event_type;
       if (typeof eventType !== 'string' || eventType.trim().length === 0) {
-        this.config.loggerProvider.warn(EMPTY_EVENT_TYPE_MESSAGE);
+        this.config.loggerProvider.error(EMPTY_EVENT_TYPE_MESSAGE);
         return buildResult(event, 0, EMPTY_EVENT_TYPE_MESSAGE);
       }
 

--- a/packages/analytics-core/src/types/messages.ts
+++ b/packages/analytics-core/src/types/messages.ts
@@ -2,6 +2,7 @@ export const SUCCESS_MESSAGE = 'Event tracked successfully';
 export const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred';
 export const MAX_RETRIES_EXCEEDED_MESSAGE = 'Event rejected due to exceeded retry count';
 export const OPT_OUT_MESSAGE = 'Event skipped due to optOut config';
+export const EMPTY_EVENT_TYPE_MESSAGE = 'Event skipped due to empty event type';
 export const MISSING_API_KEY_MESSAGE = 'Event rejected due to missing API key';
 export const INVALID_API_KEY = 'Invalid API key';
 export const CLIENT_NOT_INITIALIZED = 'Client not initialized';

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -490,7 +490,7 @@ describe('core-client', () => {
       ['a missing', undefined],
     ])('should drop an event with %s event type', async (_description, eventType) => {
       const client = new AmplitudeCore();
-      const loggerProvider = { ...mockLoggerProvider, warn: jest.fn() };
+      const loggerProvider = { ...mockLoggerProvider, error: jest.fn() };
       client.config = { ...mockConfig, loggerProvider } as BrowserConfig;
       const push = jest.spyOn(client.timeline, 'push');
 
@@ -499,13 +499,13 @@ describe('core-client', () => {
 
       expect(result).toEqual({ event, code: 0, message: EMPTY_EVENT_TYPE_MESSAGE });
       expect(push).toHaveBeenCalledTimes(0);
-      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
-      expect(loggerProvider.warn).toHaveBeenCalledWith(EMPTY_EVENT_TYPE_MESSAGE);
+      expect(loggerProvider.error).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.error).toHaveBeenCalledWith(EMPTY_EVENT_TYPE_MESSAGE);
     });
 
     test('should not drop an event with a valid event type', async () => {
       const client = new AmplitudeCore();
-      const loggerProvider = { ...mockLoggerProvider, warn: jest.fn() };
+      const loggerProvider = { ...mockLoggerProvider, error: jest.fn() };
       client.config = { ...mockConfig, loggerProvider } as BrowserConfig;
       const push = jest.spyOn(client.timeline, 'push').mockReturnValueOnce(Promise.resolve(success));
 
@@ -513,7 +513,7 @@ describe('core-client', () => {
 
       expect(result).toBe(success);
       expect(push).toHaveBeenCalledTimes(1);
-      expect(loggerProvider.warn).toHaveBeenCalledTimes(0);
+      expect(loggerProvider.error).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/packages/analytics-core/test/core-client.test.ts
+++ b/packages/analytics-core/test/core-client.test.ts
@@ -4,7 +4,7 @@ import { Event, IdentifyEvent, SpecialEventType, UserProperties } from '../src/t
 import { Plugin, EnrichmentPlugin } from '../src/types/plugin';
 import { Status } from '../src/types/status';
 import { AmplitudeCore, Identify, Revenue } from '../src/index';
-import { CLIENT_NOT_INITIALIZED, OPT_OUT_MESSAGE } from '../src/types/messages';
+import { CLIENT_NOT_INITIALIZED, EMPTY_EVENT_TYPE_MESSAGE, OPT_OUT_MESSAGE } from '../src/types/messages';
 import { useDefaultConfig } from './helpers/default';
 import { IdentifyOperation } from '../src/identify';
 import { UNSET_VALUE } from '../src/types/constants';
@@ -482,6 +482,38 @@ describe('core-client', () => {
 
       expect(onIdentityChanged).toHaveBeenCalledTimes(1);
       expect(onIdentityChanged).toHaveBeenCalledWith({ userProperties: undefined });
+    });
+
+    test.each([
+      ['an empty', ''],
+      ['a whitespace-only', '   '],
+      ['a missing', undefined],
+    ])('should drop an event with %s event type', async (_description, eventType) => {
+      const client = new AmplitudeCore();
+      const loggerProvider = { ...mockLoggerProvider, warn: jest.fn() };
+      client.config = { ...mockConfig, loggerProvider } as BrowserConfig;
+      const push = jest.spyOn(client.timeline, 'push');
+
+      const event = { event_type: eventType } as Event;
+      const result = await client.process(event);
+
+      expect(result).toEqual({ event, code: 0, message: EMPTY_EVENT_TYPE_MESSAGE });
+      expect(push).toHaveBeenCalledTimes(0);
+      expect(loggerProvider.warn).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.warn).toHaveBeenCalledWith(EMPTY_EVENT_TYPE_MESSAGE);
+    });
+
+    test('should not drop an event with a valid event type', async () => {
+      const client = new AmplitudeCore();
+      const loggerProvider = { ...mockLoggerProvider, warn: jest.fn() };
+      client.config = { ...mockConfig, loggerProvider } as BrowserConfig;
+      const push = jest.spyOn(client.timeline, 'push').mockReturnValueOnce(Promise.resolve(success));
+
+      const result = await client.process({ event_type: 'event_type' });
+
+      expect(result).toBe(success);
+      expect(push).toHaveBeenCalledTimes(1);
+      expect(loggerProvider.warn).toHaveBeenCalledTimes(0);
     });
   });
 


### PR DESCRIPTION
### Summary

[SDKW-50](https://linear.app/amplitude/issue/SDKW-50) — 99.6% of dropped Browser SDK events have a blank event name and get 400d by the event server ([Slack thread](https://amplitude.slack.com/archives/C04HSDQA2VB/p1785532786537939?thread_ts=1785450589.313969&cid=C04HSDQA2VB)). Beyond being pointless traffic, a blank event type in a batch forces the rest of that batch to be retried.

This adds the same client-side validation the Kotlin SDK just picked up in [amplitude/Amplitude-Kotlin#444](https://github.com/amplitude/Amplitude-Kotlin/pull/444): drop the event before upload, with a log line calling it out.

The log is at **error** level rather than warn ([per review](https://github.com/amplitude/Amplitude-TypeScript/pull/1920#discussion_r3693621101)): a dropped event is something customers want surfaced quickly, and since `LogLevel.Error` is `1` while `Warn` is `2`, `error()` is visible at every log level except `None`.

**Where:** `AmplitudeCore.process()` (`packages/analytics-core/src/core-client.ts`), right after the existing `optOut` check — the direct analogue of Kotlin's `Amplitude.process()`. This is the single funnel into the timeline: both `dispatch()` and `dispatchWithCallback()` route through it, so the check covers `track`/`logEvent`, `identify`, `groupIdentify`, `setGroup`, and `revenue` for every SDK built on core (browser, node, react-native).

**What counts as empty:** `event_type` that is empty, whitespace-only, or not a string. Kotlin's `isBlank()` covers empty + whitespace; the `typeof` guard is the JS-specific part — `track({})` or `track(undefined)` reaches `process()` with `event_type === undefined`, since `createTrackEvent` passes object input straight through.

Dropped events return `buildResult(event, 0, EMPTY_EVENT_TYPE_MESSAGE)`, matching how `optOut` and `CLIENT_NOT_INITIALIZED` already report skipped events, so callers awaiting `track()` get a result rather than a hang, and the promise message matches the logged error.

**Not covered (deliberate, matches Kotlin):** the destination plugin's `setup()` restores unsent events from storage and calls `execute()` directly, bypassing `process()`. Blank events persisted by older SDK versions will still be uploaded once — but a 400 lists them in `eventsWithInvalidFields`, so `handleInvalidResponse` drops them instead of retrying forever. Not worth a second gate.

### Testing

New tests in `packages/analytics-core/test/core-client.test.ts` under `describe('process')`, mirroring the Kotlin test's shape (dropped event never reaches the pipeline; a valid event still flows):

- `test.each` over empty / whitespace-only / missing `event_type` — asserts `timeline.push` is never called, the result is `EMPTY_EVENT_TYPE_MESSAGE` with code 0, and exactly one error is logged.
- A valid `event_type` still reaches `timeline.push` with nothing logged to `error`.

Verified locally:
- `analytics-core`: 873 tests pass, 100% statements/branches/functions/lines (the package's enforced threshold).
- `analytics-browser`: 499 tests pass, 100% coverage.
- Full workspace `pnpm test`: all 29 projects pass.
- `pnpm lint` (0 errors) and `pnpm typecheck` clean on `analytics-core`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No — but note it is a **behavior change**: an event that previously made a doomed round-trip to the server is now dropped locally and its `track()` promise resolves with code 0 instead of 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation in the shared event funnel; no API or auth changes, though callers now get a local code-0 skip instead of a failed upload for blank event names.
> 
> **Overview**
> **Client-side guard in `AmplitudeCore.process()`** drops events whose `event_type` is missing, not a string, or only whitespace—right after the existing `optOut` check and before `timeline.push`. That blocks doomed uploads that 400 the event server and can force batch retries.
> 
> Dropped events follow the same skip pattern as opt-out: `buildResult` with code `0`, message `EMPTY_EVENT_TYPE_MESSAGE`, and a warning on the logger. Valid event types still go through the pipeline unchanged.
> 
> Tests cover empty, whitespace-only, and undefined `event_type` (no `push`, correct result/warn) plus a happy path that still calls `push`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72764b81565ed1827e5c89ed90f227272817151. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
