### PR TITLE
chore: fix analytics-browser test coverage failure on node 26

### DIFF
--- a/packages/analytics-browser/test/storage/local-storage.test.ts
+++ b/packages/analytics-browser/test/storage/local-storage.test.ts
@@ -37,17 +37,17 @@ describe('local-storage', () => {
   });
 
   test('should not be enabled if "window.localStorage" getter throws an error', async () => {
-    let backupLocalStorage: Storage | null = null;
+    const blockedScope = {
+      get localStorage(): Storage {
+        // simulates security error: https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/
+        const err = `SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document`;
+        throw new Error(err);
+      },
+    };
+    const spy = jest
+      .spyOn(AnalyticsCore, 'getGlobalScope')
+      .mockReturnValue(blockedScope as unknown as typeof globalThis);
     try {
-      backupLocalStorage = window.localStorage;
-      Object.defineProperty(window, 'localStorage', {
-        get: () => {
-          // simulates security error: https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/
-          const err = `SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document`;
-          throw new Error(err);
-        },
-        configurable: true,
-      });
       const configs = [undefined, { loggerProvider: undefined }, { loggerProvider: new Logger() }];
       await Promise.all(
         configs.map(async (config) => {
@@ -56,10 +56,7 @@ describe('local-storage', () => {
         }),
       );
     } finally {
-      Object.defineProperty(window, 'localStorage', {
-        get: () => backupLocalStorage,
-        configurable: true,
-      });
+      spy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

Main is red on the Node 26 matrix job: [run 31537612156](https://github.com/amplitude/Amplitude-TypeScript/actions/runs/31537612156/job/93932379305). All 499 `analytics-browser` tests pass, but the 100% global coverage threshold fails:

```
Jest: "global" coverage threshold for statements (100%) not met: 99.85%
Jest: "global" coverage threshold for branches (100%) not met: 99.09%
Jest: "global" coverage threshold for lines (100%) not met: 99.83%
```

The uncovered code is the `catch` block in `LocalStorage`'s constructor (`src/storage/local-storage.ts:17-18`).

## Root cause

The test that exercises that branch redefined the global via `Object.defineProperty(window, 'localStorage', { get() { throw ... } })`. On Node 26 that redefinition no longer takes effect in jsdom — reading `window.localStorage` afterwards returns the real storage instead of throwing. The test still passed (it only asserts `isEnabled() === false`), it just stopped covering the `catch` branch.

Verified locally with a probe: on Node 24 the redefined getter throws, on Node 26 it does not.

## Fix

Mock `getGlobalScope()` to return a scope whose `localStorage` getter throws — the same approach used for the equivalent `session-replay-browser` failures in #1927.

## Testing

`analytics-browser` locally, all three matrix versions:

| Node | Result |
| --- | --- |
| 22.23.0 | 25 suites / 499 tests pass, 100% coverage |
| 24.18.0 | 25 suites / 499 tests pass, 100% coverage |
| 26.7.0 | 25 suites / 499 tests pass, 100% coverage |

Also ran the full monorepo suite on Node 26 to check for other Node-26-only breakage hidden behind the nx bail — including the 10 packages the failed run never reached (`analytics-client-common`, `session-replay-browser`, `targeting`, `unified`, etc.). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)