### PR TITLE
feat: hackathon client configurator

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "nodemon": "^3.0.1",
     "nx": "^21.2.1",
     "prettier": "^2.8.1",
+    "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       prettier:
         specifier: ^2.8.1
         version: 2.8.8
+      prismjs:
+        specifier: ^1.30.0
+        version: 1.30.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -8783,6 +8786,10 @@ packages:
   pretty-format@30.4.1:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
 
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
@@ -18680,7 +18687,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.19.130
-      ts-node: 10.9.2(@types/node@18.19.130)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21295,6 +21302,8 @@ snapshots:
       react-is-18: react-is@18.3.1
       react-is-19: react-is@19.2.7
 
+  prismjs@1.30.0: {}
+
   proc-log@5.0.0: {}
 
   proc-log@6.0.0: {}
@@ -22626,25 +22635,6 @@ snapshots:
       '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.28.5)
       jest-util: 30.4.1
-
-  ts-node@10.9.2(@types/node@18.19.130)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.130
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5):
     dependencies:

--- a/test-server/configurator-run.html
+++ b/test-server/configurator-run.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Amplitude Browser Client Configurator — Run</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/configurator/run.jsx"></script>
+  </body>
+</html>

--- a/test-server/configurator.html
+++ b/test-server/configurator.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Amplitude Browser Client Configurator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/configurator/main.jsx"></script>
+  </body>
+</html>

--- a/test-server/configurator/autocapture-options.js
+++ b/test-server/configurator/autocapture-options.js
@@ -1,0 +1,382 @@
+import { createDefaultValues } from './fields.js';
+
+// Mirrors the AutocaptureOptions interface in
+// packages/analytics-core/src/types/config/browser-config.ts — same order, same documented defaults.
+// Each `description` is the JSDoc from the corresponding interface property, shown as the field's
+// tooltip. PageTrackingOptions has no JSDoc on its members, so those descriptions are summarised
+// from the types instead.
+//
+// Sub-options cover the nested config each autocapture option accepts in place of a boolean, limited
+// to what a form can express: booleans, strings, numbers, enums and string lists. Deliberately not
+// exposed, because a form can't represent them:
+//   - callbacks: shouldTrackEventResolver, shouldTrackSubmit, pageViews.trackOn's function form
+//   - deprecated fields: elementInteractions.debounceTime / exposureDuration
+//   - remote-config-only or deeply nested: networkTracking.captureRules, elementInteractions.pageActions,
+//     elementInteractions.maskTextRegex / visualTaggingOptions
+// Options whose nested form is itself an object (deadClicks, rageClicks, mainThreadBlock) are exposed
+// as the booleans that switch them on, which is the form the SDK also accepts.
+
+// Fields of NetworkCaptureRule (packages/analytics-core/src/types/network-tracking.ts). `headers`
+// covers `string[] | boolean`; `bodyRule` covers BodyCaptureRule, minus its deprecated `blocklist`.
+export const CAPTURE_RULE_FIELDS = [
+  {
+    key: 'hosts',
+    label: 'Hosts',
+    type: 'stringList',
+    hint: "default: ['*'] · supports wildcards",
+    description: 'Hosts to allow for network capture. Supports wildcard.',
+  },
+  {
+    key: 'urls',
+    label: 'URLs',
+    type: 'regexList',
+    regexLabel: 'URL regexes',
+    hint: "default: ['*'] · takes precedence over hosts",
+    description: 'URL patterns to allow for network capture. Supports wildcard. This takes precedence over hosts.',
+  },
+  {
+    key: 'methods',
+    label: 'Methods',
+    type: 'stringList',
+    hint: "default: ['*']",
+    description: 'Methods to allow for network capture.',
+  },
+  {
+    key: 'statusCodeRange',
+    label: 'Status code range',
+    type: 'string',
+    hint: "default: '500-599'",
+    description: 'Range list that defines the status codes to be captured.',
+  },
+  {
+    key: 'requestHeaders',
+    label: 'Request headers',
+    type: 'headers',
+    hint: 'default: false',
+    description:
+      'Capture headers from network request. If true, SAFE_HEADERS are captured. If false, no headers are captured. If a string array, the headers in the array are captured.',
+  },
+  {
+    key: 'responseHeaders',
+    label: 'Response headers',
+    type: 'headers',
+    hint: 'default: false',
+    description:
+      'Capture headers from network response. If true, SAFE_HEADERS are captured. If false, no headers are captured. If a string array, the headers in the array are captured.',
+  },
+  {
+    key: 'requestBody',
+    label: 'Request body',
+    type: 'bodyRule',
+    description: 'Determines what to capture from the request body.',
+  },
+  {
+    key: 'responseBody',
+    label: 'Response body',
+    type: 'bodyRule',
+    description: 'Determines what to capture from the response body.',
+  },
+];
+
+// Descriptions for the two BodyCaptureRule members, used by the rule editor.
+export const BODY_RULE_DESCRIPTIONS = {
+  allowlist:
+    'List of JSON pointers to capture from a request or response body (JSON objects only). Includes nothing by default. Any keys defined in excludelist will be excluded from the capture. The leading / is optional, * matches any key, ** matches any number of keys, and the structure of the JSON is preserved.',
+  excludelist:
+    'List of JSON pointers to exclude from a request or response body (JSON objects only). This "uncaptures" any attributes that are captured by the allowlist.',
+};
+
+// Rules carry an id purely so React list keys stay stable when one is removed; the serializer walks
+// CAPTURE_RULE_FIELDS, so it never reaches the snippet.
+let nextRuleId = 0;
+export function createCaptureRule() {
+  nextRuleId += 1;
+  return {
+    id: `rule-${nextRuleId}`,
+    hosts: '',
+    urls: { list: '', regexes: '' },
+    methods: '',
+    statusCodeRange: '',
+    requestHeaders: { mode: '', list: '' },
+    responseHeaders: { mode: '', list: '' },
+    requestBody: { allowlist: '', excludelist: '' },
+    responseBody: { allowlist: '', excludelist: '' },
+  };
+}
+
+const pageUrlAllowlist = {
+  key: 'pageUrlAllowlist',
+  label: 'Page URL allowlist',
+  type: 'regexList',
+  hint: 'default: all pages',
+  description:
+    'List of page URLs to allow auto tracking on. When provided, only allow tracking on these URLs. Both full URLs and regex are supported.',
+};
+
+const pageUrlExcludelist = {
+  key: 'pageUrlExcludelist',
+  label: 'Page URL excludelist',
+  type: 'regexList',
+  hint: 'default: none',
+  description:
+    'List of page URLs to exclude from auto tracking. When provided, tracking will be blocked on these URLs. Both full URLs and regex are supported. This takes precedence over pageUrlAllowlist.',
+};
+
+const dataAttributePrefix = {
+  key: 'dataAttributePrefix',
+  label: 'Data attribute prefix',
+  type: 'string',
+  hint: "default: 'data-amp-track-'",
+  description: 'Prefix for data attributes to allow auto collecting.',
+};
+
+export const AUTOCAPTURE_OPTIONS = [
+  {
+    key: 'attribution',
+    label: 'Attribution',
+    defaultValue: true,
+    description: 'Enables/disables marketing attribution tracking or config with detailed attribution options.',
+    subOptions: [
+      {
+        key: 'excludeReferrers',
+        label: 'Exclude referrers',
+        type: 'regexList',
+        hint: 'default: your own domain',
+        description:
+          'The rules to determine which referrers are excluded from being tracked as traffic source. Applies only to userProperty tracking; ignored by eventProperty tracking.',
+      },
+      {
+        key: 'excludeInternalReferrers',
+        label: 'Exclude internal referrers',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          "Exclude internal referrers from campaign attribution (a referrer is 'internal' if it is on the same domain as the current page). Applies only to userProperty tracking; ignored by eventProperty tracking.",
+      },
+      {
+        key: 'initialEmptyValue',
+        label: 'Initial empty value',
+        type: 'string',
+        hint: "default: 'EMPTY'",
+        description:
+          'The value to represent undefined/no initial campaign parameter for first-touch attribution. Applies only to userProperty tracking; ignored by eventProperty tracking.',
+      },
+      {
+        key: 'resetSessionOnNewCampaign',
+        label: 'Reset session on new campaign',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'The flag of if Amplitude to start a new session if any campaign parameter changes. Applies only to userProperty tracking; ignored by eventProperty tracking.',
+      },
+      {
+        key: 'trackingMethod',
+        label: 'Tracking method',
+        type: 'enum',
+        hint: 'default: both',
+        description:
+          "The attribution persistence strategy for campaign parameters. Provide a single method to enable one strategy, or an array to enable multiple methods at the same time. For example, ['userProperty', 'eventProperty'] updates user properties and also attaches campaign params to event properties.",
+        choices: [
+          { value: 'userProperty', label: 'userProperty' },
+          { value: 'eventProperty', label: 'eventProperty' },
+          { value: 'both', label: 'both', runtime: ['userProperty', 'eventProperty'] },
+        ],
+      },
+      {
+        key: 'fallbackAttributionEvent',
+        label: 'Fallback attribution event',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Fires an [Amplitude] Attribution event as a heartbeat on every page view, such as on page load and SPA URL changes. Applies only to eventProperty tracking; ignored by userProperty tracking.',
+      },
+    ],
+  },
+  {
+    key: 'fileDownloads',
+    label: 'File downloads',
+    defaultValue: true,
+    description: 'Enables/disables file downloads tracking.',
+  },
+  {
+    key: 'formInteractions',
+    label: 'Form interactions',
+    defaultValue: true,
+    description: 'Enables/disables form interaction tracking or configures with detailed options.',
+  },
+  {
+    key: 'pageViews',
+    label: 'Page views',
+    defaultValue: true,
+    description: 'Enables/disables default page view tracking.',
+    subOptions: [
+      {
+        key: 'trackOn',
+        label: 'Track on',
+        type: 'enum',
+        hint: 'default: every page load',
+        description:
+          "When to track a page view. Set to 'attribution' to only track page views that carry campaign parameters.",
+        choices: [{ value: 'attribution', label: 'attribution' }],
+      },
+      {
+        key: 'trackHistoryChanges',
+        label: 'Track history changes',
+        type: 'enum',
+        hint: 'default: all',
+        description:
+          "Which History API changes count as a new page view: 'all' for any URL change, 'pathOnly' to ignore query and hash changes.",
+        choices: [
+          { value: 'all', label: 'all' },
+          { value: 'pathOnly', label: 'pathOnly' },
+        ],
+      },
+      {
+        key: 'eventType',
+        label: 'Event type',
+        type: 'string',
+        hint: "default: '[Amplitude] Page Viewed'",
+        description: 'The event type used for the tracked page view event.',
+      },
+      {
+        key: 'pageCounter',
+        label: 'Page counter',
+        type: 'number',
+        hint: 'default: unset',
+        description:
+          "User's Nth instance of performing a default Page Viewed event within a session. Used for landing page analysis.",
+      },
+    ],
+  },
+  {
+    key: 'sessions',
+    label: 'Sessions',
+    defaultValue: true,
+    description: 'Enables/disables session tracking.',
+  },
+  {
+    key: 'elementInteractions',
+    label: 'Element interactions',
+    defaultValue: false,
+    description: 'Enables/disables user interactions tracking.',
+    subOptions: [
+      {
+        key: 'cssSelectorAllowlist',
+        label: 'CSS selector allowlist',
+        type: 'stringList',
+        hint: 'default: a, button, input, select, textarea, label, …',
+        description:
+          'List of CSS selectors to allow auto tracking on. When provided, allow elements matching any selector to be tracked.',
+      },
+      {
+        key: 'actionClickAllowlist',
+        label: 'Action click allowlist',
+        type: 'stringList',
+        hint: 'default: none',
+        description:
+          'CSS selector allowlist for tracking clicks that result in a DOM change/navigation on elements not already allowed by the cssSelectorAllowlist. Only applies to click-based interaction tracking; has no effect on viewport/exposure-based features.',
+      },
+      pageUrlAllowlist,
+      pageUrlExcludelist,
+      dataAttributePrefix,
+    ],
+  },
+  {
+    key: 'frustrationInteractions',
+    label: 'Frustration interactions',
+    defaultValue: false,
+    description: 'Enables/disables frustration interactions tracking.',
+    subOptions: [
+      {
+        key: 'deadClicks',
+        label: 'Dead clicks',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Configuration for dead clicks tracking. Set to false to disable dead click tracking. Set to true or an options object to enable with default or custom settings.',
+      },
+      {
+        key: 'rageClicks',
+        label: 'Rage clicks',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Configuration for rage clicks tracking. Set to false to disable rage click tracking. Set to true or an options object to enable with default settings.',
+      },
+      pageUrlAllowlist,
+      pageUrlExcludelist,
+      dataAttributePrefix,
+    ],
+  },
+  {
+    key: 'networkTracking',
+    label: 'Network tracking',
+    defaultValue: false,
+    description: 'Enables/disables network request tracking or config with detailed network tracking options.',
+    subOptions: [
+      {
+        key: 'ignoreAmplitudeRequests',
+        label: 'Ignore Amplitude requests',
+        type: 'boolean',
+        defaultValue: true,
+        description: 'Suppresses tracking Amplitude requests from network capture.',
+      },
+      {
+        key: 'ignoreHosts',
+        label: 'Ignore hosts',
+        type: 'stringList',
+        hint: 'default: none · supports wildcards',
+        description: 'Hosts to ignore for network capture. Supports wildcard.',
+      },
+      {
+        key: 'captureRules',
+        label: 'Capture rules',
+        type: 'ruleList',
+        description:
+          'Rules to determine which network requests should be captured. Performs matching on array in reverse order.',
+        fields: CAPTURE_RULE_FIELDS,
+      },
+    ],
+  },
+  {
+    key: 'webVitals',
+    label: 'Web vitals',
+    defaultValue: false,
+    description: 'Enables/disables web vitals tracking.',
+  },
+  {
+    key: 'performanceTracking',
+    label: 'Performance tracking',
+    defaultValue: false,
+    description: 'Enables/disables performance tracking.',
+    subOptions: [
+      {
+        key: 'mainThreadBlock',
+        label: 'Main thread block',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Configuration for main thread block tracking. Uses the Long Animation Frames API where available, falling back to Long Tasks. Set to false to disable tracking. Set to true or an options object to enable with default or custom settings.',
+      },
+      pageUrlAllowlist,
+      pageUrlExcludelist,
+    ],
+  },
+  {
+    key: 'pageUrlEnrichment',
+    label: 'Page URL enrichment',
+    defaultValue: true,
+    experimental: true,
+    description: 'Enables/disables page url enrichment.',
+  },
+];
+
+export function createDefaultAutocaptureOptions() {
+  return Object.fromEntries(AUTOCAPTURE_OPTIONS.map((option) => [option.key, option.defaultValue]));
+}
+
+export function createDefaultSubOptions() {
+  return Object.fromEntries(
+    AUTOCAPTURE_OPTIONS.map((option) => [option.key, createDefaultValues(option.subOptions ?? [])]),
+  );
+}

--- a/test-server/configurator/autocapture-panel.jsx
+++ b/test-server/configurator/autocapture-panel.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { CheckboxField, Panel } from './components.jsx';
+import { AUTOCAPTURE_OPTIONS } from './autocapture-options.js';
+import { changedFields } from './fields.js';
+import { OptionField } from './option-field.jsx';
+
+const SUB_LABEL_WIDTH = 210;
+
+function hintFor(option) {
+  const parts = [`SDK default: ${String(option.defaultValue)}`];
+  if (option.experimental) {
+    parts.push('experimental');
+  }
+  return `(${parts.join(' · ')})`;
+}
+
+// AUTOCAPTURE_OPTIONS aren't typed fields, so compare against each option's own default rather than
+// going through changedFields.
+function customisedCount(values, subValues) {
+  return AUTOCAPTURE_OPTIONS.filter(
+    (option) =>
+      values[option.key] !== option.defaultValue ||
+      changedFields(option.subOptions ?? [], subValues[option.key] ?? {}).length > 0,
+  ).length;
+}
+
+export function AutocapturePanel({ values, onChange, subValues, onSubChange }) {
+  const count = customisedCount(values, subValues);
+
+  return (
+    <Panel
+      title="Autocapture options"
+      description="Each option below maps to a key on the autocapture config object."
+      badge={count > 0 ? `${count} customised` : null}
+    >
+      {AUTOCAPTURE_OPTIONS.map((option) => {
+        const enabled = values[option.key];
+
+        return (
+          <div key={option.key}>
+            <CheckboxField
+              id={`autocapture-${option.key}`}
+              label={option.label}
+              checked={enabled}
+              onChange={(checked) => onChange(option.key, checked)}
+              labelWidth={200}
+              hint={hintFor(option)}
+              description={option.description}
+            />
+            {enabled && option.subOptions ? (
+              <OptionField
+                id={`autocapture-${option.key}`}
+                field={{
+                  key: option.key,
+                  label: `${option.label} sub-config`,
+                  type: 'group',
+                  fields: option.subOptions,
+                }}
+                value={subValues[option.key] ?? {}}
+                onChange={(next) => onSubChange(option.key, next)}
+                labelWidth={SUB_LABEL_WIDTH}
+              />
+            ) : null}
+          </div>
+        );
+      })}
+    </Panel>
+  );
+}

--- a/test-server/configurator/components.jsx
+++ b/test-server/configurator/components.jsx
@@ -1,0 +1,244 @@
+import React from 'react';
+// Prism's default build already registers the javascript grammar, so no component import is needed.
+import Prism from 'prismjs';
+import './syntax-theme.css';
+
+const styles = {
+  field: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 },
+  label: { fontWeight: 600 },
+  // Signals that the label carries a tooltip drawn from the SDK's own JSDoc.
+  documentedLabel: {
+    cursor: 'help',
+    textDecoration: 'underline dotted',
+    textDecorationColor: '#bbb',
+    textUnderlineOffset: 3,
+  },
+  textInput: { width: 360, maxWidth: '100%', padding: '6px 8px', font: 'inherit' },
+  // Monospace so escapes and character classes stay legible while typing a pattern.
+  textarea: {
+    width: 360,
+    maxWidth: '100%',
+    padding: '6px 8px',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 13,
+    resize: 'vertical',
+  },
+  select: { padding: '5px 8px', font: 'inherit' },
+  hint: { color: '#888', fontSize: 12 },
+  subGroup: { padding: '0 0 0 16px', borderLeft: '2px solid #e2e2e2', margin: '0 0 12px 4px' },
+  subGroupTitle: { fontSize: 12, color: '#666', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: 0.4 },
+  button: { font: 'inherit', fontSize: 13, padding: '4px 10px', cursor: 'pointer' },
+  card: { border: '1px solid #ddd', borderRadius: 6, background: '#fff', padding: '10px 12px 2px', marginBottom: 10 },
+  cardHeader: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 },
+  cardTitle: { fontSize: 13, fontWeight: 600, margin: 0 },
+  note: { color: '#888', fontSize: 12, margin: '0 0 8px' },
+  panel: {
+    border: '1px solid #ddd',
+    borderRadius: 6,
+    background: '#fafafa',
+    marginBottom: 12,
+  },
+  panelSummary: { cursor: 'pointer', padding: '10px 16px', fontSize: 14, fontWeight: 600 },
+  panelBody: { padding: '4px 16px 4px' },
+  panelBadge: { marginLeft: 8, fontSize: 12, fontWeight: 400, color: '#666' },
+  panelDescription: { color: '#666', fontSize: 12, margin: '0 0 12px' },
+  pre: {
+    background: '#1e1e2e',
+    color: '#e6e6f0',
+    margin: 0,
+    padding: 16,
+    borderRadius: 6,
+    overflowX: 'auto',
+    fontSize: 13,
+    lineHeight: 1.5,
+  },
+};
+
+// Row layout shared by every control: label on the same line as the input it points at. Pass
+// labelWidth to line up the inputs of a stacked group of fields.
+export function Field({ id, label, labelWidth, description, children }) {
+  const labelStyle = {
+    ...styles.label,
+    ...(labelWidth ? { width: labelWidth, flex: 'none' } : null),
+    ...(description ? styles.documentedLabel : null),
+  };
+  return (
+    <div style={styles.field}>
+      <label htmlFor={id} style={labelStyle} title={description}>
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+// The onChange props below hand back the value rather than the event, so call sites can pass a
+// setState function directly.
+export function TextField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  labelWidth,
+  type = 'text',
+  width,
+  hint,
+  description,
+}) {
+  return (
+    <Field id={id} label={label} labelWidth={labelWidth} description={description}>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        style={width ? { ...styles.textInput, width } : styles.textInput}
+      />
+      {hint ? <span style={styles.hint}>{hint}</span> : null}
+    </Field>
+  );
+}
+
+// For config fields the blank first choice leaves the key out of the generated config entirely; pass
+// allowUnset={false} for a select where every choice is a real value.
+export function SelectField({ id, label, value, onChange, choices, labelWidth, hint, description, allowUnset = true }) {
+  return (
+    <Field id={id} label={label} labelWidth={labelWidth} description={description}>
+      <select id={id} value={value} onChange={(event) => onChange(event.target.value)} style={styles.select}>
+        {allowUnset ? <option value="">(unset)</option> : null}
+        {choices.map((choice) => (
+          <option key={choice.value} value={choice.value}>
+            {choice.label}
+          </option>
+        ))}
+      </select>
+      {hint ? <span style={styles.hint}>{hint}</span> : null}
+    </Field>
+  );
+}
+
+export function TextareaField({ id, label, value, onChange, placeholder, labelWidth, rows = 2, hint, description }) {
+  return (
+    <Field id={id} label={label} labelWidth={labelWidth} description={description}>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        rows={rows}
+        spellCheck={false}
+        style={styles.textarea}
+      />
+      {hint ? <span style={styles.hint}>{hint}</span> : null}
+    </Field>
+  );
+}
+
+// An option typed `(string | RegExp)[]`. Exact values and patterns are collected separately because
+// only the patterns become regex literals, then the two are merged into a single array.
+export function RegexListField({ id, label, regexLabel, description, hint, labelWidth, value = {}, onChange }) {
+  return (
+    <>
+      <TextField
+        id={id}
+        label={label}
+        hint={hint}
+        description={description}
+        labelWidth={labelWidth}
+        value={value.list}
+        onChange={(list) => onChange({ ...value, list })}
+        placeholder="comma-separated"
+      />
+      <TextareaField
+        id={`${id}-regexes`}
+        label={regexLabel ?? `${label} regexes`}
+        hint="one per line"
+        description={`Regular expressions, one per line, merged into the same ${label.toLowerCase()} array as the exact values above and emitted as /pattern/ literals.`}
+        labelWidth={labelWidth}
+        value={value.regexes}
+        onChange={(regexes) => onChange({ ...value, regexes })}
+        placeholder={'\\.example\\.com$'}
+      />
+    </>
+  );
+}
+
+export function SubGroup({ title, description, children }) {
+  return (
+    <div style={styles.subGroup}>
+      {title ? (
+        <p
+          style={description ? { ...styles.subGroupTitle, ...styles.documentedLabel } : styles.subGroupTitle}
+          title={description}
+        >
+          {title}
+        </p>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+export function CheckboxField({ id, label, checked, onChange, labelWidth, hint, description }) {
+  return (
+    <Field id={id} label={label} labelWidth={labelWidth} description={description}>
+      <input id={id} type="checkbox" checked={checked} onChange={(event) => onChange(event.target.checked)} />
+      {hint ? <span style={styles.hint}>{hint}</span> : null}
+    </Field>
+  );
+}
+
+// Left uncontrolled so the browser owns the open/closed state; the panel re-renders on every
+// keystroke elsewhere on the page and a controlled `open` would fight that.
+export function Panel({ title, description, badge, defaultOpen = false, children }) {
+  return (
+    <details style={styles.panel} open={defaultOpen}>
+      <summary style={styles.panelSummary}>
+        {title}
+        {badge ? <span style={styles.panelBadge}>{badge}</span> : null}
+      </summary>
+      <div style={styles.panelBody}>
+        {description ? <p style={styles.panelDescription}>{description}</p> : null}
+        {children}
+      </div>
+    </details>
+  );
+}
+
+export function Button({ onClick, children }) {
+  return (
+    <button type="button" onClick={onClick} style={styles.button}>
+      {children}
+    </button>
+  );
+}
+
+export function Note({ children }) {
+  return <p style={styles.note}>{children}</p>;
+}
+
+export function Card({ title, action, children }) {
+  return (
+    <div style={styles.card}>
+      <div style={styles.cardHeader}>
+        <p style={styles.cardTitle}>{title}</p>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// Prism escapes the source while tokenising, so its output is safe to inject.
+export function CodeBlock({ code, language = 'javascript', maxHeight }) {
+  const highlighted = Prism.highlight(code, Prism.languages[language], language);
+  return (
+    <pre style={maxHeight ? { ...styles.pre, maxHeight, overflowY: 'auto' } : styles.pre}>
+      <code className={`language-${language}`} dangerouslySetInnerHTML={{ __html: highlighted }} />
+    </pre>
+  );
+}

--- a/test-server/configurator/config-options.js
+++ b/test-server/configurator/config-options.js
@@ -1,0 +1,362 @@
+// The rest of ExternalBrowserConfig (packages/analytics-core/src/types/config/browser-config.ts) and
+// the IConfig it extends, minus `autocapture` which has its own panel. Defaults come from the
+// BrowserConfig constructor in packages/analytics-browser/src/config.ts, and each `description` is
+// the JSDoc from the corresponding interface property (used as the field's tooltip).
+//
+// Deliberately not exposed:
+//   - set elsewhere in this UI: apiKey, autocapture
+//   - hidden from BrowserOptions: transportProvider, requestMetadata
+//   - class instances a form can't build: loggerProvider, storageProvider, identify
+//   - Amplitude-internal: plan, ingestionMetadata
+//   - deprecated: defaultTracking (use autocapture), fetchRemoteConfig (use remoteConfig.fetchRemoteConfig),
+//     networkTrackingOptions (use autocapture.networkTracking)
+//   - `transport` is offered as its TransportType string; the TransportOptions object form
+//     (headers/enableKeepalive/referrerPolicy) is not exposed
+//   - `customEnrichment` is offered as a boolean; its object form takes a `body` of JS source
+export const CONFIG_SECTIONS = [
+  {
+    title: 'Identity',
+    fields: [
+      {
+        key: 'userId',
+        label: 'User ID',
+        type: 'string',
+        hint: 'default: unset',
+        description:
+          'The identifier for the user being tracked. This should be unique for each user and not hardcoded.',
+      },
+      {
+        key: 'deviceId',
+        label: 'Device ID',
+        type: 'string',
+        hint: 'default: random UUID',
+        description:
+          'The identifier for the device running your application. This should be unique for each device and not hardcoded.',
+      },
+      {
+        key: 'sessionId',
+        label: 'Session ID',
+        type: 'number',
+        hint: 'default: current timestamp',
+        description:
+          'The custom Session ID for the current session. This should be unique for each session and not hardcoded.',
+      },
+      {
+        key: 'instanceName',
+        label: 'Instance name',
+        type: 'string',
+        topLevel: 'shared',
+        hint: "default: '$default'",
+        description: 'The instance name. For tracking events to multiple Amplitude projects in your application.',
+      },
+      {
+        key: 'partnerId',
+        label: 'Partner ID',
+        type: 'string',
+        hint: 'default: unset',
+        description:
+          'The partner identifier. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to partner_id.',
+      },
+      {
+        key: 'appVersion',
+        label: 'App version',
+        type: 'string',
+        hint: 'default: unset',
+        description: 'An app version for events tracked. This can be the version of your application.',
+      },
+      {
+        key: 'minIdLength',
+        label: 'Min ID length',
+        type: 'number',
+        hint: 'default: 5',
+        description: 'The minimum length for the value of userId and deviceId properties.',
+      },
+    ],
+  },
+  {
+    title: 'Session & page',
+    fields: [
+      {
+        key: 'sessionTimeout',
+        label: 'Session timeout (ms)',
+        type: 'number',
+        hint: 'default: 1800000 (30 min)',
+        description: 'The period of inactivity from the last tracked event before a session expires in milliseconds.',
+      },
+      {
+        key: 'pageCounter',
+        label: 'Page counter',
+        type: 'number',
+        hint: 'default: unset',
+        description:
+          "User's Nth instance of performing a default Page Viewed event within a session. Used for landing page analysis.",
+      },
+    ],
+  },
+  {
+    title: 'Server & transport',
+    fields: [
+      {
+        key: 'serverZone',
+        label: 'Server zone',
+        type: 'enum',
+        topLevel: 'shared',
+        hint: "default: 'US'",
+        description: 'The Amplitude server zone. Set this to EU for Amplitude projects created in EU data center.',
+        choices: [
+          { value: 'US', label: 'US' },
+          { value: 'EU', label: 'EU' },
+        ],
+      },
+      {
+        key: 'serverUrl',
+        label: 'Server URL',
+        type: 'string',
+        hint: 'default: Amplitude endpoint for the zone',
+        description: 'The URL where events are upload to.',
+      },
+      {
+        key: 'transport',
+        label: 'Transport',
+        type: 'enum',
+        hint: "default: 'fetch'",
+        description: 'Network transport mechanism used to send events.',
+        choices: [
+          { value: 'fetch', label: 'fetch' },
+          { value: 'xhr', label: 'xhr' },
+          { value: 'beacon', label: 'beacon' },
+        ],
+      },
+      {
+        key: 'useBatch',
+        label: 'Use batch API',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'The flag of whether to upload events to Batch API instead of the default HTTP V2 API.',
+      },
+      {
+        key: 'enableRequestBodyCompression',
+        label: 'Compress request body',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Compress network request body payloads with gzip. For custom serverUrl values, this option controls whether compression is attempted. For default Amplitude endpoints, compression remains enabled. Compression is best-effort and only applies when the platform supports it, the payload meets the minimum size threshold, and the transport can set request headers.',
+      },
+      {
+        key: 'offline',
+        label: 'Offline',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Whether the SDK is connected to network.',
+      },
+    ],
+  },
+  {
+    title: 'Event flushing',
+    fields: [
+      {
+        key: 'flushIntervalMillis',
+        label: 'Flush interval (ms)',
+        type: 'number',
+        hint: 'default: 1000',
+        description: 'The interval of uploading events to Amplitude in milliseconds.',
+      },
+      {
+        key: 'flushMaxRetries',
+        label: 'Flush max retries',
+        type: 'number',
+        hint: 'default: 5',
+        description:
+          'The maximum number of retries for failed upload attempts. This is only applicable to retryable errors.',
+      },
+      {
+        key: 'flushQueueSize',
+        label: 'Flush queue size',
+        type: 'number',
+        hint: 'default: 30',
+        description: 'The maximum number of events that are batched in a single upload attempt.',
+      },
+    ],
+  },
+  {
+    title: 'Logging & diagnostics',
+    fields: [
+      {
+        key: 'logLevel',
+        label: 'Log level',
+        type: 'enum',
+        hint: 'default: 2 (Warn)',
+        description:
+          'Level of logs to be printed in the developer console. Valid values are LogLevel.None, LogLevel.Error, LogLevel.Warn, LogLevel.Verbose, LogLevel.Debug.',
+        choices: [
+          { value: '0', label: '0 — None', runtime: 0 },
+          { value: '1', label: '1 — Error', runtime: 1 },
+          { value: '2', label: '2 — Warn', runtime: 2 },
+          { value: '3', label: '3 — Verbose', runtime: 3 },
+          { value: '4', label: '4 — Debug', runtime: 4 },
+        ],
+      },
+      {
+        key: 'enableDiagnostics',
+        label: 'Enable diagnostics',
+        type: 'boolean',
+        defaultValue: true,
+        description: 'Whether to enable diagnostics.',
+      },
+      {
+        key: 'optOut',
+        label: 'Opt out',
+        type: 'boolean',
+        topLevel: true,
+        defaultValue: false,
+        description:
+          'The flag to opt this device out of Amplitude tracking. If this flag is set, no additional information will be stored for the user.',
+      },
+    ],
+  },
+  {
+    title: 'Storage',
+    fields: [
+      {
+        key: 'identityStorage',
+        label: 'Identity storage',
+        type: 'enum',
+        hint: "default: 'cookie'",
+        description: 'The storage for user identify.',
+        choices: [
+          { value: 'cookie', label: 'cookie' },
+          { value: 'localStorage', label: 'localStorage' },
+          { value: 'sessionStorage', label: 'sessionStorage' },
+          { value: 'none', label: 'none' },
+        ],
+      },
+      {
+        key: 'cookieOptions',
+        label: 'Cookie options',
+        type: 'group',
+        description: 'Configuration for cookie.',
+        fields: [
+          {
+            key: 'domain',
+            label: 'Domain',
+            type: 'string',
+            hint: 'default: your top level domain',
+            description: 'The domain property of cookies created.',
+          },
+          {
+            key: 'expiration',
+            label: 'Expiration (days)',
+            type: 'number',
+            hint: 'default: 365',
+            description: 'The expiration of cookies created in days.',
+          },
+          {
+            key: 'sameSite',
+            label: 'Same site',
+            type: 'enum',
+            hint: "default: 'Lax'",
+            description: 'How cookies are sent with cross-site requests.',
+            choices: [
+              { value: 'Strict', label: 'Strict' },
+              { value: 'Lax', label: 'Lax' },
+              { value: 'None', label: 'None' },
+            ],
+          },
+          {
+            key: 'secure',
+            label: 'Secure',
+            type: 'boolean',
+            defaultValue: false,
+            description: 'The flag of if send cookies over secure protocols.',
+          },
+          {
+            key: 'upgrade',
+            label: 'Upgrade',
+            type: 'boolean',
+            defaultValue: true,
+            description: 'The flag of if upgrade the cookies created by maintenance Browser SDK.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Tracking & remote config',
+    fields: [
+      {
+        key: 'trackingOptions',
+        label: 'Tracking options',
+        type: 'group',
+        description: 'The configurations for tracking additional properties.',
+        fields: [
+          {
+            key: 'ipAddress',
+            label: 'IP address',
+            type: 'boolean',
+            defaultValue: true,
+            description: 'Enables/disables ip address tracking.',
+          },
+          {
+            key: 'language',
+            label: 'Language',
+            type: 'boolean',
+            defaultValue: true,
+            description: 'Enables/disables language tracking.',
+          },
+          {
+            key: 'platform',
+            label: 'Platform',
+            type: 'boolean',
+            defaultValue: true,
+            description: 'Enables/disables platform tracking.',
+          },
+        ],
+      },
+      {
+        key: 'remoteConfig',
+        label: 'Remote config',
+        type: 'group',
+        description: 'Remote configuration options.',
+        fields: [
+          {
+            key: 'fetchRemoteConfig',
+            label: 'Fetch remote config',
+            type: 'boolean',
+            defaultValue: true,
+            description:
+              'Whether to fetch remote configuration. The remote configuration can be updated in the Amplitude platform under Settings > Autocapture.',
+          },
+          {
+            key: 'serverUrl',
+            label: 'Server URL',
+            type: 'string',
+            hint: 'default: Amplitude remote config endpoint',
+            description:
+              'Custom server URL for remote configuration requests. If not provided, defaults to the standard Amplitude remote config endpoint based on serverZone (US or EU). Use this to proxy remote config requests through your own server.',
+          },
+        ],
+      },
+      {
+        key: 'customEnrichment',
+        label: 'Custom enrichment',
+        type: 'boolean',
+        defaultValue: false,
+        hint: '(experimental · boolean form only)',
+        description: 'The configurations for custom enrichment.',
+      },
+    ],
+  },
+];
+
+export const CONFIG_OPTIONS = CONFIG_SECTIONS.flatMap((section) => section.fields);
+
+// Promoted options. They stay in their section above so the schema, defaults and snippet
+// serialization keep treating them like any other field; only the rendering moves.
+//
+// `topLevel: 'shared'` marks the options initAll() takes at the top level of its config rather than
+// under `analytics`, because every SDK it initialises gets them (UnifiedSharedOptions in
+// packages/unified/src/unified.ts). They aren't analytics-specific, so they render next to the API
+// key, above the per-SDK sections. `topLevel: true` is for options that are analytics-only but
+// common enough to be worth reaching without opening a panel.
+export const SHARED_CONFIG_OPTIONS = CONFIG_OPTIONS.filter((field) => field.topLevel === 'shared');
+export const TOP_LEVEL_CONFIG_OPTIONS = CONFIG_OPTIONS.filter((field) => field.topLevel === true);

--- a/test-server/configurator/default-state.js
+++ b/test-server/configurator/default-state.js
@@ -1,0 +1,23 @@
+import { createDefaultAutocaptureOptions, createDefaultSubOptions } from './autocapture-options.js';
+import { CONFIG_OPTIONS } from './config-options.js';
+import { ENGAGEMENT_OPTIONS } from './engagement-options.js';
+import { createDefaultValues } from './fields.js';
+import { SESSION_REPLAY_OPTIONS } from './session-replay-options.js';
+
+// Everything the form holds, in one shape, so it can be diffed against a saved link and restored from
+// one. These are also exactly the arguments buildSnippet() and buildRuntimeConfig() take, which is why
+// the run page can rebuild a configuration from nothing but the link the form produced.
+export function createDefaultState() {
+  return {
+    apiKey: '',
+    format: 'esm',
+    configOptions: createDefaultValues(CONFIG_OPTIONS),
+    autocapture: true,
+    autocaptureOptions: createDefaultAutocaptureOptions(),
+    autocaptureSubOptions: createDefaultSubOptions(),
+    sessionReplay: false,
+    sessionReplayOptions: createDefaultValues(SESSION_REPLAY_OPTIONS),
+    engagement: false,
+    engagementOptions: createDefaultValues(ENGAGEMENT_OPTIONS),
+  };
+}

--- a/test-server/configurator/engagement-options.js
+++ b/test-server/configurator/engagement-options.js
@@ -1,0 +1,160 @@
+// The options the Guides and Surveys plugin accepts, from InitOptions in @amplitude/engagement-browser
+// (index.d.ts of the installed package, pinned by packages/unified). Each `description` is the JSDoc
+// from the corresponding property and each `hint` its @default.
+//
+// The plugin fills several of these in from the analytics config it is added to — `init(config.apiKey,
+// { serverZone: config.serverZone, ...options, options: { logLevel: config.logLevel, logger:
+// config.loggerProvider, ...options.options } })` — so anything left unset here follows the analytics
+// SDK rather than the standalone default.
+//
+// Deliberately not exposed:
+//   - shared with the other SDKs: serverZone (initAll takes it at the top level, and the plugin reads
+//     it off the analytics config)
+//   - driven by the section's Enabled checkbox: skip
+//   - class instances a form can't build: options.logger
+//   - callbacks a form can't build: the function form of token (the string form is offered)
+//   - the open-ended index signature on `options`
+export const ENGAGEMENT_SECTIONS = [
+  {
+    title: 'General',
+    fields: [
+      {
+        key: 'locale',
+        label: 'Locale',
+        type: 'string',
+        hint: 'default: unset — uses the default language',
+        description: 'Sets the locale for localization.',
+      },
+      {
+        key: 'autoRefreshIntervalSeconds',
+        label: 'Auto-refresh interval (s)',
+        type: 'number',
+        hint: 'default: disabled · minimum 60',
+        description:
+          'Auto-refresh interval in seconds. If not specified, 0, or negative, auto-refresh is disabled. When enabled, the SDK will automatically refresh (re-fetch targeting, user interaction state, and reload guides and surveys configuration) at this interval. Must be greater than or equal to 60 seconds.',
+      },
+      {
+        key: 'token',
+        label: 'Token',
+        type: 'string',
+        hint: 'default: unset',
+        description:
+          "JWT token for identity verification. Included in the user object sent to the server. The token should be an HS256-signed JWT containing the user's user_id, generated server-side using your project's secret key.",
+      },
+      {
+        key: 'nonce',
+        label: 'Nonce',
+        type: 'string',
+        hint: 'default: unset',
+        description:
+          'Sets a nonce value for Content Security Policy (CSP) compliance. This allows inline styles required by Guides and Surveys to be executed when CSP is enabled.',
+      },
+    ],
+  },
+  {
+    title: 'Rendering & logging',
+    fields: [
+      {
+        key: 'options',
+        label: 'Options',
+        type: 'group',
+        description: 'Rendering, loading and logging behaviour of the Guides and Surveys bundle.',
+        fields: [
+          {
+            key: 'splitting',
+            label: 'Splitting',
+            type: 'boolean',
+            defaultValue: true,
+            description: 'Enables code splitting for faster initial load times.',
+          },
+          {
+            key: 'headless',
+            label: 'Headless',
+            type: 'boolean',
+            defaultValue: false,
+            description: 'Enables headless mode for custom rendering.',
+          },
+          {
+            key: 'renderCssInDom',
+            label: 'Render CSS in DOM',
+            type: 'boolean',
+            defaultValue: false,
+            description: 'Renders CSS styles directly in the DOM instead of using CSS-in-JS.',
+          },
+          {
+            key: 'persistResourceCenter',
+            label: 'Persist Resource Center',
+            type: 'boolean',
+            defaultValue: false,
+            description: 'Persists Resource Center state across sessions.',
+          },
+          {
+            key: 'mountElementId',
+            label: 'Mount element ID',
+            type: 'string',
+            hint: 'default: unset',
+            description: 'Custom DOM element ID where the SDK should mount its container.',
+          },
+          {
+            key: 'logLevel',
+            label: 'Log level',
+            type: 'enum',
+            hint: 'default: the analytics log level',
+            description: 'Sets the log level.',
+            choices: [
+              { value: '0', label: '0 — None', runtime: 0 },
+              { value: '1', label: '1 — Error', runtime: 1 },
+              { value: '2', label: '2 — Warn', runtime: 2 },
+              { value: '3', label: '3 — Verbose', runtime: 3 },
+              { value: '4', label: '4 — Debug', runtime: 4 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Server URLs',
+    fields: [
+      {
+        key: 'useEngagementDomain',
+        label: 'Use engagement domain',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Uses the amplitudeengagement.com domain for all API, chat, media, and CDN requests instead of the default amplitude.com domain. Only supported in prod US and prod EU. Explicit serverUrl, chatUrl, mediaUrl, or cdnUrl values take precedence.',
+      },
+      {
+        key: 'serverUrl',
+        label: 'Server URL',
+        type: 'string',
+        hint: 'default: Amplitude endpoint for the zone',
+        description: 'Sets a custom server URL for API requests. Useful for proxy setups.',
+      },
+      {
+        key: 'chatUrl',
+        label: 'Chat URL',
+        type: 'string',
+        hint: 'default: Amplitude endpoint for the zone',
+        description: 'Sets a custom URL for chat functionality.',
+      },
+      {
+        key: 'mediaUrl',
+        label: 'Media URL',
+        type: 'string',
+        hint: 'default: Amplitude endpoint for the zone',
+        description:
+          'Sets a custom URL for proxying guide and survey images. Useful for proxy setups when images are blocked.',
+      },
+      {
+        key: 'cdnUrl',
+        label: 'CDN URL',
+        type: 'string',
+        hint: 'default: Amplitude CDN for the zone',
+        description: 'Sets a custom CDN URL for static assets. Useful for proxy setups.',
+      },
+    ],
+  },
+];
+
+export const ENGAGEMENT_OPTIONS = ENGAGEMENT_SECTIONS.flatMap((section) => section.fields);

--- a/test-server/configurator/fields.js
+++ b/test-server/configurator/fields.js
@@ -1,0 +1,69 @@
+// Shared behaviour for every field in the configurator, used by both the top-level config schema and
+// the autocapture sub-options.
+//
+// Field types:
+//   boolean    - checkbox seeded at the SDK default
+//   string     - text input; blank means "leave unset"
+//   number     - numeric input; blank means "leave unset"
+//   enum       - select of `choices`; blank means "leave unset"
+//   stringList - comma-separated text, emitted as an array literal
+//   regexList  - for `(string | RegExp)[]` options: exact values plus patterns, merged into one array
+//   group      - nested object of `fields` (e.g. cookieOptions)
+//   ruleList   - repeatable list of objects (networkTracking.captureRules)
+
+// Exact values are comma-separated, but patterns get a line each: a regex is free to contain a comma
+// (`\d{1,3}`), so splitting them on one would quietly break the pattern.
+export function parseList(value) {
+  return splitOn(value, ',');
+}
+
+export function parsePatterns(value) {
+  return splitOn(value, '\n');
+}
+
+function splitOn(value, separator) {
+  return String(value ?? '')
+    .split(separator)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function createDefaultValue(field) {
+  switch (field.type) {
+    case 'boolean':
+      return field.defaultValue;
+    case 'ruleList':
+      return [];
+    case 'regexList':
+      return { list: '', regexes: '' };
+    case 'group':
+      return createDefaultValues(field.fields);
+    default:
+      return '';
+  }
+}
+
+export function createDefaultValues(fields = []) {
+  return Object.fromEntries(fields.map((field) => [field.key, createDefaultValue(field)]));
+}
+
+// A field only reaches the generated snippet once it differs from the SDK default, which keeps the
+// output to just what was deliberately configured.
+export function isFieldChanged(field, value) {
+  switch (field.type) {
+    case 'boolean':
+      return value !== field.defaultValue;
+    case 'ruleList':
+      return Array.isArray(value) && value.length > 0;
+    case 'regexList':
+      return parseList(value?.list).length > 0 || parsePatterns(value?.regexes).length > 0;
+    case 'group':
+      return changedFields(field.fields, value ?? {}).length > 0;
+    default:
+      return value !== undefined && String(value).trim() !== '';
+  }
+}
+
+export function changedFields(fields = [], values = {}) {
+  return fields.filter((field) => isFieldChanged(field, values[field.key]));
+}

--- a/test-server/configurator/main.jsx
+++ b/test-server/configurator/main.jsx
@@ -1,0 +1,302 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Button, CheckboxField, CodeBlock, SelectField, TextField } from './components.jsx';
+import { AutocapturePanel } from './autocapture-panel.jsx';
+import { SectionPanels } from './section-panels.jsx';
+import { CONFIG_SECTIONS, SHARED_CONFIG_OPTIONS, TOP_LEVEL_CONFIG_OPTIONS } from './config-options.js';
+import { ENGAGEMENT_SECTIONS } from './engagement-options.js';
+import { SESSION_REPLAY_SECTIONS, TOP_LEVEL_SESSION_REPLAY_OPTIONS } from './session-replay-options.js';
+import { createDefaultState } from './default-state.js';
+import { OptionField } from './option-field.jsx';
+import { decodeStateFromUrl, encodeStateToUrl, hasSavedState } from './share-link.js';
+import { buildSnippet, SNIPPET_FORMATS, snippetLanguage } from './snippet.js';
+
+const styles = {
+  page: { fontFamily: 'system-ui, sans-serif', maxWidth: 1400, margin: '48px auto', padding: '0 16px' },
+  heading: { marginBottom: 8 },
+  intro: { color: '#666', marginTop: 0 },
+  // Two columns that collapse to one when the viewport can't fit both, no media query needed: each
+  // column asks for its basis width and wraps once there isn't room.
+  layout: { display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 24 },
+  configColumn: { flex: '1 1 520px', minWidth: 0 },
+  // Sticks alongside the config column, which is far taller once a few panels are open.
+  outputColumn: { flex: '1 1 400px', minWidth: 0, position: 'sticky', top: 24 },
+  sectionHeading: { fontSize: 16, margin: '0 0 8px' },
+  // The API key belongs to both sections below, so it sits above the first rule.
+  formSection: { borderTop: '1px solid #e5e5e5', paddingTop: 16, marginTop: 20 },
+  toolbar: { display: 'flex', alignItems: 'center', gap: 10, margin: '0 0 20px' },
+  toolbarNote: { color: '#888', fontSize: 12 },
+};
+
+// Lines up the labels of the handful of fields sitting above the panels.
+const TOP_LABEL_WIDTH = 100;
+
+const DEFAULT_STATE = createDefaultState();
+
+// Sibling page that initialises the SDK with whatever the link carries.
+const RUN_PAGE = '/configurator-run.html';
+
+function Configurator({ initialState }) {
+  const [apiKey, setApiKey] = useState(initialState.apiKey);
+  const [format, setFormat] = useState(initialState.format);
+  const [configOptions, setConfigOptions] = useState(initialState.configOptions);
+  const [autocapture, setAutocapture] = useState(initialState.autocapture);
+  // Kept when autocapture is switched off so the selections come back on re-enable.
+  const [autocaptureOptions, setAutocaptureOptions] = useState(initialState.autocaptureOptions);
+  const [autocaptureSubOptions, setAutocaptureSubOptions] = useState(initialState.autocaptureSubOptions);
+  const [sessionReplay, setSessionReplay] = useState(initialState.sessionReplay);
+  const [sessionReplayOptions, setSessionReplayOptions] = useState(initialState.sessionReplayOptions);
+  const [engagement, setEngagement] = useState(initialState.engagement);
+  const [engagementOptions, setEngagementOptions] = useState(initialState.engagementOptions);
+  const [savedState, setSavedState] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [blockedRunUrl, setBlockedRunUrl] = useState(null);
+
+  const setConfigOption = (key, value) => {
+    setConfigOptions((previous) => ({ ...previous, [key]: value }));
+  };
+
+  const setSessionReplayOption = (key, value) => {
+    setSessionReplayOptions((previous) => ({ ...previous, [key]: value }));
+  };
+
+  const setEngagementOption = (key, value) => {
+    setEngagementOptions((previous) => ({ ...previous, [key]: value }));
+  };
+
+  const setAutocaptureOption = (key, value) => {
+    setAutocaptureOptions((previous) => ({ ...previous, [key]: value }));
+  };
+
+  const updateAutocaptureSubOptions = (parentKey, value) => {
+    setAutocaptureSubOptions((previous) => ({ ...previous, [parentKey]: value }));
+  };
+
+  const state = {
+    apiKey,
+    format,
+    configOptions,
+    autocapture,
+    autocaptureOptions,
+    autocaptureSubOptions,
+    sessionReplay,
+    sessionReplayOptions,
+    engagement,
+    engagementOptions,
+  };
+
+  // Comparing against the state that was saved means the confirmation goes away by itself as soon as
+  // anything is edited again.
+  const isSaved = savedState !== null && JSON.stringify(savedState) === JSON.stringify(state);
+
+  const copyLink = async () => {
+    const url = await encodeStateToUrl(state, DEFAULT_STATE);
+    window.history.replaceState(null, '', url);
+    setSavedState(state);
+    // The clipboard is unavailable outside a secure context, which this page often is when it's
+    // served to another device on the network, so the address bar is the fallback.
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+    } catch (error) {
+      console.warn('Could not copy the URL to the clipboard', error);
+      setCopied(false);
+    }
+  };
+
+  // The run page reads the same link the copy button writes, so running is a matter of pointing a new
+  // tab at it. The tab is opened before the state is encoded, because awaiting first spends the click
+  // that lets a pop-up through.
+  const run = async () => {
+    const tab = window.open('', '_blank');
+    const url = await encodeStateToUrl(state, DEFAULT_STATE, new URL(RUN_PAGE, window.location.href).toString());
+    if (tab) {
+      tab.location = url;
+      setBlockedRunUrl(null);
+    } else {
+      setBlockedRunUrl(url);
+    }
+  };
+
+  let linkNote =
+    'Copy this configuration as a link to bookmark or share, or run it in a new tab with the SDK initialised.';
+  if (isSaved) {
+    linkNote = copied
+      ? 'Copied to your clipboard, and saved to the address bar.'
+      : 'Saved to the address bar — the clipboard was unavailable, so copy it from there.';
+  }
+
+  return (
+    <main style={styles.page}>
+      <h1 style={styles.heading}>Amplitude Browser Client Configurator</h1>
+      <p style={styles.intro}>
+        Build an <code>amplitude.init()</code> call. Only options you change from their SDK default are included.
+      </p>
+
+      <div style={styles.toolbar}>
+        <Button onClick={copyLink}>Copy Link</Button>
+        <Button onClick={run}>Run</Button>
+        {blockedRunUrl ? (
+          <span style={styles.toolbarNote}>
+            A pop-up blocker stopped the new tab —{' '}
+            <a href={blockedRunUrl} target="_blank" rel="noreferrer">
+              open the run page
+            </a>
+            .
+          </span>
+        ) : (
+          <span style={styles.toolbarNote}>{linkNote}</span>
+        )}
+      </div>
+
+      <div style={styles.layout}>
+        <div style={styles.configColumn}>
+          <TextField
+            id="api-key"
+            label="API Key"
+            labelWidth={TOP_LABEL_WIDTH}
+            value={apiKey}
+            onChange={setApiKey}
+            placeholder="your project API key"
+            description="Your Amplitude Project API key."
+          />
+          {SHARED_CONFIG_OPTIONS.map((field) => (
+            <OptionField
+              key={field.key}
+              id={`config-${field.key}`}
+              field={field}
+              value={configOptions[field.key]}
+              onChange={(value) => setConfigOption(field.key, value)}
+              labelWidth={TOP_LABEL_WIDTH}
+            />
+          ))}
+
+          <section style={styles.formSection}>
+            <h2 style={styles.sectionHeading}>Analytics</h2>
+
+            {TOP_LEVEL_CONFIG_OPTIONS.map((field) => (
+              <OptionField
+                key={field.key}
+                id={`config-${field.key}`}
+                field={field}
+                value={configOptions[field.key]}
+                onChange={(value) => setConfigOption(field.key, value)}
+                labelWidth={TOP_LABEL_WIDTH}
+              />
+            ))}
+
+            <CheckboxField
+              id="autocapture"
+              label="Autocapture"
+              labelWidth={TOP_LABEL_WIDTH}
+              checked={autocapture}
+              onChange={setAutocapture}
+              description="The configurations for auto-captured events."
+            />
+            {autocapture ? (
+              <AutocapturePanel
+                values={autocaptureOptions}
+                onChange={setAutocaptureOption}
+                subValues={autocaptureSubOptions}
+                onSubChange={updateAutocaptureSubOptions}
+              />
+            ) : null}
+
+            <SectionPanels
+              sections={CONFIG_SECTIONS}
+              values={configOptions}
+              onChange={setConfigOption}
+              idPrefix="config"
+            />
+          </section>
+
+          <section style={styles.formSection}>
+            <h2 style={styles.sectionHeading}>Session Replay</h2>
+
+            <CheckboxField
+              id="session-replay"
+              label="Enabled"
+              labelWidth={TOP_LABEL_WIDTH}
+              checked={sessionReplay}
+              onChange={setSessionReplay}
+              description="Installs the session replay plugin alongside the analytics SDK."
+            />
+            {sessionReplay ? (
+              <>
+                {TOP_LEVEL_SESSION_REPLAY_OPTIONS.map((field) => (
+                  <OptionField
+                    key={field.key}
+                    id={`session-replay-${field.key}`}
+                    field={field}
+                    value={sessionReplayOptions[field.key]}
+                    onChange={(value) => setSessionReplayOption(field.key, value)}
+                    labelWidth={TOP_LABEL_WIDTH}
+                  />
+                ))}
+
+                <SectionPanels
+                  sections={SESSION_REPLAY_SECTIONS}
+                  values={sessionReplayOptions}
+                  onChange={setSessionReplayOption}
+                  idPrefix="session-replay"
+                />
+              </>
+            ) : null}
+          </section>
+
+          <section style={styles.formSection}>
+            <h2 style={styles.sectionHeading}>Guides and Surveys</h2>
+
+            <CheckboxField
+              id="engagement"
+              label="Enabled"
+              labelWidth={TOP_LABEL_WIDTH}
+              checked={engagement}
+              onChange={setEngagement}
+              description="Installs the Guides and Surveys plugin alongside the analytics SDK."
+            />
+            {engagement ? (
+              <SectionPanels
+                sections={ENGAGEMENT_SECTIONS}
+                values={engagementOptions}
+                onChange={setEngagementOption}
+                idPrefix="engagement"
+              />
+            ) : null}
+          </section>
+        </div>
+
+        <div style={styles.outputColumn}>
+          <h2 style={styles.sectionHeading}>Generated code</h2>
+          <SelectField
+            id="snippet-format"
+            label="Format"
+            labelWidth={60}
+            value={format}
+            onChange={setFormat}
+            choices={SNIPPET_FORMATS}
+            allowUnset={false}
+          />
+          <CodeBlock code={buildSnippet(state)} language={snippetLanguage(format)} maxHeight="calc(100vh - 180px)" />
+        </div>
+      </div>
+    </main>
+  );
+}
+
+// Reading a saved link means decompressing it, which is async, so the form waits for that rather than
+// mounting with its defaults and rewriting them a moment later. Without a link there is nothing to
+// wait for, so the common case still renders on the first pass.
+function App() {
+  const [initialState, setInitialState] = useState(() => (hasSavedState() ? null : createDefaultState()));
+
+  useEffect(() => {
+    if (initialState === null) {
+      void decodeStateFromUrl(createDefaultState()).then(setInitialState);
+    }
+  }, [initialState]);
+
+  return initialState === null ? null : <Configurator initialState={initialState} />;
+}
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/test-server/configurator/network-capture-rules.jsx
+++ b/test-server/configurator/network-capture-rules.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Button, Card, Note, RegexListField, SelectField, SubGroup, TextField } from './components.jsx';
+import { BODY_RULE_DESCRIPTIONS, CAPTURE_RULE_FIELDS, createCaptureRule } from './autocapture-options.js';
+
+const RULE_LABEL_WIDTH = 160;
+
+const HEADER_CHOICES = [
+  { value: 'true', label: 'true (safe headers)' },
+  { value: 'false', label: 'false' },
+  { value: 'custom', label: 'custom list' },
+];
+
+// requestHeaders/responseHeaders accept `string[] | boolean`, so the list input only appears once
+// "custom list" is picked.
+function HeadersField({ id, label, hint, description, value, onChange }) {
+  return (
+    <>
+      <SelectField
+        id={id}
+        label={label}
+        hint={hint}
+        description={description}
+        labelWidth={RULE_LABEL_WIDTH}
+        value={value.mode}
+        onChange={(mode) => onChange({ ...value, mode })}
+        choices={HEADER_CHOICES}
+      />
+      {value.mode === 'custom' ? (
+        <TextField
+          id={`${id}-list`}
+          label="Header names"
+          labelWidth={RULE_LABEL_WIDTH}
+          value={value.list}
+          onChange={(list) => onChange({ ...value, list })}
+          placeholder="comma-separated"
+        />
+      ) : null}
+    </>
+  );
+}
+
+function BodyRuleField({ id, label, description, value, onChange }) {
+  return (
+    <SubGroup title={label} description={description}>
+      <TextField
+        id={`${id}-allowlist`}
+        label="Allowlist"
+        labelWidth={RULE_LABEL_WIDTH}
+        description={BODY_RULE_DESCRIPTIONS.allowlist}
+        value={value.allowlist}
+        onChange={(allowlist) => onChange({ ...value, allowlist })}
+        placeholder="JSON pointers, comma-separated"
+      />
+      <TextField
+        id={`${id}-excludelist`}
+        label="Excludelist"
+        labelWidth={RULE_LABEL_WIDTH}
+        description={BODY_RULE_DESCRIPTIONS.excludelist}
+        value={value.excludelist}
+        onChange={(excludelist) => onChange({ ...value, excludelist })}
+        placeholder="JSON pointers, comma-separated"
+      />
+    </SubGroup>
+  );
+}
+
+function RuleField({ id, field, value, onChange }) {
+  const shared = {
+    id,
+    label: field.label,
+    hint: field.hint,
+    description: field.description,
+    labelWidth: RULE_LABEL_WIDTH,
+  };
+
+  switch (field.type) {
+    case 'headers':
+      return <HeadersField {...shared} value={value} onChange={onChange} />;
+    case 'bodyRule':
+      return <BodyRuleField {...shared} value={value} onChange={onChange} />;
+    case 'stringList':
+      return <TextField {...shared} value={value} onChange={onChange} placeholder="comma-separated" />;
+    case 'regexList':
+      return <RegexListField {...shared} regexLabel={field.regexLabel} value={value} onChange={onChange} />;
+    default:
+      return <TextField {...shared} value={value} onChange={onChange} />;
+  }
+}
+
+export function CaptureRulesEditor({ rules, onChange }) {
+  const updateRule = (index, key, value) =>
+    onChange(rules.map((rule, position) => (position === index ? { ...rule, [key]: value } : rule)));
+
+  return (
+    <SubGroup title="Capture rules">
+      {rules.length === 0 ? (
+        <Note>No rules — the SDK captures 500-599 responses from all hosts by default.</Note>
+      ) : (
+        <Note>Rules are matched in reverse order, so the last rule listed wins.</Note>
+      )}
+
+      {rules.map((rule, index) => (
+        <Card
+          key={rule.id}
+          title={`Rule ${index + 1}`}
+          action={<Button onClick={() => onChange(rules.filter((_, position) => position !== index))}>Remove</Button>}
+        >
+          {CAPTURE_RULE_FIELDS.map((field) => (
+            <RuleField
+              key={field.key}
+              id={`network-rule-${rule.id}-${field.key}`}
+              field={field}
+              value={rule[field.key]}
+              onChange={(value) => updateRule(index, field.key, value)}
+            />
+          ))}
+        </Card>
+      ))}
+
+      <Button onClick={() => onChange([...rules, createCaptureRule()])}>Add rule</Button>
+    </SubGroup>
+  );
+}

--- a/test-server/configurator/option-field.jsx
+++ b/test-server/configurator/option-field.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { CheckboxField, RegexListField, SelectField, SubGroup, TextField } from './components.jsx';
+import { CaptureRulesEditor } from './network-capture-rules.jsx';
+
+// Renders one schema field. onChange always receives the field's complete new value, so a `group`
+// merges its children before handing the object up and callers need no path handling.
+export function OptionField({ id, field, value, onChange, labelWidth }) {
+  const shared = { id, label: field.label, hint: field.hint, description: field.description, labelWidth };
+
+  switch (field.type) {
+    case 'boolean':
+      return <CheckboxField {...shared} checked={value} onChange={onChange} />;
+    case 'enum':
+      return <SelectField {...shared} value={value} onChange={onChange} choices={field.choices} />;
+    case 'number':
+      return <TextField {...shared} type="number" width={160} value={value} onChange={onChange} />;
+    case 'stringList':
+      return <TextField {...shared} value={value} onChange={onChange} placeholder="comma-separated" />;
+    case 'regexList':
+      return <RegexListField {...shared} regexLabel={field.regexLabel} value={value} onChange={onChange} />;
+    case 'ruleList':
+      return <CaptureRulesEditor rules={value} onChange={onChange} />;
+    case 'group':
+      return (
+        <SubGroup title={field.label} description={field.description}>
+          {field.fields.map((child) => (
+            <OptionField
+              key={child.key}
+              id={`${id}-${child.key}`}
+              field={child}
+              value={value?.[child.key]}
+              onChange={(childValue) => onChange({ ...value, [child.key]: childValue })}
+              labelWidth={labelWidth}
+            />
+          ))}
+        </SubGroup>
+      );
+    default:
+      return <TextField {...shared} value={value} onChange={onChange} />;
+  }
+}

--- a/test-server/configurator/run.jsx
+++ b/test-server/configurator/run.jsx
@@ -1,0 +1,280 @@
+// Runs the configuration the configurator built: the same link the form produces opens here, and this
+// page initialises the real SDK with it and shows what comes out.
+//
+// The SDK is loaded as ESM from packages/ (vite aliases @amplitude/* to this checkout), so what runs is
+// the code in this working tree, not a published bundle. Those imports are dynamic, because they resolve
+// to built output: a checkout that hasn't run `pnpm build` should say so on the page rather than fail to
+// render at all.
+import React, { useEffect, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Button, Card, CodeBlock, Note } from './components.jsx';
+import { createDefaultState } from './default-state.js';
+import { buildRuntimeConfig } from './runtime-config.js';
+import { decodeStateFromUrl, hasSavedState } from './share-link.js';
+import { buildSnippet, PLACEHOLDER_API_KEY } from './snippet.js';
+
+const styles = {
+  page: { fontFamily: 'system-ui, sans-serif', maxWidth: 1400, margin: '48px auto', padding: '0 16px' },
+  heading: { marginBottom: 8 },
+  intro: { color: '#666', marginTop: 0 },
+  layout: { display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 24 },
+  column: { flex: '1 1 460px', minWidth: 0 },
+  outputColumn: { flex: '1 1 460px', minWidth: 0, position: 'sticky', top: 24 },
+  sectionHeading: { fontSize: 16, margin: '0 0 8px' },
+  toolbar: { display: 'flex', alignItems: 'center', gap: 10, margin: '0 0 20px' },
+  status: { padding: '8px 12px', borderRadius: 6, fontSize: 13, margin: '0 0 16px' },
+  ready: { background: '#e8f5e9', color: '#1b5e20' },
+  pending: { background: '#f3f3f3', color: '#555' },
+  failed: { background: '#fdecea', color: '#8e1c14' },
+  controls: { display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 10, marginBottom: 12 },
+  form: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 },
+  input: { padding: '6px 8px', font: 'inherit', width: 180 },
+  log: { maxHeight: 460, overflowY: 'auto', border: '1px solid #ddd', borderRadius: 6, background: '#fff' },
+  logRow: { display: 'flex', gap: 10, padding: '6px 10px', borderBottom: '1px solid #f0f0f0', fontSize: 13 },
+  logTime: { color: '#999', fontVariantNumeric: 'tabular-nums', flex: 'none' },
+  logType: { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', minWidth: 0, wordBreak: 'break-word' },
+  logDetails: { padding: '0 10px 8px', margin: 0 },
+  empty: { color: '#888', fontSize: 13, padding: '10px' },
+};
+
+// Enough rows to watch a burst of autocapture without letting a long-lived page grow without bound.
+const MAX_LOGGED_EVENTS = 200;
+
+const CUSTOM_EVENT = 'Configurator Test Event';
+
+// Records every event on its way through the pipeline, which is what makes autocapture visible here.
+// Enrichment plugins see events after the SDK has built them, so the payload shown is the real one.
+function eventLogPlugin(onEvent) {
+  return {
+    name: 'configurator-event-log',
+    type: 'enrichment',
+    setup: async () => undefined,
+    execute: async (event) => {
+      onEvent(event);
+      return event;
+    },
+  };
+}
+
+// Guides and Surveys is served per project rather than per version, so its bundle is fetched by API
+// key: https://amplitude.com/docs/sdks/guides-and-surveys/sdk. The npm package the ESM snippet imports
+// is a loader for that same script and isn't part of this workspace, so the page loads it directly.
+function loadEngagementScript(apiKey) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = `https://cdn.amplitude.com/script/${apiKey}.engagement.js`;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`No Guides and Surveys bundle for API key ${apiKey}`));
+    document.head.appendChild(script);
+  });
+}
+
+// Same order as the ESM snippet: Guides and Surveys is added before init() so analytics drives its
+// setup with an identity already resolved, session replay after, as their docs call for. A plugin that
+// won't load is reported as a warning rather than thrown, since analytics is worth running without it.
+async function runSdk(state, onEvent) {
+  const { apiKey, analytics, sessionReplay, engagement } = buildRuntimeConfig(state);
+  const key = apiKey || import.meta.env.VITE_AMPLITUDE_API_KEY || PLACEHOLDER_API_KEY;
+  const installed = ['analytics'];
+  const warnings = [];
+
+  const amplitude = await import('@amplitude/analytics-browser');
+  amplitude.add(eventLogPlugin(onEvent));
+
+  if (engagement) {
+    try {
+      await loadEngagementScript(key);
+      amplitude.add(window.engagement.plugin(engagement));
+      installed.push('guides and surveys');
+    } catch (error) {
+      // A missing bundle is the normal outcome for a placeholder key, and no reason not to run the rest.
+      warnings.push(`Guides and Surveys didn't load: ${error.message}`);
+    }
+  }
+
+  await amplitude.init(key, analytics).promise;
+
+  if (sessionReplay) {
+    try {
+      const { sessionReplayPlugin } = await import('@amplitude/plugin-session-replay-browser');
+      await amplitude.add(sessionReplayPlugin(sessionReplay)).promise;
+      installed.push('session replay');
+    } catch (error) {
+      warnings.push(`Session replay didn't load: ${error.message}`);
+    }
+  }
+
+  return { amplitude, key, installed, warnings };
+}
+
+function EventLog({ events }) {
+  if (events.length === 0) {
+    return (
+      <div style={styles.log}>
+        <p style={styles.empty}>Nothing tracked yet. Use the controls above, or click around the page.</p>
+      </div>
+    );
+  }
+  return (
+    <div style={styles.log}>
+      {events.map((entry) => (
+        <details key={entry.id}>
+          <summary style={styles.logRow}>
+            <span style={styles.logTime}>{entry.time}</span>
+            <span style={styles.logType}>{entry.type}</span>
+          </summary>
+          <div style={styles.logDetails}>
+            <CodeBlock code={entry.payload} maxHeight={280} />
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+// Ordinary page furniture, here so the autocapture options that need something to capture have
+// something to capture.
+function Sandbox({ onTrack, onFetch, onNavigate }) {
+  return (
+    <>
+      <div style={styles.controls}>
+        <Button onClick={onTrack}>Track a custom event</Button>
+        <Button onClick={onFetch}>Fetch /api/test</Button>
+        <Button onClick={onNavigate}>Change the URL</Button>
+      </div>
+      <div style={styles.controls}>
+        <button type="button" id="plain-button">
+          A plain button
+        </button>
+        <a href="#event-log">A link</a>
+        <a href="/configurator/sample-download.csv" download>
+          A download
+        </a>
+      </div>
+      <form style={styles.form} onSubmit={(event) => event.preventDefault()}>
+        <input style={styles.input} name="favourite-config" placeholder="Type something" autoComplete="off" />
+        <button type="submit">Submit a form</button>
+      </form>
+    </>
+  );
+}
+
+function Runner() {
+  const [snippet, setSnippet] = useState('');
+  const [status, setStatus] = useState({ kind: 'pending', message: 'Reading the configuration…' });
+  const [events, setEvents] = useState([]);
+  // init() is not idempotent, and effects run twice in development.
+  const startedRef = useRef(false);
+  const nextIdRef = useRef(0);
+  const navigationsRef = useRef(0);
+  const sdkRef = useRef(null);
+
+  const logEvent = (event) => {
+    nextIdRef.current += 1;
+    const entry = {
+      id: nextIdRef.current,
+      time: new Date().toLocaleTimeString(),
+      type: event.event_type,
+      payload: JSON.stringify(event, null, 2),
+    };
+    setEvents((previous) => [entry, ...previous].slice(0, MAX_LOGGED_EVENTS));
+  };
+
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    (async () => {
+      const state = await decodeStateFromUrl(createDefaultState());
+      setSnippet(buildSnippet({ ...state, format: 'esm' }));
+      setStatus({ kind: 'pending', message: 'Initialising the SDK…' });
+      try {
+        const { amplitude, key, installed, warnings } = await runSdk(state, logEvent);
+        sdkRef.current = amplitude;
+        setStatus({
+          kind: 'ready',
+          message: `Running ${installed.join(', ')} with API key ${key}.`,
+          warnings,
+          placeholder: key === PLACEHOLDER_API_KEY,
+        });
+      } catch (error) {
+        setStatus({ kind: 'failed', message: `The SDK failed to start: ${error.message}` });
+      }
+    })();
+  }, []);
+
+  const trackCustomEvent = () => {
+    sdkRef.current?.track(CUSTOM_EVENT, { source: 'run page' });
+  };
+
+  const fetchTestEndpoint = () => {
+    // Nothing reads the response; the point is a request for network tracking to capture.
+    fetch('/api/test').catch(() => undefined);
+  };
+
+  // A History API change is what page view tracking watches for. Only the fragment moves, so the
+  // configuration in the query string survives a reload.
+  const changeUrl = () => {
+    navigationsRef.current += 1;
+    window.history.pushState(
+      {},
+      '',
+      `${window.location.pathname}${window.location.search}#page-${navigationsRef.current}`,
+    );
+  };
+
+  const statusStyle = { ...styles.status, ...styles[status.kind] };
+
+  return (
+    <div style={styles.page}>
+      <h1 style={styles.heading}>Running the configured client</h1>
+      <p style={styles.intro}>
+        This page initialises <code>@amplitude/analytics-browser</code> from this checkout with the configuration in the
+        link, then logs every event the SDK builds.
+      </p>
+      <div style={styles.toolbar}>
+        <a href={`/configurator.html${window.location.search}`}>← Back to the configurator</a>
+      </div>
+      <p style={statusStyle}>{status.message}</p>
+      {status.placeholder ? (
+        <Note>
+          No API key is configured, so events are built and logged here but Amplitude will reject them. Set one in the
+          configurator, or put <code>VITE_AMPLITUDE_API_KEY</code> in <code>.env</code>.
+        </Note>
+      ) : null}
+      {!hasSavedState() ? <Note>The link carries no configuration, so these are the form&apos;s defaults.</Note> : null}
+      {(status.warnings ?? []).map((warning) => (
+        <Note key={warning}>{warning}</Note>
+      ))}
+      <div style={styles.layout}>
+        <div style={styles.column}>
+          <h2 style={styles.sectionHeading}>Sandbox</h2>
+          <Card title="Things to capture">
+            <Note>
+              Each control exercises a different autocapture option, so what shows up in the log depends on what the
+              configuration switched on. Network requests are only captured when a rule matches: by default that is
+              status codes 500-599, so <code>/api/test</code> needs a rule to appear.
+            </Note>
+            <Sandbox onTrack={trackCustomEvent} onFetch={fetchTestEndpoint} onNavigate={changeUrl} />
+          </Card>
+          <h2 style={styles.sectionHeading} id="event-log">
+            Event log
+          </h2>
+          <Note>Newest first. Expand a row for the full payload the SDK would send.</Note>
+          <EventLog events={events} />
+        </div>
+        <div style={styles.outputColumn}>
+          <h2 style={styles.sectionHeading}>What this page is running</h2>
+          <Note>
+            The same ESM code the configurator generates for this configuration. Guides and Surveys is the one
+            difference: the page loads its per-project bundle from the CDN, which is what that npm import wraps.
+          </Note>
+          <CodeBlock code={snippet} maxHeight="60vh" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')).render(<Runner />);

--- a/test-server/configurator/runtime-config.js
+++ b/test-server/configurator/runtime-config.js
@@ -1,0 +1,138 @@
+// Turns the form state into the values the SDKs actually take, for the run page.
+//
+// This is the same walk snippet.js does, one step short of it: snippet.js renders each field as source
+// text, this returns the value that source would evaluate to. The two are deliberately separate rather
+// than the snippet being generated from these values, because the snippet also owns indentation and
+// only it needs to worry about how a value reads. They have to agree, so a change to how a field type
+// is interpreted belongs in both — the round-trip is covered by comparing the two.
+import { AUTOCAPTURE_OPTIONS, CAPTURE_RULE_FIELDS } from './autocapture-options.js';
+import { CONFIG_OPTIONS } from './config-options.js';
+import { ENGAGEMENT_OPTIONS } from './engagement-options.js';
+import { changedFields, parseList, parsePatterns } from './fields.js';
+import { SESSION_REPLAY_OPTIONS } from './session-replay-options.js';
+
+// Patterns are written bare (`\.example\.com$`), but an already-delimited literal with flags is
+// honoured so a pattern needing /i still works.
+function toRegExp(pattern) {
+  const delimited = /^\/(.*)\/([dgimsuvy]*)$/.exec(pattern);
+  return delimited ? new RegExp(delimited[1], delimited[2]) : new RegExp(pattern);
+}
+
+// The exact values first, then the patterns, matching how the SDK's own remote config merges its
+// `<option>Regex` companions onto the end of the exact list.
+function regexListValue(value = {}) {
+  return [...parseList(value.list), ...parsePatterns(value.regexes).map(toRegExp)];
+}
+
+// A choice carries `runtime` when the value the SDK wants isn't the string the select holds.
+function enumValue(field, value) {
+  const { runtime } = field.choices.find((choice) => choice.value === value) ?? {};
+  return runtime === undefined ? value : runtime;
+}
+
+// `string[] | boolean`: an explicit boolean, or a custom header list.
+function headersValue(value = {}) {
+  if (value.mode === 'true' || value.mode === 'false') {
+    return value.mode === 'true';
+  }
+  if (value.mode === 'custom' && parseList(value.list).length > 0) {
+    return parseList(value.list);
+  }
+  return undefined;
+}
+
+function bodyRuleValue(value = {}) {
+  const entries = ['allowlist', 'excludelist']
+    .filter((key) => parseList(value[key] ?? '').length > 0)
+    .map((key) => [key, parseList(value[key])]);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+// Returns undefined for anything the user left alone, so untouched fields stay off the object.
+function ruleFieldValue(field, value) {
+  switch (field.type) {
+    case 'headers':
+      return headersValue(value);
+    case 'bodyRule':
+      return bodyRuleValue(value);
+    case 'stringList':
+      return parseList(value).length > 0 ? parseList(value) : undefined;
+    case 'regexList': {
+      const merged = regexListValue(value);
+      return merged.length > 0 ? merged : undefined;
+    }
+    default:
+      return String(value ?? '').trim() !== '' ? String(value).trim() : undefined;
+  }
+}
+
+function ruleValue(rule) {
+  const entries = CAPTURE_RULE_FIELDS.map((field) => [field.key, ruleFieldValue(field, rule[field.key])]).filter(
+    ([, value]) => value !== undefined,
+  );
+  return Object.fromEntries(entries);
+}
+
+function fieldValue(field, value) {
+  switch (field.type) {
+    case 'boolean':
+      return value;
+    case 'number':
+      return Number(value);
+    case 'stringList':
+      return parseList(value);
+    case 'regexList':
+      return regexListValue(value);
+    case 'ruleList':
+      return value.map(ruleValue);
+    case 'group':
+      return fieldSetValue(field.fields, value, field.requiredKeys);
+    case 'enum':
+      return enumValue(field, value);
+    default:
+      return value;
+  }
+}
+
+// `requiredKeys` are non-optional on the type they describe, so once anything else in the object is
+// set they are carried along at their default.
+function fieldSetValue(fields, values = {}, requiredKeys = []) {
+  const changed = changedFields(fields, values);
+  const included = fields.filter((field) => changed.includes(field) || requiredKeys.includes(field.key));
+  return Object.fromEntries(included.map((field) => [field.key, fieldValue(field, values[field.key])]));
+}
+
+// Disabled -> false. Enabled with nothing customised -> true. Enabled with customised sub-options -> an
+// object holding just those.
+function autocaptureValue(option, enabled, subValues) {
+  if (!enabled) {
+    return false;
+  }
+  if (changedFields(option.subOptions ?? [], subValues).length === 0) {
+    return true;
+  }
+  return fieldSetValue(option.subOptions, subValues);
+}
+
+function autocaptureConfig({ autocapture, autocaptureOptions, autocaptureSubOptions }) {
+  if (!autocapture) {
+    return false;
+  }
+  return Object.fromEntries(
+    AUTOCAPTURE_OPTIONS.map((option) => [
+      option.key,
+      autocaptureValue(option, autocaptureOptions[option.key], autocaptureSubOptions[option.key]),
+    ]),
+  );
+}
+
+export function buildRuntimeConfig(state) {
+  const analytics = fieldSetValue(CONFIG_OPTIONS, state.configOptions);
+  return {
+    apiKey: state.apiKey.trim(),
+    analytics: { ...analytics, autocapture: autocaptureConfig(state) },
+    // The plugins are only built when their section is switched on; null means "don't install it".
+    sessionReplay: state.sessionReplay ? fieldSetValue(SESSION_REPLAY_OPTIONS, state.sessionReplayOptions) : null,
+    engagement: state.engagement ? fieldSetValue(ENGAGEMENT_OPTIONS, state.engagementOptions) : null,
+  };
+}

--- a/test-server/configurator/sample-download.csv
+++ b/test-server/configurator/sample-download.csv
@@ -1,0 +1,3 @@
+event,count
+[Amplitude] Page Viewed,3
+[Amplitude] Element Clicked,7

--- a/test-server/configurator/section-panels.jsx
+++ b/test-server/configurator/section-panels.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Panel } from './components.jsx';
+import { changedFields } from './fields.js';
+import { OptionField } from './option-field.jsx';
+
+const LABEL_WIDTH = 210;
+
+// Renders a schema split into sections as one collapsible panel each, used for both the browser
+// config and the session replay options.
+export function SectionPanels({ sections, values, onChange, idPrefix }) {
+  return (
+    <>
+      {sections.map((section) => {
+        // Promoted fields are rendered at the top of the form instead, so they are left out here and
+        // out of the badge count.
+        const fields = section.fields.filter((field) => !field.topLevel);
+        const setCount = changedFields(fields, values).length;
+
+        return (
+          <Panel key={section.title} title={section.title} badge={setCount > 0 ? `${setCount} set` : null}>
+            {fields.map((field) => (
+              <OptionField
+                key={field.key}
+                id={`${idPrefix}-${field.key}`}
+                field={field}
+                value={values[field.key]}
+                onChange={(value) => onChange(field.key, value)}
+                labelWidth={LABEL_WIDTH}
+              />
+            ))}
+          </Panel>
+        );
+      })}
+    </>
+  );
+}

--- a/test-server/configurator/session-replay-options.js
+++ b/test-server/configurator/session-replay-options.js
@@ -1,0 +1,379 @@
+// The options `sessionReplayPlugin()` accepts, from SessionReplayOptions in
+// packages/plugin-session-replay-browser/src/typings/session-replay.ts. Most of those properties only
+// carry an `@see` link, so the descriptions below come from the standalone type they point at,
+// SessionReplayLocalConfig in packages/session-replay-browser/src/config/types.ts.
+//
+// Defaults are the runtime ones from packages/session-replay-browser/src/config/local-config.ts and
+// constants.ts, which is not always what the plugin README's table says: SR-4646 moved storeType to
+// 'memory', useWebWorker to true, mergeMutations to true, eagerFullSnapshotSend and
+// captureFullSnapshotOnFocus to false, and minIntervalMs to 1000.
+//
+// Deliberately not exposed:
+//   - callbacks a form can't build: customSessionId, handleSendEvents, handleFetchConfig
+//   - deprecated: experimental (superseded by useWebWorker)
+//   - repeatable object lists: interactionConfig.ugcFilterRules, privacyConfig.urlMaskLevels
+//     (the latter isn't on the plugin's own type and isn't forwarded to the standalone SDK)
+//   - supplied by the analytics SDK: sessionId, sessionReplayId, optOut, serverZone, version
+
+// `enabled` is required on these nested types, so it is emitted whenever anything else in the group
+// is, otherwise the generated object wouldn't type-check.
+const performanceConfig = {
+  key: 'performanceConfig',
+  label: 'Performance config',
+  type: 'group',
+  requiredKeys: ['enabled'],
+  description:
+    "Performance configuration config. If enabled, we will defer compression to be done during the browser's idle periods.",
+  fields: [
+    {
+      key: 'enabled',
+      label: 'Enabled',
+      type: 'boolean',
+      defaultValue: true,
+      description: "If enabled, event compression will be deferred to occur during the browser's idle periods.",
+    },
+    {
+      key: 'timeout',
+      label: 'Timeout (ms)',
+      type: 'number',
+      hint: 'default: unset',
+      description:
+        'Optional timeout in milliseconds for the requestIdleCallback API. If specified, this value will be used to set a maximum time for the browser to wait before executing the deferred compression task, even if the browser is not idle.',
+    },
+    {
+      key: 'mergeMutations',
+      label: 'Merge mutations',
+      type: 'boolean',
+      defaultValue: true,
+      description:
+        'If enabled, consecutive mutation events are merged into a single event before compression. This reduces the stored event count and coalesces bursts of inline style mutations on the same node (last-write-wins), without changing replay semantics.',
+    },
+    {
+      key: 'interaction',
+      label: 'Interaction',
+      type: 'group',
+      description: 'Performance configuration for interaction tracking (clicks, scrolls).',
+      fields: [
+        {
+          key: 'timeoutMs',
+          label: 'Timeout (ms)',
+          type: 'number',
+          hint: 'default: no timeout',
+          description:
+            'Maximum time in milliseconds allowed for CSS selector generation. If selector generation takes longer than this, it will throw a timeout error.',
+        },
+        {
+          key: 'maxNumberOfTries',
+          label: 'Max number of tries',
+          type: 'number',
+          hint: 'default: 10000',
+          description:
+            'Maximum number of attempts to optimize/simplify the CSS selector path. Higher values may produce shorter selectors but take longer to compute.',
+        },
+        {
+          key: 'threshold',
+          label: 'Threshold',
+          type: 'number',
+          hint: 'default: 1000',
+          description:
+            'Maximum number of CSS selector combinations to test for uniqueness. If more combinations would be generated, falls back to a simpler strategy.',
+        },
+      ],
+    },
+  ],
+};
+
+export const SESSION_REPLAY_SECTIONS = [
+  {
+    title: 'Sampling & debugging',
+    fields: [
+      {
+        key: 'sampleRate',
+        label: 'Sample rate',
+        type: 'number',
+        topLevel: true,
+        hint: 'default: 0 — nothing is recorded until you set this',
+        description:
+          'Use this option to control how many sessions to select for replay collection. The number should be a decimal between 0 and 1, for example 0.4, representing the fraction of sessions to have randomly selected for replay collection. Over a large number of sessions, 0.4 would select 40% of those sessions. Sample rates as small as six decimal places (0.000001) are supported.',
+      },
+      {
+        key: 'debugMode',
+        label: 'Debug mode',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Adds additional debug event property to help debug instrumentation issues (such as mismatching apps). Only recommended for debugging initial setup, and not recommended for production.',
+      },
+      {
+        key: 'forceSessionTracking',
+        label: 'Force session tracking',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'If this is enabled we will force the browser SDK to also send start and end session events.',
+      },
+      {
+        key: 'deviceId',
+        label: 'Device ID',
+        type: 'string',
+        hint: 'default: the analytics device ID',
+        description: 'Override the device ID for session replay.',
+      },
+    ],
+  },
+  {
+    title: 'Privacy',
+    fields: [
+      {
+        key: 'privacyConfig',
+        label: 'Privacy config',
+        type: 'group',
+        description: 'Supports advanced masking configs with CSS selectors.',
+        fields: [
+          {
+            key: 'defaultMaskLevel',
+            label: 'Default mask level',
+            type: 'enum',
+            hint: "default: 'medium'",
+            description:
+              'light masks only the subset of inputs deemed sensitive (password, credit card, telephone number, email) — information we never want to capture. medium masks all form fields (inputs); page text is captured as-is. conservative masks all inputs and all texts.',
+            choices: [
+              { value: 'light', label: 'light' },
+              { value: 'medium', label: 'medium' },
+              { value: 'conservative', label: 'conservative' },
+            ],
+          },
+          {
+            key: 'blockSelector',
+            label: 'Block selector',
+            type: 'stringList',
+            hint: 'default: none · .amp-block always applies',
+            description:
+              'CSS selectors for elements to block from the replay entirely. A blocked element appears as a placeholder with the same dimensions.',
+          },
+          {
+            key: 'maskSelector',
+            label: 'Mask selector',
+            type: 'stringList',
+            hint: 'default: none · .amp-mask always applies',
+            description:
+              'CSS selectors for elements whose text, and their children’s text, is replaced with asterisks.',
+          },
+          {
+            key: 'unmaskSelector',
+            label: 'Unmask selector',
+            type: 'stringList',
+            hint: 'default: none · .amp-unmask is always added',
+            description: 'CSS selectors for elements to leave unmasked, exempting them from the default mask level.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Performance & storage',
+    fields: [
+      performanceConfig,
+      {
+        key: 'storeType',
+        label: 'Store type',
+        type: 'enum',
+        hint: "default: 'memory'",
+        description:
+          'Specifies how replay events should be stored. idb uses IndexedDB to persist replay events when all events cannot be sent during capture. memory stores replay events only in memory, meaning events are lost when the page is closed. If IndexedDB is unavailable, the system falls back to memory.',
+        choices: [
+          { value: 'idb', label: 'idb' },
+          { value: 'memory', label: 'memory' },
+        ],
+      },
+      {
+        key: 'useWebWorker',
+        label: 'Use web worker',
+        type: 'boolean',
+        defaultValue: true,
+        description:
+          'If true, the SDK will compress replay events using a web worker. This offloads compression to a separate thread, improving performance on the main thread. Set to false to keep compression on the main thread.',
+      },
+      {
+        key: 'flushIntervalConfig',
+        label: 'Flush interval config',
+        type: 'group',
+        description:
+          'Bounds on the rrweb event-split interval. Lowering them buys replay availability latency improvements at the cost of more requests; raising them reduces request volume at the cost of slightly delayed replay availability.',
+        fields: [
+          {
+            key: 'minIntervalMs',
+            label: 'Min interval (ms)',
+            type: 'number',
+            hint: 'default: 1000',
+            description:
+              'Lower bound on the rrweb event-split interval in milliseconds. Also the increment added to the interval after each split. Must be > 0; values are clamped to a 100ms floor.',
+          },
+          {
+            key: 'maxIntervalMs',
+            label: 'Max interval (ms)',
+            type: 'number',
+            hint: 'default: 10000',
+            description: 'Upper bound on the rrweb event-split interval in milliseconds. Must be >= minIntervalMs.',
+          },
+        ],
+      },
+      {
+        key: 'maxPersistedEventsSizeBytes',
+        label: 'Max persisted events size (bytes)',
+        type: 'number',
+        hint: 'default: 6000000 · advanced',
+        description:
+          'Raw (uncompressed) UTF-8 byte cap for a single buffered events list before the store splits it into its own request. Larger values produce fewer, larger requests (the primary steady-state lever for request volume); smaller values split sooner. Payloads are gzipped on the wire, so several hundred KB of replay JSON compresses to well under 100 KB. Advanced/debug knob — the default already balances request volume against the server’s decompressed-size split threshold. Clamped to a safe range.',
+      },
+      {
+        key: 'maxSingleEventSizeBytes',
+        label: 'Max single event size (bytes)',
+        type: 'number',
+        hint: 'default: 9000000 · advanced',
+        description:
+          'Raw (uncompressed) UTF-8 byte cap for a single rrweb event. Events larger than this are dropped (with a warning) both at capture time and as a pre-send backstop, because the SR ingest service rejects a single event above ~10 MB. Lower this to exercise drop behavior for large full snapshots while debugging. Clamped to a safe range.',
+      },
+      {
+        key: 'sendTimeoutMs',
+        label: 'Send timeout (ms)',
+        type: 'number',
+        hint: 'default: 10000 · 0 disables',
+        description:
+          'Milliseconds to wait for a send request before aborting it. fetch() has no native timeout, so a request stuck "pending" would block the serial flush loop indefinitely; the SDK aborts after this many ms and routes the abort as a retryable failure. Set to 0 (or a negative value) to disable the timeout entirely. Tuning this higher is useful when large, slow-but-succeeding uploads are being aborted at the default and counted as failures.',
+      },
+    ],
+  },
+  {
+    title: 'Capture behavior',
+    fields: [
+      {
+        key: 'shouldInlineStylesheet',
+        label: 'Inline stylesheets',
+        type: 'boolean',
+        defaultValue: true,
+        description:
+          'If stylesheets are inlined, the contents of the stylesheet will be stored. During replay, the stored stylesheet will be used instead of attempting to fetch it remotely. This prevents replays from appearing broken due to missing stylesheets. Note: inlining stylesheets may not work in all cases.',
+      },
+      {
+        key: 'captureAdoptedStyleSheets',
+        label: 'Capture adopted stylesheets',
+        type: 'boolean',
+        defaultValue: true,
+        description:
+          'When true (default), the CSS rules of any adoptedStyleSheets on shadow roots and the document are serialized inline within the full snapshot. This makes the snapshot self-contained so that shadow DOM styles are replayed correctly even if subsequent incremental AdoptedStyleSheet events are dropped in transit. Set to false to revert to the legacy behavior where adopted stylesheet rules are emitted as separate incremental events.',
+      },
+      {
+        key: 'captureDocumentTitle',
+        label: 'Capture document title',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Whether to capture document title in URL change events. When disabled, the title field will be empty in URL change events.',
+      },
+      {
+        key: 'applyBackgroundColorToBlockedElements',
+        label: 'Background colour on blocked elements',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'If true, applies a background color to blocked elements for visual masking.',
+      },
+      {
+        key: 'eagerFullSnapshotSend',
+        label: 'Eager full snapshot send',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'When true, every rrweb full snapshot is flushed to the server immediately so replays become playable as early as possible. When false (default), full-snapshot sends are deferred to the normal interval/size flush cadence instead. The snapshot is still compressed and buffered immediately either way; only the eager network send is suppressed.',
+      },
+      {
+        key: 'captureFullSnapshotOnFocus',
+        label: 'Full snapshot on focus',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'When true, the window focus listener forces a fresh rrweb full snapshot every time the page regains focus, so the replay reflects any DOM changes that happened while the tab was backgrounded. When false (default), the on-focus full snapshot is skipped entirely. On pages with heavy focus churn this fires constantly, and combined with eagerFullSnapshotSend each focus produces an immediate network send.',
+      },
+      {
+        key: 'enableUrlChangePolling',
+        label: 'URL change polling',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Enables URL change polling as a fallback for SPA route tracking. When enabled, the SDK will periodically check for URL changes every second in addition to patching the History API. This is useful for edge cases where route changes might bypass the standard History API methods.',
+      },
+      {
+        key: 'urlChangePollingInterval',
+        label: 'URL change polling interval (ms)',
+        type: 'number',
+        hint: 'default: 1000',
+        description:
+          'Specifies the interval in milliseconds for URL change polling when enableUrlChangePolling is true. The SDK will check for URL changes at this interval as a fallback for SPA route tracking.',
+      },
+      {
+        key: 'crossOriginIframes',
+        label: 'Cross-origin iframes',
+        type: 'group',
+        requiredKeys: ['enabled'],
+        description:
+          'Enables recording of cross-origin iframes. Both the parent page and each child iframe page must load the Amplitude Session Replay SDK with this option enabled. When enabled, rrweb uses postMessage to relay child DOM events to the parent, which merges them into a single unified event stream.',
+        fields: [
+          { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: false },
+          {
+            key: 'coordinateChildren',
+            label: 'Coordinate children',
+            type: 'boolean',
+            defaultValue: true,
+            description:
+              'When true (default), the parent SDK sends start/stop signals to child iframes via postMessage, keeping their recording lifecycle in sync with the parent. Privacy note: the child page’s rrweb instance performs its own DOM serialization, so the parent’s privacy config does NOT automatically apply inside the iframe. Set to false to skip coordination and manage the child recording lifecycle yourself.',
+          },
+        ],
+      },
+      {
+        key: 'interactionConfig',
+        label: 'Interaction config',
+        type: 'group',
+        requiredKeys: ['enabled', 'batch'],
+        description:
+          'Interaction (click and scroll) capture. Normally driven by remote config; set it here to configure it locally.',
+        fields: [
+          { key: 'enabled', label: 'Enabled', type: 'boolean', defaultValue: false },
+          { key: 'batch', label: 'Batch', type: 'boolean', defaultValue: false },
+          {
+            key: 'trackEveryNms',
+            label: 'Track every (ms)',
+            type: 'number',
+            hint: 'default: 30000',
+            description: 'How often interaction events are captured, in milliseconds.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Server URLs',
+    fields: [
+      {
+        key: 'configServerUrl',
+        label: 'Config server URL',
+        type: 'string',
+        hint: 'default: Amplitude endpoint for the zone',
+        description:
+          'Specifies the endpoint URL to fetch remote configuration. If provided, it overrides the default server zone configuration.',
+      },
+      {
+        key: 'trackServerUrl',
+        label: 'Track server URL',
+        type: 'string',
+        hint: 'default: Amplitude endpoint for the zone',
+        description:
+          'Specifies the endpoint URL for sending session replay data. If provided, it overrides the default server zone configuration.',
+      },
+    ],
+  },
+];
+
+export const SESSION_REPLAY_OPTIONS = SESSION_REPLAY_SECTIONS.flatMap((section) => section.fields);
+
+// Nothing is recorded until the sample rate is set, so it is rendered above the panels rather than
+// inside one. It stays in its section above so defaults and snippet serialization are unaffected.
+export const TOP_LEVEL_SESSION_REPLAY_OPTIONS = SESSION_REPLAY_OPTIONS.filter((field) => field.topLevel);

--- a/test-server/configurator/share-link.js
+++ b/test-server/configurator/share-link.js
@@ -1,0 +1,99 @@
+// The form state round-trips through a single query parameter, so a bookmarked URL reopens the same
+// configuration.
+//
+// Two things keep that parameter short enough to survive being pasted around. Only the values that
+// differ from the defaults travel in the link, and what's left is deflated and base64url encoded.
+// Pruning also means a link made today still opens with current defaults for everything it doesn't
+// mention.
+const STATE_PARAM = 'config';
+
+// Raw deflate rather than gzip: same algorithm without the header and checksum, which are dead weight
+// for a string that a corrupt URL already fails loudly on.
+const COMPRESSION_FORMAT = 'deflate-raw';
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Every value in the state is already JSON — strings, booleans, and the arrays and objects the field
+// schemas build — so comparing serializations stands in for a deep equality check.
+function isEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// Returns undefined for anything matching its default, which callers drop.
+function pruneToChanges(value, defaultValue) {
+  if (isPlainObject(value) && isPlainObject(defaultValue)) {
+    const changed = Object.entries(value)
+      .map(([key, nested]) => [key, pruneToChanges(nested, defaultValue[key])])
+      .filter(([, nested]) => nested !== undefined);
+    return changed.length > 0 ? Object.fromEntries(changed) : undefined;
+  }
+  return isEqual(value, defaultValue) ? undefined : value;
+}
+
+// The schema owns the shape of the state, so only keys the defaults know about are taken from the
+// link; anything else is a leftover from an older version of the form.
+function mergeOverDefaults(defaults, saved) {
+  if (!isPlainObject(defaults) || !isPlainObject(saved)) {
+    return saved === undefined ? defaults : saved;
+  }
+  return Object.fromEntries(
+    Object.entries(defaults).map(([key, defaultValue]) => [key, mergeOverDefaults(defaultValue, saved[key])]),
+  );
+}
+
+// Response() handles the UTF-8 encoding in both directions, so the only manual step is moving between
+// the compressed bytes and text a URL can carry.
+async function deflate(text) {
+  const compressed = new Response(text).body.pipeThrough(new CompressionStream(COMPRESSION_FORMAT));
+  return new Uint8Array(await new Response(compressed).arrayBuffer());
+}
+
+async function inflate(bytes) {
+  const decompressed = new Response(bytes).body.pipeThrough(new DecompressionStream(COMPRESSION_FORMAT));
+  return new Response(decompressed).text();
+}
+
+// base64url, so the parameter survives a URL untouched: no +, / or = to be percent-encoded or eaten
+// by a form decoder.
+function toBase64Url(bytes) {
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(value) {
+  const binary = atob(value.replace(/-/g, '+').replace(/_/g, '/'));
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+// Sync, so a page opened without a saved link can render its defaults immediately rather than waiting
+// on a decode that has nothing to do.
+export function hasSavedState(search = window.location.search) {
+  return new URLSearchParams(search).get(STATE_PARAM) !== null;
+}
+
+export async function encodeStateToUrl(state, defaults, href = window.location.href) {
+  const changes = pruneToChanges(state, defaults);
+  const url = new URL(href);
+  if (changes === undefined) {
+    url.searchParams.delete(STATE_PARAM);
+  } else {
+    url.searchParams.set(STATE_PARAM, toBase64Url(await deflate(JSON.stringify(changes))));
+  }
+  return url.toString();
+}
+
+export async function decodeStateFromUrl(defaults, search = window.location.search) {
+  const saved = new URLSearchParams(search).get(STATE_PARAM);
+  if (!saved) {
+    return defaults;
+  }
+  try {
+    return mergeOverDefaults(defaults, JSON.parse(await inflate(fromBase64Url(saved))));
+  } catch (error) {
+    // A truncated or hand-edited link shouldn't leave the page blank.
+    console.warn(`Ignoring unreadable ?${STATE_PARAM} parameter`, error);
+    return defaults;
+  }
+}

--- a/test-server/configurator/snippet.js
+++ b/test-server/configurator/snippet.js
@@ -1,0 +1,321 @@
+import { AUTOCAPTURE_OPTIONS, CAPTURE_RULE_FIELDS } from './autocapture-options.js';
+import { CONFIG_OPTIONS, SHARED_CONFIG_OPTIONS } from './config-options.js';
+import { ENGAGEMENT_OPTIONS } from './engagement-options.js';
+import { changedFields, parseList, parsePatterns } from './fields.js';
+// The script loader users are told to paste into <head>, read straight from the artifact the release
+// scripts generate so the pinned SDK version and its integrity hash always match this checkout.
+import SNIPPET_LOADER from '../../packages/analytics-browser/generated/amplitude-snippet.js?raw';
+import { SESSION_REPLAY_OPTIONS } from './session-replay-options.js';
+// Versioned CDN bundle, named by packages/plugin-session-replay-browser/scripts/publish/upload-to-s3.js
+// and read from the package so it tracks this checkout. Its IIFE build exposes `window.sessionReplay`.
+import { version as sessionReplayPluginVersion } from '../../packages/plugin-session-replay-browser/package.json';
+
+const SESSION_REPLAY_PLUGIN_URL = `https://cdn.amplitude.com/libs/plugin-session-replay-browser-${sessionReplayPluginVersion}-min.js.gz`;
+
+// Stands in for the key so the code block is readable before anything is typed.
+export const PLACEHOLDER_API_KEY = 'YOUR_API_KEY';
+
+// The ways the same configuration can be handed to the SDK. `language` is the Prism grammar the
+// generated code is highlighted with.
+export const SNIPPET_FORMATS = [
+  { value: 'esm', label: 'ESM', language: 'javascript' },
+  { value: 'snippet', label: 'Browser Snippet', language: 'html' },
+  { value: 'unified', label: 'Unified SDK', language: 'javascript' },
+];
+
+export function snippetLanguage(format) {
+  return SNIPPET_FORMATS.find((candidate) => candidate.value === format)?.language ?? 'javascript';
+}
+
+function quote(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+// Both formatters take the indent of their own closing brace/bracket; contents sit two deeper.
+function formatObject(entries, closingIndent) {
+  const lines = entries.map(([key, literal]) => `${closingIndent}  ${key}: ${literal},`).join('\n');
+  return `{\n${lines}\n${closingIndent}}`;
+}
+
+function formatArray(literals, closingIndent) {
+  const lines = literals.map((literal) => `${closingIndent}  ${literal},`).join('\n');
+  return `[\n${lines}\n${closingIndent}]`;
+}
+
+function formatStringList(value) {
+  return `[${parseList(value).map(quote).join(', ')}]`;
+}
+
+// Patterns are written bare (`\.example\.com$`), but an already-delimited literal with flags is left
+// alone so a pattern needing /i can still be expressed.
+function toRegexLiteral(pattern) {
+  if (/^\/.*\/[dgimsuvy]*$/.test(pattern)) {
+    return pattern;
+  }
+  return `/${pattern.replace(/(?<!\\)\//g, '\\/')}/`;
+}
+
+// The exact values first, then the patterns as regex literals, matching how the SDK's own remote
+// config merges its `<option>Regex` companions onto the end of the exact list.
+function regexListLiterals(value = {}) {
+  return [...parseList(value.list).map(quote), ...parsePatterns(value.regexes).map(toRegexLiteral)];
+}
+
+// `string[] | boolean`: an explicit boolean, or a custom header list.
+function serializeHeaders(value = {}) {
+  if (value.mode === 'true' || value.mode === 'false') {
+    return value.mode;
+  }
+  if (value.mode === 'custom' && parseList(value.list).length > 0) {
+    return formatStringList(value.list);
+  }
+  return null;
+}
+
+function serializeBodyRule(value = {}, closingIndent) {
+  const entries = ['allowlist', 'excludelist']
+    .filter((key) => parseList(value[key] ?? '').length > 0)
+    .map((key) => [key, formatStringList(value[key])]);
+  return entries.length > 0 ? formatObject(entries, closingIndent) : null;
+}
+
+// Returns null for anything the user left alone, so untouched fields stay out of the snippet.
+function serializeRuleField(field, value, closingIndent) {
+  switch (field.type) {
+    case 'headers':
+      return serializeHeaders(value);
+    case 'bodyRule':
+      return serializeBodyRule(value, closingIndent);
+    case 'stringList':
+      return parseList(value).length > 0 ? formatStringList(value) : null;
+    case 'regexList': {
+      const literals = regexListLiterals(value);
+      return literals.length > 0 ? `[${literals.join(', ')}]` : null;
+    }
+    default:
+      return String(value ?? '').trim() !== '' ? quote(String(value).trim()) : null;
+  }
+}
+
+function serializeRule(rule, closingIndent) {
+  const entries = CAPTURE_RULE_FIELDS.map((field) => [
+    field.key,
+    serializeRuleField(field, rule[field.key], `${closingIndent}  `),
+  ]).filter(([, literal]) => literal !== null);
+  return entries.length > 0 ? formatObject(entries, closingIndent) : '{}';
+}
+
+// A choice carries `runtime` when the value the SDK wants isn't the string the select holds: a numeric
+// log level, or the pair of strings behind `trackingMethod: both`.
+function formatEnumValue(field, value) {
+  const { runtime } = field.choices.find((choice) => choice.value === value) ?? {};
+  if (runtime === undefined) {
+    return quote(value);
+  }
+  if (Array.isArray(runtime)) {
+    return `[${runtime.map(quote).join(', ')}]`;
+  }
+  return typeof runtime === 'number' ? String(runtime) : quote(runtime);
+}
+
+function serializeField(field, value, closingIndent) {
+  switch (field.type) {
+    case 'boolean':
+      return String(value);
+    case 'number':
+      return String(Number(value));
+    case 'stringList':
+      return formatStringList(value);
+    case 'regexList':
+      return `[${regexListLiterals(value).join(', ')}]`;
+    case 'ruleList':
+      return formatArray(
+        value.map((rule) => serializeRule(rule, `${closingIndent}  `)),
+        closingIndent,
+      );
+    case 'group':
+      return serializeFieldSet(field.fields, value, closingIndent, field.requiredKeys);
+    case 'enum':
+      return formatEnumValue(field, value);
+    default:
+      return quote(value);
+  }
+}
+
+// `requiredKeys` are non-optional on the type they describe, so once anything else in the object is
+// emitted they have to be emitted too, at their default, or the object wouldn't type-check.
+function serializeFieldSet(fields, values = {}, closingIndent, requiredKeys = []) {
+  const changed = changedFields(fields, values);
+  const emitted = fields.filter((field) => changed.includes(field) || requiredKeys.includes(field.key));
+  const entries = emitted.map((field) => [field.key, serializeField(field, values[field.key], `${closingIndent}  `)]);
+  return formatObject(entries, closingIndent);
+}
+
+// Disabled -> `false`. Enabled with nothing customised -> `true`. Enabled with customised
+// sub-options -> an object holding just those.
+function serializeAutocaptureOption(option, enabled, subValues, closingIndent) {
+  if (!enabled) {
+    return 'false';
+  }
+  if (changedFields(option.subOptions ?? [], subValues).length === 0) {
+    return 'true';
+  }
+  return serializeFieldSet(option.subOptions, subValues, closingIndent);
+}
+
+// `indent` is where the enclosing object's closing brace sits, so entries land one level deeper.
+function configEntries(configOptions, indent, includeKey = () => true) {
+  return changedFields(CONFIG_OPTIONS, configOptions)
+    .filter((field) => includeKey(field.key))
+    .map((field) => [field.key, serializeField(field, configOptions[field.key], `${indent}  `)]);
+}
+
+function autocaptureEntry({ autocapture, autocaptureOptions, autocaptureSubOptions }, indent) {
+  if (!autocapture) {
+    return ['autocapture', 'false'];
+  }
+  const entries = AUTOCAPTURE_OPTIONS.map((option) => [
+    option.key,
+    serializeAutocaptureOption(
+      option,
+      autocaptureOptions[option.key],
+      autocaptureSubOptions[option.key],
+      `${indent}    `,
+    ),
+  ]);
+  return ['autocapture', formatObject(entries, `${indent}  `)];
+}
+
+// initAll() spreads its shared options over the analytics ones, so one of these nested under
+// `analytics` would be overwritten with undefined. They have to be hoisted. This is the same set the
+// form renders above the per-SDK sections.
+const UNIFIED_SHARED_KEYS = SHARED_CONFIG_OPTIONS.map((field) => field.key);
+
+function unifiedEntries(state) {
+  const analytics = [
+    ...configEntries(state.configOptions, '  ', (key) => !UNIFIED_SHARED_KEYS.includes(key)),
+    autocaptureEntry(state, '  '),
+  ];
+  return [
+    ...configEntries(state.configOptions, '', (key) => UNIFIED_SHARED_KEYS.includes(key)),
+    ['analytics', formatObject(analytics, '  ')],
+  ];
+}
+
+// Session replay and Guides and Surveys are plugins rather than config keys, so each format installs
+// them differently, but the options object they take is built the same way.
+function pluginEntries(fields, values, indent) {
+  return changedFields(fields, values).map((field) => [
+    field.key,
+    serializeField(field, values[field.key], `${indent}  `),
+  ]);
+}
+
+// A plugin with nothing customised is still worth emitting: the bare call is what tells the reader
+// the product is wired up at all.
+function pluginCall(fields, values, factory, indent) {
+  const entries = pluginEntries(fields, values, indent);
+  return entries.length > 0 ? `${factory}(${formatObject(entries, indent)})` : `${factory}()`;
+}
+
+// Guides and Surveys is served per project rather than per version, so the script tag carries the API
+// key: https://amplitude.com/docs/sdks/guides-and-surveys/sdk.
+function engagementScriptUrl(apiKey) {
+  return `https://cdn.amplitude.com/script/${apiKey}.engagement.js`;
+}
+
+function indentBlock(text, indent) {
+  return text
+    .trim()
+    .split('\n')
+    .map((line) => (line.trim() === '' ? '' : `${indent}${line}`))
+    .join('\n');
+}
+
+export function buildSnippet({
+  apiKey,
+  format = 'esm',
+  configOptions = {},
+  autocapture,
+  autocaptureOptions = {},
+  autocaptureSubOptions = {},
+  sessionReplay,
+  sessionReplayOptions = {},
+  engagement,
+  engagementOptions = {},
+}) {
+  const state = { configOptions, autocapture, autocaptureOptions, autocaptureSubOptions };
+  const rawApiKey = apiKey.trim() || PLACEHOLDER_API_KEY;
+  const key = quote(rawApiKey);
+
+  if (format === 'unified') {
+    const entries = unifiedEntries(state);
+    // initAll() installs both plugins itself, so these keys only customise them, and are left out
+    // entirely when there is nothing to customise. Guides and Surveys is the one that has to be
+    // spelled out when switched off, since `skip` is how a unified setup opts out of it.
+    if (sessionReplay) {
+      const replay = pluginEntries(SESSION_REPLAY_OPTIONS, sessionReplayOptions, '  ');
+      if (replay.length > 0) {
+        entries.push(['sessionReplay', formatObject(replay, '  ')]);
+      }
+    }
+    const guides = engagement ? pluginEntries(ENGAGEMENT_OPTIONS, engagementOptions, '  ') : [['skip', 'true']];
+    if (guides.length > 0) {
+      entries.push(['engagement', formatObject(guides, '  ')]);
+    }
+    return `import { initAll } from '@amplitude/unified';
+
+initAll(${key}, ${formatObject(entries, '')});`;
+  }
+
+  if (format === 'snippet') {
+    const entries = [...configEntries(state.configOptions, '    '), autocaptureEntry(state, '    ')];
+    // Each plugin bundle is a separate blocking script so its global is defined by the time the next
+    // inline script runs. amplitude.add() is queued by the loader either way.
+    const replay = sessionReplay
+      ? `
+  <script src="${SESSION_REPLAY_PLUGIN_URL}"></script>
+  <script type="text/javascript">
+    amplitude.add(${pluginCall(SESSION_REPLAY_OPTIONS, sessionReplayOptions, 'sessionReplay.plugin', '    ')});
+  </script>`
+      : '';
+    const guides = engagement
+      ? `
+  <script src="${engagementScriptUrl(rawApiKey)}"></script>
+  <script type="text/javascript">
+    amplitude.add(${pluginCall(ENGAGEMENT_OPTIONS, engagementOptions, 'window.engagement.plugin', '    ')});
+  </script>`
+      : '';
+    return `<head>
+  <script type="text/javascript">
+${indentBlock(SNIPPET_LOADER, '    ')}
+
+    amplitude.init(${key}, ${formatObject(entries, '    ')});
+  </script>${replay}${guides}
+</head>`;
+  }
+
+  const entries = [...configEntries(state.configOptions, ''), autocaptureEntry(state, '')];
+  const imports = [`import * as amplitude from '@amplitude/analytics-browser';`];
+  const beforeInit = [];
+  const afterInit = [];
+  if (engagement) {
+    imports.push(`import { plugin as engagementPlugin } from '@amplitude/engagement-browser';`);
+    // Added before init() so the analytics SDK drives the plugin's setup with the user identity and
+    // session already resolved, as its docs call for. Session replay's own README inits first.
+    beforeInit.push(`amplitude.add(${pluginCall(ENGAGEMENT_OPTIONS, engagementOptions, 'engagementPlugin', '')});`);
+  }
+  if (sessionReplay) {
+    imports.push(`import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';`);
+    afterInit.push(
+      `amplitude.add(${pluginCall(SESSION_REPLAY_OPTIONS, sessionReplayOptions, 'sessionReplayPlugin', '')});`,
+    );
+  }
+  return [
+    imports.join('\n'),
+    '',
+    ...beforeInit,
+    `amplitude.init(${key}, ${formatObject(entries, '')});`,
+    ...afterInit,
+  ].join('\n');
+}

--- a/test-server/configurator/syntax-theme.css
+++ b/test-server/configurator/syntax-theme.css
@@ -1,0 +1,60 @@
+/*
+ * Token colours for the generated code block. Written locally rather than importing one of
+ * prismjs/themes/*.css, because this Vite config limits server.fs.allow to packages/ and
+ * test-server/, so a stylesheet served out of node_modules would 403 in dev.
+ */
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6c7086;
+}
+
+.token.punctuation,
+.token.operator {
+  color: #9399b2;
+}
+
+.token.keyword,
+.token.control-flow {
+  color: #cba6f7;
+}
+
+.token.string,
+.token.template-string,
+.token.regex,
+.token.char {
+  color: #a6e3a1;
+}
+
+.token.boolean,
+.token.number,
+.token.constant {
+  color: #fab387;
+}
+
+.token.literal-property,
+.token.property,
+.token.property-access {
+  color: #89b4fa;
+}
+
+.token.function,
+.token.method,
+.token.class-name {
+  color: #89dceb;
+}
+
+/* Markup tokens, for the script tag wrapping the browser snippet. */
+.token.tag {
+  color: #f38ba8;
+}
+
+.token.attr-name {
+  color: #f9e2af;
+}
+
+.token.attr-value {
+  color: #a6e3a1;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 // vite.config.js
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
 import glob from 'fast-glob';
@@ -152,6 +153,9 @@ export default defineConfig({
     // trc-e2e is a standalone React SPA with its own dedicated vite config (see `dev:trc`).
     // It references /main.jsx and must not be swept into the shared multi-page build.
     htmlEntriesPlugin('**/*.html', { cwd: testServerDir, ignore: ['**/trc-e2e/**'] }),
+    // Scoped to configurator/ so the babel + react-refresh transform stays off the other test pages
+    // and the packages/* builds they pull in.
+    react({ include: [/\/configurator\/.*\.[jt]sx?$/] }),
     gzipServePlugin(),
     fileListingPlugin(),
     spaRoutingPlugin(),


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained developer tool under `test-server/` plus a scoped Vite React plugin and `prismjs` dependency. No production SDK packages or runtime behavior are changed.
> 
> **Overview**
> Adds an **Amplitude Browser Client Configurator** under `test-server/configurator/` — a form UI for composing analytics, autocapture, session replay, and Guides & Surveys options, then generating init code.
> 
> **Generated output** supports three formats: ESM, browser snippet, and Unified SDK. Only options that differ from SDK defaults are emitted. Configurations can be **copied as compressed share links** and opened on a sibling **run page** that initializes the local workspace SDK and logs captured events in a sandbox.
> 
> Also wires Vite’s React plugin for `configurator/` only and adds `prismjs` for syntax-highlighted code output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98106e950e1f606cda7a39d0eb1596e6cc2e86fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->