### PR TITLE
fix(analytics-node): add a request timeout to the HTTP transport

### DIFF
--- a/packages/analytics-core/src/types/config/node-config.ts
+++ b/packages/analytics-core/src/types/config/node-config.ts
@@ -1,5 +1,11 @@
 import { IConfig } from './core-config';
 
-export type NodeConfig = IConfig;
+export interface NodeConfig extends IConfig {
+  /**
+   * The maximum time in milliseconds an event upload may stay idle before it is
+   * aborted and retried. Guards against uploads that never complete.
+   */
+  requestTimeoutMillis: number;
+}
 
 export type NodeOptions = Omit<Partial<NodeConfig>, 'apiKey'>;

--- a/packages/analytics-node/src/config.ts
+++ b/packages/analytics-node/src/config.ts
@@ -1,13 +1,17 @@
 import { Config, NodeOptions, NodeConfig as INodeConfig } from '@amplitude/analytics-core';
-import { Http } from './transports/http';
+import { DEFAULT_REQUEST_TIMEOUT_MILLIS, Http } from './transports/http';
 
 export class NodeConfig extends Config implements INodeConfig {
+  requestTimeoutMillis: number;
+
   constructor(apiKey: string, options?: NodeOptions) {
+    const requestTimeoutMillis = options?.requestTimeoutMillis ?? DEFAULT_REQUEST_TIMEOUT_MILLIS;
     super({
-      transportProvider: new Http(),
+      transportProvider: new Http(requestTimeoutMillis),
       ...options,
       apiKey,
     });
+    this.requestTimeoutMillis = requestTimeoutMillis;
   }
 }
 

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -3,8 +3,8 @@ import * as http from 'http';
 import * as https from 'https';
 
 /**
- * Node's HTTP client applies no socket or request timeout of its own, so without
- * this a stalled upload hangs forever. Matches the 10s network timeout used by
+ * Node's HTTP client applies no timeout of its own, so without this a stalled or
+ * slow-trickling upload hangs forever. Matches the 10s network timeout used by
  * the Amplitude Java and Python SDKs.
  */
 export const DEFAULT_REQUEST_TIMEOUT_MILLIS = 10000;
@@ -48,11 +48,15 @@ export class Http extends BaseTransport implements Transport {
       // leaves Destination.flushId set forever, which silently no-ops all later
       // flushes while the event queue keeps growing. See SDK-188.
       let settled = false;
+      // A plain object rather than a bare variable, so `deadline` can be assigned
+      // once req exists without ESLint flagging the let as a const candidate.
+      const timer: { deadline?: ReturnType<typeof setTimeout> } = {};
       const settle = (response: Response | null) => {
         if (settled) {
           return;
         }
         settled = true;
+        clearTimeout(timer.deadline);
         resolve(response);
       };
 
@@ -91,10 +95,17 @@ export class Http extends BaseTransport implements Transport {
       // Unlike the cases above, a request that never reached the server keeps its
       // long-standing drop-on-error behavior.
       req.on('error', () => settle(null));
-      req.setTimeout(this.requestTimeoutMillis, () => {
+
+      // An absolute deadline, not req.setTimeout()'s socket-inactivity timer:
+      // that resets on every byte of traffic, so a response trickled slower than
+      // requestTimeoutMillis but never finished would keep it from firing at all.
+      // unref() so it can't keep the event loop alive on its own.
+      timer.deadline = setTimeout(() => {
         req.destroy();
         settle(this.buildResponse({ code: REQUEST_TIMEOUT_STATUS_CODE }));
-      });
+      }, this.requestTimeoutMillis);
+      timer.deadline.unref();
+
       req.end(requestPayload);
     });
   }

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -9,8 +9,11 @@ import * as https from 'https';
  */
 export const DEFAULT_REQUEST_TIMEOUT_MILLIS = 10000;
 
-// buildResponse() maps 408 to Status.Timeout, which Destination retries with backoff.
+// buildResponse() maps 408 to Status.Timeout and 0 to Status.Unknown. Destination
+// retries both with backoff, bounded by flushMaxRetries, rather than dropping the
+// batch the way it does for a null response.
 const REQUEST_TIMEOUT_STATUS_CODE = 408;
+const INCOMPLETE_RESPONSE_STATUS_CODE = 0;
 
 export class Http extends BaseTransport implements Transport {
   constructor(private readonly requestTimeoutMillis: number = DEFAULT_REQUEST_TIMEOUT_MILLIS) {
@@ -53,20 +56,25 @@ export class Http extends BaseTransport implements Transport {
         resolve(response);
       };
 
+      // A connection that drops mid-response is transient, so retry rather than
+      // discard the batch. Amplitude dedupes on insert_id, making a replay of a
+      // batch the server may already have processed safe.
+      const settleAsIncomplete = () => settle(this.buildResponse({ code: INCOMPLETE_RESPONSE_STATUS_CODE }));
+
       const req = protocol.request(options, (res) => {
         res.setEncoding('utf8');
         let responsePayload = '';
         res.on('data', (chunk: string) => {
           responsePayload += chunk;
         });
-        res.on('aborted', () => settle(null));
-        res.on('error', () => settle(null));
+        res.on('aborted', settleAsIncomplete);
+        res.on('error', settleAsIncomplete);
 
         res.on('end', () => {
           // A truncated body tells us nothing about whether the server accepted
-          // the batch, so treat it like any other connection error.
+          // the batch.
           if (!res.complete) {
-            settle(null);
+            settleAsIncomplete();
             return;
           }
           try {
@@ -80,6 +88,8 @@ export class Http extends BaseTransport implements Transport {
         });
       });
 
+      // Unlike the cases above, a request that never reached the server keeps its
+      // long-standing drop-on-error behavior.
       req.on('error', () => settle(null));
       req.setTimeout(this.requestTimeoutMillis, () => {
         req.destroy();

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -48,9 +48,9 @@ export class Http extends BaseTransport implements Transport {
       // leaves Destination.flushId set forever, which silently no-ops all later
       // flushes while the event queue keeps growing. See SDK-188.
       let settled = false;
-      // A plain object rather than a bare variable, so `deadline` can be assigned
-      // once req exists without ESLint flagging the let as a const candidate.
-      const timer: { deadline?: ReturnType<typeof setTimeout> } = {};
+      // `timer` is declared below, once req exists. Safe to close over here
+      // because protocol.request() never invokes its response callback
+      // synchronously, so nothing can call settle() before that runs.
       const settle = (response: Response | null) => {
         if (settled) {
           return;
@@ -100,10 +100,12 @@ export class Http extends BaseTransport implements Transport {
       // that resets on every byte of traffic, so a response trickled slower than
       // requestTimeoutMillis but never finished would keep it from firing at all.
       // unref() so it can't keep the event loop alive on its own.
-      timer.deadline = setTimeout(() => {
-        req.destroy();
-        settle(this.buildResponse({ code: REQUEST_TIMEOUT_STATUS_CODE }));
-      }, this.requestTimeoutMillis);
+      const timer = {
+        deadline: setTimeout(() => {
+          req.destroy();
+          settle(this.buildResponse({ code: REQUEST_TIMEOUT_STATUS_CODE }));
+        }, this.requestTimeoutMillis),
+      };
       timer.deadline.unref();
 
       req.end(requestPayload);

--- a/packages/analytics-node/src/transports/http.ts
+++ b/packages/analytics-node/src/transports/http.ts
@@ -2,7 +2,21 @@ import { BaseTransport, Payload, Response, Transport } from '@amplitude/analytic
 import * as http from 'http';
 import * as https from 'https';
 
+/**
+ * Node's HTTP client applies no socket or request timeout of its own, so without
+ * this a stalled upload hangs forever. Matches the 10s network timeout used by
+ * the Amplitude Java and Python SDKs.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MILLIS = 10000;
+
+// buildResponse() maps 408 to Status.Timeout, which Destination retries with backoff.
+const REQUEST_TIMEOUT_STATUS_CODE = 408;
+
 export class Http extends BaseTransport implements Transport {
+  constructor(private readonly requestTimeoutMillis: number = DEFAULT_REQUEST_TIMEOUT_MILLIS) {
+    super();
+  }
+
   send(serverUrl: string, payload: Payload): Promise<Response | null> {
     let protocol: typeof http | typeof https;
     if (serverUrl.startsWith('http://')) {
@@ -27,27 +41,50 @@ export class Http extends BaseTransport implements Transport {
       protocol: url.protocol,
     };
     return new Promise((resolve) => {
+      // Every path below must settle exactly once. A send() that never settles
+      // leaves Destination.flushId set forever, which silently no-ops all later
+      // flushes while the event queue keeps growing. See SDK-188.
+      let settled = false;
+      const settle = (response: Response | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(response);
+      };
+
       const req = protocol.request(options, (res) => {
         res.setEncoding('utf8');
         let responsePayload = '';
         res.on('data', (chunk: string) => {
           responsePayload += chunk;
         });
+        res.on('aborted', () => settle(null));
+        res.on('error', () => settle(null));
 
         res.on('end', () => {
-          if (res.complete && responsePayload.length > 0) {
-            try {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              const parsedResponsePayload: Record<string, any> = JSON.parse(responsePayload);
-              const result = this.buildResponse(parsedResponsePayload);
-              resolve(result);
-            } catch {
-              resolve(this.buildResponse({ code: res.statusCode }));
-            }
+          // A truncated body tells us nothing about whether the server accepted
+          // the batch, so treat it like any other connection error.
+          if (!res.complete) {
+            settle(null);
+            return;
+          }
+          try {
+            // An empty body lands here too, and falls back to the status line.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const parsedResponsePayload: Record<string, any> = JSON.parse(responsePayload);
+            settle(this.buildResponse(parsedResponsePayload));
+          } catch {
+            settle(this.buildResponse({ code: res.statusCode }));
           }
         });
       });
-      req.on('error', () => resolve(null));
+
+      req.on('error', () => settle(null));
+      req.setTimeout(this.requestTimeoutMillis, () => {
+        req.destroy();
+        settle(this.buildResponse({ code: REQUEST_TIMEOUT_STATUS_CODE }));
+      });
       req.end(requestPayload);
     });
   }

--- a/packages/analytics-node/test/config.test.ts
+++ b/packages/analytics-node/test/config.test.ts
@@ -20,6 +20,7 @@ describe('config', () => {
         loggerProvider: logger,
         logLevel: LogLevel.Warn,
         minIdLength: undefined,
+        requestTimeoutMillis: 10000,
         offline: false,
         _optOut: false,
         plan: undefined,
@@ -30,6 +31,12 @@ describe('config', () => {
         transportProvider: new Http(),
         useBatch: false,
       });
+    });
+
+    test('should overwrite the request timeout', () => {
+      const config = new Config.NodeConfig(API_KEY, { requestTimeoutMillis: 500 });
+      expect(config.requestTimeoutMillis).toBe(500);
+      expect(config.transportProvider).toEqual(new Http(500));
     });
   });
 
@@ -47,6 +54,7 @@ describe('config', () => {
         loggerProvider: logger,
         logLevel: LogLevel.Warn,
         minIdLength: undefined,
+        requestTimeoutMillis: 10000,
         offline: false,
         _optOut: false,
         plan: undefined,

--- a/packages/analytics-node/test/destination-integration.test.ts
+++ b/packages/analytics-node/test/destination-integration.test.ts
@@ -13,12 +13,20 @@ describe('destination integration: upload timeout', () => {
   let serverUrl: string;
   let requestCount: number;
 
+  let uploadsPerEvent: Map<string, number>;
+
   const listen = async (handler: http.RequestListener) => {
     requestCount = 0;
+    uploadsPerEvent = new Map();
     server = http.createServer((req, res) => {
-      req.resume();
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
       req.on('end', () => {
         requestCount += 1;
+        const body = JSON.parse(Buffer.concat(chunks).toString()) as { events: { insert_id: string }[] };
+        body.events.forEach(({ insert_id }) =>
+          uploadsPerEvent.set(insert_id, (uploadsPerEvent.get(insert_id) ?? 0) + 1),
+        );
         handler(req, res);
       });
     });
@@ -91,6 +99,34 @@ describe('destination integration: upload timeout', () => {
 
     expect(destination.queue).toHaveLength(0);
     expect(destination.flushId).toBeNull();
+  });
+
+  test('should retry rather than drop when uploads time out', async () => {
+    await listen(() => {
+      // Never respond to anything.
+    });
+    const destination = await setupDestination({ flushMaxRetries: 4 });
+
+    const results = await Promise.all(events(10).map((event) => destination.execute(event)));
+
+    // Held in memory and re-uploaded until flushMaxRetries is exhausted, rather
+    // than discarded after the first failed attempt.
+    expect([...uploadsPerEvent.values()]).toEqual(Array(10).fill(4));
+    expect(results.every((result) => result.message === 'Event rejected due to exceeded retry count')).toBe(true);
+  });
+
+  test('should retry rather than drop when the response is truncated', async () => {
+    await listen((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': '200' });
+      res.write('{"code":200,"events_ing');
+      setTimeout(() => res.socket?.destroy(), 5);
+    });
+    const destination = await setupDestination({ flushMaxRetries: 3 });
+
+    const results = await Promise.all(events(10).map((event) => destination.execute(event)));
+
+    expect([...uploadsPerEvent.values()]).toEqual(Array(10).fill(3));
+    expect(results.every((result) => result.message === 'Event rejected due to exceeded retry count')).toBe(true);
   });
 
   test('should drain the queue when uploads return an empty body', async () => {

--- a/packages/analytics-node/test/destination-integration.test.ts
+++ b/packages/analytics-node/test/destination-integration.test.ts
@@ -1,0 +1,111 @@
+import { Destination, Event, LogLevel } from '@amplitude/analytics-core';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { NodeConfig } from '../src/config';
+
+/**
+ * SDK-188: an upload that never settles used to pin Destination.flushId, which
+ * made every later flush a no-op while execute() kept appending to an uncapped
+ * queue. These assert the queue drains no matter how the upload fails.
+ */
+describe('destination integration: upload timeout', () => {
+  let server: http.Server;
+  let serverUrl: string;
+  let requestCount: number;
+
+  const listen = async (handler: http.RequestListener) => {
+    requestCount = 0;
+    server = http.createServer((req, res) => {
+      req.resume();
+      req.on('end', () => {
+        requestCount += 1;
+        handler(req, res);
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    serverUrl = `http://localhost:${(server.address() as AddressInfo).port}/2/httpapi`;
+  };
+
+  const setupDestination = async (overrides = {}) => {
+    const config = new NodeConfig('a'.repeat(32), {
+      serverUrl,
+      requestTimeoutMillis: 50,
+      flushIntervalMillis: 10,
+      flushQueueSize: 5,
+      logLevel: LogLevel.None,
+      ...overrides,
+    });
+    const destination = new Destination();
+    destination.retryTimeout = 10;
+    await destination.setup(config);
+    return destination;
+  };
+
+  const events = (count: number): Event[] =>
+    Array.from({ length: count }, (_, i) => ({ event_type: 'exposure', insert_id: `id-${i}` }));
+
+  // Callbacks fire inside send(), one tick before flush() clears flushId. Poll
+  // instead of asserting immediately; a flushId that never clears is the bug.
+  const waitForFlushToRelease = async (destination: Destination) => {
+    for (let i = 0; i < 200 && destination.flushId !== null; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  };
+
+  afterEach(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  test('should recover once a stalled upload times out', async () => {
+    await listen((_, res) => {
+      // Hold the first upload open forever, then behave normally.
+      if (requestCount === 1) {
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ code: 200 }));
+    });
+    const destination = await setupDestination();
+
+    const results = await Promise.all(events(20).map((event) => destination.execute(event)));
+
+    expect(requestCount).toBeGreaterThan(1);
+    expect(results.every((result) => result.code === 200)).toBe(true);
+    await waitForFlushToRelease(destination);
+
+    expect(destination.queue).toHaveLength(0);
+    expect(destination.flushId).toBeNull();
+  });
+
+  test('should drain the queue when every upload stalls', async () => {
+    await listen(() => {
+      // Never respond to anything.
+    });
+    const destination = await setupDestination({ flushMaxRetries: 2 });
+
+    const results = await Promise.all(events(20).map((event) => destination.execute(event)));
+
+    expect(results.every((result) => result.code === 500)).toBe(true);
+    await waitForFlushToRelease(destination);
+
+    expect(destination.queue).toHaveLength(0);
+    expect(destination.flushId).toBeNull();
+  });
+
+  test('should drain the queue when uploads return an empty body', async () => {
+    await listen((_, res) => {
+      res.writeHead(200, { 'Content-Length': '0' });
+      res.end();
+    });
+    const destination = await setupDestination();
+
+    const results = await Promise.all(events(20).map((event) => destination.execute(event)));
+
+    expect(results.every((result) => result.code === 200)).toBe(true);
+    await waitForFlushToRelease(destination);
+
+    expect(destination.queue).toHaveLength(0);
+    expect(destination.flushId).toBeNull();
+  });
+});

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -1,6 +1,8 @@
 import { Http } from '../../src/transports/http';
 import http from 'http';
 import https from 'https';
+import { EventEmitter } from 'events';
+import { AddressInfo } from 'net';
 import { Status } from '@amplitude/analytics-core';
 
 describe('http transport', () => {
@@ -30,6 +32,7 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn().mockImplementation((_: string, cb: (error: Error) => void) => cb(new Error())),
+        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -65,6 +68,7 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn().mockImplementation((_: string, cb: (error: Error) => void) => cb(new Error())),
+        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -111,6 +115,7 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn(),
+        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -148,6 +153,7 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn(),
+        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -156,5 +162,101 @@ describe('http transport', () => {
     expect(response?.status).toBe(Status.Failed);
     expect(response?.statusCode).toBe(502);
     expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Regression coverage for SDK-188: each of these used to leave send() pending
+// forever, wedging Destination.flushId and growing the event queue without bound.
+describe('http transport: responses that never complete', () => {
+  const payload = { api_key: '', events: [] };
+  let server: http.Server;
+  let url: string;
+
+  const listen = async (handler: http.RequestListener) => {
+    server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    url = `http://localhost:${(server.address() as AddressInfo).port}/2/httpapi`;
+  };
+
+  afterEach(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  test('should time out when the server never responds', async () => {
+    await listen(() => {
+      // Accept the request and hold it open indefinitely.
+    });
+
+    const response = await new Http(50).send(url, payload);
+
+    expect(response?.status).toBe(Status.Timeout);
+    expect(response?.statusCode).toBe(408);
+  });
+
+  test('should fall back to the status code when the response body is empty', async () => {
+    await listen((_, res) => {
+      res.writeHead(200, { 'Content-Length': '0' });
+      res.end();
+    });
+
+    const response = await new Http().send(url, payload);
+
+    expect(response?.status).toBe(Status.Success);
+    expect(response?.statusCode).toBe(200);
+  });
+
+  test('should resolve null when the response is truncated', async () => {
+    await listen((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': '200' });
+      res.write('{"code":200,"events_ingested":');
+      setTimeout(() => res.socket?.destroy(), 10);
+    });
+
+    const response = await new Http().send(url, payload);
+
+    expect(response).toBeNull();
+  });
+
+  test('should resolve null when the connection is refused', async () => {
+    await listen(() => undefined);
+    const port = (server.address() as AddressInfo).port;
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+    server = http.createServer();
+
+    const response = await new Http().send(`http://localhost:${port}/2/httpapi`, payload);
+
+    expect(response).toBeNull();
+  });
+
+  test('should settle only once when the response errors after ending', async () => {
+    const res = new EventEmitter() as http.IncomingMessage;
+    res.setEncoding = jest.fn();
+    res.complete = false;
+    const req = { on: jest.fn(), setTimeout: jest.fn(), end: jest.fn(), destroy: jest.fn() };
+    jest.spyOn(http, 'request').mockImplementation(((_: unknown, cb: (r: http.IncomingMessage) => void) => {
+      setImmediate(() => {
+        cb(res);
+        res.emit('end');
+        res.emit('aborted');
+        res.emit('error', new Error('ECONNRESET'));
+      });
+      return req;
+    }) as unknown as typeof http.request);
+
+    await expect(new Http().send('http://localhost:3000', payload)).resolves.toBeNull();
+  });
+
+  test('should abort the request when the timeout fires', async () => {
+    const req = { on: jest.fn(), setTimeout: jest.fn(), end: jest.fn(), destroy: jest.fn() };
+    jest.spyOn(http, 'request').mockImplementation((() => req) as unknown as typeof http.request);
+
+    const response = new Http(1234).send('http://localhost:3000', payload);
+    expect(req.setTimeout).toHaveBeenCalledWith(1234, expect.any(Function));
+
+    (req.setTimeout.mock.calls[0][1] as () => void)();
+    expect(req.destroy).toHaveBeenCalledTimes(1);
+    expect((await response)?.status).toBe(Status.Timeout);
   });
 });

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -5,156 +5,75 @@ import { EventEmitter } from 'events';
 import { AddressInfo } from 'net';
 import { Status } from '@amplitude/analytics-core';
 
+const PAYLOAD = { api_key: '', events: [] };
+
+/**
+ * Stands in for http.request()/https.request(). Two details are deliberate,
+ * because the transport's correctness depends on them holding for the real API:
+ * the returned request exposes destroy(), and the response callback fires on a
+ * later tick rather than synchronously.
+ */
+const mockRequest = (responseBody: string, statusCode?: number) => {
+  const req = { on: jest.fn(), end: jest.fn(), destroy: jest.fn() };
+  const implementation = ((_: unknown, cb: (res: http.IncomingMessage) => void) => {
+    const res = new EventEmitter() as http.IncomingMessage;
+    res.setEncoding = jest.fn();
+    res.complete = true;
+    res.statusCode = statusCode;
+    setImmediate(() => {
+      cb(res);
+      res.emit('data', responseBody);
+      res.emit('end');
+    });
+    return req;
+  }) as unknown as typeof http.request;
+  return { req, implementation };
+};
+
 describe('http transport', () => {
   test('should send to http url', async () => {
-    const provider = new Http();
-    const url = 'http://localhost:3000';
-    const payload = {
-      api_key: '',
-      events: [],
-    };
+    const request = jest
+      .spyOn(http, 'request')
+      .mockImplementation(mockRequest(JSON.stringify({ code: 200 })).implementation);
 
-    const request = jest.spyOn(http, 'request').mockImplementation((_, cb) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      cb({
-        complete: true,
-        on: jest.fn().mockImplementation((event: string, callback: (data?: string) => void) => {
-          if (event === 'data') {
-            callback(JSON.stringify({ code: 200 }));
-          }
-          if (event === 'end') {
-            callback();
-          }
-        }),
-        setEncoding: jest.fn(),
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return {
-        on: jest.fn().mockImplementation((_: string, cb: (error: Error) => void) => cb(new Error())),
-        end: jest.fn(),
-      } as any;
-    });
+    const response = await new Http().send('http://localhost:3000', PAYLOAD);
 
-    const response = await provider.send(url, payload);
     expect(response?.statusCode).toBe(200);
     expect(request).toHaveBeenCalledTimes(1);
   });
 
   test('should send to https url', async () => {
-    const provider = new Http();
-    const url = 'https://localhost:3000';
-    const payload = {
-      api_key: '',
-      events: [],
-    };
+    const request = jest
+      .spyOn(https, 'request')
+      .mockImplementation(mockRequest(JSON.stringify({ code: 200 })).implementation);
 
-    const request = jest.spyOn(https, 'request').mockImplementation((_, cb) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      cb({
-        complete: true,
-        on: jest.fn().mockImplementation((event: string, callback: (data?: string) => void) => {
-          if (event === 'data') {
-            callback(JSON.stringify({ code: 200 }));
-          }
-          if (event === 'end') {
-            callback();
-          }
-        }),
-        setEncoding: jest.fn(),
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return {
-        on: jest.fn().mockImplementation((_: string, cb: (error: Error) => void) => cb(new Error())),
-        end: jest.fn(),
-      } as any;
-    });
+    const response = await new Http().send('https://localhost:3000', PAYLOAD);
 
-    const response = await provider.send(url, payload);
     expect(response?.statusCode).toBe(200);
     expect(request).toHaveBeenCalledTimes(1);
   });
 
   test('should throw an error if no protocal', () => {
-    const provider = new Http();
-    const url = 'localhost:3000';
-    const payload = {
-      api_key: '',
-      events: [],
-    };
-
-    expect(() => provider.send(url, payload)).toThrow('Invalid server url');
+    expect(() => new Http().send('localhost:3000', PAYLOAD)).toThrow('Invalid server url');
   });
 
   test('should handle error', async () => {
-    const provider = new Http();
-    const url = 'http://localhost:3000';
-    const payload = {
-      api_key: '',
-      events: [],
-    };
+    const request = jest
+      .spyOn(http, 'request')
+      .mockImplementation(mockRequest(JSON.stringify({ code: 400 })).implementation);
 
-    const request = jest.spyOn(http, 'request').mockImplementation((_, cb) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      cb({
-        complete: true,
-        on: jest.fn().mockImplementation((event: string, callback: (data?: string) => void) => {
-          if (event === 'data') {
-            callback(JSON.stringify({ code: 400 }));
-          }
-          if (event === 'end') {
-            callback();
-          }
-        }),
-        setEncoding: jest.fn(),
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return {
-        on: jest.fn(),
-        end: jest.fn(),
-      } as any;
-    });
+    const response = await new Http().send('http://localhost:3000', PAYLOAD);
 
-    const response = await provider.send(url, payload);
     expect(response?.statusCode).toBe(400);
     expect(response?.status).toBe(Status.Invalid);
     expect(request).toHaveBeenCalledTimes(1);
   });
 
   test('should handle unexpected error', async () => {
-    const provider = new Http();
-    const url = 'http://localhost:3000';
-    const payload = {
-      api_key: '',
-      events: [],
-    };
+    const request = jest.spyOn(http, 'request').mockImplementation(mockRequest('<', 502).implementation);
 
-    const request = jest.spyOn(http, 'request').mockImplementation((_, cb) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      cb({
-        statusCode: 502,
-        complete: true,
-        on: jest.fn().mockImplementation((event: string, callback: (data?: string) => void) => {
-          if (event === 'data') {
-            callback('<');
-          }
-          if (event === 'end') {
-            callback();
-          }
-        }),
-        setEncoding: jest.fn(),
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return {
-        on: jest.fn(),
-        end: jest.fn(),
-      } as any;
-    });
+    const response = await new Http().send('http://localhost:3000', PAYLOAD);
 
-    const response = await provider.send(url, payload);
     expect(response?.status).toBe(Status.Failed);
     expect(response?.statusCode).toBe(502);
     expect(request).toHaveBeenCalledTimes(1);
@@ -164,7 +83,6 @@ describe('http transport', () => {
 // Regression coverage for SDK-188: each of these used to leave send() pending
 // forever, wedging Destination.flushId and growing the event queue without bound.
 describe('http transport: responses that never complete', () => {
-  const payload = { api_key: '', events: [] };
   // Undefined for the tests that mock http.request instead of listening, so each
   // test in this block stays runnable on its own.
   let server: http.Server | undefined;
@@ -195,7 +113,7 @@ describe('http transport: responses that never complete', () => {
       // Accept the request and hold it open indefinitely.
     });
 
-    const response = await new Http(50).send(url, payload);
+    const response = await new Http(50).send(url, PAYLOAD);
 
     expect(response?.status).toBe(Status.Timeout);
     expect(response?.statusCode).toBe(408);
@@ -207,7 +125,7 @@ describe('http transport: responses that never complete', () => {
       res.end();
     });
 
-    const response = await new Http().send(url, payload);
+    const response = await new Http().send(url, PAYLOAD);
 
     expect(response?.status).toBe(Status.Success);
     expect(response?.statusCode).toBe(200);
@@ -220,7 +138,7 @@ describe('http transport: responses that never complete', () => {
       setTimeout(() => res.socket?.destroy(), 10);
     });
 
-    const response = await new Http().send(url, payload);
+    const response = await new Http().send(url, PAYLOAD);
 
     expect(response?.status).toBe(Status.Unknown);
     expect(response?.statusCode).toBe(0);
@@ -232,7 +150,7 @@ describe('http transport: responses that never complete', () => {
     const port = ((server as http.Server).address() as AddressInfo).port;
     await close();
 
-    const response = await new Http().send(`http://localhost:${port}/2/httpapi`, payload);
+    const response = await new Http().send(`http://localhost:${port}/2/httpapi`, PAYLOAD);
 
     expect(response).toBeNull();
   });
@@ -254,7 +172,7 @@ describe('http transport: responses that never complete', () => {
       return req;
     }) as unknown as typeof http.request);
 
-    const response = await new Http().send('http://localhost:3000', payload);
+    const response = await new Http().send('http://localhost:3000', PAYLOAD);
     expect(response?.status).toBe(Status.Unknown);
     expect(response?.statusCode).toBe(0);
   });
@@ -268,7 +186,7 @@ describe('http transport: responses that never complete', () => {
       const req = { on: jest.fn(), end: jest.fn(), destroy: jest.fn() };
       jest.spyOn(http, 'request').mockImplementation((() => req) as unknown as typeof http.request);
 
-      const response = new Http(1234).send('http://localhost:3000', payload);
+      const response = new Http(1234).send('http://localhost:3000', PAYLOAD);
       await jest.advanceTimersByTimeAsync(1234);
 
       expect(req.destroy).toHaveBeenCalledTimes(1);
@@ -296,7 +214,7 @@ describe('http transport: responses that never complete', () => {
         return req;
       }) as unknown as typeof http.request);
 
-      const responsePromise = new Http(1234).send('http://localhost:3000', payload);
+      const responsePromise = new Http(1234).send('http://localhost:3000', PAYLOAD);
       await jest.advanceTimersByTimeAsync(0);
       expect((await responsePromise)?.status).toBe(Status.Success);
 

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -206,7 +206,7 @@ describe('http transport: responses that never complete', () => {
     expect(response?.statusCode).toBe(200);
   });
 
-  test('should resolve null when the response is truncated', async () => {
+  test('should report a truncated response as retryable', async () => {
     await listen((_, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': '200' });
       res.write('{"code":200,"events_ingested":');
@@ -215,7 +215,8 @@ describe('http transport: responses that never complete', () => {
 
     const response = await new Http().send(url, payload);
 
-    expect(response).toBeNull();
+    expect(response?.status).toBe(Status.Unknown);
+    expect(response?.statusCode).toBe(0);
   });
 
   test('should resolve null when the connection is refused', async () => {
@@ -231,6 +232,8 @@ describe('http transport: responses that never complete', () => {
   });
 
   test('should settle only once when the response errors after ending', async () => {
+    // res 'end' with complete === false wins the race; the later 'aborted' and
+    // 'error' events must not settle a second time.
     const res = new EventEmitter() as http.IncomingMessage;
     res.setEncoding = jest.fn();
     res.complete = false;
@@ -245,7 +248,9 @@ describe('http transport: responses that never complete', () => {
       return req;
     }) as unknown as typeof http.request);
 
-    await expect(new Http().send('http://localhost:3000', payload)).resolves.toBeNull();
+    const response = await new Http().send('http://localhost:3000', payload);
+    expect(response?.status).toBe(Status.Unknown);
+    expect(response?.statusCode).toBe(0);
   });
 
   test('should abort the request when the timeout fires', async () => {

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -32,7 +32,6 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn().mockImplementation((_: string, cb: (error: Error) => void) => cb(new Error())),
-        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -68,7 +67,6 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn().mockImplementation((_: string, cb: (error: Error) => void) => cb(new Error())),
-        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -115,7 +113,6 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn(),
-        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -153,7 +150,6 @@ describe('http transport', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         on: jest.fn(),
-        setTimeout: jest.fn(),
         end: jest.fn(),
       } as any;
     });
@@ -247,7 +243,7 @@ describe('http transport: responses that never complete', () => {
     const res = new EventEmitter() as http.IncomingMessage;
     res.setEncoding = jest.fn();
     res.complete = false;
-    const req = { on: jest.fn(), setTimeout: jest.fn(), end: jest.fn(), destroy: jest.fn() };
+    const req = { on: jest.fn(), end: jest.fn(), destroy: jest.fn() };
     jest.spyOn(http, 'request').mockImplementation(((_: unknown, cb: (r: http.IncomingMessage) => void) => {
       setImmediate(() => {
         cb(res);
@@ -263,15 +259,51 @@ describe('http transport: responses that never complete', () => {
     expect(response?.statusCode).toBe(0);
   });
 
-  test('should abort the request when the timeout fires', async () => {
-    const req = { on: jest.fn(), setTimeout: jest.fn(), end: jest.fn(), destroy: jest.fn() };
-    jest.spyOn(http, 'request').mockImplementation((() => req) as unknown as typeof http.request);
+  test('should abort the request when the deadline fires, even if the socket stays active', async () => {
+    // A real socket-inactivity timer (req.setTimeout()) would never fire here,
+    // since fake time never means the connection went idle. This proves the
+    // deadline is wall-clock, not activity-based.
+    jest.useFakeTimers();
+    try {
+      const req = { on: jest.fn(), end: jest.fn(), destroy: jest.fn() };
+      jest.spyOn(http, 'request').mockImplementation((() => req) as unknown as typeof http.request);
 
-    const response = new Http(1234).send('http://localhost:3000', payload);
-    expect(req.setTimeout).toHaveBeenCalledWith(1234, expect.any(Function));
+      const response = new Http(1234).send('http://localhost:3000', payload);
+      await jest.advanceTimersByTimeAsync(1234);
 
-    (req.setTimeout.mock.calls[0][1] as () => void)();
-    expect(req.destroy).toHaveBeenCalledTimes(1);
-    expect((await response)?.status).toBe(Status.Timeout);
+      expect(req.destroy).toHaveBeenCalledTimes(1);
+      const result = await response;
+      expect(result?.status).toBe(Status.Timeout);
+      expect(result?.statusCode).toBe(408);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('should clear the deadline once settled, so it never fires late', async () => {
+    jest.useFakeTimers();
+    try {
+      const req = { on: jest.fn(), end: jest.fn(), destroy: jest.fn() };
+      jest.spyOn(http, 'request').mockImplementation(((_: unknown, cb: (r: http.IncomingMessage) => void) => {
+        const res = new EventEmitter() as http.IncomingMessage;
+        res.setEncoding = jest.fn();
+        res.complete = true;
+        setImmediate(() => {
+          cb(res);
+          res.emit('data', JSON.stringify({ code: 200 }));
+          res.emit('end');
+        });
+        return req;
+      }) as unknown as typeof http.request);
+
+      const responsePromise = new Http(1234).send('http://localhost:3000', payload);
+      await jest.advanceTimersByTimeAsync(0);
+      expect((await responsePromise)?.status).toBe(Status.Success);
+
+      await jest.advanceTimersByTimeAsync(1234);
+      expect(req.destroy).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/packages/analytics-node/test/transport/http.test.ts
+++ b/packages/analytics-node/test/transport/http.test.ts
@@ -169,18 +169,29 @@ describe('http transport', () => {
 // forever, wedging Destination.flushId and growing the event queue without bound.
 describe('http transport: responses that never complete', () => {
   const payload = { api_key: '', events: [] };
-  let server: http.Server;
+  // Undefined for the tests that mock http.request instead of listening, so each
+  // test in this block stays runnable on its own.
+  let server: http.Server | undefined;
   let url: string;
 
   const listen = async (handler: http.RequestListener) => {
-    server = http.createServer(handler);
-    await new Promise<void>((resolve) => server.listen(0, resolve));
-    url = `http://localhost:${(server.address() as AddressInfo).port}/2/httpapi`;
+    const newServer = http.createServer(handler);
+    server = newServer;
+    await new Promise<void>((resolve) => newServer.listen(0, resolve));
+    url = `http://localhost:${(newServer.address() as AddressInfo).port}/2/httpapi`;
+  };
+
+  const close = async () => {
+    if (!server?.listening) {
+      return;
+    }
+    server.closeAllConnections();
+    await new Promise((resolve) => (server as http.Server).close(resolve));
   };
 
   afterEach(async () => {
-    server.closeAllConnections();
-    await new Promise((resolve) => server.close(resolve));
+    await close();
+    server = undefined;
   });
 
   test('should time out when the server never responds', async () => {
@@ -220,11 +231,10 @@ describe('http transport: responses that never complete', () => {
   });
 
   test('should resolve null when the connection is refused', async () => {
+    // Bind then release a port so the send() below is guaranteed to hit nothing.
     await listen(() => undefined);
-    const port = (server.address() as AddressInfo).port;
-    server.closeAllConnections();
-    await new Promise((resolve) => server.close(resolve));
-    server = http.createServer();
+    const port = ((server as http.Server).address() as AddressInfo).port;
+    await close();
 
     const response = await new Http().send(`http://localhost:${port}/2/httpapi`, payload);
 


### PR DESCRIPTION
Fixes [SDK-188](https://linear.app/amplitude/issue/SDK-188/memory-leak-in-analytics-node-due-to-missing-http-timeout).

## What's the problem?

`@amplitude/analytics-node` never gave up on a broken network request. If the connection to Amplitude's servers stalled, the SDK waited forever for a response. While it waited, it stopped sending anything else, but kept collecting new events in memory. Memory grew without bound until the process crashed.

Reproduced against the published SDK: 20,000 events into a server that never responds → 1 request sent, 0 events ever delivered, +118 MB of heap growth that never comes back down.

## How do we solve it?

We give every upload a **10-second time limit**, matching what our Java and Python SDKs already do. If a full response doesn't come back in time, we cancel the request and treat it as a failure instead of waiting forever. We fixed a couple of related "wait forever" cases the same way: an empty response body, and a response that gets cut off mid-way.

New optional config, for anyone who wants a different limit:

```ts
amplitude.init(API_KEY, { requestTimeoutMillis: 5000 });
```

## What happens now if a request stalls?

It **retries, it doesn't drop**. A timed-out or cut-off upload goes back into the in-memory queue and retries with backoff, up to 12 attempts by default (`flushMaxRetries`) — same as any other failure, before or after this fix. Verified live: with the retry limit set to 4, a stalled upload retried exactly 4 times before giving up.

One case is intentionally left as-is: a request that never reaches the server at all (connection refused, bad DNS) still drops immediately, same as before this PR. That's existing behavior and out of scope here.

## Anything risky?

Low risk. We didn't touch the existing retry/backoff logic — we only made sure a stalled request always reports a result instead of hanging silently, so it can enter that logic like any other failure would. All 38 tests pass (existing + new), and re-running the original repro shows memory stays flat and the queue drains to zero instead of growing forever.

## What's *not* fixed here

Unlike Java (`MAX_CACHED_EVENTS = 16000`) and Python (`MAX_BUFFER_CAPACITY = 20000`), the Node SDK still has **no cap** on the in-memory queue. If the server is down for a long time, events can still pile up unbounded — just slower now, since retries succeed once things recover instead of piling up instantly on the first try. That's shared logic used by the browser and React Native SDKs too, so it's a separate follow-up rather than part of this fix.

Tracked as [SDK-209](https://linear.app/amplitude/issue/SDK-209/cap-the-in-memory-event-queue-in-destination-analytics-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

