### PR TITLE
fix(android): skip explicit Kotlin plugin when AGP registers the kotlin extension

### DIFF
--- a/packages/analytics-react-native/android/build.gradle
+++ b/packages/analytics-react-native/android/build.gradle
@@ -13,7 +13,27 @@ if (findProject(':app') != null) {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// Android Gradle Plugin 9 ships built-in Kotlin support and applies the Kotlin
+// plugin itself. Applying it a second time fails the configuration phase with
+// "Cannot add extension with name 'kotlin'". Apply it only when AGP is not
+// providing Kotlin: AGP 8 and older, or AGP 9 with android.builtInKotlin=false.
+def shouldApplyKotlinPlugin() {
+  def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpMajor <= 8) {
+    return true
+  }
+  // AGP 10 removes the opt-out: built-in Kotlin is always active there.
+  if (agpMajor >= 10) {
+    return false
+  }
+  def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+  def builtInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+  return !builtInKotlinEnabled
+}
+
+if (shouldApplyKotlinPlugin()) {
+  apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"

--- a/packages/plugin-session-replay-react-native/android/build.gradle
+++ b/packages/plugin-session-replay-react-native/android/build.gradle
@@ -18,7 +18,27 @@ if (findProject(':app') != null) {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// Android Gradle Plugin 9 ships built-in Kotlin support and applies the Kotlin
+// plugin itself. Applying it a second time fails the configuration phase with
+// "Cannot add extension with name 'kotlin'". Apply it only when AGP is not
+// providing Kotlin: AGP 8 and older, or AGP 9 with android.builtInKotlin=false.
+def shouldApplyKotlinPlugin() {
+  def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpMajor <= 8) {
+    return true
+  }
+  // AGP 10 removes the opt-out: built-in Kotlin is always active there.
+  if (agpMajor >= 10) {
+    return false
+  }
+  def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+  def builtInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+  return !builtInKotlinEnabled
+}
+
+if (shouldApplyKotlinPlugin()) {
+  apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"

--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -18,7 +18,27 @@ if (findProject(':app') != null) {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// Android Gradle Plugin 9 ships built-in Kotlin support and applies the Kotlin
+// plugin itself. Applying it a second time fails the configuration phase with
+// "Cannot add extension with name 'kotlin'". Apply it only when AGP is not
+// providing Kotlin: AGP 8 and older, or AGP 9 with android.builtInKotlin=false.
+def shouldApplyKotlinPlugin() {
+  def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpMajor <= 8) {
+    return true
+  }
+  // AGP 10 removes the opt-out: built-in Kotlin is always active there.
+  if (agpMajor >= 10) {
+    return false
+  }
+  def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+  def builtInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+  return !builtInKotlinEnabled
+}
+
+if (shouldApplyKotlinPlugin()) {
+  apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"


### PR DESCRIPTION
## Problem

Android Gradle Plugin 9 ships built-in Kotlin support and enables it by default, so
AGP registers the `kotlin` extension itself. When a library *also* applies `kotlin-android`
explicitly, the two collide and configuration fails before anything compiles. AGP
words it two ways, both the same problem:

```
> Failed to apply plugin 'kotlin-android'.
   > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```
```
> The 'kotlin-android' plugin is no longer required for Kotlin support since AGP 9.0.
```

The apply is unconditional in these files, so on an AGP 9 project they cannot be built
at all. There is no consumer-side workaround short of patching the file — setting
`android.builtInKotlin=false` project-wide just to build one dependency is not a
reasonable ask, and that escape hatch is removed in AGP 10.

## Change

Apply the plugin only when nothing has registered the `kotlin` extension yet:

```groovy
if (project.extensions.findByName('kotlin') == null) {
    apply plugin: "kotlin-android"
}
```

Files changed:

- `packages/analytics-react-native/android/build.gradle`
- `packages/plugin-session-replay-react-native/android/build.gradle`
- `packages/session-replay-react-native/android/build.gradle`

## Why this shape

Earlier revisions of this PR derived the answer from the AGP version and the
`android.builtInKotlin` property. Asking for the extension directly is better on
three counts:

- **It tests the condition that actually fails.** The collision is "something already
  registered `kotlin`", so that is what the guard checks. No AGP version table to keep
  in sync.
- **It cannot be fooled.** `android.builtInKotlin` is a global switch, but built-in
  Kotlin can also be enabled per module with the `com.android.built-in-kotlin` plugin,
  so the global value can disagree with the module. Reading
  `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` has its own trap: it resolves
  against the buildscript classpath, which is not always the AGP that ends up running.
- **It covers AGP 10 for free.** The `android.builtInKotlin` opt-out is removed there,
  and this guard needs no special case for it.

| AGP | `android.builtInKotlin` | `kotlin` extension | explicit apply |
|---|---|---|---|
| 8.x | unset or `false` | absent | yes (unchanged) |
| 9.x | unset or `true` | registered by AGP | no |
| 9.x | `false` | absent | yes |
| 10+ | n/a (removed) | registered by AGP | no |

The guard sits after `apply plugin: 'com.android.library'` in every file it touches,
so AGP has already registered its extensions by the time it runs. I checked that
ordering per file rather than assuming it.

## What I verified, and what I did not

- **Verified end to end** on a real Expo SDK 58 / React Native 0.87 project with AGP
  9.2.1 and Gradle 9.4.1: `:app:assembleDebug` succeeds both with
  `-Pandroid.newDsl=true -Pandroid.builtInKotlin=true` and with both flags off. That
  run used the earlier version-based guard; the extension guard in this revision is
  the shape now used across the rest of this sweep and already merged in several of
  those repos.
- Syntax-checked these files with Groovy's `Phases.CONVERSION`.
- **Not run:** this repo's own CI or example app. A CI run is the real confirmation
  and I could not do that from outside.

Found while sweeping 157 popular React Native libraries for AGP 9 new-DSL compatibility.
34 failed with the new DSL enabled, and 29 of those failed on exactly this — it is the
most common blocker by a wide margin.

This guard shape was suggested by the RevenueCat maintainers on
[RevenueCat/react-native-purchases#1934](https://github.com/RevenueCat/react-native-purchases/pull/1934),
who had already hit the same issue in their Capacitor and Flutter SDKs. I have
since standardised on it across this sweep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-configuration-only changes for Gradle/AGP compatibility; no runtime app logic or security-sensitive code paths.
> 
> **Overview**
> Fixes Android Gradle Plugin 9 configuration failures where built-in Kotlin already registers the `kotlin` extension and an unconditional `kotlin-android` apply collides.
> 
> All three React Native Android library modules (`analytics-react-native`, `plugin-session-replay-react-native`, `session-replay-react-native`) now apply `kotlin-android` **only** when `project.extensions.findByName('kotlin')` is null, after `com.android.library`, so AGP 8 and opt-out AGP 9 setups still get the plugin while AGP 9+ built-in Kotlin does not double-register.
> 
> For **`session-replay-react-native`**, New/Old Architecture Kotlin sources under `src/newarch/java` and `src/oldarch/java` are also added to `kotlin.srcDirs` (mirroring existing `java.srcDirs`), because AGP built-in Kotlin does not pick up those paths from `java.srcDirs` alone—without that change, `.kt` files there are skipped and the build hits unresolved references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442615e550592d398f59088118242eee754ee65a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

