### PR TITLE
fix(analytics-core): safely stringify timeline events

### DIFF
--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -7,6 +7,7 @@ import { Event } from './types/event/event';
 import { Result } from './types/result';
 import { buildResult } from './utils/result-builder';
 import { UUID } from './utils/uuid';
+import { safeJsonStringify } from './utils/safe-stringify';
 
 type PluginStatus = 'locked' | 'installed';
 
@@ -124,7 +125,7 @@ export class Timeline {
       const e = await plugin.execute({ ...event });
       if (e === null) {
         this.loggerProvider.log(
-          `Timeline.apply: Event filtered out by before plugin '${String(plugin.name)}', event: ${JSON.stringify(
+          `Timeline.apply: Event filtered out by before plugin '${String(plugin.name)}', event: ${safeJsonStringify(
             event,
           )}`,
         );
@@ -133,7 +134,7 @@ export class Timeline {
       } else {
         event = e;
         this.loggerProvider.log(
-          `Timeline.apply: Event after before plugin '${String(plugin.name)}', event: ${JSON.stringify(event)}`,
+          `Timeline.apply: Event after before plugin '${String(plugin.name)}', event: ${safeJsonStringify(event)}`,
         );
       }
     }
@@ -151,16 +152,16 @@ export class Timeline {
       const e = await plugin.execute({ ...event });
       if (e === null) {
         this.loggerProvider.log(
-          `Timeline.apply: Event filtered out by enrichment plugin '${String(plugin.name)}', event: ${JSON.stringify(
-            event,
-          )}`,
+          `Timeline.apply: Event filtered out by enrichment plugin '${String(
+            plugin.name,
+          )}', event: ${safeJsonStringify(event)}`,
         );
         resolve({ event, code: 0, message: '' });
         return;
       } else {
         event = e;
         this.loggerProvider.log(
-          `Timeline.apply: Event after enrichment plugin '${String(plugin.name)}', event: ${JSON.stringify(event)}`,
+          `Timeline.apply: Event after enrichment plugin '${String(plugin.name)}', event: ${safeJsonStringify(event)}`,
         );
       }
     }
@@ -170,7 +171,7 @@ export class Timeline {
     );
 
     // Log final event before sending to destinations
-    this.loggerProvider.log(`Timeline.apply: Final event before destinations, event: ${JSON.stringify(event)}`);
+    this.loggerProvider.log(`Timeline.apply: Final event before destinations, event: ${safeJsonStringify(event)}`);
 
     const executeDestinations = destination.map((plugin) => {
       const eventClone = { ...event };

--- a/packages/analytics-core/src/timeline.ts
+++ b/packages/analytics-core/src/timeline.ts
@@ -152,9 +152,9 @@ export class Timeline {
       const e = await plugin.execute({ ...event });
       if (e === null) {
         this.loggerProvider.log(
-          `Timeline.apply: Event filtered out by enrichment plugin '${String(
-            plugin.name,
-          )}', event: ${safeJsonStringify(event)}`,
+          `Timeline.apply: Event filtered out by enrichment plugin '${String(plugin.name)}', event: ${safeJsonStringify(
+            event,
+          )}`,
         );
         resolve({ event, code: 0, message: '' });
         return;

--- a/packages/analytics-core/test/timeline.test.ts
+++ b/packages/analytics-core/test/timeline.test.ts
@@ -397,6 +397,52 @@ describe('timeline', () => {
       expect(beforeExecute).toHaveBeenCalledTimes(0);
     });
 
+    test('should handle circular event properties while logging plugin results', async () => {
+      const beforeExecute = jest.fn().mockImplementation((event: Event) => Promise.resolve(event));
+      const enrichmentExecute = jest.fn().mockImplementation((event: Event) => Promise.resolve(event));
+      const destinationExecute = jest.fn().mockImplementation((event: Event) =>
+        Promise.resolve({
+          event,
+          code: 200,
+          message: 'success',
+        }),
+      );
+
+      timeline.plugins = [
+        {
+          name: 'plugin:before',
+          type: 'before',
+          execute: beforeExecute,
+        },
+        {
+          name: 'plugin:enrichment',
+          type: 'enrichment',
+          execute: enrichmentExecute,
+        },
+        {
+          name: 'plugin:destination',
+          type: 'destination',
+          execute: destinationExecute,
+        },
+      ];
+
+      const circularProperties: Record<string, unknown> = {};
+      circularProperties.self = circularProperties;
+      const event: Event = {
+        event_type: 'circular-event',
+        event_properties: circularProperties,
+      };
+      const callback = jest.fn();
+
+      await expect(timeline.apply([event, callback])).resolves.toBeUndefined();
+      await Promise.resolve();
+
+      expect(beforeExecute).toHaveBeenCalledTimes(1);
+      expect(enrichmentExecute).toHaveBeenCalledTimes(1);
+      expect(destinationExecute).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
     test("should pass event's extra to plugins", async () => {
       const beforeExecute = jest.fn().mockImplementationOnce((event: Event) => {
         expect(event.extra).toStrictEqual({ 'extra-key': 'extra-value' });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`Timeline.apply` logs each event after before/enrichment plugins with `JSON.stringify(event)`. That call is in the argument list of `logger.log()`, so it runs even when debug logging is off.

When an event contains a circular DOM/`Window` reference, stringify throws and timeline processing rejects instead of delivering the event.

Sentry: [STARGATE-CLIENT-BS2](https://amplitude.sentry.io/issues/STARGATE-CLIENT-BS2) (~77 events, ~68 users on the Stargate Events page). Linear: [DC-2169](https://linear.app/amplitude/issue/DC-2169/medium-circular-structure-to-json-error-in-amplitude-analytics-browser).

This PR uses the SDK’s existing `safeJsonStringify` instead of `JSON.stringify` at those five timeline logging call sites. It also adds an upstream regression test covering a circular event passing through before, enrichment, and destination plugins.

Linear ticket: DC-2169

## Testing

Passed:

- `pnpm install`
- `pnpm build`
- `pnpm docs:check`
- `pnpm test`
- `pnpm --filter @amplitude/analytics-core build`
- `pnpm --filter @amplitude/analytics-core test --runInBand --forceExit` — 56 suites, 877 tests
- `pnpm lint`
- `pnpm lint:deps`

`pnpm test:examples` cannot start on unchanged `main`: the root script references the nonexistent `jest.setup.examples.js` setup file.

No UI change; no screenshots.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58972afc-e21e-4e0f-921f-d421b2e871c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58972afc-e21e-4e0f-921f-d421b2e871c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

