### PR TITLE
feat(session-replay-react-native): add teardown and runtime setOptOut

### DIFF
--- a/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
+++ b/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
@@ -13,11 +13,25 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.bridge.ReadableMap
 
+private data class StoredSessionReplayConfig(
+  val apiKey: String,
+  val deviceId: String,
+  val sessionId: Long,
+  val serverZone: String,
+  val sampleRate: Double,
+  val enableRemoteConfig: Boolean,
+  val maskLevel: MaskLevel,
+)
+
 // `@ReactMethod` is required on the legacy architecture and ignored on the new
 // one, so it stays on the overrides below.
 class SessionReplayReactNativeModule(private val reactContext: ReactApplicationContext) :
   SessionReplayReactNativeSpec(reactContext) {
-  private lateinit var sessionReplay: SessionReplay
+  private var sessionReplay: SessionReplay? = null
+  private var lastConfig: StoredSessionReplayConfig? = null
+  // Matches Flutter: preserve "was started" across opt-out so opt-in can resume.
+  private var wasStarted: Boolean = false
+  private var optedOut: Boolean = false
 
   override fun getName(): String {
     return NAME
@@ -27,7 +41,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   override fun setup(config: ReadableMap, promise: Promise) {
     try {
       val apiKey = config.getString("apiKey") ?: throw IllegalArgumentException("apiKey is required")
-      val deviceId = config.getString("deviceId")
+      val deviceId = config.getString("deviceId") ?: ""
       val sessionId = config.getDouble("sessionId").toLong()
       val serverZone = config.getString("serverZone") ?: "US"
       val sampleRate = config.getDouble("sampleRate")
@@ -65,23 +79,19 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
           Opt Out: $optOut
       """.trimIndent())
 
-      sessionReplay = SessionReplay(
+      lastConfig = StoredSessionReplayConfig(
         apiKey = apiKey,
-        context = reactContext.applicationContext,
-        deviceId = deviceId ?: "",
+        deviceId = deviceId,
         sessionId = sessionId,
-        optOut = optOut,
+        serverZone = serverZone,
         sampleRate = sampleRate,
-        logger = LogcatLogger.logger,
         enableRemoteConfig = enableRemoteConfig,
-        serverZone = when (serverZone) {
-          "EU" -> ServerZone.EU
-          else -> ServerZone.US
-        },
-        autoStart = autoStart,
-        privacyConfig = PrivacyConfig(maskLevel = maskLevel),
+        maskLevel = maskLevel,
       )
-      
+      optedOut = optOut
+      wasStarted = autoStart && !optOut
+      createSessionReplay(optOut = optOut, autoStart = autoStart)
+
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("SETUP_ERROR", e.message, e)
@@ -91,7 +101,9 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   @ReactMethod
   override fun setSessionId(sessionId: Double, promise: Promise) {
     try {
-      sessionReplay.setSessionId(sessionId.toLong())
+      val id = sessionId.toLong()
+      lastConfig = lastConfig?.copy(sessionId = id)
+      sessionReplay?.setSessionId(id)
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("SET_SESSION_ID_ERROR", e.message, e)
@@ -101,7 +113,9 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   @ReactMethod
   override fun setDeviceId(deviceId: String?, promise: Promise) {
     try {
-      sessionReplay.setDeviceId(deviceId ?: "")
+      val id = deviceId ?: ""
+      lastConfig = lastConfig?.copy(deviceId = id)
+      sessionReplay?.setDeviceId(id)
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("SET_DEVICE_ID_ERROR", e.message, e)
@@ -111,7 +125,12 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   @ReactMethod
   override fun getSessionId(promise: Promise) {
     try {
-      promise.resolve(sessionReplay.getSessionId().toDouble())
+      val id = sessionReplay?.getSessionId() ?: lastConfig?.sessionId
+      if (id == null) {
+        promise.reject("GET_SESSION_ID_ERROR", "SessionReplay is not initialized", null)
+        return
+      }
+      promise.resolve(id.toDouble())
     } catch (e: Exception) {
       promise.reject("GET_SESSION_ID_ERROR", e.message, e)
     }
@@ -120,7 +139,11 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   @ReactMethod
   override fun getSessionReplayProperties(promise: Promise) {
     try {
-      val properties: Map<String, Any> = sessionReplay.getSessionReplayProperties()
+      if (optedOut) {
+        promise.resolve(WritableNativeMap())
+        return
+      }
+      val properties: Map<String, Any> = sessionReplay?.getSessionReplayProperties() ?: emptyMap()
       val map: WritableMap = WritableNativeMap()
       for ((key, value) in properties) {
         if (value is String) {
@@ -140,11 +163,22 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
       promise.reject("GET_PROPERTIES_ERROR", e.message, e)
     }
   }
-  
+
   @ReactMethod
   override fun start(promise: Promise) {
     try {
-      sessionReplay.start()
+      if (optedOut) {
+        LogcatLogger.logger.debug("start skipped: opted out")
+        promise.resolve(null)
+        return
+      }
+      val replay = sessionReplay
+      if (replay == null) {
+        promise.reject("START_ERROR", "SessionReplay is not initialized", null)
+        return
+      }
+      wasStarted = true
+      replay.start()
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("START_ERROR", e.message, e)
@@ -154,7 +188,8 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   @ReactMethod
   override fun stop(promise: Promise) {
     try {
-      sessionReplay.stop()
+      wasStarted = false
+      sessionReplay?.stop()
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("STOP_ERROR", e.message, e)
@@ -164,7 +199,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   @ReactMethod
   override fun flush(promise: Promise) {
     try {
-      sessionReplay.flush()
+      sessionReplay?.flush()
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("FLUSH_ERROR", e.message, e)
@@ -172,14 +207,74 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   }
 
   @ReactMethod
-  fun teardown() {
-    sessionReplay.shutdown()
+  override fun teardown(promise: Promise) {
+    try {
+      sessionReplay?.shutdown()
+      sessionReplay = null
+      lastConfig = null
+      wasStarted = false
+      optedOut = false
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("TEARDOWN_ERROR", e.message, e)
+    }
+  }
+
+  // Until session-replay-android exposes a public runtime setter (SDKA-78),
+  // match Flutter: shutdown() without stop() so buffered data is not flushed,
+  // then recreate on opt-in. Do not use stop()/start() as a stand-in.
+  @ReactMethod
+  override fun setOptOut(optOut: Boolean, promise: Promise) {
+    try {
+      if (lastConfig == null) {
+        promise.reject("SET_OPT_OUT_ERROR", "SessionReplay is not initialized", null)
+        return
+      }
+      optedOut = optOut
+      if (optOut) {
+        LogcatLogger.logger.debug(
+          "setOptOut(true): shutting down native SessionReplay without stop()/flush (Flutter workaround until SDKA-78)",
+        )
+        sessionReplay?.shutdown()
+        sessionReplay = null
+      } else if (sessionReplay == null) {
+        LogcatLogger.logger.debug(
+          "setOptOut(false): recreating native SessionReplay; resume start=$wasStarted",
+        )
+        createSessionReplay(optOut = false, autoStart = false)
+        if (wasStarted) {
+          sessionReplay?.start()
+        }
+      }
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("SET_OPT_OUT_ERROR", e.message, e)
+    }
   }
 
   override fun invalidate() {
-    if (::sessionReplay.isInitialized) {
-      sessionReplay.shutdown()
-    }
+    sessionReplay?.shutdown()
+    sessionReplay = null
+  }
+
+  private fun createSessionReplay(optOut: Boolean, autoStart: Boolean) {
+    val config = lastConfig ?: throw IllegalStateException("SessionReplay config is missing")
+    sessionReplay = SessionReplay(
+      apiKey = config.apiKey,
+      context = reactContext.applicationContext,
+      deviceId = config.deviceId,
+      sessionId = config.sessionId,
+      optOut = optOut,
+      sampleRate = config.sampleRate,
+      logger = LogcatLogger.logger,
+      enableRemoteConfig = config.enableRemoteConfig,
+      serverZone = when (config.serverZone) {
+        "EU" -> ServerZone.EU
+        else -> ServerZone.US
+      },
+      autoStart = autoStart,
+      privacyConfig = PrivacyConfig(maskLevel = config.maskLevel),
+    )
   }
 
   companion object {

--- a/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
+++ b/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
@@ -17,4 +17,6 @@ abstract class SessionReplayReactNativeSpec(reactContext: ReactApplicationContex
   abstract fun start(promise: Promise)
   abstract fun stop(promise: Promise)
   abstract fun flush(promise: Promise)
+  abstract fun teardown(promise: Promise)
+  abstract fun setOptOut(optOut: Boolean, promise: Promise)
 }

--- a/packages/session-replay-react-native/example/App.tsx
+++ b/packages/session-replay-react-native/example/App.tsx
@@ -42,6 +42,8 @@ import {
   getSessionReplayProperties,
   setSessionId,
   setDeviceId,
+  teardown,
+  setOptOut,
   AmpMaskView,
 } from '@amplitude/session-replay-react-native';
 
@@ -167,6 +169,28 @@ function HomeScreen({ navigation }: HomeProps): React.JSX.Element {
           <Button
             title="getProps"
             onPress={runFn('getSessionReplayProperties', getSessionReplayProperties)}
+          />
+          <Button
+            title="setOptOut true"
+            onPress={runFn('setOptOut', () => setOptOut(true))}
+          />
+          <Button
+            title="setOptOut false"
+            onPress={runFn('setOptOut', () => setOptOut(false))}
+          />
+          <Button title="teardown" onPress={runFn('teardown', teardown)} />
+          <Button
+            title="re-init"
+            onPress={runFn('init', () =>
+              init({
+                apiKey: 'YOUR_AMPLITUDE_API_KEY',
+                deviceId: verificationDeviceId,
+                sessionId: Date.now(),
+                sampleRate: 1,
+                enableRemoteConfig: false,
+                logLevel: 4,
+              }),
+            )}
           />
         </View>
 

--- a/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
+++ b/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
@@ -18,6 +18,10 @@ RCT_EXTERN_METHOD(start:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReject
 
 RCT_EXTERN_METHOD(stop:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(teardown:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setOptOut:(BOOL)optOut resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
 @end
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/packages/session-replay-react-native/ios/NativeSessionReplay.swift
+++ b/packages/session-replay-react-native/ios/NativeSessionReplay.swift
@@ -124,6 +124,21 @@ class NativeSessionReplay: NSObject, RCTBridgeModule {
         sessionReplay.flush()
         resolve(nil)
     }
+
+    @objc(teardown:reject:)
+    func teardown(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        logger?.debug(message: "teardown")
+        sessionReplay?.stop()
+        sessionReplay = nil
+        resolve(nil)
+    }
+
+    @objc(setOptOut:resolve:reject:)
+    func setOptOut(_ optOut: Bool, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        logger?.debug(message: "setOptOut: \(optOut)")
+        sessionReplay?.optOut = optOut
+        resolve(nil)
+    }
     
     @objc(invalidate)
     func invalidate() {

--- a/packages/session-replay-react-native/src/index.tsx
+++ b/packages/session-replay-react-native/src/index.tsx
@@ -7,6 +7,8 @@ export {
   start,
   stop,
   setDeviceId,
+  teardown,
+  setOptOut,
 } from './session-replay';
 export { type SessionReplayConfig, type MaskLevel, type PrivacyConfig } from './session-replay-config';
 

--- a/packages/session-replay-react-native/src/native-module.ts
+++ b/packages/session-replay-react-native/src/native-module.ts
@@ -116,4 +116,16 @@ export interface NativeSessionReplaySpec {
    * Ends the current recording session and processes any captured data.
    */
   stop(): Promise<void>;
+
+  /**
+   * Shuts down the native session replay SDK and releases native resources.
+   * After teardown, `setup` may be called again.
+   */
+  teardown(): Promise<void>;
+
+  /**
+   * Updates the runtime opt-out flag on the native session replay SDK.
+   * @param optOut - When true, session replay collection is disabled
+   */
+  setOptOut(optOut: boolean): Promise<void>;
 }

--- a/packages/session-replay-react-native/src/plugin-session-replay.ts
+++ b/packages/session-replay-react-native/src/plugin-session-replay.ts
@@ -6,7 +6,15 @@ import {
 } from '@amplitude/analytics-types';
 
 import { SessionReplayPluginConfig, getDefaultSessionReplayPluginConfig } from './plugin-session-replay-config';
-import { getSessionId, getSessionReplayProperties, privateInit, setSessionId, start, stop } from './session-replay';
+import {
+  getSessionId,
+  getSessionReplayProperties,
+  privateInit,
+  setSessionId,
+  start,
+  stop,
+  teardown as teardownSessionReplay,
+} from './session-replay';
 import { createSessionReplayLogger } from './logger';
 
 /**
@@ -128,7 +136,7 @@ export class SessionReplayPlugin implements EnrichmentPlugin<ReactNativeClient, 
 
   async teardown(): Promise<void> {
     if (this.isInitialized) {
-      await stop();
+      await teardownSessionReplay();
     }
 
     this.config = null;

--- a/packages/session-replay-react-native/src/session-replay.ts
+++ b/packages/session-replay-react-native/src/session-replay.ts
@@ -209,6 +209,10 @@ export async function start(): Promise<void> {
     logger.warn('SessionReplay is not initialized');
     return;
   }
+  if (fullConfig?.optOut) {
+    logger.debug('start skipped: opted out');
+    return;
+  }
   await NativeSessionReplay.start();
 }
 
@@ -230,6 +234,56 @@ export async function stop(): Promise<void> {
     return;
   }
   await NativeSessionReplay.stop();
+}
+
+/**
+ * Shut down the native session replay SDK and clear JavaScript state.
+ * After teardown, {@link init} may be called again.
+ *
+ * @returns Promise that resolves when teardown is complete
+ *
+ * @example
+ * ```typescript
+ * await teardown();
+ * await init({ apiKey: 'YOUR_API_KEY', deviceId, sessionId });
+ * ```
+ */
+export async function teardown(): Promise<void> {
+  if (!isInitialized) {
+    logger.warn('SessionReplay is not initialized');
+    return;
+  }
+  await NativeSessionReplay.teardown();
+  isInitialized = false;
+  fullConfig = null;
+}
+
+/**
+ * Opt in or out of session replay collection at runtime.
+ * Complements the init-time `optOut` config flag.
+ *
+ * On iOS this sets `SessionReplay.optOut`, which starts or stops capture as needed.
+ * On Android, until SDKA-78 ships a native setter, the bridge matches Flutter:
+ * `shutdown()` without `stop()` (so buffered data is not flushed), then recreate
+ * the native SDK on opt-in and `start()` only if recording was already started.
+ *
+ * @param optOut - When true, session replay collection is disabled
+ * @returns Promise that resolves when the native flag is updated
+ *
+ * @example
+ * ```typescript
+ * await setOptOut(true);
+ * ```
+ */
+export async function setOptOut(optOut: boolean): Promise<void> {
+  if (!isInitialized) {
+    logger.warn('SessionReplay is not initialized');
+    return;
+  }
+  if (fullConfig) {
+    fullConfig = { ...fullConfig, optOut };
+  }
+  await NativeSessionReplay.setOptOut(optOut);
 }
 
 function nativeConfig(config: ResolvedSessionReplayConfig): NativeSessionReplayConfig {

--- a/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
+++ b/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
@@ -19,6 +19,8 @@ export interface Spec extends TurboModule {
   start(): Promise<void>;
   stop(): Promise<void>;
   flush(): Promise<void>;
+  teardown(): Promise<void>;
+  setOptOut(optOut: boolean): Promise<void>;
 }
 
 // Use non-enforcing `get` (returns null when the native module isn't linked)

--- a/packages/session-replay-react-native/test/__mocks__/react-native.ts
+++ b/packages/session-replay-react-native/test/__mocks__/react-native.ts
@@ -8,6 +8,8 @@ const ampNativeSessionReplay = {
   getSessionReplayProperties: jest.fn().mockResolvedValue({ replayId: 'test-id' }),
   setDeviceId: jest.fn().mockResolvedValue(undefined),
   setSessionId: jest.fn().mockResolvedValue(undefined),
+  teardown: jest.fn().mockResolvedValue(undefined),
+  setOptOut: jest.fn().mockResolvedValue(undefined),
 };
 
 // Resolve on both architectures: NativeModules (old arch) and TurboModuleRegistry

--- a/packages/session-replay-react-native/test/index.test.ts
+++ b/packages/session-replay-react-native/test/index.test.ts
@@ -2,6 +2,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 // Use the mock from __mocks__ directory
 jest.mock('react-native');
@@ -18,6 +21,7 @@ import {
   start,
   stop,
   setDeviceId,
+  setOptOut,
   SessionReplayPlugin,
   AmpMaskView,
   type SessionReplayConfig,
@@ -98,6 +102,33 @@ describe('Index Exports', () => {
       await init(testConfig); // Initialize first
       await setDeviceId(testDeviceId);
       expect(NativeModules.AMPNativeSessionReplay.setDeviceId).toHaveBeenCalledWith(testDeviceId);
+    });
+
+    it('should export setOptOut function that updates the runtime opt-out flag', async () => {
+      await init(testConfig);
+      await setOptOut(true);
+      expect(NativeModules.AMPNativeSessionReplay.setOptOut).toHaveBeenCalledWith(true);
+    });
+
+    it('should export teardown that shuts down native state and allows re-init', async () => {
+      let setupMock!: jest.Mock;
+      let teardownMock!: jest.Mock;
+      let pending!: Promise<void>;
+      jest.isolateModules(() => {
+        const { init: freshInit, teardown: freshTeardown } = require('../src/index') as typeof import('../src/index');
+        const { NativeModules: freshNativeModules } = require('react-native') as typeof import('react-native');
+        const native = (freshNativeModules as jest.Mocked<typeof NativeModules>).AMPNativeSessionReplay;
+        setupMock = native.setup;
+        teardownMock = native.teardown;
+        pending = (async () => {
+          await freshInit(testConfig);
+          await freshTeardown();
+          await freshInit(testConfig);
+        })();
+      });
+      await pending;
+      expect(teardownMock).toHaveBeenCalledTimes(1);
+      expect(setupMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/session-replay-react-native/test/plugin-session-replay.test.ts
+++ b/packages/session-replay-react-native/test/plugin-session-replay.test.ts
@@ -97,8 +97,8 @@ describe('SessionReplayPlugin Integration', () => {
     await plugin.stop();
     expect(NativeModules.AMPNativeSessionReplay.stop).toHaveBeenCalled();
     await plugin.teardown();
-    // teardown should call stop again (idempotent)
-    expect(NativeModules.AMPNativeSessionReplay.stop).toHaveBeenCalledTimes(2);
+    expect(NativeModules.AMPNativeSessionReplay.teardown).toHaveBeenCalledTimes(1);
+    expect(NativeModules.AMPNativeSessionReplay.stop).toHaveBeenCalledTimes(1);
   });
 
   it('should call getSessionReplayProperties', async () => {

--- a/packages/session-replay-react-native/test/session-replay.test.ts
+++ b/packages/session-replay-react-native/test/session-replay.test.ts
@@ -10,7 +10,16 @@ jest.mock('react-native');
 
 jest.mock('../src/logger', () => require('./utils/logger'));
 
-import { init, start, stop, getSessionId, getSessionReplayProperties, type SessionReplayConfig } from '../src/index';
+import {
+  init,
+  start,
+  stop,
+  getSessionId,
+  getSessionReplayProperties,
+  setOptOut,
+  teardown,
+  type SessionReplayConfig,
+} from '../src/index';
 import { NativeModules } from 'react-native';
 import { LogLevel } from '@amplitude/analytics-types';
 
@@ -53,12 +62,20 @@ describe('Session Replay Integration Tests', () => {
     await stop();
     expect(mockNativeModules.AMPNativeSessionReplay.stop).toHaveBeenCalled();
 
+    await setOptOut(true);
+    expect(mockNativeModules.AMPNativeSessionReplay.setOptOut).toHaveBeenCalledWith(true);
+
+    await teardown();
+    expect(mockNativeModules.AMPNativeSessionReplay.teardown).toHaveBeenCalled();
+
     const calls = jest.mocked(mockNativeModules.AMPNativeSessionReplay);
     expect(calls.setup).toHaveBeenCalled();
     expect(calls.start).toHaveBeenCalled();
     expect(calls.getSessionId).toHaveBeenCalled();
     expect(calls.getSessionReplayProperties).toHaveBeenCalled();
     expect(calls.stop).toHaveBeenCalled();
+    expect(calls.setOptOut).toHaveBeenCalled();
+    expect(calls.teardown).toHaveBeenCalled();
   });
 
   // These tests cover the resolution chain in `nativeConfig()` for the


### PR DESCRIPTION
### Summary

Adds two runtime lifecycle APIs to the React Native session replay SDK: `teardown()` and `setOptOut()`. Previously the only way to release the native SDK or stop capture after `init` was to tear down the whole plugin.

Linear: SDKRN-62

**JS API**
- `teardown()` releases the native SDK and clears JS state, so `init()` can be called again.
- `setOptOut(optOut)` toggles capture at runtime and keeps the resolved config in sync.
- `start()` is now a no-op while opted out, so an opt-out cannot be defeated by a later `start()` call.
- `SessionReplayPlugin.teardown()` now calls native teardown instead of `stop()`, so plugin teardown actually releases native resources.

**iOS** writes the natively mutable `SessionReplay.optOut` property, which gates capture directly. `teardown()` nils the instance, which triggers the SDK's own `deinit` cleanup.

**Android** has no public runtime opt-out setter — `SessionReplayInternal` keeps `optOut` as a private constructor-only property (tracked in SDKA-78). Until that setter ships, the bridge mirrors what the Flutter SDK does: dispose the native instance *without* calling `stop()` so buffered frames are not flushed, then recreate the SDK on opt-in and only resume `start()` if recording was already running. This replaces the previous stop/start stand-in, which flushed buffered data on opt-out and was therefore a privacy bug.

To support recreate-on-opt-in, the Android bridge now retains the resolved init config and keeps `sessionReplay` nullable rather than `lateinit`, so every call site degrades gracefully before setup and after teardown.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No — both APIs are additive. The one behavior change is `SessionReplayPlugin.teardown()` releasing native resources instead of only stopping capture, which is the documented intent of teardown.

### Test plan

- [x] `jest` — 57/57 pass, including new coverage for `setOptOut`, `teardown`, and teardown-then-re-init
- [x] `tsc --noEmit` clean
- [x] `prettier --check` and `eslint` clean
- [ ] On-device verification of the opt-out and teardown/re-init flows against native debug replay servers (harness in progress, not part of this PR)

---
*Posted automatically with Cursor. LLMs make mistakes — please verify before acting.*
<!-- posted-by: cursor-agent -->
