### PR TITLE
fix(session-replay-react-native): pass null deviceId through to native SDKs

### DIFF
--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -96,7 +96,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.amplitude:session-replay-android:[0.24.0,0.25.0)")
+  // TODO(SDKRN-68): 0.29.0 is blocked on session-replay-android#471 merging and publishing to Maven Central.
+  implementation("com.amplitude:session-replay-android:[0.29.0,0.30.0)")
   implementation("com.amplitude:analytics-android:[1.25.0,1.26.0)")
 
   // For < 0.71, this will be from the local maven repo

--- a/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
+++ b/packages/session-replay-react-native/android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt
@@ -108,7 +108,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
   override fun setDeviceId(deviceId: String?, promise: Promise) {
     try {
       nativeConfig = requireNotNull(nativeConfig).copy(deviceId = deviceId)
-      sessionReplay?.setDeviceId(deviceId ?: "")
+      sessionReplay?.setDeviceId(deviceId)
       promise.resolve(null)
     } catch (e: Exception) {
       promise.reject("SET_DEVICE_ID_ERROR", e.message, e)
@@ -218,7 +218,7 @@ class SessionReplayReactNativeModule(private val reactContext: ReactApplicationC
     return SessionReplay(
       apiKey = config.apiKey,
       context = reactContext.applicationContext,
-      deviceId = config.deviceId ?: "",
+      deviceId = config.deviceId,
       sessionId = config.sessionId,
       optOut = config.optOut,
       sampleRate = config.sampleRate,

--- a/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
+++ b/packages/session-replay-react-native/ios/AMPNativeSessionReplay.mm
@@ -8,7 +8,7 @@ RCT_EXTERN_METHOD(getSessionId:(RCTPromiseResolveBlock)resolve reject:(RCTPromis
 
 RCT_EXTERN_METHOD(setSessionId:(nonnull NSNumber)sessionId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(setDeviceId:(NSString)deviceId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(setDeviceId:(nullable NSString *)deviceId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(setOptOut:(BOOL)optOut resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/session-replay-react-native/ios/NativeSessionReplay.swift
+++ b/packages/session-replay-react-native/ios/NativeSessionReplay.swift
@@ -71,7 +71,7 @@ class NativeSessionReplay: NSObject, RCTBridgeModule {
     }
     
     @objc(setDeviceId:resolve:reject:)
-    func setDeviceId(_ deviceId: NSString, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+    func setDeviceId(_ deviceId: NSString?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         logger?.debug(message: "setDeviceId: \(deviceId)")
         sessionReplay?.deviceId = deviceId as String?
         resolve(nil)

--- a/packages/session-replay-react-native/test/session-replay.test.ts
+++ b/packages/session-replay-react-native/test/session-replay.test.ts
@@ -13,6 +13,8 @@ jest.mock('../src/logger', () => require('./utils/logger'));
 import { init, start, stop, getSessionId, teardown, setOptOut, type SessionReplayConfig } from '../src/index';
 import { NativeModules } from 'react-native';
 import { LogLevel } from '@amplitude/analytics-types';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 const mockNativeModules = NativeModules as jest.Mocked<typeof NativeModules>;
 
@@ -108,6 +110,65 @@ describe('Session Replay Integration Tests', () => {
     await pending;
     expect(nativeModule.setOptOut).not.toHaveBeenCalled();
     expect(nativeModule.teardown).not.toHaveBeenCalled();
+  });
+
+  describe('nullable device ID contract', () => {
+    it('forwards a null device ID during initialization', async () => {
+      let pending!: Promise<void>;
+      let setupMock!: jest.Mock;
+      jest.isolateModules(() => {
+        const { init: freshInit } = require('../src/index') as typeof import('../src/index');
+        const { NativeModules: freshNativeModules } = require('react-native') as typeof import('react-native');
+        setupMock = (freshNativeModules as jest.Mocked<typeof NativeModules>).AMPNativeSessionReplay.setup;
+        pending = freshInit({ apiKey: 'test-api-key', deviceId: null });
+      });
+
+      await pending;
+      expect(setupMock).toHaveBeenCalledWith(expect.objectContaining({ deviceId: null }));
+      expect(setupMock).not.toHaveBeenCalledWith(expect.objectContaining({ deviceId: '' }));
+    });
+
+    it('forwards null when clearing the device ID', async () => {
+      let pending!: Promise<void>;
+      let setDeviceIdMock!: jest.Mock;
+      jest.isolateModules(() => {
+        const { init: freshInit, setDeviceId: freshSetDeviceId } =
+          require('../src/index') as typeof import('../src/index');
+        const { NativeModules: freshNativeModules } = require('react-native') as typeof import('react-native');
+        setDeviceIdMock = (freshNativeModules as jest.Mocked<typeof NativeModules>).AMPNativeSessionReplay.setDeviceId;
+        pending = (async () => {
+          await freshInit({ apiKey: 'test-api-key' });
+          await freshSetDeviceId(null);
+        })();
+      });
+
+      await pending;
+      expect(setDeviceIdMock).toHaveBeenCalledWith(null);
+      expect(setDeviceIdMock).not.toHaveBeenCalledWith('');
+    });
+
+    it('keeps the Android bridge nullable without empty-string coercion', () => {
+      const source = readFileSync(
+        join(
+          __dirname,
+          '../android/src/main/java/com/amplitude/sessionreplayreactnative/SessionReplayReactNativeModule.kt',
+        ),
+        'utf8',
+      );
+
+      expect(source).toContain('sessionReplay?.setDeviceId(deviceId)');
+      expect(source).toContain('deviceId = config.deviceId,');
+      expect(source).not.toContain('deviceId ?: ""');
+      expect(source).not.toContain('config.deviceId ?: ""');
+    });
+
+    it('declares the iOS setDeviceId bridge parameter nullable', () => {
+      const swiftSource = readFileSync(join(__dirname, '../ios/NativeSessionReplay.swift'), 'utf8');
+      const objcSource = readFileSync(join(__dirname, '../ios/AMPNativeSessionReplay.mm'), 'utf8');
+
+      expect(swiftSource).toContain('func setDeviceId(_ deviceId: NSString?');
+      expect(objcSource).toContain('setDeviceId:(nullable NSString *)deviceId');
+    });
   });
 
   // These tests cover the resolution chain in `nativeConfig()` for the


### PR DESCRIPTION
## Summary
- Preserve the nullable React Native public API (`string | null`) and keep `null` meaning clear/unset.
- Stop coercing `null` to an empty string in Android setup and `setDeviceId`; pass it directly to session-replay-android.
- Declare the iOS Objective-C and Swift `setDeviceId` bridge parameter nullable end to end.
- Add JS forwarding and native bridge contract tests to prevent null-to-empty-string regressions.

## Blocks on
- [SDKRN-68](https://linear.app/amplitude/issue/SDKRN-68/post-ga-nullable-device-id-android-native-support-first-then-flutter): land after GA.
- [SDKA-95](https://linear.app/amplitude/issue/SDKA-95/session-replay-android-support-nullable-device-id) / [session-replay-android#471](https://github.com/amplitude/session-replay-android/pull/471): merge and publish the nullable Android API to Maven Central.
- This PR targets the inferred next minor range `[0.29.0,0.30.0)`. If #471 ships under a different version, update that range before landing.

## Test plan
- [x] TDD red run: new Android and iOS bridge contract tests failed before implementation.
- [x] `pnpm exec jest --runInBand --testPathPattern='\\.test\\.(ts|tsx)$'` (62 tests passed)
- [x] `pnpm typecheck`
- [x] `pnpm build` in `packages/session-replay-react-native`
- [x] ESLint and Prettier checks for `test/session-replay.test.ts`
- [ ] Android `:app:compileDebugKotlin` currently stops at dependency resolution because Maven Central has no `com.amplitude:session-replay-android` version in `[0.29.0,0.30.0)` yet. Re-run after #471 is published.

---
*Posted automatically with Cursor. LLMs make mistakes — please verify before acting.*
<!-- posted-by: cursor-agent -->