### PR TITLE
chore(plugin-session-replay-react-native): bump Android SDK for SDKRN-69

### DIFF
--- a/packages/plugin-session-replay-react-native/android/build.gradle
+++ b/packages/plugin-session-replay-react-native/android/build.gradle
@@ -84,7 +84,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-    implementation("com.amplitude:session-replay-android:[0.24.0,0.25.0)")
+    implementation("com.amplitude:session-replay-android:[0.30.0,0.31.0)")
     implementation("com.amplitude:analytics-android:[1.25.0,1.26.0)")
 
   // For < 0.71, this will be from the local maven repo

--- a/packages/plugin-session-replay-react-native/package.json
+++ b/packages/plugin-session-replay-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/plugin-session-replay-react-native",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Amplitude Session Replay plugin for React Native",
   "keywords": [
     "analytics",

--- a/packages/plugin-session-replay-react-native/src/version.ts
+++ b/packages/plugin-session-replay-react-native/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.5.1';
+export const VERSION = '0.5.2';


### PR DESCRIPTION
## Summary
- Bump `@amplitude/plugin-session-replay-react-native` to **0.5.2**
- Bump `session-replay-android` dependency to `[0.30.0,0.31.0)` to pick up the MaskableCanvas `drawGlyphs` / `drawRenderNode` masking fix ([SDKRN-69](https://linear.app/amplitude/issue/SDKRN-69/android-under-masks-pii-in-session-replay))

## Blocked on
**Blocked on [session-replay-android deployment](https://github.com/amplitude/session-replay-android/pull/486)** — do not merge until Android SDK **0.30.0** (or whichever release includes the fix) is published.

## Test plan
- [ ] Verify Android build after `session-replay-android` fix is released
- [ ] Confirm nested `Text` under `AmpMaskView` masks correctly in replay