### PR TITLE
fix(build): use @babel/preset-env in snippet build scripts

### DIFF
--- a/scripts/version/create-bookmarklet-snippet.js
+++ b/scripts/version/create-bookmarklet-snippet.js
@@ -53,7 +53,7 @@ const outputText =
     autoTrackingPluginVersion,
   );
 const { code: transpiledOutputText } = babel.transformSync(outputText, {
-  presets: ['env'],
+  presets: ['@babel/preset-env'],
 });
 
 // Write to disk

--- a/scripts/version/create-snippet.js
+++ b/scripts/version/create-snippet.js
@@ -35,7 +35,7 @@ const integrity = algorithm + '-' + crypto.createHash(algorithm).update(inputTex
 const version = getVersion() || '';
 const outputText = header + snippet(getName() + nameSuffix, integrity, version, globalVar);
 const { code: transpiledOutputText } = babel.transformSync(outputText, {
-  presets: ['env'],
+  presets: ['@babel/preset-env'],
 });
 
 // Write to disk


### PR DESCRIPTION
## Summary
- Fixes the `publish-v2` GHA build failure ([run](https://github.com/amplitude/Amplitude-TypeScript/actions/runs/31618033193/job/94190403501)): `Error: Cannot find module 'babel-preset-env'` during the `analytics-browser` build step.
- Root cause: #1909 removed the `babel-core`/`babel-preset-env` (Babel 6) devDependencies from root `package.json` as "unused" per knip's static analysis. However `scripts/version/create-snippet.js` and `scripts/version/create-bookmarklet-snippet.js` still reference the preset via its Babel 6 shorthand (`presets: ['env']`), which resolves at runtime to a package literally named `babel-preset-env` — a dynamic string reference knip's static analysis can't see.
- Fix: point both scripts at `@babel/preset-env` (Babel 7) instead. It's already hoisted to the root `node_modules` via the `@babel/*` `public-hoist-pattern` in `.npmrc` (as a transitive dep of react-native), so no new dependency is needed and the deprecated Babel 6 packages don't come back.

## Test plan
- [x] Ran `pnpm build` for `@amplitude/analytics-core` then `GENERATE_SNIPPET=true pnpm build` for `@amplitude/analytics-browser` locally — the snippet generation step (`create-snippet.js`/`create-bookmarklet-snippet.js`) that was previously failing now completes successfully (`Generated amplitude-bookmarklet.html`, snippet bundles created).
- [ ] CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbQ3BBGboAJANKpS7hVk1E)_