### PR TITLE
fix(unified): correct public types and README examples

### DIFF
--- a/packages/unified/README.md
+++ b/packages/unified/README.md
@@ -25,16 +25,12 @@ yarn add @amplitude/unified
 
 The Unified SDK provides a single entry point for all Amplitude features, including Analytics, Experiment, and Session Replay. It simplifies the integration process by handling the initialization and configuration of all components.
 
-### 1. Import Amplitude Unified SDK
+### 1. Initialize Amplitude Unified SDK
 
 ```typescript
-import { initAll } from '@amplitude/unified';
-```
+import { Identify, experiment, identify, initAll, sessionReplay, track } from '@amplitude/unified';
 
-### 2. Initialize the SDK
-
-```typescript
-initAll('YOUR_API_KEY', {
+await initAll('YOUR_API_KEY', {
   // Shared options for all SDKs (optional)
   serverZone: 'US', // or 'EU'
   instanceName: 'my-instance',
@@ -61,18 +57,11 @@ initAll('YOUR_API_KEY', {
 });
 ```
 
-### 3. Access SDK Features
+### 2. Access SDK Features
 
 The Unified SDK provides access to all Amplitude features through a single interface:
 
 ```typescript
-import {
-  track,
-  identify,
-  experiment,
-  sessionReplay
-} from '@amplitude/unified';
-
 // Track events
 track('Button Clicked', { buttonName: 'Sign Up' });
 
@@ -80,13 +69,17 @@ track('Button Clicked', { buttonName: 'Sign Up' });
 identify(new Identify().set('userType', 'premium'));
 
 // Access Experiment features
-const variant = await experiment.fetch('experiment-key');
+const experimentClient = experiment();
+if (experimentClient) {
+  await experimentClient.fetch();
+  const variant = experimentClient.variant('experiment-key');
+}
 
 // Access Session Replay features
-sessionReplay.flush();
+await sessionReplay()?.flush(false);
 
 // Access Guides and Surveys features via engagement global
-const activeGuidesAndSurveys = await engagement.gs.list();
+const activeGuidesAndSurveys = window.engagement.gs.list();
 ```
 
 ## Configuration Options
@@ -112,7 +105,7 @@ All options from `@amplitude/plugin-experiment-browser` are supported. See the [
 
 ### Guides and Surveys Options
 
-All options from `@amplitude/engagement-browser` are supported. See the [Guides and Surveys documentation](hhttps://amplitude.com/docs/guides-and-surveys/sdk) for details.
+All options from `@amplitude/engagement-browser` are supported. See the [Guides and Surveys documentation](https://amplitude.com/docs/guides-and-surveys/sdk) for details.
 
 ## Learn More
 

--- a/packages/unified/src/unified.ts
+++ b/packages/unified/src/unified.ts
@@ -21,6 +21,10 @@ export interface UnifiedSharedOptions {
 }
 
 export type UnifiedOptions = UnifiedSharedOptions & {
+  /**
+   * Analytics Browser SDK configuration options.
+   * See {@link https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2#configure-the-sdk | Configure the SDK}.
+   */
   analytics?: BrowserOptions;
   sessionReplay?: Omit<SessionReplayOptions, keyof UnifiedSharedOptions>;
   experiment?: Omit<ExperimentPluginConfig, keyof UnifiedSharedOptions>;
@@ -29,17 +33,19 @@ export type UnifiedOptions = UnifiedSharedOptions & {
 
 export interface UnifiedClient extends BrowserClient {
   initAll(apiKey: string, unifiedOptions?: UnifiedOptions): Promise<void>;
-  sessionReplay(): AmplitudeSessionReplay;
+  sessionReplay(): AmplitudeSessionReplay | undefined;
   experiment(): IExperimentClient | undefined;
 }
 
 export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  private _sessionReplay: AmplitudeSessionReplay;
+  private _sessionReplay?: AmplitudeSessionReplay;
   private _initAllPromise?: Promise<void>;
 
-  sessionReplay(): AmplitudeSessionReplay {
+  /**
+   * Returns the Session Replay client after initAll() has completed, or undefined before initialization or when the
+   * Session Replay plugin is unavailable.
+   */
+  sessionReplay(): AmplitudeSessionReplay | undefined {
     return this._sessionReplay;
   }
 
@@ -65,8 +71,8 @@ export class AmplitudeUnified extends AmplitudeBrowser implements UnifiedClient 
    * Initialize SDKs with configuration options.
    *
    * @param apiKey Amplitude API key.
-   * @param analyticsOptions Analytics configuration options. Refer to {@link https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2#configure-the-sdk here} for more info.
-   * @param unifiedOptions Shared configuration for all SDKs and for blade SDKs.
+   * @param unifiedOptions Shared and SDK-specific configuration options. `unifiedOptions.analytics` configures the
+   * Analytics Browser SDK.
    */
   async initAll(apiKey: string, unifiedOptions?: UnifiedOptions) {
     if (this._initAllPromise) {


### PR DESCRIPTION
## Summary

- align the Session Replay accessor type with its pre-initialization runtime behavior
- document the nested Analytics configuration and remove the stale parameter documentation
- correct the bundled Unified SDK README examples for initialization, Identify, Experiment, Session Replay, and Guides & Surveys

## Validation

- pnpm --filter @amplitude/unified typecheck
- pnpm --filter @amplitude/unified lint
- pnpm --filter @amplitude/unified test --runInBand --watchman=false (19 tests, 100% coverage)
- pnpm docs:check
- consumer-style TypeScript compilation of the corrected README example

The full workspace build was attempted with the Nx daemon disabled, but stalled in the existing session-replay-browser Rollup bundle step. The missing Session Replay declarations were built directly, after which all focused Unified SDK checks passed.

Fixes SDK-258
