### PR TITLE
fix(autocapture): prevent scroll gestures from triggering dead clicks

### DIFF
--- a/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture-plugin.ts
@@ -66,6 +66,7 @@ export type AutoCaptureOptionsWithDefaults = Required<
 
 export enum ObservablesEnum {
   ClickObservable = 'clickObservable',
+  PointerDownObservable = 'pointerDownObservable',
   ChangeObservable = 'changeObservable',
   NavigateObservable = 'navigateObservable',
   MutationObservable = 'mutationObservable',

--- a/packages/plugin-autocapture-browser/src/autocapture/track-error-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-error-click.ts
@@ -23,9 +23,9 @@ export function trackErrorClicks({
   allObservables: AllWindowObservables;
   shouldTrackErrorClick: shouldTrackEvent;
 }) {
-  const { clickObservable, browserErrorObservable } = allObservables;
+  const { pointerDownObservable, browserErrorObservable } = allObservables;
 
-  const filteredClickObservable = clickObservable.filter((click) => {
+  const filteredClickObservable = pointerDownObservable.filter((click) => {
     return (
       filterOutNonTrackableEvents(click) &&
       shouldTrackErrorClick('click', click.closestTrackedAncestor) &&

--- a/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-rage-click.ts
@@ -104,7 +104,7 @@ export function trackRageClicks({
   allObservables: AllWindowObservables;
   shouldTrackRageClick: shouldTrackEvent;
 }) {
-  const { clickObservable, selectionObservable }: AllWindowObservables = allObservables;
+  const { pointerDownObservable, selectionObservable }: AllWindowObservables = allObservables;
 
   // Keep track of all clicks within the sliding window
   let clickWindow: ClickEvent[] = [];
@@ -129,7 +129,7 @@ export function trackRageClicks({
   }
 
   const rageClickObservable = asyncMap(
-    clickObservable.filter((click) => shouldTrackRageClick('click', click.closestTrackedAncestor)),
+    pointerDownObservable.filter((click) => shouldTrackRageClick('click', click.closestTrackedAncestor)),
     async (click: ClickEvent): Promise<RageClickEvent | null> => {
       // add this click's coordinates to the bounding box
       addCoordinates(clickBoundingBox, click);

--- a/packages/plugin-autocapture-browser/src/frustration-plugin.ts
+++ b/packages/plugin-autocapture-browser/src/frustration-plugin.ts
@@ -31,6 +31,7 @@ import { trackThrashedCursor } from './autocapture/track-thrashed-cursor';
 
 export interface AllWindowObservables {
   [ObservablesEnum.ClickObservable]: Observable<ElementBasedTimestampedEvent<MouseEvent>>;
+  [ObservablesEnum.PointerDownObservable]: Observable<ElementBasedTimestampedEvent<MouseEvent>>;
   [ObservablesEnum.MutationObservable]: Observable<TimestampedEvent<MutationRecord[]>>;
   [ObservablesEnum.BrowserErrorObservable]: Observable<TimestampedEvent<BrowserErrorEvent>>;
   [ObservablesEnum.NavigateObservable]?: Observable<TimestampedEvent<NavigateEvent>>;
@@ -123,17 +124,24 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions = {}):
 
   // Create observables on events on the window
   const createObservables = (): AllWindowObservables => {
-    const clickObservable = multicast(
-      createClickObservable('pointerdown').map((click) => {
-        return dataExtractor.addAdditionalEventProperties(
-          click,
-          'click',
-          combinedCssSelectors,
-          dataAttributePrefix,
-          true, // capture when cursor is pointer
-        );
-      }),
-    );
+    const createEnrichedClickObservable = (clickType: 'click' | 'pointerdown') =>
+      multicast(
+        createClickObservable(clickType).map((click) => {
+          return dataExtractor.addAdditionalEventProperties(
+            click,
+            'click',
+            combinedCssSelectors,
+            dataAttributePrefix,
+            true, // capture when cursor is pointer
+          );
+        }),
+      );
+
+    // A native click represents a completed activation, so scroll gestures do not
+    // become dead-click candidates. Rage and error clicks continue to use
+    // pointerdown so their existing mobile behavior remains unchanged.
+    const clickObservable = createEnrichedClickObservable('click');
+    const pointerDownObservable = createEnrichedClickObservable('pointerdown');
 
     const browserErrorObservables = multicast(
       createErrorObservable().map((error) => {
@@ -219,6 +227,9 @@ export const frustrationPlugin = (options: FrustrationInteractionsOptions = {}):
 
     return {
       [ObservablesEnum.ClickObservable]: clickObservable as Observable<ElementBasedTimestampedEvent<MouseEvent>>,
+      [ObservablesEnum.PointerDownObservable]: pointerDownObservable as Observable<
+        ElementBasedTimestampedEvent<MouseEvent>
+      >,
       [ObservablesEnum.MutationObservable]: enrichedMutationObservable,
       [ObservablesEnum.NavigateObservable]: enrichedNavigateObservable,
       [ObservablesEnum.BrowserErrorObservable]: browserErrorObservables,

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin-click-source.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin-click-source.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BrowserConfig, EnrichmentPlugin } from '@amplitude/analytics-core';
+import { frustrationPlugin } from '../../src/frustration-plugin';
+import { AMPLITUDE_ELEMENT_DEAD_CLICKED_EVENT, AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT } from '../../src/constants';
+import { createMockBrowserClient } from '../mock-browser-client';
+
+describe('frustrationPlugin click sources', () => {
+  let plugin: EnrichmentPlugin | undefined;
+  let instance: ReturnType<typeof createMockBrowserClient>;
+  let link: HTMLAnchorElement;
+  let originalNavigation: Window['navigation'];
+
+  const config = {
+    defaultTracking: false,
+    loggerProvider: {
+      debug: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+    },
+  } as unknown as BrowserConfig;
+
+  const setupPlugin = async ({ deadClicks, rageClicks }: { deadClicks: boolean; rageClicks: boolean }) => {
+    plugin = frustrationPlugin({
+      deadClicks,
+      rageClicks,
+      errorClicks: false,
+      thrashedCursor: false,
+    });
+    await plugin.setup?.(config, instance);
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalNavigation = window.navigation;
+    (window as any).navigation = undefined;
+    instance = createMockBrowserClient();
+    document.body.innerHTML = '<a id="product-card" href="/product/1"><img alt="Product" /></a>';
+    link = document.querySelector('#product-card') as HTMLAnchorElement;
+    link.addEventListener('click', (event) => event.preventDefault());
+  });
+
+  afterEach(async () => {
+    await plugin?.teardown?.();
+    document.body.innerHTML = '';
+    (window as any).navigation = originalNavigation;
+    jest.useRealTimers();
+  });
+
+  it('does not classify a scroll gesture beginning on a link as a dead click', async () => {
+    await setupPlugin({ deadClicks: true, rageClicks: false });
+
+    link.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, cancelable: true, button: 0, clientX: 50, clientY: 100 }),
+    );
+    link.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 50, clientY: 160 }));
+    link.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true }));
+    window.dispatchEvent(new Event('scroll'));
+
+    await jest.advanceTimersByTimeAsync(3_100);
+
+    expect(instance.track).not.toHaveBeenCalled();
+  });
+
+  it('classifies a completed click with no resulting change as a dead click', async () => {
+    await setupPlugin({ deadClicks: true, rageClicks: false });
+
+    link.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, clientX: 50, clientY: 100 }),
+    );
+    await jest.advanceTimersByTimeAsync(3_100);
+
+    expect(instance.track).toHaveBeenCalledWith(
+      AMPLITUDE_ELEMENT_DEAD_CLICKED_EVENT,
+      expect.objectContaining({
+        '[Amplitude] Element Tag': 'a',
+        '[Amplitude] X': 50,
+        '[Amplitude] Y': 100,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('does not classify a completed click followed by a DOM mutation as dead', async () => {
+    await setupPlugin({ deadClicks: true, rageClicks: false });
+    link.addEventListener('click', () => link.setAttribute('data-selected', 'true'), { once: true });
+
+    link.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, clientX: 50, clientY: 100 }),
+    );
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(3_100);
+
+    expect(instance.track).not.toHaveBeenCalled();
+  });
+
+  it('continues to classify rage interactions from pointerdown events', async () => {
+    await setupPlugin({ deadClicks: false, rageClicks: true });
+
+    for (let clickCount = 0; clickCount < 4; clickCount++) {
+      link.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          clientX: 50,
+          clientY: 100,
+        }),
+      );
+    }
+    await jest.advanceTimersByTimeAsync(1_100);
+
+    expect(instance.track).toHaveBeenCalledWith(
+      AMPLITUDE_ELEMENT_RAGE_CLICKED_EVENT,
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/frustration-plugin.test.ts
@@ -7,6 +7,7 @@ import { trackErrorClicks } from '../../src/autocapture/track-error-click';
 import { trackThrashedCursor } from '../../src/autocapture/track-thrashed-cursor';
 import { BrowserErrorEvent, createErrorObservable } from '../../src/observables';
 import { dispatchUnhandledRejection } from '../utils';
+import { ObservablesEnum } from '../../src/autocapture-plugin';
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
@@ -420,7 +421,7 @@ describe('frustrationPlugin', () => {
   });
 
   describe('observables', () => {
-    it('should create click + mutation observables with correct properties', async () => {
+    it('should create separate click and pointerdown observables with correct properties', async () => {
       plugin = frustrationPlugin({});
       await plugin?.setup?.(config as BrowserConfig, instance);
 
@@ -428,12 +429,15 @@ describe('frustrationPlugin', () => {
       const observables = rageClickCall.allObservables;
 
       expect(observables).toHaveProperty('clickObservable');
+      expect(observables).toHaveProperty(ObservablesEnum.PointerDownObservable);
       expect(observables).toHaveProperty('mutationObservable');
       expect(observables).toHaveProperty('navigateObservable');
 
-      // Test click observable
+      // Dead clicks use completed click events, while rage/error clicks use pointerdown.
       const clickSpy = jest.fn();
-      const subscription = observables.clickObservable.subscribe(clickSpy);
+      const pointerDownSpy = jest.fn();
+      const clickSubscription = observables.clickObservable.subscribe(clickSpy);
+      const pointerDownSubscription = observables[ObservablesEnum.PointerDownObservable].subscribe(pointerDownSpy);
 
       // Create and trigger a mock click event
       const testElement = document.createElement('button');
@@ -447,11 +451,23 @@ describe('frustrationPlugin', () => {
       });
       testElement.dispatchEvent(mockPointerDownEvent);
 
-      // Verify click was captured
-      expect(clickSpy).toHaveBeenCalled();
+      expect(pointerDownSpy).toHaveBeenCalledTimes(1);
+      expect(clickSpy).not.toHaveBeenCalled();
+
+      testElement.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(pointerDownSpy).toHaveBeenCalledTimes(1);
 
       // Cleanup
-      subscription.unsubscribe();
+      clickSubscription.unsubscribe();
+      pointerDownSubscription.unsubscribe();
       document.body.removeChild(testElement);
 
       // Test mutation observable

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-dead-click.test.ts
@@ -44,6 +44,7 @@ describe('trackDeadClick', () => {
     });
     allObservables = {
       [ObservablesEnum.ClickObservable]: clickObservable,
+      [ObservablesEnum.PointerDownObservable]: new Observable<any>(() => undefined),
       [ObservablesEnum.MutationObservable]: mutationObservable,
       [ObservablesEnum.NavigateObservable]: navigateObservable,
       [ObservablesEnum.BrowserErrorObservable]: browserErrorObservable,

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-error-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-error-click.test.ts
@@ -37,7 +37,8 @@ describe('trackErrorClicks', () => {
     });
     mouseMoveObservable = new Observable<any>(() => {});
     allObservables = {
-      [ObservablesEnum.ClickObservable]: clickObservable,
+      [ObservablesEnum.ClickObservable]: new Observable<any>(() => {}),
+      [ObservablesEnum.PointerDownObservable]: clickObservable,
       [ObservablesEnum.MutationObservable]: mutationObservable,
       [ObservablesEnum.NavigateObservable]: navigateObservable,
       [ObservablesEnum.BrowserErrorObservable]: browserErrorObservable,

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-rage-click.test.ts
@@ -37,7 +37,8 @@ describe('trackRageClicks', () => {
     });
     mouseMoveObservable = new Observable<any>(() => {});
     allObservables = {
-      [ObservablesEnum.ClickObservable]: clickObservable,
+      [ObservablesEnum.ClickObservable]: new Observable<any>(() => {}),
+      [ObservablesEnum.PointerDownObservable]: clickObservable,
       [ObservablesEnum.NavigateObservable]: new Observable<any>(() => {}),
       [ObservablesEnum.MutationObservable]: new Observable<any>(() => {}),
       [ObservablesEnum.BrowserErrorObservable]: new Observable<any>(() => {}),

--- a/test-server/autocapture/dead-click-scroll-flick.html
+++ b/test-server/autocapture/dead-click-scroll-flick.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dead Click Scroll Flick Test</title>
+    <style>
+      :root {
+        color: #26222c;
+        background: #f7f5f8;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      .test-guide {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        padding: 12px 16px;
+        border-bottom: 1px solid #dcd5e0;
+        background: rgba(255, 255, 255, 0.96);
+        box-shadow: 0 2px 10px rgba(36, 25, 42, 0.08);
+      }
+
+      .test-guide h1 {
+        margin: 0 0 6px;
+        font-size: 17px;
+      }
+
+      .test-guide p {
+        margin: 3px 0;
+        color: #625a69;
+        font-size: 13px;
+        line-height: 1.35;
+      }
+
+      .event-status {
+        margin-top: 9px;
+        padding: 8px 10px;
+        border-radius: 6px;
+        background: #f0ebf3;
+        color: #4d315c;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+      }
+
+      .wrapper {
+        max-width: 760px;
+        margin: 0 auto;
+        background: #fff;
+      }
+
+      .contents-main-upper {
+        padding: 18px 14px 80px;
+      }
+
+      .section-title {
+        margin: 0 0 14px;
+        font-size: 20px;
+      }
+
+      .list-products-01 {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 18px 12px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .box-link {
+        display: block;
+        min-height: 320px;
+        color: inherit;
+        text-decoration: none;
+        touch-action: pan-y;
+        -webkit-tap-highlight-color: rgba(100, 64, 120, 0.12);
+      }
+
+      .box-image {
+        display: grid;
+        height: 244px;
+        margin: 0;
+        place-items: center;
+        overflow: hidden;
+        border-radius: 3px;
+        background: linear-gradient(145deg, var(--card-color), #eee7f1);
+      }
+
+      .product-shape {
+        width: 64%;
+        height: 72%;
+        border-radius: 42% 42% 16% 16%;
+        background: rgba(255, 255, 255, 0.76);
+        box-shadow: 0 14px 30px rgba(49, 34, 58, 0.14);
+        transform: rotate(var(--tilt));
+      }
+
+      .txt-name {
+        margin: 8px 0 3px;
+        font-size: 13px;
+        line-height: 1.35;
+      }
+
+      .txt-price {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 700;
+      }
+
+      .tag {
+        display: inline-block;
+        margin-top: 6px;
+        padding: 2px 5px;
+        background: #d89bb7;
+        color: #fff;
+        font-size: 10px;
+      }
+
+      @media (min-width: 680px) {
+        .list-products-01 {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <aside class="test-guide">
+      <h1>Dead-click scroll-flick reproduction</h1>
+      <p>
+        <strong>Scroll test:</strong> start a vertical flick on any product card. No dead-click event should appear.
+      </p>
+      <p>
+        <strong>Control:</strong> tap a card without moving. A dead-click event should appear after about 3 seconds.
+      </p>
+      <p><strong>Rage control:</strong> rapidly tap the same card at least four times.</p>
+      <div id="event-status" class="event-status">No frustration events captured.</div>
+    </aside>
+
+    <div class="wrapper">
+      <main>
+        <div class="contents-main-upper">
+          <div class="sec-cmn-02">
+            <h2 class="section-title">Product list</h2>
+            <div class="mod-product-view-tab js-product-view-tab">
+              <ul id="product-list" class="list-products-01 col-sp-02"></ul>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script type="module">
+      import * as amplitude from '@amplitude/analytics-browser';
+
+      const productList = document.getElementById('product-list');
+      const eventStatus = document.getElementById('event-status');
+      const colors = ['#c8d7cd', '#e7c8cb', '#c9c7dd', '#ddd1bd', '#bfcfd9', '#d8c6d9'];
+
+      for (let index = 1; index <= 30; index += 1) {
+        const item = document.createElement('li');
+        item.innerHTML = `
+          <div class="card-product-01">
+            <a class="box-link" href="#product-${index}" style="--card-color: ${
+          colors[index % colors.length]
+        }; --tilt: ${index % 2 ? '-4deg' : '4deg'}">
+              <figure class="box-image"><span class="product-shape"></span></figure>
+              <p class="txt-name">Sample product ${String(index).padStart(2, '0')}</p>
+              <p class="txt-price">$${(24 + index).toFixed(2)}</p>
+              <span class="tag">NEW</span>
+            </a>
+          </div>
+        `;
+        productList.appendChild(item);
+      }
+
+      // A stationary tap intentionally has no effect, making it a dead-click control.
+      // Preventing navigation does not mutate the DOM and therefore does not cancel detection.
+      productList.addEventListener('click', (event) => event.preventDefault());
+
+      let deadClickCount = 0;
+      let rageClickCount = 0;
+      const inspectorPlugin = {
+        name: 'dead-click-scroll-flick-inspector',
+        type: 'enrichment',
+        setup: async () => {},
+        execute: async (event) => {
+          if (event.event_type === '[Amplitude] Dead Click') {
+            deadClickCount += 1;
+          }
+          if (event.event_type === '[Amplitude] Rage Click') {
+            rageClickCount += 1;
+          }
+          if (event.event_type === '[Amplitude] Dead Click' || event.event_type === '[Amplitude] Rage Click') {
+            const properties = event.event_properties ?? {};
+            eventStatus.textContent = `Dead clicks: ${deadClickCount} | Rage clicks: ${rageClickCount} | last: ${event.event_type} | tag: ${properties['[Amplitude] Element Tag']}`;
+          }
+          return event;
+        },
+      };
+
+      window.amplitude = amplitude;
+      amplitude.add(inspectorPlugin);
+      amplitude.init(
+        import.meta.env.VITE_AMPLITUDE_API_KEY || 'dead-click-local-test',
+        import.meta.env.VITE_AMPLITUDE_USER_ID || 'dead-click-scroll-flick-test-user',
+        {
+          logLevel: 'debug',
+          autocapture: {
+            frustrationInteractions: {
+              deadClicks: true,
+              rageClicks: true,
+              errorClicks: false,
+              thrashedCursor: false,
+            },
+          },
+        },
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- use completed native `click` events as dead-click candidates so canceled touch scroll gestures are ignored
- preserve `pointerdown` input for rage-click and error-click detection
- add regression coverage for the detector event sources and a manual scroll-flick test page

## Root cause

The shared click observable listened to `pointerdown`. On touch devices, beginning a scroll over an allowlisted element emitted a `pointerdown` even though the gesture never completed as a click. If the page did not navigate or mutate within the dead-click timeout, the SDK incorrectly reported a dead click.

## Event-source history and rationale

Dead-click and rage-click tracking were originally introduced in [#1146](https://github.com/amplitude/Amplitude-TypeScript/pull/1146) using one shared native `click` observable. [#1210](https://github.com/amplitude/Amplitude-TypeScript/pull/1210) later changed that shared observable to `pointerdown` to improve rage-click capture on mobile. Rapid mobile taps can be consumed by browser scrolling, panning, or zoom gestures before a completed `click` is emitted, whereas `pointerdown` records each attempted press immediately. That makes `pointerdown` the appropriate signal for counting repeated rage interactions.

Because the observable was shared, the rage-click fix also moved dead-click detection to `pointerdown`, even though that was not the stated purpose of #1210. A dead click represents a completed activation that produced no response; a touch that begins a scroll is not a completed activation. This PR splits the streams so rage clicks keep the mobile behavior from #1210 while dead clicks return to their original native `click` boundary.

Error clicks continue to use `pointerdown` for a separate reason: the correlated browser error may occur in an early pointer handler before a native `click` is emitted. Other frustration signals retain their existing event sources.

## Impact

Scroll flicks that begin over large interactive elements such as product-card links no longer produce dead-click false positives. Existing rage-click and error-click behavior remains unchanged.

## Testing

- `pnpm --filter @amplitude/plugin-autocapture-browser build`
- `pnpm --filter @amplitude/plugin-autocapture-browser exec jest --watchman=false --runInBand` (24 suites, 418 tests)
- `pnpm --filter @amplitude/plugin-autocapture-browser lint`
- `git diff --check`

## Linear

[SDK-200: Need to be fixed: Dead Click false positives from scroll-flick touches](https://linear.app/amplitude/issue/SDK-200/need-to-be-fixed-dead-click-false-positives-from-scroll-flick-touches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes frustration autocapture event sourcing for dead vs rage/error clicks; behavior is well-tested but affects analytics signal semantics on touch devices.
>
> **Overview**
> **Dead-click detection** now listens for completed native `click` events instead of sharing a single `pointerdown` stream, so touch scroll-flicks that start on links (e.g. product cards) no longer time out as dead clicks when no navigation or mutation occurs.
>
> The frustration plugin wires **two enriched observables**: `click` for dead clicks and `pointerdown` for rage and error clicks, preserving prior mobile behavior for those signals. `PointerDownObservable` is added to `ObservablesEnum` and `AllWindowObservables`.
>
> Regression tests cover scroll-gesture vs real dead click vs mutation cancellation and rage-from-`pointerdown`; unit tests mock the split streams. A manual **scroll-flick** test page was added under `test-server/autocapture/`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22f96d293ddaae7c9cb77d8b1e2873543ec3460. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
