### PR TITLE
feat(analytics-react-native): add diagnostics client

### DIFF
--- a/packages/analytics-core/src/diagnostics/diagnostics-client.ts
+++ b/packages/analytics-core/src/diagnostics/diagnostics-client.ts
@@ -194,6 +194,12 @@ export class DiagnosticsClient implements IDiagnosticsClient {
       enabled?: boolean;
       sampleRate?: number;
     },
+    /**
+     * Storage for diagnostics data. Defaults to IndexedDB, which only exists in the browser —
+     * non-browser SDKs inject their own implementation. Internal: this is a constructor argument,
+     * not a public config option.
+     */
+    storage?: IDiagnosticsStorage,
   ) {
     this.apiKey = apiKey;
     this.logger = logger;
@@ -205,7 +211,9 @@ export class DiagnosticsClient implements IDiagnosticsClient {
     this.startTimestamp = Date.now();
     this.shouldTrack = isTimestampInSampleTemp(this.startTimestamp, this.config.sampleRate) && this.config.enabled;
 
-    if (DiagnosticsStorage.isSupported()) {
+    if (storage) {
+      this.storage = storage;
+    } else if (DiagnosticsStorage.isSupported()) {
       this.storage = new DiagnosticsStorage(apiKey, logger);
     } else {
       this.logger.debug('DiagnosticsClient: IndexedDB is not supported');

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -31,7 +31,14 @@ export { getStorageKey } from './storage/helpers';
 
 export { BrowserStorage } from './storage/browser-storage';
 
-export { DiagnosticsClient, IDiagnosticsClient } from './diagnostics/diagnostics-client';
+export { DiagnosticsClient, IDiagnosticsClient, HistogramStats } from './diagnostics/diagnostics-client';
+export {
+  IDiagnosticsStorage,
+  TagRecord,
+  CounterRecord,
+  HistogramRecord,
+  EventRecord,
+} from './diagnostics/diagnostics-storage';
 export { registerSdkLoaderMetadata } from './diagnostics/uncaught-sdk-errors';
 
 export { BaseTransport } from './transports/base';

--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -4,8 +4,15 @@ import { UserSession } from '../user-session';
 import { RemoteConfigOptions } from './browser-config';
 import { NetworkTrackingOptions } from '../network-tracking';
 import { IRemoteConfigClient } from '../../remote-config/remote-config';
+import { IDiagnosticsClient } from '../../diagnostics/diagnostics-client';
 
-type HiddenOptions = 'apiKey' | 'lastEventId' | 'persistedAppVersion' | 'persistedAppBuild' | 'remoteConfigClient';
+type HiddenOptions =
+  | 'apiKey'
+  | 'lastEventId'
+  | 'persistedAppVersion'
+  | 'persistedAppBuild'
+  | 'remoteConfigClient'
+  | 'diagnosticsClient';
 
 /* @experimental This config is experimental pending GA of React Native autocapture. */
 export interface ReactNativeAutocaptureOptions {
@@ -42,6 +49,7 @@ export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   /* @experimental this config is experimental pending GA of React Native autocapture */
   remoteConfig?: RemoteConfigOptions;
   remoteConfigClient?: IRemoteConfigClient;
+  diagnosticsClient?: IDiagnosticsClient;
   /* @experimental This config is experimental pending GA of React Native autocapture. */
   autocapture?: boolean | ReactNativeAutocaptureOptions;
 }

--- a/packages/analytics-core/src/types/config/react-native-config.ts
+++ b/packages/analytics-core/src/types/config/react-native-config.ts
@@ -4,15 +4,8 @@ import { UserSession } from '../user-session';
 import { RemoteConfigOptions } from './browser-config';
 import { NetworkTrackingOptions } from '../network-tracking';
 import { IRemoteConfigClient } from '../../remote-config/remote-config';
-import { IDiagnosticsClient } from '../../diagnostics/diagnostics-client';
 
-type HiddenOptions =
-  | 'apiKey'
-  | 'lastEventId'
-  | 'persistedAppVersion'
-  | 'persistedAppBuild'
-  | 'remoteConfigClient'
-  | 'diagnosticsClient';
+type HiddenOptions = 'apiKey' | 'lastEventId' | 'persistedAppVersion' | 'persistedAppBuild' | 'remoteConfigClient';
 
 /* @experimental This config is experimental pending GA of React Native autocapture. */
 export interface ReactNativeAutocaptureOptions {
@@ -49,7 +42,6 @@ export interface ReactNativeConfig extends Omit<IConfig, 'requestMetadata'> {
   /* @experimental this config is experimental pending GA of React Native autocapture */
   remoteConfig?: RemoteConfigOptions;
   remoteConfigClient?: IRemoteConfigClient;
-  diagnosticsClient?: IDiagnosticsClient;
   /* @experimental This config is experimental pending GA of React Native autocapture. */
   autocapture?: boolean | ReactNativeAutocaptureOptions;
 }

--- a/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
+++ b/packages/analytics-core/test/diagnostics/diagnostics-client.test.ts
@@ -956,4 +956,42 @@ describe('DiagnosticsClient', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith('DiagnosticsClient: Should track is', false);
     });
   });
+
+  describe('injected storage', () => {
+    const createInjectedStorage = () =>
+      ({
+        setTags: jest.fn().mockResolvedValue(undefined),
+        incrementCounters: jest.fn().mockResolvedValue(undefined),
+        setHistogramStats: jest.fn().mockResolvedValue(undefined),
+        addEventRecords: jest.fn().mockResolvedValue(undefined),
+        setLastFlushTimestamp: jest.fn().mockResolvedValue(undefined),
+        getLastFlushTimestamp: jest.fn().mockResolvedValue(undefined),
+        getAllAndClear: jest.fn().mockResolvedValue({ tags: [], counters: [], histogramStats: [], events: [] }),
+      } as unknown as DiagnosticsStorage);
+
+    test('should use the injected storage instead of IndexedDB', () => {
+      const injected = createInjectedStorage();
+
+      const client = new DiagnosticsClient(apiKey, mockLogger, 'US', undefined, injected);
+
+      expect(client.storage).toBe(injected);
+      expect(DiagnosticsStorage).not.toHaveBeenCalled();
+    });
+
+    test('should use the injected storage even when IndexedDB is unsupported', () => {
+      (DiagnosticsStorage.isSupported as jest.Mock).mockReturnValue(false);
+      const injected = createInjectedStorage();
+
+      const client = new DiagnosticsClient(apiKey, mockLogger, 'US', undefined, injected);
+
+      expect(client.storage).toBe(injected);
+    });
+
+    test('should fall back to IndexedDB when no storage is injected', () => {
+      const client = new DiagnosticsClient(apiKey, mockLogger);
+
+      expect(client.storage).toBeDefined();
+      expect(DiagnosticsStorage).toHaveBeenCalledWith(apiKey, mockLogger);
+    });
+  });
 });

--- a/packages/analytics-react-native/.gitignore
+++ b/packages/analytics-react-native/.gitignore
@@ -33,6 +33,7 @@ project.xcworkspace
 #
 .idea
 .gradle
+.settings
 local.properties
 android.iml
 **/*/.project

--- a/packages/analytics-react-native/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-react-native/src/diagnostics/diagnostics-storage.ts
@@ -1,0 +1,202 @@
+import {
+  CounterRecord,
+  EventRecord,
+  HistogramRecord,
+  HistogramStats,
+  IDiagnosticsStorage,
+  ILogger,
+  TagRecord,
+} from '@amplitude/analytics-core';
+import { getAsyncStorage } from '../storage/local-storage';
+
+const MAX_PERSISTENT_STORAGE_EVENTS_COUNT = 10;
+/**
+ * Bound on distinct tag/counter/histogram keys. The browser leaves IndexedDB unbounded and only
+ * caps in memory, but everything here lives in one AsyncStorage entry, and Android limits the
+ * size of a single entry.
+ */
+const MAX_PERSISTENT_STORAGE_KEYS_COUNT = 1000;
+
+interface DiagnosticsBlob {
+  tags: Record<string, string>;
+  counters: Record<string, number>;
+  histograms: Record<string, HistogramStats>;
+  events: EventRecord[];
+  lastFlushTimestamp?: number;
+}
+
+const emptyBlob = (): DiagnosticsBlob => ({ tags: {}, counters: {}, histograms: {}, events: [] });
+
+/**
+ * Diagnostics storage for React Native, backed by AsyncStorage.
+ *
+ * The blob is held in memory and serialized to a single AsyncStorage key. Keeping memory as the
+ * source of truth avoids read-modify-write races: AsyncStorage has no transactions, so merging
+ * from disk on every mutation could interleave. One key also means one write per save tick
+ * instead of one per data type.
+ *
+ * AsyncStorage is an optional peer dependency. When it isn't installed this degrades to
+ * memory-only — diagnostics still accumulate and flush for the life of the app, and are lost on
+ * app kill. Nothing here throws on that path.
+ */
+export class ReactNativeDiagnosticsStorage implements IDiagnosticsStorage {
+  readonly storageKey: string;
+  private readonly logger: ILogger;
+  private blob: DiagnosticsBlob = emptyBlob();
+  private readonly ready: Promise<void>;
+  /** Serializes writes so concurrent callers can't clobber each other's snapshot of the blob. */
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(apiKey: string, logger: ILogger) {
+    this.logger = logger;
+    this.storageKey = `AMP_diagnostics_${apiKey.substring(0, 10)}`;
+    this.ready = this.hydrate();
+  }
+
+  private async hydrate(): Promise<void> {
+    const storage = getAsyncStorage();
+    if (!storage) {
+      return;
+    }
+    try {
+      const raw = await storage.getItem(this.storageKey);
+      if (raw) {
+        // Spread over an empty blob so a payload written by an older version that lacks a field
+        // doesn't leave it undefined.
+        this.blob = { ...emptyBlob(), ...(JSON.parse(raw) as DiagnosticsBlob) };
+      }
+    } catch (error) {
+      this.logger.debug('ReactNativeDiagnosticsStorage: Failed to read persisted diagnostics', error);
+    }
+  }
+
+  private persist(): Promise<void> {
+    const storage = getAsyncStorage();
+    if (!storage) {
+      return Promise.resolve();
+    }
+    this.writeQueue = this.writeQueue.then(async () => {
+      try {
+        await storage.setItem(this.storageKey, JSON.stringify(this.blob));
+      } catch (error) {
+        // The JS package resolved but the native bridge is missing, or the entry exceeded the
+        // platform size limit. Diagnostics stay in memory.
+        this.logger.debug('ReactNativeDiagnosticsStorage: Failed to persist diagnostics', error);
+      }
+    });
+    return this.writeQueue;
+  }
+
+  /** True when `key` is new and the collection is already at its key cap. */
+  private isAtKeyLimit(collection: Record<string, unknown>, key: string): boolean {
+    return !(key in collection) && Object.keys(collection).length >= MAX_PERSISTENT_STORAGE_KEYS_COUNT;
+  }
+
+  async setTags(tags: Record<string, string>): Promise<void> {
+    if (Object.keys(tags).length === 0) {
+      return;
+    }
+    await this.ready;
+    for (const [key, value] of Object.entries(tags)) {
+      if (this.isAtKeyLimit(this.blob.tags, key)) {
+        continue;
+      }
+      this.blob.tags[key] = value;
+    }
+    await this.persist();
+  }
+
+  async incrementCounters(counters: Record<string, number>): Promise<void> {
+    if (Object.keys(counters).length === 0) {
+      return;
+    }
+    await this.ready;
+    for (const [key, increment] of Object.entries(counters)) {
+      if (this.isAtKeyLimit(this.blob.counters, key)) {
+        continue;
+      }
+      this.blob.counters[key] = (this.blob.counters[key] ?? 0) + increment;
+    }
+    await this.persist();
+  }
+
+  async setHistogramStats(histogramStats: Record<string, HistogramStats>): Promise<void> {
+    if (Object.keys(histogramStats).length === 0) {
+      return;
+    }
+    await this.ready;
+    for (const [key, stats] of Object.entries(histogramStats)) {
+      if (this.isAtKeyLimit(this.blob.histograms, key)) {
+        continue;
+      }
+      const existing = this.blob.histograms[key];
+      this.blob.histograms[key] = existing
+        ? {
+            count: existing.count + stats.count,
+            min: Math.min(existing.min, stats.min),
+            max: Math.max(existing.max, stats.max),
+            sum: existing.sum + stats.sum,
+          }
+        : { ...stats };
+    }
+    await this.persist();
+  }
+
+  async addEventRecords(
+    events: Array<{ event_name: string; time: number; event_properties: Record<string, any> }>,
+  ): Promise<void> {
+    if (events.length === 0) {
+      return;
+    }
+    await this.ready;
+    const availableSlots = Math.max(0, MAX_PERSISTENT_STORAGE_EVENTS_COUNT - this.blob.events.length);
+    if (availableSlots < events.length) {
+      this.logger.debug(
+        `ReactNativeDiagnosticsStorage: Only added ${availableSlots} of ${events.length} events due to storage limit`,
+      );
+    }
+    if (availableSlots === 0) {
+      return;
+    }
+    // Keep the least recent, matching the browser's persistent storage.
+    this.blob.events.push(...events.slice(0, availableSlots));
+    await this.persist();
+  }
+
+  async setLastFlushTimestamp(timestamp: number): Promise<void> {
+    await this.ready;
+    this.blob.lastFlushTimestamp = timestamp;
+    await this.persist();
+  }
+
+  async getLastFlushTimestamp(): Promise<number | undefined> {
+    await this.ready;
+    return this.blob.lastFlushTimestamp;
+  }
+
+  async getAllAndClear(): Promise<{
+    tags: TagRecord[];
+    counters: CounterRecord[];
+    histogramStats: HistogramRecord[];
+    events: EventRecord[];
+  }> {
+    await this.ready;
+
+    const tags: TagRecord[] = Object.entries(this.blob.tags).map(([key, value]) => ({ key, value }));
+    const counters: CounterRecord[] = Object.entries(this.blob.counters).map(([key, value]) => ({ key, value }));
+    const histogramStats: HistogramRecord[] = Object.entries(this.blob.histograms).map(([key, stats]) => ({
+      key,
+      ...stats,
+    }));
+    const events = this.blob.events;
+
+    // Tags survive: they describe the environment, not one reporting window. Matches
+    // DiagnosticsStorage.getAllAndClear in analytics-core.
+    this.blob.counters = {};
+    this.blob.histograms = {};
+    this.blob.events = [];
+    await this.persist();
+
+    return { tags, counters, histogramStats, events };
+  }
+}

--- a/packages/analytics-react-native/src/diagnostics/diagnostics-storage.ts
+++ b/packages/analytics-react-native/src/diagnostics/diagnostics-storage.ts
@@ -10,12 +10,6 @@ import {
 import { getAsyncStorage } from '../storage/local-storage';
 
 const MAX_PERSISTENT_STORAGE_EVENTS_COUNT = 10;
-/**
- * Bound on distinct tag/counter/histogram keys. The browser leaves IndexedDB unbounded and only
- * caps in memory, but everything here lives in one AsyncStorage entry, and Android limits the
- * size of a single entry.
- */
-const MAX_PERSISTENT_STORAGE_KEYS_COUNT = 1000;
 
 interface DiagnosticsBlob {
   tags: Record<string, string>;
@@ -61,9 +55,7 @@ export class ReactNativeDiagnosticsStorage implements IDiagnosticsStorage {
     try {
       const raw = await storage.getItem(this.storageKey);
       if (raw) {
-        // Spread over an empty blob so a payload written by an older version that lacks a field
-        // doesn't leave it undefined.
-        this.blob = { ...emptyBlob(), ...(JSON.parse(raw) as DiagnosticsBlob) };
+        this.blob = JSON.parse(raw) as DiagnosticsBlob;
       }
     } catch (error) {
       this.logger.debug('ReactNativeDiagnosticsStorage: Failed to read persisted diagnostics', error);
@@ -80,16 +72,11 @@ export class ReactNativeDiagnosticsStorage implements IDiagnosticsStorage {
         await storage.setItem(this.storageKey, JSON.stringify(this.blob));
       } catch (error) {
         // The JS package resolved but the native bridge is missing, or the entry exceeded the
-        // platform size limit. Diagnostics stay in memory.
+        // platform size limit. Memory stays authoritative and the next save tick rewrites.
         this.logger.debug('ReactNativeDiagnosticsStorage: Failed to persist diagnostics', error);
       }
     });
     return this.writeQueue;
-  }
-
-  /** True when `key` is new and the collection is already at its key cap. */
-  private isAtKeyLimit(collection: Record<string, unknown>, key: string): boolean {
-    return !(key in collection) && Object.keys(collection).length >= MAX_PERSISTENT_STORAGE_KEYS_COUNT;
   }
 
   async setTags(tags: Record<string, string>): Promise<void> {
@@ -98,9 +85,6 @@ export class ReactNativeDiagnosticsStorage implements IDiagnosticsStorage {
     }
     await this.ready;
     for (const [key, value] of Object.entries(tags)) {
-      if (this.isAtKeyLimit(this.blob.tags, key)) {
-        continue;
-      }
       this.blob.tags[key] = value;
     }
     await this.persist();
@@ -112,9 +96,6 @@ export class ReactNativeDiagnosticsStorage implements IDiagnosticsStorage {
     }
     await this.ready;
     for (const [key, increment] of Object.entries(counters)) {
-      if (this.isAtKeyLimit(this.blob.counters, key)) {
-        continue;
-      }
       this.blob.counters[key] = (this.blob.counters[key] ?? 0) + increment;
     }
     await this.persist();
@@ -126,9 +107,6 @@ export class ReactNativeDiagnosticsStorage implements IDiagnosticsStorage {
     }
     await this.ready;
     for (const [key, stats] of Object.entries(histogramStats)) {
-      if (this.isAtKeyLimit(this.blob.histograms, key)) {
-        continue;
-      }
       const existing = this.blob.histograms[key];
       this.blob.histograms[key] = existing
         ? {

--- a/packages/analytics-react-native/src/lib-prefix.ts
+++ b/packages/analytics-react-native/src/lib-prefix.ts
@@ -1,0 +1,1 @@
+export const LIBPREFIX = 'amplitude-react-native-ts';

--- a/packages/analytics-react-native/src/plugins/context.ts
+++ b/packages/analytics-react-native/src/plugins/context.ts
@@ -8,6 +8,7 @@ import {
 } from '@amplitude/analytics-core';
 import UAParser from '@amplitude/ua-parser-js';
 import { VERSION } from '../version';
+import { LIBPREFIX } from '../lib-prefix';
 import { NativeModules } from 'react-native';
 
 const BROWSER_PLATFORM = 'Web';
@@ -46,7 +47,7 @@ export class Context implements BeforePlugin {
   nativeModule: AmplitudeReactNative | undefined = NativeModules.AmplitudeReactNative as
     | AmplitudeReactNative
     | undefined;
-  library = `amplitude-react-native-ts/${VERSION}`;
+  library = `${LIBPREFIX}/${VERSION}`;
 
   constructor() {
     let agent: string | undefined;

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -147,10 +147,8 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     let remoteConfigClient: IRemoteConfigClient | undefined;
 
     // Step 0.2: Fetch diagnostics config
-    // Defaults leave diagnostics inert: isTimestampInSampleTemp() is always false at rate 0, so
-    // nothing is recorded until remote config raises the sample rate.
-    let diagnosticsSampleRate = 0;
-    let enableDiagnostics = true;
+    // let diagnosticsSampleRate: number;
+    // let enableDiagnostics: boolean = false;
     if (fetchRemoteConfig) {
       remoteConfigClient = new RemoteConfigClient(
         options.apiKey,
@@ -180,15 +178,15 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
               );
               if (remoteConfig) {
                 // Validate and set sampleRate (must be a valid number)
-                const sampleRate = remoteConfig.sampleRate as number;
-                if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
-                  diagnosticsSampleRate = sampleRate;
-                }
-                // Validate and set enabled (must be a boolean)
-                const enabled = remoteConfig.enabled as boolean;
-                if (typeof enabled === 'boolean') {
-                  enableDiagnostics = enabled;
-                }
+                // const sampleRate = remoteConfig.sampleRate as number;
+                // if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
+                //   diagnosticsSampleRate = sampleRate;
+                // }
+                // // Validate and set enabled (must be a boolean)
+                // const enabled = remoteConfig.enabled as boolean;
+                // if (typeof enabled === 'boolean') {
+                //   enableDiagnostics = enabled;
+                // }
               }
               resolve();
             },
@@ -199,12 +197,13 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     // Step 0.3: Initialize diagnostics client as early as possible so it can record failures
     // during config setup. Mirrors the browser SDK; storage is injected because RN has no
-    // IndexedDB.
+    // IndexedDB. Options are left at their defaults (enabled, sample rate 0), which keeps the
+    // client inert until the remote config gate above is turned on.
     const diagnosticsClient = new DiagnosticsClient(
       options.apiKey,
       loggerProvider,
       serverZone,
-      { enabled: enableDiagnostics, sampleRate: diagnosticsSampleRate },
+      undefined,
       new ReactNativeDiagnosticsStorage(options.apiKey, loggerProvider),
     );
     diagnosticsClient.setTag('library', `${LIBPREFIX}/${VERSION}`);
@@ -258,7 +257,6 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     await super._init(reactNativeOptions);
     this.config.remoteConfigClient = remoteConfigClient;
-    this.config.diagnosticsClient = diagnosticsClient;
 
     // Step 2.1: parse autocapture config (always reset so re-init clears prior flags)
     const autocaptureConfig = this.config.autocapture;

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -34,11 +34,15 @@ import {
   NetworkTrackingOptions,
   normalizeNetworkCaptureRules,
   safeJsonStringify,
+  DiagnosticsClient,
 } from '@amplitude/analytics-core';
 import { plugin as networkCapturePlugin } from '@amplitude/plugin-network-capture-browser';
 import { CampaignTracker } from './campaign/campaign-tracker';
 import { Context } from './plugins/context';
 import { networkConnectivityCheckerPlugin } from './plugins/network-connectivity-checker';
+import { ReactNativeDiagnosticsStorage } from './diagnostics/diagnostics-storage';
+import { LIBPREFIX } from './lib-prefix';
+import { VERSION } from './version';
 import { useReactNativeConfig, createCookieStorage, shouldFetchRemoteConfig } from './config';
 import { updateReactNativeConfigWithRemoteConfig } from './config/joined-config';
 import { parseOldCookies } from './cookie-migration';
@@ -143,8 +147,10 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     let remoteConfigClient: IRemoteConfigClient | undefined;
 
     // Step 0.2: Fetch diagnostics config
-    // let diagnosticsSampleRate: number;
-    // let enableDiagnostics: boolean = false;
+    // Defaults leave diagnostics inert: isTimestampInSampleTemp() is always false at rate 0, so
+    // nothing is recorded until remote config raises the sample rate.
+    let diagnosticsSampleRate = 0;
+    let enableDiagnostics = true;
     if (fetchRemoteConfig) {
       remoteConfigClient = new RemoteConfigClient(
         options.apiKey,
@@ -174,15 +180,15 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
               );
               if (remoteConfig) {
                 // Validate and set sampleRate (must be a valid number)
-                // const sampleRate = remoteConfig.sampleRate as number;
-                // if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
-                //   diagnosticsSampleRate = sampleRate;
-                // }
-                // // Validate and set enabled (must be a boolean)
-                // const enabled = remoteConfig.enabled as boolean;
-                // if (typeof enabled === 'boolean') {
-                //   enableDiagnostics = enabled;
-                // }
+                const sampleRate = remoteConfig.sampleRate as number;
+                if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
+                  diagnosticsSampleRate = sampleRate;
+                }
+                // Validate and set enabled (must be a boolean)
+                const enabled = remoteConfig.enabled as boolean;
+                if (typeof enabled === 'boolean') {
+                  enableDiagnostics = enabled;
+                }
               }
               resolve();
             },
@@ -190,6 +196,20 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
         });
       }
     }
+
+    // Step 0.3: Initialize diagnostics client as early as possible so it can record failures
+    // during config setup. Mirrors the browser SDK; storage is injected because RN has no
+    // IndexedDB.
+    const diagnosticsClient = new DiagnosticsClient(
+      options.apiKey,
+      loggerProvider,
+      serverZone,
+      { enabled: enableDiagnostics, sampleRate: diagnosticsSampleRate },
+      new ReactNativeDiagnosticsStorage(options.apiKey, loggerProvider),
+    );
+    diagnosticsClient.setTag('library', `${LIBPREFIX}/${VERSION}`);
+    diagnosticsClient.setTag('platform', 'ReactNative');
+    diagnosticsClient.setTag('os', Platform.OS);
 
     // Step 1: Read cookies stored by old SDK
     const oldCookies = await parseOldCookies(options.apiKey, options);
@@ -238,6 +258,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
 
     await super._init(reactNativeOptions);
     this.config.remoteConfigClient = remoteConfigClient;
+    this.config.diagnosticsClient = diagnosticsClient;
 
     // Step 2.1: parse autocapture config (always reset so re-init clears prior flags)
     const autocaptureConfig = this.config.autocapture;
@@ -281,7 +302,7 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     if (this.config.offline !== OfflineDisabled) {
       await this.add(networkConnectivityCheckerPlugin()).promise;
     }
-    await this.add(new Destination()).promise;
+    await this.add(new Destination({ diagnosticsClient })).promise;
     await this.add(new Context()).promise;
     await this.add(new IdentityEventSender()).promise;
 

--- a/packages/analytics-react-native/src/storage/local-storage.ts
+++ b/packages/analytics-react-native/src/storage/local-storage.ts
@@ -1,6 +1,6 @@
 import { Storage, getGlobalScope } from '@amplitude/analytics-core';
 
-interface AsyncStorageLike {
+export interface AsyncStorageLike {
   getItem(key: string): Promise<string | null>;
   setItem(key: string, value: string): Promise<void>;
   removeItem(key: string): Promise<void>;
@@ -25,7 +25,7 @@ interface AsyncStorageLike {
 // for the success-case caching that `require()` gives us for free.
 let asyncStorage: AsyncStorageLike | null | undefined = undefined;
 
-const getAsyncStorage = (): AsyncStorageLike | null | undefined => {
+export const getAsyncStorage = (): AsyncStorageLike | null | undefined => {
   if (asyncStorage !== undefined) {
     return asyncStorage;
   }

--- a/packages/analytics-react-native/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-react-native/test/diagnostics/diagnostics-storage.test.ts
@@ -248,18 +248,6 @@ describe('ReactNativeDiagnosticsStorage', () => {
       expect(counters).toEqual([{ key: 'analytics.error', value: 4 }]);
     });
 
-    test('should tolerate a blob written without newer fields', async () => {
-      fakeAsyncStorage.entries.set('AMP_diagnostics_1234567890', JSON.stringify({ tags: { a: 'b' } }));
-
-      const storage = createStorage();
-
-      const { tags, counters, histogramStats, events } = await storage.getAllAndClear();
-      expect(tags).toEqual([{ key: 'a', value: 'b' }]);
-      expect(counters).toEqual([]);
-      expect(histogramStats).toEqual([]);
-      expect(events).toEqual([]);
-    });
-
     test('should log and start empty on unparsable persisted data', async () => {
       fakeAsyncStorage.entries.set('AMP_diagnostics_1234567890', 'not json');
 
@@ -339,46 +327,6 @@ describe('ReactNativeDiagnosticsStorage', () => {
       const { counters } = await createStorage().getAllAndClear();
 
       expect(counters).toEqual([]);
-    });
-  });
-
-  describe('key limits', () => {
-    // Exercises the cap that keeps the single AsyncStorage entry bounded.
-    const overLimit = (prefix: string) =>
-      Object.fromEntries(Array.from({ length: 1001 }, (_, i) => [`${prefix}${i}`, 1]));
-
-    test('should stop adding new counter keys at the limit but keep updating known ones', async () => {
-      const storage = createStorage();
-
-      await storage.incrementCounters(overLimit('c'));
-      await storage.incrementCounters({ c0: 5, 'brand.new': 1 });
-
-      const { counters } = await storage.getAllAndClear();
-      expect(counters).toHaveLength(1000);
-      expect(counters.find((c) => c.key === 'c0')?.value).toBe(6);
-      expect(counters.find((c) => c.key === 'brand.new')).toBeUndefined();
-    });
-
-    test('should cap tag keys', async () => {
-      const storage = createStorage();
-
-      await storage.setTags(
-        Object.fromEntries(Array.from({ length: 1001 }, (_, i) => [`t${i}`, 'v'])) as Record<string, string>,
-      );
-
-      const { tags } = await storage.getAllAndClear();
-      expect(tags).toHaveLength(1000);
-    });
-
-    test('should cap histogram keys', async () => {
-      const storage = createStorage();
-
-      await storage.setHistogramStats(
-        Object.fromEntries(Array.from({ length: 1001 }, (_, i) => [`h${i}`, { count: 1, min: 1, max: 1, sum: 1 }])),
-      );
-
-      const { histogramStats } = await storage.getAllAndClear();
-      expect(histogramStats).toHaveLength(1000);
     });
   });
 });

--- a/packages/analytics-react-native/test/diagnostics/diagnostics-storage.test.ts
+++ b/packages/analytics-react-native/test/diagnostics/diagnostics-storage.test.ts
@@ -1,0 +1,384 @@
+import { ILogger } from '@amplitude/analytics-core';
+import { ReactNativeDiagnosticsStorage } from '../../src/diagnostics/diagnostics-storage';
+import * as localStorageModule from '../../src/storage/local-storage';
+
+const mockLogger: ILogger = {
+  disable: jest.fn(),
+  enable: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+const apiKey = '1234567890abcdefg';
+
+/** In-memory stand-in for the AsyncStorage module surface we use. */
+const createFakeAsyncStorage = () => {
+  const entries = new Map<string, string>();
+  return {
+    entries,
+    getItem: jest.fn((key: string) => Promise.resolve(entries.get(key) ?? null)),
+    setItem: jest.fn((key: string, value: string) => {
+      entries.set(key, value);
+      return Promise.resolve();
+    }),
+    removeItem: jest.fn((key: string) => {
+      entries.delete(key);
+      return Promise.resolve();
+    }),
+    clear: jest.fn(() => {
+      entries.clear();
+      return Promise.resolve();
+    }),
+  };
+};
+
+describe('ReactNativeDiagnosticsStorage', () => {
+  let fakeAsyncStorage: ReturnType<typeof createFakeAsyncStorage>;
+  let getAsyncStorageSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fakeAsyncStorage = createFakeAsyncStorage();
+    getAsyncStorageSpy = jest.spyOn(localStorageModule, 'getAsyncStorage').mockReturnValue(fakeAsyncStorage);
+  });
+
+  afterEach(() => {
+    getAsyncStorageSpy.mockRestore();
+  });
+
+  const createStorage = () => new ReactNativeDiagnosticsStorage(apiKey, mockLogger);
+
+  describe('storage key', () => {
+    test('should namespace by the first 10 characters of the api key', () => {
+      expect(createStorage().storageKey).toBe('AMP_diagnostics_1234567890');
+    });
+  });
+
+  describe('tags', () => {
+    test('should persist and return tags', async () => {
+      const storage = createStorage();
+
+      await storage.setTags({ library: 'amplitude-react-native-ts/1.0.0', platform: 'ReactNative' });
+
+      const { tags } = await storage.getAllAndClear();
+      expect(tags).toEqual([
+        { key: 'library', value: 'amplitude-react-native-ts/1.0.0' },
+        { key: 'platform', value: 'ReactNative' },
+      ]);
+    });
+
+    test('should overwrite an existing tag', async () => {
+      const storage = createStorage();
+
+      await storage.setTags({ platform: 'ReactNative' });
+      await storage.setTags({ platform: 'Web' });
+
+      const { tags } = await storage.getAllAndClear();
+      expect(tags).toEqual([{ key: 'platform', value: 'Web' }]);
+    });
+
+    test('should keep tags across getAllAndClear', async () => {
+      const storage = createStorage();
+      await storage.setTags({ platform: 'ReactNative' });
+
+      await storage.getAllAndClear();
+      const { tags } = await storage.getAllAndClear();
+
+      expect(tags).toEqual([{ key: 'platform', value: 'ReactNative' }]);
+    });
+
+    test('should no-op on an empty set', async () => {
+      const storage = createStorage();
+
+      await storage.setTags({});
+
+      expect(fakeAsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('counters', () => {
+    test('should accumulate across calls', async () => {
+      const storage = createStorage();
+
+      await storage.incrementCounters({ 'analytics.error': 2 });
+      await storage.incrementCounters({ 'analytics.error': 3, 'network.retry': 1 });
+
+      const { counters } = await storage.getAllAndClear();
+      expect(counters).toEqual([
+        { key: 'analytics.error', value: 5 },
+        { key: 'network.retry', value: 1 },
+      ]);
+    });
+
+    test('should reset on getAllAndClear', async () => {
+      const storage = createStorage();
+      await storage.incrementCounters({ 'analytics.error': 2 });
+
+      await storage.getAllAndClear();
+      const { counters } = await storage.getAllAndClear();
+
+      expect(counters).toEqual([]);
+    });
+
+    test('should no-op on an empty set', async () => {
+      const storage = createStorage();
+
+      await storage.incrementCounters({});
+
+      expect(fakeAsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('histograms', () => {
+    test('should accumulate count and sum and merge min/max', async () => {
+      const storage = createStorage();
+
+      await storage.setHistogramStats({ 'sr.time': { count: 1, min: 50, max: 50, sum: 50 } });
+      await storage.setHistogramStats({ 'sr.time': { count: 2, min: 10, max: 90, sum: 100 } });
+
+      const { histogramStats } = await storage.getAllAndClear();
+      expect(histogramStats).toEqual([{ key: 'sr.time', count: 3, min: 10, max: 90, sum: 150 }]);
+    });
+
+    test('should reset on getAllAndClear', async () => {
+      const storage = createStorage();
+      await storage.setHistogramStats({ 'sr.time': { count: 1, min: 50, max: 50, sum: 50 } });
+
+      await storage.getAllAndClear();
+      const { histogramStats } = await storage.getAllAndClear();
+
+      expect(histogramStats).toEqual([]);
+    });
+
+    test('should no-op on an empty set', async () => {
+      const storage = createStorage();
+
+      await storage.setHistogramStats({});
+
+      expect(fakeAsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('events', () => {
+    const event = (name: string) => ({ event_name: name, time: 1, event_properties: {} });
+
+    test('should append event records', async () => {
+      const storage = createStorage();
+
+      await storage.addEventRecords([event('a'), event('b')]);
+
+      const { events } = await storage.getAllAndClear();
+      expect(events.map((e) => e.event_name)).toEqual(['a', 'b']);
+    });
+
+    test('should cap at 10 events and keep the least recent', async () => {
+      const storage = createStorage();
+
+      await storage.addEventRecords(Array.from({ length: 12 }, (_, i) => event(`e${i}`)));
+
+      const { events } = await storage.getAllAndClear();
+      expect(events).toHaveLength(10);
+      expect(events[0].event_name).toBe('e0');
+      expect(events[9].event_name).toBe('e9');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'ReactNativeDiagnosticsStorage: Only added 10 of 12 events due to storage limit',
+      );
+    });
+
+    test('should drop events once full', async () => {
+      const storage = createStorage();
+      await storage.addEventRecords(Array.from({ length: 10 }, (_, i) => event(`e${i}`)));
+      fakeAsyncStorage.setItem.mockClear();
+
+      await storage.addEventRecords([event('overflow')]);
+
+      expect(fakeAsyncStorage.setItem).not.toHaveBeenCalled();
+      const { events } = await storage.getAllAndClear();
+      expect(events.map((e) => e.event_name)).not.toContain('overflow');
+    });
+
+    test('should reset on getAllAndClear', async () => {
+      const storage = createStorage();
+      await storage.addEventRecords([event('a')]);
+
+      await storage.getAllAndClear();
+      const { events } = await storage.getAllAndClear();
+
+      expect(events).toEqual([]);
+    });
+
+    test('should no-op on an empty list', async () => {
+      const storage = createStorage();
+
+      await storage.addEventRecords([]);
+
+      expect(fakeAsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('last flush timestamp', () => {
+    test('should be undefined before it is set', async () => {
+      expect(await createStorage().getLastFlushTimestamp()).toBeUndefined();
+    });
+
+    test('should round-trip', async () => {
+      const storage = createStorage();
+
+      await storage.setLastFlushTimestamp(1700000000000);
+
+      expect(await storage.getLastFlushTimestamp()).toBe(1700000000000);
+    });
+  });
+
+  describe('persistence', () => {
+    test('should hydrate a new instance from the persisted blob', async () => {
+      const first = createStorage();
+      await first.setTags({ platform: 'ReactNative' });
+      await first.incrementCounters({ 'analytics.error': 4 });
+      await first.setLastFlushTimestamp(1700000000000);
+
+      const second = createStorage();
+
+      expect(await second.getLastFlushTimestamp()).toBe(1700000000000);
+      const { tags, counters } = await second.getAllAndClear();
+      expect(tags).toEqual([{ key: 'platform', value: 'ReactNative' }]);
+      expect(counters).toEqual([{ key: 'analytics.error', value: 4 }]);
+    });
+
+    test('should tolerate a blob written without newer fields', async () => {
+      fakeAsyncStorage.entries.set('AMP_diagnostics_1234567890', JSON.stringify({ tags: { a: 'b' } }));
+
+      const storage = createStorage();
+
+      const { tags, counters, histogramStats, events } = await storage.getAllAndClear();
+      expect(tags).toEqual([{ key: 'a', value: 'b' }]);
+      expect(counters).toEqual([]);
+      expect(histogramStats).toEqual([]);
+      expect(events).toEqual([]);
+    });
+
+    test('should log and start empty on unparsable persisted data', async () => {
+      fakeAsyncStorage.entries.set('AMP_diagnostics_1234567890', 'not json');
+
+      const storage = createStorage();
+
+      const { tags } = await storage.getAllAndClear();
+      expect(tags).toEqual([]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'ReactNativeDiagnosticsStorage: Failed to read persisted diagnostics',
+        expect.anything(),
+      );
+    });
+
+    test('should log and keep data in memory when a write fails', async () => {
+      const storage = createStorage();
+      fakeAsyncStorage.setItem.mockRejectedValueOnce(new Error('native module missing'));
+
+      await storage.incrementCounters({ 'analytics.error': 1 });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'ReactNativeDiagnosticsStorage: Failed to persist diagnostics',
+        expect.anything(),
+      );
+      const { counters } = await storage.getAllAndClear();
+      expect(counters).toEqual([{ key: 'analytics.error', value: 1 }]);
+    });
+
+    test('should serialize concurrent writes without losing data', async () => {
+      const storage = createStorage();
+
+      await Promise.all([
+        storage.incrementCounters({ a: 1 }),
+        storage.incrementCounters({ b: 2 }),
+        storage.setTags({ t: 'v' }),
+        storage.addEventRecords([{ event_name: 'e', time: 1, event_properties: {} }]),
+      ]);
+
+      const persisted = JSON.parse(fakeAsyncStorage.entries.get('AMP_diagnostics_1234567890') as string) as {
+        counters: Record<string, number>;
+        tags: Record<string, string>;
+        events: unknown[];
+      };
+      expect(persisted.counters).toEqual({ a: 1, b: 2 });
+      expect(persisted.tags).toEqual({ t: 'v' });
+      expect(persisted.events).toHaveLength(1);
+    });
+  });
+
+  describe('without AsyncStorage installed', () => {
+    beforeEach(() => {
+      getAsyncStorageSpy.mockReturnValue(null);
+    });
+
+    test('should keep data in memory and never throw', async () => {
+      const storage = createStorage();
+
+      await storage.setTags({ platform: 'ReactNative' });
+      await storage.incrementCounters({ 'analytics.error': 2 });
+      await storage.setHistogramStats({ 'sr.time': { count: 1, min: 5, max: 5, sum: 5 } });
+      await storage.addEventRecords([{ event_name: 'e', time: 1, event_properties: {} }]);
+      await storage.setLastFlushTimestamp(42);
+
+      expect(await storage.getLastFlushTimestamp()).toBe(42);
+      const { tags, counters, histogramStats, events } = await storage.getAllAndClear();
+      expect(tags).toEqual([{ key: 'platform', value: 'ReactNative' }]);
+      expect(counters).toEqual([{ key: 'analytics.error', value: 2 }]);
+      expect(histogramStats).toEqual([{ key: 'sr.time', count: 1, min: 5, max: 5, sum: 5 }]);
+      expect(events).toHaveLength(1);
+    });
+
+    test('should not share data between instances', async () => {
+      const first = createStorage();
+      await first.incrementCounters({ 'analytics.error': 1 });
+
+      const { counters } = await createStorage().getAllAndClear();
+
+      expect(counters).toEqual([]);
+    });
+  });
+
+  describe('key limits', () => {
+    // Exercises the cap that keeps the single AsyncStorage entry bounded.
+    const overLimit = (prefix: string) =>
+      Object.fromEntries(Array.from({ length: 1001 }, (_, i) => [`${prefix}${i}`, 1]));
+
+    test('should stop adding new counter keys at the limit but keep updating known ones', async () => {
+      const storage = createStorage();
+
+      await storage.incrementCounters(overLimit('c'));
+      await storage.incrementCounters({ c0: 5, 'brand.new': 1 });
+
+      const { counters } = await storage.getAllAndClear();
+      expect(counters).toHaveLength(1000);
+      expect(counters.find((c) => c.key === 'c0')?.value).toBe(6);
+      expect(counters.find((c) => c.key === 'brand.new')).toBeUndefined();
+    });
+
+    test('should cap tag keys', async () => {
+      const storage = createStorage();
+
+      await storage.setTags(
+        Object.fromEntries(Array.from({ length: 1001 }, (_, i) => [`t${i}`, 'v'])) as Record<string, string>,
+      );
+
+      const { tags } = await storage.getAllAndClear();
+      expect(tags).toHaveLength(1000);
+    });
+
+    test('should cap histogram keys', async () => {
+      const storage = createStorage();
+
+      await storage.setHistogramStats(
+        Object.fromEntries(Array.from({ length: 1001 }, (_, i) => [`h${i}`, { count: 1, min: 1, max: 1, sum: 1 }])),
+      );
+
+      const { histogramStats } = await storage.getAllAndClear();
+      expect(histogramStats).toHaveLength(1000);
+    });
+  });
+});

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -1,4 +1,5 @@
 import { AmplitudeReactNative } from '../src/react-native-client';
+import { ReactNativeDiagnosticsStorage } from '../src/diagnostics/diagnostics-storage';
 import * as core from '@amplitude/analytics-core';
 import * as Capture from '../src/amp-capture';
 import * as CookieMigration from '../src/cookie-migration';
@@ -1600,13 +1601,20 @@ describe('react-native-client', () => {
   });
 
   describe('diagnostics', () => {
-    test('should attach a diagnostics client to config', async () => {
+    test('should give Destination a diagnostics client backed by RN storage', async () => {
       const client = new AmplitudeReactNative();
+      const addSpy = jest.spyOn(client, 'add');
+
       await client.init(API_KEY, undefined, { ...useDefaultConfig() }).promise;
 
-      const diagnosticsClient = client.config.diagnosticsClient;
+      const destination = addSpy.mock.calls
+        .map(([plugin]) => plugin as core.Destination)
+        .find((plugin) => plugin.name === 'amplitude');
+      expect(destination).toBeDefined();
+      // Without this the analytics.events.sent / .dropped counters never fire on RN.
+      const diagnosticsClient = destination?.diagnosticsClient as core.DiagnosticsClient | undefined;
       expect(diagnosticsClient).toBeDefined();
-      expect((diagnosticsClient as core.DiagnosticsClient).storage).toBeDefined();
+      expect(diagnosticsClient?.storage).toBeInstanceOf(ReactNativeDiagnosticsStorage);
     });
   });
 });

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -1598,4 +1598,15 @@ describe('react-native-client', () => {
       );
     });
   });
+
+  describe('diagnostics', () => {
+    test('should attach a diagnostics client to config', async () => {
+      const client = new AmplitudeReactNative();
+      await client.init(API_KEY, undefined, { ...useDefaultConfig() }).promise;
+
+      const diagnosticsClient = client.config.diagnosticsClient;
+      expect(diagnosticsClient).toBeDefined();
+      expect((diagnosticsClient as core.DiagnosticsClient).storage).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
# Summary

Brings diagnostics to the React Native SDK.

Ticket: [SDKRN-53](https://linear.app/amplitude/issue/SDKRN-53/rn-diagnostics-sdk-client) · Design doc: [RN Diagnostics Client — Design](https://linear.app/amplitude/document/rn-diagnostics-client-design-ca04cd9000c7)

The diagnostics client in `analytics-core` hard-coded IndexedDB, so it was inert on RN — `storage` stayed undefined, `isStorageAndTrackEnabled()` returned false, and every `setTag`/`increment`/`recordEvent` no-oped.

Storage is now an injected constructor argument, with an AsyncStorage-backed implementation in the RN package. **No new public config option** — storage is a constructor argument on an internally-constructed class, so it never reaches `ReactNativeOptions`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Manul test

### Android

1. Hardcode diagnostics client enabled and sample rate 1
2. Build the SDK
3. Start the example app locally `examples/react-native/app`
4. Inspect DB and see tags and counter are set 
<img width="2000" height="777" alt="image" src="https://github.com/user-attachments/assets/428fe4e5-bf71-4569-901a-e93b2d1d3f6f" />

```
{
  "tags": {
    "library": "amplitude-react-native-ts/1.6.9",
    "platform": "ReactNative",
    "os": "android"
  },
  "counters": {
    "sdk.diagnostics.sampled.in.and.enabled": 1
  },
  "histograms": {},
  "events": [],
  "lastFlushTimestamp": 1787164874918
}
```

5. Wait for 5 minutes. See a diagnostics request and DB is updated: tags persist, counter is reset, last flush timestamp is updated too 
<img width="2000" height="735" alt="image" src="https://github.com/user-attachments/assets/0eedb225-53db-480b-96ee-ad9a98352179" />

<img width="1566" height="506" alt="image" src="https://github.com/user-attachments/assets/d986508d-4c22-4f4f-80b1-d2438004e579" />

```
{
  "tags": {
    "library": "amplitude-react-native-ts/1.6.9",
    "platform": "ReactNative",
    "os": "android"
  },
  "counters": {},
  "histograms": {},
  "events": [],
  "lastFlushTimestamp": 1787165175311
}
```

### iOS

Repeat the steps above for Android. Observe DB update and a diagnostics request.

<img width="695" height="563" alt="Screenshot 2026-08-19 at 12 10 47 PM" src="https://github.com/user-attachments/assets/404c4f75-a138-4d2c-8cbd-c8e5119dbdf2" />

<img width="900" height="746" alt="image" src="https://github.com/user-attachments/assets/18663744-f6b7-44dc-a1c6-a61e842f0d6e" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 01cb0de80e304eb246f18834acd613944fb2a66e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->