### PR TITLE
feat(session-replay-react-native)!: require explicit replay start

### DIFF
--- a/packages/segment-session-replay-plugin-react-native/README.md
+++ b/packages/segment-session-replay-plugin-react-native/README.md
@@ -49,25 +49,40 @@ await segmentClient.add(createSegmentSessionReplayPlugin(sessionReplayConfig));
 
 ### Plugin Configuration
 
-The plugin accepts a `SessionReplayConfig` object
+The plugin accepts a `SegmentSessionReplayPluginConfig` object: every option from the
+`SessionReplayConfig` of `@amplitude/session-replay-react-native`, plus:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `autoStart` | `true` | Start recording as soon as the plugin is added to the Segment client. |
+
+Set `autoStart: false` to control when recording begins, then call `start()` from
+`@amplitude/session-replay-react-native` yourself:
+
+```js
+import { start } from '@amplitude/session-replay-react-native';
+
+await segmentClient.add(createSegmentSessionReplayPlugin({ ...sessionReplayConfig, autoStart: false }));
+
+// later, once you're ready to record
+await start();
+```
 
 ### Automatic Integration
 
 The plugin automatically:
 
 1. **Initializes Session Replay**: Sets up Amplitude Session Replay with your configuration
-2. **Syncs Session Data**: Updates session ID and device ID for each Segment event
-3. **Enriches Events**: Adds session replay properties to track and screen events
+2. **Starts Recording**: Begins recording once configured, unless `autoStart` is `false`
+3. **Syncs Session Data**: Updates session ID and device ID for each Segment event
 4. **Manages Lifecycle**: Handles start/stop operations for session replay
 
 ### Event Processing
 
-The plugin processes the following Segment event types:
-- `TrackEvent`: Adds session replay properties to track events
-- `ScreenEvent`: Adds session replay properties to screen events
-
-For these events, the plugin:
+For every event, the plugin:
 - Extracts session ID from event properties or Amplitude integration data
 - Extracts device ID from event context or anonymous ID
-- Adds session replay properties to the event before sending to Segment
+- Forwards both to Session Replay so the recording is attributed correctly
+
+Events are passed through unmodified; the plugin does not add properties to them.
 

--- a/packages/segment-session-replay-plugin-react-native/src/index.ts
+++ b/packages/segment-session-replay-plugin-react-native/src/index.ts
@@ -1,1 +1,4 @@
-export { createSegmentSessionReplayPlugin } from './segment-session-replay-plugin';
+export {
+  createSegmentSessionReplayPlugin,
+  type SegmentSessionReplayPluginConfig,
+} from './segment-session-replay-plugin';

--- a/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
+++ b/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
@@ -10,6 +10,21 @@ import {
 } from '@amplitude/session-replay-react-native';
 import { VERSION } from './version';
 
+/**
+ * Configuration for the Segment Session Replay plugin.
+ *
+ * Extends the standalone `SessionReplayConfig` with plugin-owned options. The
+ * standalone SDK requires an explicit `start()`, so `autoStart` lives here to
+ * keep "add the plugin and record" working without the caller wiring it up.
+ */
+export interface SegmentSessionReplayPluginConfig extends SessionReplayConfig {
+  /**
+   * Whether to automatically start recording when the plugin is configured
+   * @default true
+   */
+  autoStart?: boolean;
+}
+
 function getSessionId(event: SegmentEvent): number {
   const amplitudeSessionId =
     (event.integrations?.['Actions Amplitude'] as { session_id: number })?.['session_id'] ?? null;
@@ -34,24 +49,29 @@ export class SegmentSessionReplayPlugin extends Plugin {
   version: string = VERSION;
   type: PluginType = PluginType.enrichment;
 
-  private sessionReplayConfig: SessionReplayConfig;
+  private sessionReplayConfig: SegmentSessionReplayPluginConfig;
 
   // @review: This is to ensure the plugin is initialized before the first event is processed.
   // because `configure` is not asynchronous
   private initPromise: Promise<void> | null = null;
 
-  constructor(config: SessionReplayConfig) {
+  constructor(config: SegmentSessionReplayPluginConfig) {
     super();
     this.sessionReplayConfig = config;
   }
 
   async configure(analytics: SegmentClient): Promise<void> {
     super.configure(analytics);
+    const { autoStart = true, ...sessionReplayConfig } = this.sessionReplayConfig;
     this.initPromise = init({
       deviceId: analytics.userInfo.get().anonymousId,
-      ...this.sessionReplayConfig,
+      ...sessionReplayConfig,
     });
     await this.initPromise;
+
+    if (autoStart) {
+      await start();
+    }
   }
 
   async execute(event: SegmentEvent): Promise<SegmentEvent> {
@@ -82,6 +102,6 @@ export class SegmentSessionReplayPlugin extends Plugin {
   }
 }
 
-export function createSegmentSessionReplayPlugin(config: SessionReplayConfig): Plugin {
+export function createSegmentSessionReplayPlugin(config: SegmentSessionReplayPluginConfig): Plugin {
   return new SegmentSessionReplayPlugin(config);
 }

--- a/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
+++ b/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
@@ -2,7 +2,6 @@ import { Plugin, PluginType, type SegmentEvent, EventType, SegmentClient } from 
 
 import {
   type SessionReplayConfig,
-  getSessionReplayProperties,
   init,
   setDeviceId,
   setSessionId,
@@ -63,11 +62,6 @@ export class SegmentSessionReplayPlugin extends Plugin {
 
     await setSessionId(sessionId);
     await setDeviceId(deviceId);
-
-    if (event.type === EventType.TrackEvent || event.type === EventType.ScreenEvent) {
-      const properties = await getSessionReplayProperties();
-      event.properties = { ...event.properties, ...properties };
-    }
 
     return event;
   }

--- a/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
+++ b/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
@@ -84,6 +84,30 @@ describe('SegmentSessionReplayPlugin', () => {
 
       expect(init).toHaveBeenCalledWith({ ...mockConfig, deviceId: 'test-anonymous-id' });
     });
+
+    it('should start recording after init by default', async () => {
+      await plugin.configure(mockAnalytics);
+
+      expect(start).toHaveBeenCalled();
+    });
+
+    it('should not start recording when autoStart is false', async () => {
+      const manualStartPlugin = new SegmentSessionReplayPlugin({ ...mockConfig, autoStart: false });
+
+      await manualStartPlugin.configure(mockAnalytics);
+
+      expect(init).toHaveBeenCalled();
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it('should not forward autoStart to the session replay SDK', async () => {
+      const manualStartPlugin = new SegmentSessionReplayPlugin({ ...mockConfig, autoStart: false });
+
+      await manualStartPlugin.configure(mockAnalytics);
+
+      const [initConfig] = (init as jest.Mock).mock.calls[0] as [Record<string, unknown>];
+      expect(Object.keys(initConfig)).not.toContain('autoStart');
+    });
   });
 
   describe('execute', () => {

--- a/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
+++ b/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
@@ -30,14 +30,7 @@ jest.mock('@segment/analytics-react-native', () => ({
 
 import { PluginType, EventType, SegmentEvent, SegmentClient } from '@segment/analytics-react-native';
 import { SegmentSessionReplayPlugin, createSegmentSessionReplayPlugin } from '../src/segment-session-replay-plugin';
-import {
-  init,
-  setDeviceId,
-  setSessionId,
-  getSessionReplayProperties,
-  start,
-  stop,
-} from '@amplitude/session-replay-react-native';
+import { init, setDeviceId, setSessionId, start, stop } from '@amplitude/session-replay-react-native';
 import { VERSION } from '../src/version';
 
 // Mock the session replay module
@@ -45,7 +38,6 @@ jest.mock('@amplitude/session-replay-react-native', () => ({
   init: jest.fn(),
   setDeviceId: jest.fn(),
   setSessionId: jest.fn(),
-  getSessionReplayProperties: jest.fn(),
   start: jest.fn(),
   stop: jest.fn(),
 }));
@@ -105,17 +97,12 @@ describe('SegmentSessionReplayPlugin', () => {
         },
       } as SegmentEvent;
 
-      const mockProperties = { replay_session_id: 'replay-123' };
-      (getSessionReplayProperties as jest.Mock).mockResolvedValue(mockProperties);
-
       const result = await plugin.execute(mockEvent);
 
       expect(setSessionId).toHaveBeenCalledWith(123);
       expect(setDeviceId).toHaveBeenCalledWith('device-123');
-      expect(getSessionReplayProperties).toHaveBeenCalled();
       expect((result as any).properties).toEqual({
         session_id: '123',
-        replay_session_id: 'replay-123',
       });
     });
 
@@ -129,17 +116,12 @@ describe('SegmentSessionReplayPlugin', () => {
         },
       } as SegmentEvent;
 
-      const mockProperties = { replay_session_id: 'replay-456' };
-      (getSessionReplayProperties as jest.Mock).mockResolvedValue(mockProperties);
-
       const result = await plugin.execute(mockEvent);
 
       expect(setSessionId).toHaveBeenCalledWith(456);
       expect(setDeviceId).toHaveBeenCalledWith('device-456');
-      expect(getSessionReplayProperties).toHaveBeenCalled();
       expect((result as any).properties).toEqual({
         session_id: '456',
-        replay_session_id: 'replay-456',
       });
     });
 
@@ -192,7 +174,7 @@ describe('SegmentSessionReplayPlugin', () => {
       expect(setSessionId).toHaveBeenCalledWith(789);
     });
 
-    it('should not call getSessionReplayProperties for non-track/screen events', async () => {
+    it('should preserve non-track/screen events', async () => {
       const mockEvent: SegmentEvent = {
         type: EventType.IdentifyEvent,
         userId: 'user-123',
@@ -201,7 +183,11 @@ describe('SegmentSessionReplayPlugin', () => {
 
       await plugin.execute(mockEvent);
 
-      expect(getSessionReplayProperties).not.toHaveBeenCalled();
+      expect(mockEvent).toEqual({
+        type: EventType.IdentifyEvent,
+        userId: 'user-123',
+        traits: {},
+      });
     });
 
     it('should handle null device ID gracefully', async () => {
@@ -232,7 +218,7 @@ describe('SegmentSessionReplayPlugin', () => {
       expect(setSessionId).toHaveBeenCalledWith(-1);
     });
 
-    it('should preserve existing properties when adding session replay properties', async () => {
+    it('should preserve existing properties without adding session replay properties', async () => {
       const mockEvent = {
         type: EventType.TrackEvent,
         event: 'test_event',
@@ -245,15 +231,11 @@ describe('SegmentSessionReplayPlugin', () => {
         },
       } as SegmentEvent;
 
-      const mockProperties = { replay_session_id: 'replay-123' };
-      (getSessionReplayProperties as jest.Mock).mockResolvedValue(mockProperties);
-
       const result = await plugin.execute(mockEvent);
 
       expect((result as any).properties).toEqual({
         existing_prop: 'value',
         session_id: '123',
-        replay_session_id: 'replay-123',
       });
     });
   });

--- a/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
+++ b/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
@@ -205,13 +205,14 @@ describe('SegmentSessionReplayPlugin', () => {
         traits: {},
       } as any;
 
-      await plugin.execute(mockEvent);
+      const result = await plugin.execute(mockEvent);
 
-      expect(mockEvent).toEqual({
+      expect(result).toEqual({
         type: EventType.IdentifyEvent,
         userId: 'user-123',
         traits: {},
       });
+      expect(mockEvent).toEqual(result);
     });
 
     it('should handle null device ID gracefully', async () => {

--- a/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
+++ b/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
@@ -9,8 +9,6 @@ import com.amplitude.core.ServerZone
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
-import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.bridge.ReadableMap
 
 // `@ReactMethod` is required on the legacy architecture and ignored on the new
@@ -33,7 +31,6 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
       val sampleRate = config.getDouble("sampleRate")
       val enableRemoteConfig = config.getBoolean("enableRemoteConfig")
       val logLevel = config.getInt("logLevel")
-      val autoStart = config.getBoolean("autoStart")
       val optOut = config.getBoolean("optOut")
       val maskLevel = when ((config.getString("maskLevel") ?: "medium").lowercase()) {
         "light" -> MaskLevel.LIGHT
@@ -60,7 +57,6 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
           Sample Rate: $sampleRate
           Enable Remote Config: $enableRemoteConfig
           Log Level: $logLevel
-          Auto Start: $autoStart
           Mask Level: $maskLevel
           Opt Out: $optOut
       """.trimIndent())
@@ -78,7 +74,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
           "EU" -> ServerZone.EU
           else -> ServerZone.US
         },
-        autoStart = autoStart,
+        autoStart = false,
         privacyConfig = PrivacyConfig(maskLevel = maskLevel),
       )
       
@@ -117,30 +113,6 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
     }
   }
 
-  @ReactMethod
-  override fun getSessionReplayProperties(promise: Promise) {
-    try {
-      val properties: Map<String, Any> = sessionReplay.getSessionReplayProperties()
-      val map: WritableMap = WritableNativeMap()
-      for ((key, value) in properties) {
-        if (value is String) {
-          map.putString(key, value)
-        } else if (value is Int) {
-          map.putInt(key, value)
-        } else if (value is Long) {
-          map.putDouble(key, value.toDouble())
-        } else if (value is Double) {
-          map.putDouble(key, value)
-        } else if (value is Boolean) {
-          map.putBoolean(key, value)
-        }
-      }
-      promise.resolve(map)
-    } catch (e: Exception) {
-      promise.reject("GET_PROPERTIES_ERROR", e.message, e)
-    }
-  }
-  
   @ReactMethod
   override fun start(promise: Promise) {
     try {

--- a/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
+++ b/packages/session-replay-react-native/android/src/oldarch/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeSpec.kt
@@ -13,7 +13,6 @@ abstract class SessionReplayReactNativeSpec(reactContext: ReactApplicationContex
   abstract fun setSessionId(sessionId: Double, promise: Promise)
   abstract fun setDeviceId(deviceId: String?, promise: Promise)
   abstract fun getSessionId(promise: Promise)
-  abstract fun getSessionReplayProperties(promise: Promise)
   abstract fun start(promise: Promise)
   abstract fun stop(promise: Promise)
   abstract fun flush(promise: Promise)

--- a/packages/session-replay-react-native/example/App.tsx
+++ b/packages/session-replay-react-native/example/App.tsx
@@ -39,7 +39,6 @@ import {
   stop,
   flush,
   getSessionId,
-  getSessionReplayProperties,
   setSessionId,
   setDeviceId,
   AmpMaskView,
@@ -92,18 +91,18 @@ function HomeScreen({ navigation }: HomeProps): React.JSX.Element {
           enableRemoteConfig: false,
           logLevel: 4,
         });
+        await start();
         const sessionId = await getSessionId();
-        const props = await getSessionReplayProperties();
         log('init() resolved deviceId=' + verificationDeviceId);
+        log('start() resolved');
         log('getSessionId() -> ' + String(sessionId));
-        log('getSessionReplayProperties() -> ' + JSON.stringify(props));
 
         // init() swallows native setup failures and resolves without throwing;
         // verify the module is actually live before showing success.
-        if (sessionId === null || Object.keys(props).length === 0) {
+        if (sessionId === null) {
           log(
             'ERROR: init() resolved but Session Replay is not initialized ' +
-              `(sessionId=${String(sessionId)}, props=${JSON.stringify(props)})`,
+              `(sessionId=${String(sessionId)})`,
           );
           setOk(false);
         } else {
@@ -163,10 +162,6 @@ function HomeScreen({ navigation }: HomeProps): React.JSX.Element {
           <Button
             title="getSessionId"
             onPress={runFn('getSessionId', getSessionId)}
-          />
-          <Button
-            title="getProps"
-            onPress={runFn('getSessionReplayProperties', getSessionReplayProperties)}
           />
         </View>
 

--- a/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
+++ b/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
@@ -6,8 +6,6 @@ RCT_EXTERN_METHOD(flush:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseReject
 
 RCT_EXTERN_METHOD(getSessionId:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getSessionReplayProperties:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(setSessionId:(nonnull NSNumber)sessionId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(setDeviceId:(NSString)deviceId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/packages/session-replay-react-native/ios/NativeSessionReplay.swift
+++ b/packages/session-replay-react-native/ios/NativeSessionReplay.swift
@@ -23,7 +23,6 @@ class NativeSessionReplay: NSObject, RCTBridgeModule {
               let sampleRate = config["sampleRate"] as? NSNumber,
               let enableRemoteConfig = config["enableRemoteConfig"] as? Bool,
               let logLevel = config["logLevel"] as? Int,
-              let autoStart = config["autoStart"] as? Bool,
               let maskLevel = config["maskLevel"] as? String,
               let optOut = config["optOut"] as? Bool else {
             reject("INVALID_CONFIG", "Invalid configuration parameters", nil)
@@ -44,7 +43,6 @@ class NativeSessionReplay: NSObject, RCTBridgeModule {
             Sample Rate: \(sampleRate)
             Enable Remote Config: \(enableRemoteConfig)
             Log Level: \(logLevel)
-            Auto Start: \(autoStart)
             Mask Level: \(maskLevel)
             Opt Out: \(optOut)
             """
@@ -62,9 +60,6 @@ class NativeSessionReplay: NSObject, RCTBridgeModule {
             enableRemoteConfig: enableRemoteConfig
         )
         
-        if (autoStart) {
-            sessionReplay.start()
-        }
         resolve(nil)
     }
     
@@ -89,15 +84,6 @@ class NativeSessionReplay: NSObject, RCTBridgeModule {
     ) {
         logger.debug(message: "getSessionId")
         resolve(NSNumber(value:sessionReplay.sessionId))
-    }
-    
-    @objc(getSessionReplayProperties:reject:)
-    func getSessionReplayProperties(
-        _ resolve: RCTPromiseResolveBlock,
-        reject: RCTPromiseRejectBlock
-    ) {
-        logger.debug(message: "getSessionReplayProperties")
-        resolve(sessionReplay.additionalEventProperties)
     }
     
     @objc(start:reject:)

--- a/packages/session-replay-react-native/src/index.tsx
+++ b/packages/session-replay-react-native/src/index.tsx
@@ -1,13 +1,4 @@
-export {
-  init,
-  setSessionId,
-  getSessionId,
-  getSessionReplayProperties,
-  flush,
-  start,
-  stop,
-  setDeviceId,
-} from './session-replay';
+export { init, setSessionId, getSessionId, flush, start, stop, setDeviceId } from './session-replay';
 export { type SessionReplayConfig, type MaskLevel, type PrivacyConfig } from './session-replay-config';
 
 export { SessionReplayPlugin } from './plugin-session-replay';

--- a/packages/session-replay-react-native/src/native-module.ts
+++ b/packages/session-replay-react-native/src/native-module.ts
@@ -30,8 +30,6 @@ export const NativeSessionReplay = (SessionReplaySpec ??
 export interface NativeSessionReplayConfig {
   /** Your Amplitude API key for authentication and data routing */
   apiKey: string;
-  /** Whether to automatically start recording when the module is initialized */
-  autoStart: boolean;
   /** Device identifier that matches the device ID sent with Amplitude events */
   deviceId: string | null;
   /** Whether to enable remote configuration for dynamic settings updates */
@@ -48,10 +46,6 @@ export interface NativeSessionReplayConfig {
   serverZone: 'US' | 'EU';
   /** Current session identifier for correlating events with recordings */
   sessionId: number;
-}
-
-export interface NativeSessionReplayProperties {
-  [key: string]: string | number | boolean;
 }
 
 /**
@@ -75,14 +69,6 @@ export interface NativeSessionReplaySpec {
    * @note OLD ARCH: ideally we want to cache that on JS side to avoid bridge overhead
    */
   getSessionId(): Promise<number>;
-
-  /**
-   * Retrieves session replay properties that should be attached to Amplitude events.
-   * These properties help correlate events with session recordings.
-   * @returns Promise resolving to an object containing session replay metadata
-   * @note OLD ARCH: ideally we want to cache that on JS side to avoid bridge overhead
-   */
-  getSessionReplayProperties(): Promise<NativeSessionReplayProperties>;
 
   /**
    * Updates the device identifier used for session replay tracking.

--- a/packages/session-replay-react-native/src/plugin-session-replay.ts
+++ b/packages/session-replay-react-native/src/plugin-session-replay.ts
@@ -6,7 +6,7 @@ import {
 } from '@amplitude/analytics-types';
 
 import { SessionReplayPluginConfig, getDefaultSessionReplayPluginConfig } from './plugin-session-replay-config';
-import { getSessionId, getSessionReplayProperties, privateInit, setSessionId, start, stop } from './session-replay';
+import { getSessionId, privateInit, setSessionId, start, stop } from './session-replay';
 import { createSessionReplayLogger } from './logger';
 
 /**
@@ -72,11 +72,13 @@ export class SessionReplayPlugin implements EnrichmentPlugin<ReactNativeClient, 
         sampleRate: this.sessionReplayConfig.sampleRate,
         enableRemoteConfig: this.sessionReplayConfig.enableRemoteConfig,
         logLevel: this.sessionReplayConfig.logLevel,
-        autoStart: this.sessionReplayConfig.autoStart,
       },
       this.logger,
     );
     this.isInitialized = true;
+    if (this.sessionReplayConfig.autoStart) {
+      await start();
+    }
   }
 
   async execute(event: Event): Promise<Event | null> {
@@ -89,15 +91,6 @@ export class SessionReplayPlugin implements EnrichmentPlugin<ReactNativeClient, 
     // in SR.
     if (this.config?.sessionId && this.config.sessionId !== (await getSessionId())) {
       await setSessionId(this.config.sessionId);
-    }
-    // Treating config.sessionId as source of truth, if the event's session id doesn't match, the
-    // event is not of the current session (offline/late events). In that case, don't tag the events
-    if (this.config?.sessionId && this.config.sessionId === event.session_id) {
-      const sessionRecordingProperties = await getSessionReplayProperties();
-      event.event_properties = {
-        ...event.event_properties,
-        ...sessionRecordingProperties,
-      };
     }
     return Promise.resolve(event);
   }
@@ -133,27 +126,5 @@ export class SessionReplayPlugin implements EnrichmentPlugin<ReactNativeClient, 
 
     this.config = null;
     this.isInitialized = false;
-  }
-
-  /**
-   * Get session replay properties for manual event correlation.
-   * When you send events to Amplitude, call this method to get the most up-to-date session replay properties for the event.
-   *
-   * @returns Promise that resolves to an object containing session replay metadata
-   *
-   * @example
-   * ```typescript
-   * const sessionReplayProperties = await plugin.getSessionReplayProperties();
-   * analytics.track('Button Clicked', {
-   *   buttonName: 'submit',
-   *   ...sessionReplayProperties
-   * });
-   * ```
-   */
-  async getSessionReplayProperties() {
-    if (!this.isInitialized) {
-      return {};
-    }
-    return getSessionReplayProperties();
   }
 }

--- a/packages/session-replay-react-native/src/session-replay-config.ts
+++ b/packages/session-replay-react-native/src/session-replay-config.ts
@@ -28,12 +28,6 @@ export interface SessionReplayConfig {
   apiKey: string;
 
   /**
-   * Whether to automatically start recording when the SDK is initialized
-   * @default true
-   */
-  autoStart?: boolean;
-
-  /**
    * Device identifier that matches the device ID sent with Amplitude events
    * Must match the Device ID passed as event properties to Amplitude
    * @default null
@@ -107,7 +101,6 @@ export type SessionReplayConfigInternal = Omit<SessionReplayConfig, 'maskLevel'>
 
 export const getDefaultConfig: () => Required<Omit<SessionReplayConfigInternal, 'apiKey'>> = () => {
   return {
-    autoStart: true,
     deviceId: null,
     enableRemoteConfig: true,
     logLevel: LogLevel.Warn,

--- a/packages/session-replay-react-native/src/session-replay.ts
+++ b/packages/session-replay-react-native/src/session-replay.ts
@@ -36,8 +36,8 @@ let logger = createSessionReplayLogger();
  * This function must be called before any other session replay operations.
  *
  * @param config - Configuration object containing API key, device ID, session ID, and other options
- * @returns Promise that resolves when initialization is complete
- * @throws Error if initialization fails
+ * @returns Promise that resolves when initialization is complete. Native setup
+ * failures are logged and do not reject the promise.
  *
  * @example
  * ```typescript

--- a/packages/session-replay-react-native/src/session-replay.ts
+++ b/packages/session-replay-react-native/src/session-replay.ts
@@ -32,7 +32,7 @@ let isInitialized = false;
 let logger = createSessionReplayLogger();
 
 /**
- * Configure the SDK and begin collecting replays.
+ * Configure the SDK. Call `start()` explicitly to begin collecting replays.
  * This function must be called before any other session replay operations.
  *
  * @param config - Configuration object containing API key, device ID, session ID, and other options
@@ -140,38 +140,6 @@ export async function getSessionId(): Promise<number | null> {
 }
 
 /**
- * Interface for session replay properties that should be attached to Amplitude events.
- * These properties help correlate events with session recordings.
- */
-export interface SessionReplayProperties {
-  [key: string]: string | boolean | null;
-}
-
-/**
- * When you send events to Amplitude, call this function to get the most up-to-date session replay properties for the event.
- * Collect Session Replay properties to send with other event properties.
- *
- * @returns Promise that resolves to an object containing session replay metadata
- *
- * @example
- * ```typescript
- * const sessionReplayProperties = await getSessionReplayProperties();
- * analytics.track('Button Clicked', {
- *   buttonName: 'submit',
- *   ...sessionReplayProperties // Merge session replay properties
- * });
- * ```
- */
-export async function getSessionReplayProperties(): Promise<SessionReplayProperties> {
-  if (!isInitialized) {
-    logger.warn('SessionReplay is not initialized');
-    return {};
-  }
-  const properties = await NativeSessionReplay.getSessionReplayProperties();
-  return properties as SessionReplayProperties;
-}
-
-/**
  * Flush any pending session replay data to the server.
  * Forces immediate upload of recorded session data that may be buffered locally.
  *
@@ -194,13 +162,12 @@ export async function flush(): Promise<void> {
 /**
  * Start session replay recording.
  * Begins capturing user interactions and screen content for replay.
- * If autoStart is enabled in the configuration, this is called automatically during initialization.
  *
  * @returns Promise that resolves when recording starts
  *
  * @example
  * ```typescript
- * // Start recording manually if autoStart is false
+ * // Recording starts only after this explicit call.
  * await start();
  * ```
  */

--- a/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
+++ b/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
@@ -15,7 +15,6 @@ export interface Spec extends TurboModule {
   setSessionId(sessionId: number): Promise<void>;
   setDeviceId(deviceId: string | null): Promise<void>;
   getSessionId(): Promise<number>;
-  getSessionReplayProperties(): Promise<UnsafeObject>;
   start(): Promise<void>;
   stop(): Promise<void>;
   flush(): Promise<void>;

--- a/packages/session-replay-react-native/test/__mocks__/react-native.ts
+++ b/packages/session-replay-react-native/test/__mocks__/react-native.ts
@@ -5,7 +5,6 @@ const ampNativeSessionReplay = {
   stop: jest.fn().mockResolvedValue(undefined),
   flush: jest.fn().mockResolvedValue(undefined),
   getSessionId: jest.fn().mockResolvedValue(12345),
-  getSessionReplayProperties: jest.fn().mockResolvedValue({ replayId: 'test-id' }),
   setDeviceId: jest.fn().mockResolvedValue(undefined),
   setSessionId: jest.fn().mockResolvedValue(undefined),
 };

--- a/packages/session-replay-react-native/test/index.test.ts
+++ b/packages/session-replay-react-native/test/index.test.ts
@@ -49,9 +49,8 @@ describe('Index Exports', () => {
           logLevel: LogLevel.Warn,
         }),
       );
-      expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
-        expect.not.objectContaining({ autoStart: expect.anything() }),
-      );
+      const [setupConfig] = NativeModules.AMPNativeSessionReplay.setup.mock.calls[0] as [Record<string, unknown>];
+      expect(Object.keys(setupConfig)).not.toContain('autoStart');
     });
 
     it('should export setSessionId function that updates session ID', async () => {

--- a/packages/session-replay-react-native/test/index.test.ts
+++ b/packages/session-replay-react-native/test/index.test.ts
@@ -9,11 +9,11 @@ jest.mock('react-native');
 // Explicitly mock the logger module using the imported mock
 jest.mock('../src/logger', (): any => require('./utils/logger'));
 
+import * as sessionReplay from '../src/index';
 import {
   init,
   setSessionId,
   getSessionId,
-  getSessionReplayProperties,
   flush,
   start,
   stop,
@@ -26,9 +26,6 @@ import {
 } from '../src/index';
 import { NativeModules } from 'react-native';
 import { LogLevel } from '@amplitude/analytics-types';
-
-// Mock the getSessionReplayProperties return value for our tests
-NativeModules.AMPNativeSessionReplay.getSessionReplayProperties.mockResolvedValue({ replayId: 'test-id' });
 
 describe('Index Exports', () => {
   const testConfig: SessionReplayConfig = {
@@ -52,6 +49,9 @@ describe('Index Exports', () => {
           logLevel: LogLevel.Warn,
         }),
       );
+      expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
+        expect.not.objectContaining({ autoStart: expect.anything() }),
+      );
     });
 
     it('should export setSessionId function that updates session ID', async () => {
@@ -68,11 +68,8 @@ describe('Index Exports', () => {
       expect(sessionId).toBe(12345);
     });
 
-    it('should export getSessionReplayProperties function', async () => {
-      await init(testConfig); // Initialize first
-      const properties = await getSessionReplayProperties();
-      expect(NativeModules.AMPNativeSessionReplay.getSessionReplayProperties).toHaveBeenCalled();
-      expect(properties).toEqual({ replayId: 'test-id' });
+    it('should not export getSessionReplayProperties', () => {
+      expect(sessionReplay).not.toHaveProperty('getSessionReplayProperties');
     });
 
     it('should export flush function that flushes session data', async () => {
@@ -121,7 +118,6 @@ describe('Index Exports', () => {
         serverZone: 'US',
         logLevel: LogLevel.Warn,
         maskLevel: 'medium',
-        autoStart: true,
         deviceId: 'test-device',
         enableRemoteConfig: true,
         optOut: false,

--- a/packages/session-replay-react-native/test/plugin-session-replay.test.ts
+++ b/packages/session-replay-react-native/test/plugin-session-replay.test.ts
@@ -73,9 +73,8 @@ describe('SessionReplayPlugin Integration', () => {
     expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: 'test-api-key', serverZone: 'US' }),
     );
-    expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
-      expect.not.objectContaining({ autoStart: expect.anything() }),
-    );
+    const [defaultSetupConfig] = NativeModules.AMPNativeSessionReplay.setup.mock.calls[0] as [Record<string, unknown>];
+    expect(Object.keys(defaultSetupConfig)).not.toContain('autoStart');
     expect(NativeModules.AMPNativeSessionReplay.start).toHaveBeenCalledTimes(1);
   });
 
@@ -91,9 +90,8 @@ describe('SessionReplayPlugin Integration', () => {
     expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: 'test-api-key', serverZone: 'EU' }),
     );
-    expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
-      expect.not.objectContaining({ autoStart: expect.anything() }),
-    );
+    const [customSetupConfig] = NativeModules.AMPNativeSessionReplay.setup.mock.calls[0] as [Record<string, unknown>];
+    expect(Object.keys(customSetupConfig)).not.toContain('autoStart');
     expect(NativeModules.AMPNativeSessionReplay.start).not.toHaveBeenCalled();
   });
 
@@ -119,9 +117,9 @@ describe('SessionReplayPlugin Integration', () => {
 
   it('should not enrich event if not initialized', async () => {
     const plugin = new SessionReplayPlugin();
-    await plugin.setup(minimalConfig, mockReactNativeClient);
     const event = { event_type: 'test_event', event_properties: {} };
     const enriched = await plugin.execute(event);
-    expect(enriched).toEqual(event); // Should return the same event
+    expect(enriched).toEqual(event);
+    expect(NativeModules.AMPNativeSessionReplay.setup).not.toHaveBeenCalled();
   });
 });

--- a/packages/session-replay-react-native/test/plugin-session-replay.test.ts
+++ b/packages/session-replay-react-native/test/plugin-session-replay.test.ts
@@ -73,6 +73,10 @@ describe('SessionReplayPlugin Integration', () => {
     expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: 'test-api-key', serverZone: 'US' }),
     );
+    expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
+      expect.not.objectContaining({ autoStart: expect.anything() }),
+    );
+    expect(NativeModules.AMPNativeSessionReplay.start).toHaveBeenCalledTimes(1);
   });
 
   it('should instantiate and setup with custom config', async () => {
@@ -87,6 +91,10 @@ describe('SessionReplayPlugin Integration', () => {
     expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: 'test-api-key', serverZone: 'EU' }),
     );
+    expect(NativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
+      expect.not.objectContaining({ autoStart: expect.anything() }),
+    );
+    expect(NativeModules.AMPNativeSessionReplay.start).not.toHaveBeenCalled();
   });
 
   it('should call start, stop, and teardown', async () => {
@@ -101,20 +109,12 @@ describe('SessionReplayPlugin Integration', () => {
     expect(NativeModules.AMPNativeSessionReplay.stop).toHaveBeenCalledTimes(2);
   });
 
-  it('should call getSessionReplayProperties', async () => {
+  it('should not stamp session replay properties on events', async () => {
     const plugin = new SessionReplayPlugin();
     await plugin.setup(minimalConfig, mockReactNativeClient);
-    const props = await plugin.getSessionReplayProperties();
-    expect(NativeModules.AMPNativeSessionReplay.getSessionReplayProperties).toHaveBeenCalled();
-    expect(props).toEqual({ replayId: 'test-id' });
-  });
-
-  it('should execute and enrich event if initialized', async () => {
-    const plugin = new SessionReplayPlugin();
-    await plugin.setup(minimalConfig, mockReactNativeClient);
-    const event = { event_type: 'test_event', event_properties: {} };
+    const event = { event_type: 'test_event', session_id: minimalConfig.sessionId, event_properties: {} };
     const enriched = await plugin.execute(event);
-    expect(enriched).toEqual(event); // Should return the same event (enrichment is a no-op in mock)
+    expect(enriched).toEqual(event);
   });
 
   it('should not enrich event if not initialized', async () => {

--- a/packages/session-replay-react-native/test/session-replay.test.ts
+++ b/packages/session-replay-react-native/test/session-replay.test.ts
@@ -37,9 +37,10 @@ describe('Session Replay Integration Tests', () => {
         logLevel: LogLevel.Warn,
       }),
     );
-    expect(mockNativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
-      expect.not.objectContaining({ autoStart: expect.anything() }),
-    );
+    const [setupConfig] = jest.mocked(mockNativeModules.AMPNativeSessionReplay.setup).mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(Object.keys(setupConfig)).not.toContain('autoStart');
 
     await start();
     expect(mockNativeModules.AMPNativeSessionReplay.start).toHaveBeenCalled();

--- a/packages/session-replay-react-native/test/session-replay.test.ts
+++ b/packages/session-replay-react-native/test/session-replay.test.ts
@@ -10,12 +10,11 @@ jest.mock('react-native');
 
 jest.mock('../src/logger', () => require('./utils/logger'));
 
-import { init, start, stop, getSessionId, getSessionReplayProperties, type SessionReplayConfig } from '../src/index';
+import { init, start, stop, getSessionId, type SessionReplayConfig } from '../src/index';
 import { NativeModules } from 'react-native';
 import { LogLevel } from '@amplitude/analytics-types';
 
 const mockNativeModules = NativeModules as jest.Mocked<typeof NativeModules>;
-mockNativeModules.AMPNativeSessionReplay.getSessionReplayProperties.mockResolvedValue({ replayId: 'test-id' });
 
 describe('Session Replay Integration Tests', () => {
   beforeEach(() => {
@@ -38,6 +37,9 @@ describe('Session Replay Integration Tests', () => {
         logLevel: LogLevel.Warn,
       }),
     );
+    expect(mockNativeModules.AMPNativeSessionReplay.setup).toHaveBeenCalledWith(
+      expect.not.objectContaining({ autoStart: expect.anything() }),
+    );
 
     await start();
     expect(mockNativeModules.AMPNativeSessionReplay.start).toHaveBeenCalled();
@@ -46,10 +48,6 @@ describe('Session Replay Integration Tests', () => {
     expect(sessionId).toBe(12345);
     expect(mockNativeModules.AMPNativeSessionReplay.getSessionId).toHaveBeenCalled();
 
-    const properties = await getSessionReplayProperties();
-    expect(properties).toEqual({ replayId: 'test-id' });
-    expect(mockNativeModules.AMPNativeSessionReplay.getSessionReplayProperties).toHaveBeenCalled();
-
     await stop();
     expect(mockNativeModules.AMPNativeSessionReplay.stop).toHaveBeenCalled();
 
@@ -57,7 +55,6 @@ describe('Session Replay Integration Tests', () => {
     expect(calls.setup).toHaveBeenCalled();
     expect(calls.start).toHaveBeenCalled();
     expect(calls.getSessionId).toHaveBeenCalled();
-    expect(calls.getSessionReplayProperties).toHaveBeenCalled();
     expect(calls.stop).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
### Summary

- remove `autoStart` from the standalone Session Replay configuration and require explicit `start()`
- remove `getSessionReplayProperties()` across the JavaScript and native bridges
- stop standalone and Segment plugins from stamping Session Replay properties on events
- update the example and regression tests for the breaking API behavior

[SDKRN-63](https://linear.app/amplitude/issue/SDKRN-63)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: Yes

### Test plan

- [x] Build, lint, and tests for `@amplitude/session-replay-react-native` (54 tests)
- [x] Build, lint, and tests for `@amplitude/segment-session-replay-plugin-react-native` (15 tests)
- [x] Full repository build on Node 18.20.8
- [x] `pnpm docs:check`
- [x] Full repository lint on Node 18.20.8
- [ ] Full aggregate tests did not terminate after completed suites left unrelated Nx executors idle
- [ ] Example tests cannot start because `jest.setup.examples.js` is absent on `origin/main`

---
*Posted automatically with Cursor. LLMs make mistakes — please verify before acting.*
<!-- posted-by: cursor-agent -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API: recording no longer starts on init, and replay metadata is no longer attached to analytics events. Existing RN/Segment integrations that relied on autoStart or getSessionReplayProperties will stop correlating or recording until they migrate.
> 
> **Overview**
> **Breaking:** `init()` only configures Session Replay. Callers must `start()` to record. `autoStart` is removed from `SessionReplayConfig` and the native setup payload (Android always constructs native SR with `autoStart = false`).
> 
> **Also breaking:** `getSessionReplayProperties()` is removed from JS, TurboModule spec, and iOS/Android bridges. Amplitude and Segment plugins no longer merge replay metadata onto events; they only sync session/device IDs.
> 
> Plugins still auto-start by default: `SessionReplayPlugin` and new `SegmentSessionReplayPluginConfig.autoStart` (default `true`) call `start()` after init so “add plugin and record” still works. Set `autoStart: false` to start later.
> 
> Example app and tests follow the new contract (`init` then `start`, no property stamping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c31f28c935689a57a4058f050b1b31f39781ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->