### PR TITLE
chore(segment-session-replay-plugin-react-native): make package publishable via publish-v2

### DIFF
--- a/packages/segment-session-replay-plugin-react-native/package.json
+++ b/packages/segment-session-replay-plugin-react-native/package.json
@@ -18,7 +18,6 @@
   "types": "lib/typescript/index.d.ts",
   "react-native": "src/index.ts",
   "source": "src/index.ts",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "tag": "latest"


### PR DESCRIPTION
## Summary

Removes `"private": true` from `packages/segment-session-replay-plugin-react-native/package.json` so Lerna's **Publish v2.x** train no longer skips this package.

Same change as #1811 for `@amplitude/session-replay-react-native`. This package was marked private temporarily in #1201.

`publishConfig.access: "public"` is already set. After merge, dispatch **Publish v2.x** from `main` (do not use `publish-single-package.yml`).

## Test plan

- [ ] Confirm `package.json` no longer has `"private": true` (field omitted, not set to false)
- [ ] After merge, run Publish v2.x and confirm `@amplitude/segment-session-replay-plugin-react-native` is included

---
*Posted automatically with Cursor. LLMs make mistakes — please verify before acting.*
<!-- posted-by: cursor-agent -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no application code, auth, or data-path changes.
> 
> **Overview**
> Makes `@amplitude/segment-session-replay-plugin-react-native` eligible for the monorepo **Publish v2.x** flow by **removing** `"private": true` from `package.json` (the field is omitted entirely, not set to `false`).
> 
> No runtime or API changes—`publishConfig.access: "public"` was already present. After merge, the package should be included when **Publish v2.x** runs from `main`, matching the earlier unblock for `@amplitude/session-replay-react-native`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0310de0f8178542473385fe6973e9c8ecdab12d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->