### PR TITLE
fix(plugin-autocapture-browser): report exposed elements on SPA page views

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -355,14 +355,16 @@ export const autocapturePlugin = (
     const globalScope = getGlobalScope();
 
     const handleViewportContentUpdated = (isPageEnd: boolean) => {
-      if (isPageEnd && pageViewEndFired) {
-        return;
+      if (isPageEnd) {
+        if (pageViewEndFired) {
+          return;
+        }
+        pageViewEndFired = true;
+        setTimeout(() => {
+          pageViewEndFired = false;
+        }, constants.PAGE_VIEW_END_DEDUPE_MS);
       }
-      setTimeout(() => {
-        pageViewEndFired = false;
-      }, 100);
 
-      pageViewEndFired = true;
       fireViewportContentUpdated({
         amplitude,
         scrollTracker,
@@ -378,6 +380,20 @@ export const autocapturePlugin = (
       onExposure(elementPath, elementExposedForPage, currentElementExposed, handleViewportContentUpdated);
     };
 
+    let currentUrl = window.location.href;
+
+    // Same-document history updates that leave the URL unchanged are not a new page view. SPA
+    // frameworks emit them routinely (eg. rewriting history state during hydration), and treating
+    // them as a page end would flush a premature event and reset the exposure state.
+    const handleNavigation = (destinationUrl?: string) => {
+      const nextUrl = destinationUrl ?? window.location.href;
+      if (nextUrl === currentUrl) {
+        return;
+      }
+      currentUrl = nextUrl;
+      handleViewportContentUpdated(true);
+    };
+
     if (isViewportContentUpdatedEnabled) {
       trackers.exposure = trackExposure({
         allObservables,
@@ -390,14 +406,20 @@ export const autocapturePlugin = (
         subscriptions.push(trackers.exposure);
       }
 
-      const beforeUnloadHandler = () => {
+      const pageEndHandler = () => {
         handleViewportContentUpdated(true);
       };
+      // pagehide covers the cases where beforeunload is unreliable, most notably mobile browsers
+      // and pages entering the back/forward cache. Both firing is deduplicated by pageViewEndFired.
       /* istanbul ignore next */
-      globalScope?.addEventListener('beforeunload', beforeUnloadHandler);
+      globalScope?.addEventListener('beforeunload', pageEndHandler);
+      /* istanbul ignore next */
+      globalScope?.addEventListener('pagehide', pageEndHandler);
       beforeUnloadCleanup = () => {
         /* istanbul ignore next */
-        globalScope?.removeEventListener('beforeunload', beforeUnloadHandler);
+        globalScope?.removeEventListener('beforeunload', pageEndHandler);
+        /* istanbul ignore next */
+        globalScope?.removeEventListener('pagehide', pageEndHandler);
       };
       // Ensure cleanup on teardown as well
       subscriptions.push({ unsubscribe: () => beforeUnloadCleanup() });
@@ -406,13 +428,14 @@ export const autocapturePlugin = (
       const navigateObservable = allObservables[ObservablesEnum.NavigateObservable];
       if (navigateObservable) {
         subscriptions.push(
-          navigateObservable.subscribe(() => {
-            handleViewportContentUpdated(true);
+          navigateObservable.subscribe((navigateEvent) => {
+            /* istanbul ignore next */
+            handleNavigation(navigateEvent?.event?.destination?.url);
           }),
         );
       } else if (globalScope) {
         const popstateHandler = () => {
-          handleViewportContentUpdated(true);
+          handleNavigation();
         };
         /* istanbul ignore next */
         // Fallback for SPA tracking when Navigation API is not available
@@ -429,7 +452,7 @@ export const autocapturePlugin = (
           globalScope.history.pushState = new Proxy(originalPushState, {
             apply: (target, thisArg, [state, unused, url]) => {
               target.apply(thisArg, [state, unused, url]);
-              handleViewportContentUpdated(true);
+              handleNavigation();
             },
           });
         }

--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -149,6 +149,10 @@ export const autocapturePlugin = (
 
   let beforeUnloadCleanup: () => void;
 
+  // Re-emits exposure entries for the elements currently in the viewport. Set when the exposure
+  // observable is subscribed to.
+  let reobserveElementsInViewport: (() => void) | undefined;
+
   const createObservables = (): AllWindowObservables => {
     const clickObservable = multicast(
       createClickObservable().map(
@@ -220,6 +224,9 @@ export const autocapturePlugin = (
     const exposureObservable = createExposureObservable(
       mutationObservable,
       (options as AutoCaptureOptionsWithDefaults).cssSelectorAllowlist,
+      (reobserve) => {
+        reobserveElementsInViewport = reobserve;
+      },
     );
 
     return {
@@ -377,6 +384,7 @@ export const autocapturePlugin = (
         onExposure: handleExposure,
         dataExtractor,
         exposureDuration: resolvedExposureDuration,
+        reobserve: () => reobserveElementsInViewport?.(),
       });
       if (trackers.exposure) {
         subscriptions.push(trackers.exposure);

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -8,11 +8,13 @@ export function trackExposure({
   onExposure,
   dataExtractor,
   exposureDuration = DEFAULT_EXPOSURE_DURATION,
+  reobserve,
 }: {
   allObservables: AllWindowObservables;
   onExposure: (elementPath: string) => void;
   dataExtractor: DataExtractor;
   exposureDuration?: number;
+  reobserve?: () => void;
 }) {
   // Track which elements have been marked as exposed (per-element state)
   const exposureMap = new Map<Element, boolean>();
@@ -65,6 +67,9 @@ export function trackExposure({
       });
       exposureTimerMap.clear();
       exposureMap.clear();
+      // Elements that stay on screen across the reset have to be reported again, otherwise
+      // nothing above the fold is ever exposed for the next page view.
+      reobserve?.();
     },
   };
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-scroll.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-scroll.ts
@@ -19,23 +19,30 @@ export function trackScroll({
   const { scrollObservable } = allObservables;
   const state: ScrollState = { maxX: 0, maxY: 0 };
 
-  const scrollSubscription = scrollObservable.subscribe(() => {
+  // Update page-level max positions for Page View End event (never resets during page lifetime)
+  const recordCurrentPosition = () => {
     const globalScope = getGlobalScope();
     /* istanbul ignore next */
     const currentX = Math.floor(globalScope?.scrollX ?? globalScope?.pageXOffset ?? 0);
     /* istanbul ignore next */
     const currentY = Math.floor(globalScope?.scrollY ?? globalScope?.pageYOffset ?? 0);
 
-    // Update page-level max positions for Page View End event (never resets during page lifetime)
     state.maxX = Math.max(state.maxX, currentX);
     state.maxY = Math.max(state.maxY, currentY);
-  });
+  };
+
+  const scrollSubscription = scrollObservable.subscribe(recordCurrentPosition);
 
   return {
     unsubscribe: () => {
       scrollSubscription.unsubscribe();
     },
-    getState: () => state,
+    // Folding in the current position covers scrolling this subscription never saw, such as the
+    // browser jumping to a URL fragment on load or restoring the position on a reload.
+    getState: () => {
+      recordCurrentPosition();
+      return state;
+    },
     reset: () => {
       state.maxX = 0;
       state.maxY = 0;

--- a/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
@@ -53,13 +53,14 @@ export function fireViewportContentUpdated({
     eventProperties[constants.AMPLITUDE_EVENT_PROP_PAGE_VIEW_ID] = pageViewId;
   }
 
-  // Reset state for the next page view. lastScroll has to follow the scroll tracker back to
-  // zero, otherwise the next event is compared against maxima from the previous page view and
+  // Reset state for the next page view. lastScroll has to follow the scroll tracker's new
+  // baseline, otherwise the next event is compared against maxima from the previous page view and
   // an event with no exposed elements looks like a scroll change.
   const resetForNextPageView = () => {
     scrollTracker.reset();
-    lastScroll.maxX = 0;
-    lastScroll.maxY = 0;
+    const scrollBaseline = scrollTracker.getState();
+    lastScroll.maxX = scrollBaseline.maxX;
+    lastScroll.maxY = scrollBaseline.maxY;
     elementExposedForPage.clear();
     exposureTracker?.reset();
   };

--- a/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-viewport-content-updated.ts
@@ -53,6 +53,17 @@ export function fireViewportContentUpdated({
     eventProperties[constants.AMPLITUDE_EVENT_PROP_PAGE_VIEW_ID] = pageViewId;
   }
 
+  // Reset state for the next page view. lastScroll has to follow the scroll tracker back to
+  // zero, otherwise the next event is compared against maxima from the previous page view and
+  // an event with no exposed elements looks like a scroll change.
+  const resetForNextPageView = () => {
+    scrollTracker.reset();
+    lastScroll.maxX = 0;
+    lastScroll.maxY = 0;
+    elementExposedForPage.clear();
+    exposureTracker?.reset();
+  };
+
   // If elements exposed is empty and max scroll is same as last event, don't track
   if (
     currentElementExposed.size === 0 &&
@@ -60,9 +71,7 @@ export function fireViewportContentUpdated({
     pageScrollMaxState.maxY === lastScroll.maxY
   ) {
     if (isPageEnd) {
-      scrollTracker.reset();
-      elementExposedForPage.clear();
-      exposureTracker?.reset();
+      resetForNextPageView();
     }
     return;
   }
@@ -76,10 +85,7 @@ export function fireViewportContentUpdated({
   currentElementExposed.clear();
 
   if (isPageEnd) {
-    // Reset state for next page view
-    scrollTracker.reset();
-    elementExposedForPage.clear();
-    exposureTracker?.reset();
+    resetForNextPageView();
   }
 }
 

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -59,3 +59,6 @@ export const MAX_ATTRIBUTE_LENGTH = 128;
 export const PAGE_VIEW_SESSION_STORAGE_KEY = 'AMP_PAGE_VIEW';
 
 export const MAX_ELEMENT_EXPOSED_STR_LENGTH = 18_000;
+
+// Window during which a second page end (eg. a navigation followed by an unload) is ignored
+export const PAGE_VIEW_END_DEDUPE_MS = 100;

--- a/packages/plugin-autocapture-browser/src/observables.ts
+++ b/packages/plugin-autocapture-browser/src/observables.ts
@@ -74,6 +74,9 @@ const createConsoleErrorObservable = (): Observable<BrowserErrorEvent> => {
 export const createExposureObservable = (
   mutationObservable: Observable<TimestampedEvent<MutationRecord[]>>,
   selectorAllowlist: string[],
+  // Receives a function that re-emits entries for the elements currently in the viewport, or
+  // undefined once the observable is torn down.
+  registerReobserve?: (reobserve: (() => void) | undefined) => void,
 ): Observable<Event> => {
   return new Observable<Event>((observer) => {
     const globalScope = getGlobalScope();
@@ -84,9 +87,16 @@ export const createExposureObservable = (
       };
     }
 
+    const elementsInViewport = new Set<Element>();
+
     const intersectionObserver = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            elementsInViewport.add(entry.target);
+          } else {
+            elementsInViewport.delete(entry.target);
+          }
           observer.next(entry as unknown as Event);
         });
       },
@@ -122,7 +132,23 @@ export const createExposureObservable = (
       ),
     );
 
+    // An IntersectionObserver only reports threshold crossings, so elements that are already in
+    // the viewport are never reported again. Whoever resets the exposure state (eg. at the end of
+    // a page view) needs the elements on screen to be reported once more for the new page view,
+    // which re-observing does.
+    registerReobserve?.(() => {
+      const elements = Array.from(elementsInViewport);
+      elementsInViewport.clear();
+      elements.forEach((element) => {
+        intersectionObserver.unobserve(element);
+        if (element.isConnected) {
+          intersectionObserver.observe(element);
+        }
+      });
+    });
+
     return () => {
+      registerReobserve?.(undefined);
       mutationSubscription.unsubscribe();
       intersectionObserver.disconnect();
     };

--- a/packages/plugin-autocapture-browser/src/observables.ts
+++ b/packages/plugin-autocapture-browser/src/observables.ts
@@ -9,8 +9,11 @@ export const createMutationObservable = (): Observable<MutationRecord[]> => {
     const mutationObserver = new MutationObserver((mutations) => {
       observer.next(mutations);
     });
-    if (document.body) {
-      mutationObserver.observe(document.body, {
+    // Autocapture can be initialized from the document head, before the body exists. Falling back
+    // to the document element keeps the body and everything parsed into it observed.
+    const target = document.body ?? document.documentElement;
+    if (target) {
+      mutationObserver.observe(target, {
         childList: true,
         attributes: true,
         characterData: true,

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -231,4 +231,19 @@ describe('trackExposure', () => {
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
     expect(onExposure).toHaveBeenCalledWith('div#reset-div-2');
   });
+
+  test('should ask for elements in the viewport to be reported again on reset', () => {
+    const reobserve = jest.fn();
+    const tracker = trackExposure({
+      allObservables,
+      onExposure,
+      dataExtractor: new DataExtractor({}),
+      reobserve,
+    });
+
+    tracker.reset();
+    expect(reobserve).toHaveBeenCalledTimes(1);
+
+    tracker.unsubscribe();
+  });
 });

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-scroll.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-scroll.test.ts
@@ -113,6 +113,19 @@ describe('trackScroll', () => {
     expect(tracker.getState().maxY).toBe(0);
   });
 
+  test('should include the current position even when no scroll event was seen', () => {
+    // The browser jumps to a URL fragment on load, before this subscription exists
+    setScroll(0, 3106);
+
+    const tracker = trackScroll({
+      amplitude,
+      allObservables,
+    });
+    unsubscribe = tracker.unsubscribe;
+
+    expect(tracker.getState().maxY).toBe(3106);
+  });
+
   test('should reset state', () => {
     const tracker = trackScroll({
       amplitude,
@@ -125,8 +138,28 @@ describe('trackScroll', () => {
     expect(tracker.getState().maxX).toBe(100);
     expect(tracker.getState().maxY).toBe(200);
 
+    // Reset drops what the previous page view reached and rebaselines on the current position
+    setScroll(0, 0);
     tracker.reset();
     expect(tracker.getState().maxX).toBe(0);
     expect(tracker.getState().maxY).toBe(0);
+  });
+
+  test('should rebaseline on the current position when reset without scrolling back to the top', () => {
+    const tracker = trackScroll({
+      amplitude,
+      allObservables,
+    });
+    unsubscribe = tracker.unsubscribe;
+
+    setScroll(0, 3000);
+    triggerScroll();
+    setScroll(0, 1000);
+    triggerScroll();
+    expect(tracker.getState().maxY).toBe(3000);
+
+    // A SPA route change that leaves the page where it was starts the next page view at 1000
+    tracker.reset();
+    expect(tracker.getState().maxY).toBe(1000);
   });
 });

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
@@ -603,7 +603,7 @@ describe('fireViewportContentUpdated - early return when no changes', () => {
     const currentElementExposed = new Set<string>(['element-1']);
     const elementExposedForPage = new Set<string>(['element-1']);
     const lastScroll: { maxX: undefined | number; maxY: undefined | number } = { maxX: undefined, maxY: undefined };
-    // The scroll tracker is reset on page end, so it reports 0/0 for the next page view
+    // The scroll tracker rebaselines on page end, here on a page that scrolled back to the top
     const scrollState = { maxX: 100, maxY: 200 };
     const scrollTracker: ScrollTracker = {
       getState: () => scrollState,
@@ -626,6 +626,44 @@ describe('fireViewportContentUpdated - early return when no changes', () => {
     expect(lastScroll).toEqual({ maxX: 0, maxY: 0 });
 
     // Next page view has nothing exposed and no scroll: nothing new to report
+    fireViewportContentUpdated({
+      amplitude: mockAmplitude,
+      scrollTracker,
+      currentElementExposed,
+      elementExposedForPage,
+      exposureTracker: undefined,
+      isPageEnd: true,
+      lastScroll,
+    });
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should take lastScroll from the scroll baseline the tracker keeps after a page end', () => {
+    const currentElementExposed = new Set<string>(['element-1']);
+    const elementExposedForPage = new Set<string>(['element-1']);
+    const lastScroll: { maxX: undefined | number; maxY: undefined | number } = { maxX: undefined, maxY: undefined };
+    // A page view that ends without scrolling back to the top: the next one starts at 1000
+    const scrollState = { maxX: 0, maxY: 3000 };
+    const scrollTracker: ScrollTracker = {
+      getState: () => scrollState,
+      reset: jest.fn(() => {
+        scrollState.maxY = 1000;
+      }),
+    };
+
+    fireViewportContentUpdated({
+      amplitude: mockAmplitude,
+      scrollTracker,
+      currentElementExposed,
+      elementExposedForPage,
+      exposureTracker: undefined,
+      isPageEnd: true,
+      lastScroll,
+    });
+
+    expect(lastScroll).toEqual({ maxX: 0, maxY: 1000 });
+
+    // Still sitting at 1000 with nothing exposed: nothing new to report
     fireViewportContentUpdated({
       amplitude: mockAmplitude,
       scrollTracker,

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/viewport-content-updated.test.ts
@@ -599,6 +599,45 @@ describe('fireViewportContentUpdated - early return when no changes', () => {
     );
   });
 
+  test('should reset lastScroll with the scroll tracker on page end so the next empty flush is deduplicated', () => {
+    const currentElementExposed = new Set<string>(['element-1']);
+    const elementExposedForPage = new Set<string>(['element-1']);
+    const lastScroll: { maxX: undefined | number; maxY: undefined | number } = { maxX: undefined, maxY: undefined };
+    // The scroll tracker is reset on page end, so it reports 0/0 for the next page view
+    const scrollState = { maxX: 100, maxY: 200 };
+    const scrollTracker: ScrollTracker = {
+      getState: () => scrollState,
+      reset: jest.fn(() => {
+        scrollState.maxX = 0;
+        scrollState.maxY = 0;
+      }),
+    };
+
+    fireViewportContentUpdated({
+      amplitude: mockAmplitude,
+      scrollTracker,
+      currentElementExposed,
+      elementExposedForPage,
+      exposureTracker: undefined,
+      isPageEnd: true,
+      lastScroll,
+    });
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+    expect(lastScroll).toEqual({ maxX: 0, maxY: 0 });
+
+    // Next page view has nothing exposed and no scroll: nothing new to report
+    fireViewportContentUpdated({
+      amplitude: mockAmplitude,
+      scrollTracker,
+      currentElementExposed,
+      elementExposedForPage,
+      exposureTracker: undefined,
+      isPageEnd: true,
+      lastScroll,
+    });
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+  });
+
   test('should mutate lastScroll so consecutive calls deduplicate correctly', () => {
     const currentElementExposed = new Set<string>();
     const elementExposedForPage = new Set<string>();

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -138,6 +138,7 @@ describe('autoTrackingPlugin', () => {
         intersectionCallback = cb;
         return {
           observe: jest.fn(),
+          unobserve: jest.fn(),
           disconnect: jest.fn(),
         };
       });
@@ -208,6 +209,7 @@ describe('autoTrackingPlugin', () => {
         intersectionCallback = cb;
         return {
           observe: jest.fn(),
+          unobserve: jest.fn(),
           disconnect: jest.fn(),
         };
       });
@@ -273,6 +275,7 @@ describe('autoTrackingPlugin', () => {
         intersectionCallback = cb;
         return {
           observe: jest.fn(),
+          unobserve: jest.fn(),
           disconnect: jest.fn(),
         };
       });
@@ -333,6 +336,7 @@ describe('autoTrackingPlugin', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).IntersectionObserver = jest.fn(() => ({
         observe: jest.fn(),
+        unobserve: jest.fn(),
         disconnect: jest.fn(),
       }));
 
@@ -1749,6 +1753,7 @@ describe('autoTrackingPlugin', () => {
         intersectionCallback = cb;
         return {
           observe: jest.fn(),
+          unobserve: jest.fn(),
           disconnect: jest.fn(),
         };
       });
@@ -1804,7 +1809,9 @@ describe('autoTrackingPlugin', () => {
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
-      // history.pushState is proxied.
+      // history.pushState is proxied. window.location is a stub here, so the URL the browser
+      // would have updated is set by hand.
+      (window.location as any).href = 'https://www.test.com/new-page';
       history.pushState({}, 'test', '/new-page');
 
       expect(track).toHaveBeenCalledWith('[Amplitude] Viewport Content Updated', expect.any(Object));
@@ -1816,8 +1823,24 @@ describe('autoTrackingPlugin', () => {
       window.dispatchEvent(new Event('scroll'));
 
       // Verify it can fire again (pageViewEndFired should be reset to false by the proxy)
+      (window.location as any).href = 'https://www.test.com/another-page';
       history.pushState({}, 'test', '/another-page');
       expect(track).toHaveBeenCalledTimes(2);
+    });
+
+    test('should not track [Amplitude] Viewport Content Updated when a history update leaves the URL unchanged', async () => {
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider,
+      };
+      (window.location as any).href = 'https://www.test.com/page';
+      await plugin?.setup?.(config as BrowserConfig, instance);
+
+      // SPA frameworks rewrite history state without changing the URL, eg. during hydration
+      history.pushState({}, 'test', '/page');
+      window.dispatchEvent(new Event('popstate'));
+
+      expect(track).not.toHaveBeenCalled();
     });
 
     test('should track [Amplitude] Viewport Content Updated on popstate event', async () => {
@@ -1827,10 +1850,69 @@ describe('autoTrackingPlugin', () => {
       };
       await plugin?.setup?.(config as BrowserConfig, instance);
 
-      // Simulate popstate event
+      // Simulate a back navigation to a different URL
+      (window.location as any).href = 'https://www.test.com/previous-page';
       window.dispatchEvent(new Event('popstate'));
 
       expect(track).toHaveBeenCalledWith('[Amplitude] Viewport Content Updated', expect.any(Object));
+    });
+
+    test('should use the navigate event destination to decide whether the page view ended', async () => {
+      const handlers: ((event: Event) => void)[] = [];
+      (window.navigation as any) = {
+        addEventListener: (type: string, listener: (event: Event) => void) => {
+          if (type === 'navigate') {
+            handlers.push(listener);
+          }
+        },
+        removeEventListener: jest.fn(),
+      };
+      const navigateTo = (url: string) => {
+        handlers.forEach((handler) => handler({ type: 'navigate', destination: { url } } as unknown as Event));
+      };
+
+      try {
+        const config: Partial<BrowserConfig> = {
+          defaultTracking: false,
+          loggerProvider: loggerProvider,
+        };
+        (window.location as any).href = 'https://www.test.com/page';
+        await plugin?.setup?.(config as BrowserConfig, instance);
+
+        // The Navigation API also emits navigate for history updates that keep the same URL
+        navigateTo('https://www.test.com/page');
+        expect(track).not.toHaveBeenCalled();
+
+        navigateTo('https://www.test.com/other-page');
+        expect(track).toHaveBeenCalledWith('[Amplitude] Viewport Content Updated', expect.any(Object));
+      } finally {
+        (window.navigation as any) = undefined;
+      }
+    });
+
+    test('should track [Amplitude] Viewport Content Updated on pagehide', async () => {
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider,
+      };
+      await plugin?.setup?.(config as BrowserConfig, instance);
+
+      window.dispatchEvent(new Event('pagehide'));
+
+      expect(track).toHaveBeenCalledWith('[Amplitude] Viewport Content Updated', expect.any(Object));
+    });
+
+    test('should not track duplicate [Amplitude] Viewport Content Updated events for beforeunload and pagehide', async () => {
+      const config: Partial<BrowserConfig> = {
+        defaultTracking: false,
+        loggerProvider: loggerProvider,
+      };
+      await plugin?.setup?.(config as BrowserConfig, instance);
+
+      window.dispatchEvent(new Event('pagehide'));
+      window.dispatchEvent(new Event('beforeunload'));
+
+      expect(track).toHaveBeenCalledTimes(1);
     });
 
     test('should flush Viewport Content Updated event when exposure buffer limit is reached', async () => {

--- a/packages/plugin-autocapture-browser/test/observable.test.ts
+++ b/packages/plugin-autocapture-browser/test/observable.test.ts
@@ -5,7 +5,7 @@ import { TimestampedEvent } from '../src/helpers';
 describe('createExposureObservable', () => {
   let mutationObservable: Observable<TimestampedEvent<MutationRecord[]>>;
   let mockMutationObserver: { subscribe: jest.Mock };
-  let mockIntersectionObserver: { observe: jest.Mock; disconnect: jest.Mock };
+  let mockIntersectionObserver: { observe: jest.Mock; unobserve: jest.Mock; disconnect: jest.Mock };
   let intersectionCallback: (entries: IntersectionObserverEntry[]) => void;
   let observers: ((value: TimestampedEvent<MutationRecord[]>) => void)[] = [];
 
@@ -23,6 +23,7 @@ describe('createExposureObservable', () => {
     // Mock IntersectionObserver
     mockIntersectionObserver = {
       observe: jest.fn(),
+      unobserve: jest.fn(),
       disconnect: jest.fn(),
     };
 
@@ -205,6 +206,78 @@ describe('createExposureObservable', () => {
     subscription.unsubscribe();
 
     expect(mockIntersectionObserver.disconnect).toHaveBeenCalled();
+  });
+
+  test('should re-observe elements in the viewport when asked to reobserve', () => {
+    const inViewport = document.createElement('div');
+    const outOfViewport = document.createElement('div');
+    document.body.appendChild(inViewport);
+    document.body.appendChild(outOfViewport);
+
+    let reobserve: (() => void) | undefined;
+    const exposureObservable = createExposureObservable(mutationObservable, ['div'], (fn) => {
+      reobserve = fn;
+    });
+    exposureObservable.subscribe(() => {
+      return;
+    });
+
+    intersectionCallback([
+      { isIntersecting: true, intersectionRatio: 1.0, target: inViewport } as unknown as IntersectionObserverEntry,
+      { isIntersecting: false, intersectionRatio: 0.5, target: outOfViewport } as unknown as IntersectionObserverEntry,
+    ]);
+
+    mockIntersectionObserver.observe.mockClear();
+    expect(reobserve).toBeDefined();
+    reobserve?.();
+
+    // Only the element in the viewport needs to be reported again
+    expect(mockIntersectionObserver.unobserve).toHaveBeenCalledTimes(1);
+    expect(mockIntersectionObserver.unobserve).toHaveBeenCalledWith(inViewport);
+    expect(mockIntersectionObserver.observe).toHaveBeenCalledTimes(1);
+    expect(mockIntersectionObserver.observe).toHaveBeenCalledWith(inViewport);
+
+    // Reobserving again is a no-op until the observer reports the element as visible again
+    mockIntersectionObserver.observe.mockClear();
+    reobserve?.();
+    expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+  });
+
+  test('should not re-observe elements in the viewport that left the DOM', () => {
+    const removed = document.createElement('div');
+    document.body.appendChild(removed);
+
+    let reobserve: (() => void) | undefined;
+    const exposureObservable = createExposureObservable(mutationObservable, ['div'], (fn) => {
+      reobserve = fn;
+    });
+    exposureObservable.subscribe(() => {
+      return;
+    });
+
+    intersectionCallback([
+      { isIntersecting: true, intersectionRatio: 1.0, target: removed } as unknown as IntersectionObserverEntry,
+    ]);
+
+    removed.remove();
+    mockIntersectionObserver.observe.mockClear();
+    reobserve?.();
+
+    expect(mockIntersectionObserver.unobserve).toHaveBeenCalledWith(removed);
+    expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+  });
+
+  test('should clear the reobserve function on unsubscribe', () => {
+    const registerReobserve = jest.fn();
+    const exposureObservable = createExposureObservable(mutationObservable, ['div'], registerReobserve);
+    const subscription = exposureObservable.subscribe(() => {
+      return;
+    });
+
+    expect(registerReobserve).toHaveBeenCalledWith(expect.any(Function));
+
+    subscription.unsubscribe();
+    expect(registerReobserve).toHaveBeenLastCalledWith(undefined);
   });
 
   test('should handle missing IntersectionObserver support gracefully', () => {

--- a/packages/plugin-autocapture-browser/test/observables-coverage.test.ts
+++ b/packages/plugin-autocapture-browser/test/observables-coverage.test.ts
@@ -65,26 +65,50 @@ describe('Observables Coverage', () => {
   });
 
   describe('createMutationObservable', () => {
-    test('should handle missing document.body safely', () => {
-      // Save original body
+    const withoutBody = (run: () => void) => {
       const originalBody = document.body;
-      // Delete body
       Object.defineProperty(document, 'body', { value: null, configurable: true });
+      try {
+        run();
+      } finally {
+        Object.defineProperty(document, 'body', { value: originalBody, configurable: true });
+      }
+    };
 
+    test('should observe the document element when document.body does not exist yet', () => {
+      const observeSpy = jest.spyOn(MutationObserver.prototype, 'observe');
       mockGetGlobalScope.mockReturnValue(window); // Ensure global scope is present
 
-      const observable = createMutationObservable();
-      const subscription = observable.subscribe(() => {
-        return;
+      withoutBody(() => {
+        const subscription = createMutationObservable().subscribe(() => {
+          return;
+        });
+        subscription.unsubscribe();
       });
 
-      subscription.unsubscribe();
+      expect(observeSpy).toHaveBeenCalledWith(document.documentElement, expect.objectContaining({ subtree: true }));
+    });
 
-      // Restore body
-      Object.defineProperty(document, 'body', { value: originalBody, configurable: true });
+    test('should handle a document with neither body nor document element safely', () => {
+      const observeSpy = jest.spyOn(MutationObserver.prototype, 'observe');
+      const originalDocumentElement = document.documentElement;
+      Object.defineProperty(document, 'documentElement', { value: null, configurable: true });
 
-      // Verify it didn't throw and executed safely
-      expect(true).toBe(true);
+      try {
+        withoutBody(() => {
+          const subscription = createMutationObservable().subscribe(() => {
+            return;
+          });
+          subscription.unsubscribe();
+        });
+      } finally {
+        Object.defineProperty(document, 'documentElement', {
+          value: originalDocumentElement,
+          configurable: true,
+        });
+      }
+
+      expect(observeSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

On some pages `[Amplitude] Viewport Content Updated` never fires, and when it is forced it carries an empty `[Amplitude] Element Exposed` array. Reproduced on https://www.clubmed.fr/ (Next.js App Router) by loading the built SDK on the live page and capturing events through an enrichment plugin:

```
fully-visible allowlisted elements in viewport: 20
after first page-end:                           exposed: 17
after 3s dwell, no scroll:                      (no event at all)
after pushState + 2.5s dwell, no scroll:        (no event at all)
after scrolling away and back to top:           exposed: 47
```

Four separate defects combine to produce that:

1. **The Navigation API reports same-document history updates as navigations.** `history.pushState`/`replaceState` fire `navigate`, and SPA frameworks call them routinely — Next.js does it during hydration. Every one was treated as the end of a page view, flushing a premature event and resetting all exposure state. Page ends are now keyed off an actual URL change (using `NavigateEvent.destination.url`, which is available before the URL updates).

2. **Resetting the exposure state did not re-arm the IntersectionObserver.** An observer only reports threshold crossings, so after a reset nothing already in the viewport was ever reported again. Everything above the fold stayed unexposed until the user scrolled it out of view and back — which is why forcing the event returned an empty array. Elements in the viewport are now re-observed on reset so they are reported once for the new page view.

3. **`lastScroll` was not reset with the scroll tracker.** The guard that suppresses no-op events compared a zeroed scroll state against the previous page view's maxima, so it both let empty events through and suppressed the event entirely on pages that do not scroll.

4. **The mutation observer was skipped when `document.body` did not exist yet.** Initializing autocapture from the document head left it attached to nothing, so no element added afterwards was ever observed. It now falls back to the document element.

Also in this PR: `pagehide` is handled alongside `beforeunload`, since `beforeunload` does not fire reliably on mobile browsers or when a page enters the back/forward cache, and the page-end dedupe flag is only set for page ends so that a buffer flush can no longer swallow the final event.

After the fix, the same live-page scenario reports the on-screen elements at every page end:

```
after first page-end:                           exposed: 17
after 3s dwell, no scroll:                      exposed: 17
after pushState + 2.5s dwell, no scroll:        exposed: 17
after scrolling away and back to top:           exposed: 47
```

### Scroll maxima and URL fragments

Reviewing the page-end reset against anchor navigation surfaced a related bug in `trackScroll`, fixed here too. The tracker only learned from scroll events it witnessed and started from zero, so landing directly on a URL with a fragment reported a single viewport of depth — the browser jumps to the anchor before the plugin's scroll subscription exists. The maxima now fold in the current position when read, and a page end rebaselines on where the page actually is instead of assuming the top, which also covers SPA route changes that leave the scroll position where it was.

Measured on a synthetic 6000px page with anchors, `Max Page Y` for a viewport of 800 at offset 3106:

| scenario | before | after |
| --- | --- | --- |
| land on `/page#section-3` | 800 | 3906 |
| click in-page anchor to `#section-3` (page view before the jump) | 800 | 800 |
| click in-page anchor to `#section-3` (page view after the jump) | 3906 | 3906 |
| land on `/page`, stay at the top | 800 | 800 |

### Known limitation, unchanged

The exposure observer uses `threshold: 1.0`, so an allowlisted element larger than the viewport, or clipped by a scroll container, is never counted as exposed. On the clubmed.fr homepage that accounts for 2 of 22 in-viewport elements. Changing it would change event volume and semantics, so it is left alone.

### Testing

`packages/plugin-autocapture-browser` keeps 100% coverage. Unit tests cover the re-observe path, the URL-change guard for both the Navigation API and the popstate/pushState fallback, `pagehide` and its deduplication with `beforeunload`, the scroll rebaseline and the fragment-jump position, and the document element fallback. `pnpm build`, `pnpm test`, `pnpm lint`, `pnpm lint:deps` and `pnpm docs:check` pass. (`pnpm test:examples` fails on `main` too — its `jest.setup.examples.js` is missing from the repo.)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No. Pages that call `pushState`/`replaceState` without changing the URL will stop emitting a Viewport Content Updated event per call, which is the bug being fixed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88aa1e34-8552-45ee-8462-2c7443363a17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88aa1e34-8552-45ee-8462-2c7443363a17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

