### PR TITLE
fix(plugin-autocapture-browser): fix nearest label CSS coping

### DIFF
--- a/packages/plugin-autocapture-browser/src/data-extractor.ts
+++ b/packages/plugin-autocapture-browser/src/data-extractor.ts
@@ -179,7 +179,7 @@ export class DataExtractor {
     }
     let labelElement: Element | null;
     try {
-      labelElement = parent.querySelector(':scope>span,h1,h2,h3,h4,h5,h6');
+      labelElement = parent.querySelector(':scope>span,:scope>h1,:scope>h2,:scope>h3,:scope>h4,:scope>h5,:scope>h6');
     } catch {
       /* istanbul ignore next */
       labelElement = null;

--- a/packages/plugin-autocapture-browser/test/data-extractor.test.ts
+++ b/packages/plugin-autocapture-browser/test/data-extractor.test.ts
@@ -467,6 +467,20 @@ describe('data extractor', () => {
       expect(result).toEqual('nearest label');
     });
 
+    test('should not return a deeply nested label of the element (regression test)', () => {
+      const container = document.createElement('div');
+      const heading = document.createElement('h1');
+      heading.innerText = 'My App';
+      const form = document.createElement('form');
+      const input = document.createElement('input');
+      container.appendChild(heading);
+      form.appendChild(input);
+      container.appendChild(form);
+
+      const result = dataExtractor.getNearestLabel(input);
+      expect(result).toEqual('');
+    });
+
     test('should return masked nearest label when content is sensitive', () => {
       const div = document.createElement('div');
       const span = document.createElement('span');


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small DOM-query change in autocapture label enrichment only; improves event property accuracy with no auth or data-pipeline impact.
> 
> **Overview**
> **`getNearestLabel`** in the autocapture browser plugin now applies **`:scope>`** to each heading selector (`h1`–`h6`), not only to `span`. Previously, headings in the compound selector could match **any descendant** of the current parent, so nested headings could be picked as **`[Amplitude] Element Parent Label`** when walking up the DOM.
> 
> A regression test covers a **form input** under a layout where a page-level **`h1`** is not a direct child label of the input’s immediate ancestors, expecting an empty parent label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbff3f37b355fec1c2f06e1f670fed1faa5c2f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->