### PR TITLE
chore(session-replay-react-native): bump Android SDK for SDKRN-69

### DIFF
--- a/packages/session-replay-react-native/android/build.gradle
+++ b/packages/session-replay-react-native/android/build.gradle
@@ -96,7 +96,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.amplitude:session-replay-android:[0.24.0,0.25.0)")
+  implementation("com.amplitude:session-replay-android:[0.30.0,0.31.0)")
   implementation("com.amplitude:analytics-android:[1.25.0,1.26.0)")
 
   // For < 0.71, this will be from the local maven repo

--- a/packages/session-replay-react-native/package.json
+++ b/packages/session-replay-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/session-replay-react-native",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Amplitude Session Replay for React Native",
   "keywords": [
     "analytics",

--- a/packages/session-replay-react-native/src/version.ts
+++ b/packages/session-replay-react-native/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.0.1';
+export const VERSION = '1.0.2';


### PR DESCRIPTION
## Summary

- Bump `@amplitude/session-replay-react-native` to `1.0.2`
- Bump Android `session-replay-android` dependency from `[0.24.0,0.25.0)` to `[0.30.0,0.31.0)` for MaskableCanvas `drawGlyphs`/`drawRenderNode` masking fix (SDKRN-69)

## Blocked

**Blocked on new `session-replay-android` version deployment** — do not merge until Android SDK `0.30.0` (or later containing SDKRN-69) is published to Maven Central.

Published latest stable is `0.29.0`; the SDKRN-69 fix is not yet released.

## Test plan

- [ ] Verify Android build resolves `session-replay-android` once `0.30.0` is published
- [ ] Confirm MaskableCanvas glyph/render-node masking in RN sample app