### PR TITLE
feat(session-replay-react-native): consume iOS SDKs with SPM

### DIFF
--- a/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
+++ b/packages/session-replay-react-native/AmplitudeSessionReplayReactNative.podspec
@@ -49,8 +49,28 @@ Pod::Spec.new do |s|
     s.source_files = "ios/*.{h,m,mm,swift}"
   end
 
-  s.dependency 'AmplitudeSessionReplay', '>=0.11.1'
-  s.dependency 'AmplitudeCore', '>=1.4.2'
+  unless defined?(spm_dependency)
+    raise "[AmplitudeSessionReplayReactNative] Swift Package Manager dependencies require React Native >= 0.75."
+  end
+
+  spm_dependency(
+    s,
+    url: "https://github.com/amplitude/AmplitudeSessionReplay-iOS.git",
+    requirement: {
+      kind: "upToNextMajorVersion",
+      minimumVersion: "0.11.1",
+    },
+    products: ["AmplitudeSessionReplay"],
+  )
+  spm_dependency(
+    s,
+    url: "https://github.com/amplitude/AmplitudeCore-Swift.git",
+    requirement: {
+      kind: "upToNextMajorVersion",
+      minimumVersion: "1.4.2",
+    },
+    products: ["AmplitudeCoreFramework"],
+  )
 
   # This code is to support RN prior to 0.71.0. Should be removed when we drop support for RN < 0.71.0.
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
@@ -60,10 +80,13 @@ Pod::Spec.new do |s|
     if fabric_enabled
       # Fabric shadow-node C++ headers break Clang module dependency scanning.
       existing_xcconfig = s.attributes_hash["pod_target_xcconfig"] || {}
-      s.pod_target_xcconfig = existing_xcconfig.merge({
-        "DEFINES_MODULE" => "NO",
+      fabric_xcconfig = {
         "CLANG_ENABLE_EXPLICIT_MODULES" => "NO",
-      })
+      }
+      # SPM dependencies require a dynamic framework, whose Swift sources need
+      # the pod's module to expose its Objective-C headers.
+      fabric_xcconfig["DEFINES_MODULE"] = "NO" unless ENV["USE_FRAMEWORKS"] == "dynamic"
+      s.pod_target_xcconfig = existing_xcconfig.merge(fabric_xcconfig)
     end
   else
     s.dependency "React-Core"

--- a/packages/session-replay-react-native/README.md
+++ b/packages/session-replay-react-native/README.md
@@ -8,6 +8,16 @@ Amplitude Session Replay for React Native
 npm install @amplitude/session-replay-react-native
 ```
 
+### iOS
+
+React Native 0.75 or newer is required. The native Amplitude Session Replay
+dependency is installed with Swift Package Manager through React Native's
+`spm_dependency` integration.
+
+React Native's SPM integration requires dynamically linked frameworks. Set
+`USE_FRAMEWORKS=dynamic` when installing pods, or configure the equivalent
+`use_frameworks! :linkage => :dynamic` setting in your Podfile.
+
 ## React Native New Architecture
 
 This SDK supports both the New Architecture (Bridgeless / TurboModules) and the
@@ -16,10 +26,11 @@ TurboModule; on the legacy architecture it continues to work as a standard bridg
 module. No configuration is required — the correct implementation is selected
 automatically based on how your app is built.
 
-`peerDependencies` are intentionally left unconstrained (`react-native: "*"`) so
-the SDK keeps working on older React Native versions on the legacy architecture.
-The TurboModule code path is compiled only when the New Architecture is enabled,
-which itself requires React Native 0.74 or newer.
+`peerDependencies` remain unconstrained because the React Native 0.75 floor
+applies only to iOS; other platforms can continue using older React Native
+versions.
+
+The TurboModule code path is compiled only when the New Architecture is enabled.
 
 ### Fabric-based masking
 

--- a/packages/session-replay-react-native/README.md
+++ b/packages/session-replay-react-native/README.md
@@ -26,9 +26,8 @@ TurboModule; on the legacy architecture it continues to work as a standard bridg
 module. No configuration is required — the correct implementation is selected
 automatically based on how your app is built.
 
-`peerDependencies` remain unconstrained because the React Native 0.75 floor
-applies only to iOS; other platforms can continue using older React Native
-versions.
+`peerDependencies` require `react-native` `>=0.75.0`. That floor is required
+for iOS SPM integration and is the minimum supported version of this SDK.
 
 The TurboModule code path is compiled only when the New Architecture is enabled.
 

--- a/packages/session-replay-react-native/example/ios/Podfile
+++ b/packages/session-replay-react-native/example/ios/Podfile
@@ -8,11 +8,9 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-linkage = ENV['USE_FRAMEWORKS']
-if linkage != nil
-  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
-  use_frameworks! :linkage => linkage.to_sym
-end
+linkage = ENV['USE_FRAMEWORKS'] || 'dynamic'
+Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
+use_frameworks! :linkage => linkage.to_sym
 
 target 'example' do
   config = use_native_modules!

--- a/packages/session-replay-react-native/example/ios/Podfile.lock
+++ b/packages/session-replay-react-native/example/ios/Podfile.lock
@@ -1,10 +1,5 @@
 PODS:
-  - AmplitudeCore (1.4.7)
-  - AmplitudeSessionReplay (0.11.1):
-    - AmplitudeCore (< 2.0.0, >= 1.4.2)
   - AmplitudeSessionReplayReactNative (0.1.0):
-    - AmplitudeCore (>= 1.4.2)
-    - AmplitudeSessionReplay (>= 0.11.1)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1758,8 +1753,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - AmplitudeCore
-    - AmplitudeSessionReplay
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1908,9 +1901,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AmplitudeCore: 3e063bb8b28ad164b3bd5279380190789ddc9405
-  AmplitudeSessionReplay: 0fc377b9f7f029714be75f28ac79f732a76fd6d7
-  AmplitudeSessionReplayReactNative: bff75475f0f9b3b6aa9e5e441e47d17cdcb34b40
+  AmplitudeSessionReplayReactNative: 230fa3ff87644f6afdf335fc2b373db6d8464be0
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6

--- a/packages/session-replay-react-native/example/ios/example.xcodeproj/project.pbxproj
+++ b/packages/session-replay-react-native/example/ios/example.xcodeproj/project.pbxproj
@@ -8,14 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* exampleTests.m */; };
-		ADC0DE0132010001AAAAAAAA /* SRMaskViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ADC0DE0032010001AAAAAAAA /* SRMaskViewTests.mm */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		322981B30E924E639762153E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
-		34623BD523082BDD78AB9C1A /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 25353B01D3F85F2146CE0CF1 /* libPods-example.a */; };
+		77D7B9F6865FDB325584E411 /* Pods_example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94195040594842D12A5C58F7 /* Pods_example.framework */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		E9FAB128BD14FFEB562F1D7C /* libPods-example-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 32DAD93772010729404CA6D2 /* libPods-example-exampleTests.a */; };
+		ADC0DE0132010001AAAAAAAA /* SRMaskViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ADC0DE0032010001AAAAAAAA /* SRMaskViewTests.mm */; };
+		F01CCE67C19DE7B9A9C66FEF /* Pods_example_exampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C355AD3EA3383DD1CE1C90E6 /* Pods_example_exampleTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,7 +32,6 @@
 		00E356EE1AD99517003FC87E /* exampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = exampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* exampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = exampleTests.m; sourceTree = "<group>"; };
-		ADC0DE0032010001AAAAAAAA /* SRMaskViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SRMaskViewTests.mm; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = example/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = example/AppDelegate.mm; sourceTree = "<group>"; };
@@ -41,12 +40,13 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = example/main.m; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = example/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		22B0B2BD787F432973CC0578 /* Pods-example-exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-exampleTests.release.xcconfig"; path = "Target Support Files/Pods-example-exampleTests/Pods-example-exampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		25353B01D3F85F2146CE0CF1 /* libPods-example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		32DAD93772010729404CA6D2 /* libPods-example-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D91BECB0331C06B109A303A /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = example/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		94195040594842D12A5C58F7 /* Pods_example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A98B834136E69D8AEE6F9CB5 /* Pods-example-exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-exampleTests.debug.xcconfig"; path = "Target Support Files/Pods-example-exampleTests/Pods-example-exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		ADC0DE0032010001AAAAAAAA /* SRMaskViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SRMaskViewTests.mm; sourceTree = "<group>"; };
 		B11B173E9049856FF732A405 /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
+		C355AD3EA3383DD1CE1C90E6 /* Pods_example_exampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_example_exampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9FAB128BD14FFEB562F1D7C /* libPods-example-exampleTests.a in Frameworks */,
+				F01CCE67C19DE7B9A9C66FEF /* Pods_example_exampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,7 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				34623BD523082BDD78AB9C1A /* libPods-example.a in Frameworks */,
+				77D7B9F6865FDB325584E411 /* Pods_example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,8 +106,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				25353B01D3F85F2146CE0CF1 /* libPods-example.a */,
-				32DAD93772010729404CA6D2 /* libPods-example-exampleTests.a */,
+				94195040594842D12A5C58F7 /* Pods_example.framework */,
+				C355AD3EA3383DD1CE1C90E6 /* Pods_example_exampleTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -574,6 +574,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -647,6 +658,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,

--- a/packages/session-replay-react-native/example/ios/example.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/session-replay-react-native/example/ios/example.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "edc8e7889682432e73ee0bb1520b044b2bb6a26caa0fc6239d8b37ea33d0b8cc",
+  "pins" : [
+    {
+      "identity" : "amplitude-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-iOS.git",
+      "state" : {
+        "revision" : "7ec0f8971b68c1cb859028655fbff1bcde8170dd",
+        "version" : "8.22.2"
+      }
+    },
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "bbad108b92f332fdaa76b67bce3f3ae88015ad0b",
+        "version" : "1.4.10"
+      }
+    },
+    {
+      "identity" : "amplitudesessionreplay-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeSessionReplay-iOS.git",
+      "state" : {
+        "revision" : "33bfc2acd504b4482ad5c4199c84c0fe92cc9ccb",
+        "version" : "0.12.6"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "982b4c787285d213653bd2a504d6a86b52227cea",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "analytics-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/segmentio/analytics-swift",
+      "state" : {
+        "revision" : "5658b7ff5768083683b83162121bad8b4a4b267f",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "jsonsafeencoding-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/segmentio/jsonsafeencoding-swift.git",
+      "state" : {
+        "revision" : "af6a8b360984085e36c6341b21ecb35c12f47ebd",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "sovran-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/segmentio/sovran-swift.git",
+      "state" : {
+        "revision" : "24867f3e4ac62027db9827112135e6531b6f4051",
+        "version" : "1.1.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/packages/session-replay-react-native/package.json
+++ b/packages/session-replay-react-native/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": ">=0.75.0"
   },
   "codegenConfig": {
     "name": "AmpSessionReplaySpec",


### PR DESCRIPTION
## Summary
- replace the standalone iOS Session Replay and Core pod dependencies with React Native SPM dependencies
- require dynamic framework linkage for iOS and preserve Fabric module visibility
- update the example project and lock SPM package resolution

## Test plan
- [x] build `@amplitude/session-replay-react-native`
- [x] run standalone package unit tests (98 tests)
- [x] install iOS dependencies through SPM
- [x] build the existing React Native 0.77 example for an iOS simulator
- [ ] build and launch disposable React Native / Expo version matrix

Linear: https://linear.app/amplitude/issue/SDKRN-64/ga-switch-ios-session-replay-dependency-from-cocoapods-to-spm

---
*Posted automatically with Cursor. LLMs make mistakes — please verify before acting.*
<!-- posted-by: cursor-agent -->