### PR TITLE
fix(session-replay-react-native): make setDeviceId non-nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 *.p12
 *.pfx
 secrets.*
+sdk59.local.ts
 
 lerna-debug.log
 

--- a/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
+++ b/packages/segment-session-replay-plugin-react-native/src/segment-session-replay-plugin.ts
@@ -83,7 +83,9 @@ export class SegmentSessionReplayPlugin extends Plugin {
     const deviceId = getDeviceId(event);
 
     await setSessionId(sessionId);
-    await setDeviceId(deviceId);
+    if (deviceId !== null) {
+      await setDeviceId(deviceId);
+    }
 
     return event;
   }

--- a/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
+++ b/packages/segment-session-replay-plugin-react-native/test/segment-session-replay-plugin.test.ts
@@ -235,7 +235,7 @@ describe('SegmentSessionReplayPlugin', () => {
 
       await plugin.execute(mockEvent);
 
-      expect(setDeviceId).toHaveBeenCalledWith(null);
+      expect(setDeviceId).not.toHaveBeenCalled();
     });
 
     it('should handle invalid session_id string gracefully', async () => {

--- a/packages/session-replay-react-native/src/native-module.ts
+++ b/packages/session-replay-react-native/src/native-module.ts
@@ -72,10 +72,10 @@ export interface NativeSessionReplaySpec {
 
   /**
    * Updates the device identifier used for session replay tracking.
-   * @param deviceId - The device identifier string, or null to clear the device ID
+   * @param deviceId - The device identifier string
    * @note OLD ARCH: combine those into one method to avoid bridge overhead
    */
-  setDeviceId(deviceId: string | null): Promise<void>;
+  setDeviceId(deviceId: string): Promise<void>;
 
   /**
    * Updates the session identifier used for session replay tracking.

--- a/packages/session-replay-react-native/src/session-replay.ts
+++ b/packages/session-replay-react-native/src/session-replay.ts
@@ -99,17 +99,15 @@ export async function setSessionId(sessionId: number): Promise<void> {
  * Update the device ID used for session replay tracking.
  * The Device ID you pass to the SDK must match the Device ID sent as event properties to Amplitude.
  *
- * @param deviceId - The device identifier string, or null to clear the device ID
+ * @param deviceId - The device identifier string
  * @returns Promise that resolves when the device ID is updated
  *
  * @example
  * ```typescript
  * await setDeviceId('user-device-id');
- * // or clear device ID
- * await setDeviceId(null);
  * ```
  */
-export async function setDeviceId(deviceId: string | null): Promise<void> {
+export async function setDeviceId(deviceId: string): Promise<void> {
   if (!isInitialized) {
     logger.warn('SessionReplay is not initialized');
     return;

--- a/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
+++ b/packages/session-replay-react-native/src/specs/NativeAmpSessionReplay.ts
@@ -13,7 +13,7 @@ import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 export interface Spec extends TurboModule {
   setup(config: UnsafeObject): Promise<void>;
   setSessionId(sessionId: number): Promise<void>;
-  setDeviceId(deviceId: string | null): Promise<void>;
+  setDeviceId(deviceId: string): Promise<void>;
   setOptOut(optOut: boolean): Promise<void>;
   getSessionId(): Promise<number>;
   start(): Promise<void>;


### PR DESCRIPTION
### Summary

Make the public `setDeviceId` API on `@amplitude/session-replay-react-native` a non-nullable `string` (including the TurboModule spec and the JS typed facade). This matches Android and Flutter public APIs.

SDKRN-59 found that `setDeviceId(null)` was documented as clearing the device ID, but that clear was never implemented: native persists `""` (Android coerces with `?: ""`). This PR removes the documented-null contract instead of adding iOS nil-clearing. Config `deviceId?: string | null` is unchanged (init still may send `null`).

The Segment plugin only calls `setDeviceId` when the event has a device ID or anonymous ID, because it types through the standalone setter.

Native E2E was not re-run for this diff.

### Test plan

- [x] `pnpm --filter @amplitude/session-replay-react-native run test`
- [x] `pnpm --filter @amplitude/session-replay-react-native run typecheck`
- [x] `pnpm --filter @amplitude/session-replay-react-native run lint`
- [x] `pnpm --filter @amplitude/segment-session-replay-plugin-react-native exec jest test/segment-session-replay-plugin.test.ts`
- [x] `pnpm --filter @amplitude/segment-session-replay-plugin-react-native run typecheck`
- [ ] Confirm callers no longer pass `null` into `setDeviceId`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: Yes — `setDeviceId` no longer accepts `null`

---
*Posted automatically with Cursor. LLMs make mistakes — please verify before acting.*
<!-- posted-by: cursor-agent -->