### PR TITLE
fix(autocapture): expose zones when the mid-height line is viewed

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,8 +1,8 @@
 const limits = [
   {
     // analytics-browser bundle
-    // Bumped 66kb → 67kb for Contentsquare-compatible midpoint exposure,
-    // including overflow-container and clipping-ancestor support. Current: ~66.1kb gzipped.
+    // Bumped 66kb → 67kb for midpoint exposure, including overflow-container
+    // and clipping-ancestor support. Current: ~66.1kb gzipped.
     path: './packages/analytics-browser/lib/scripts/amplitude-min.js.gz',
     limit: '67kb',
     brotli: false,

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,10 +1,10 @@
 const limits = [
   {
     // analytics-browser bundle
-    // Bumped 65kb → 66kb for shadow DOM support in plugin-autocapture-browser
-    // (SR-4788). Current actual: ~65.0kb gzipped.
+    // Bumped 66kb → 67kb for Contentsquare-compatible midpoint exposure,
+    // including overflow-container and clipping-ancestor support. Current: ~66.1kb gzipped.
     path: './packages/analytics-browser/lib/scripts/amplitude-min.js.gz',
-    limit: '66kb',
+    limit: '67kb',
     brotli: false,
   },
   {

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -26,6 +26,7 @@ declare global {
       viewedDepth: (element: Element) => number;
       isMidHeightLineVisible: (element: Element) => boolean;
       flush: () => void;
+      setAutoFlush: (enabled: boolean) => void;
       exposedPaths: string[];
       EXPOSURE_DURATION: number;
     };
@@ -81,6 +82,9 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
   async function openHarness(page: Page): Promise<void> {
     await page.goto('/autocapture/viewport-exposure.html');
     await expect(page.locator('#status')).toHaveText('initialized');
+    // The page auto-flushes so a human sees exposures while scrolling. That resets
+    // exposure state on a timer, so drive flushes by hand inside the tests.
+    await page.evaluate(() => window.__exposureHarness.setAutoFlush(false));
     // The initial snapshot reports whatever is already on screen; drop it so each
     // test only sees exposures caused by its own scrolling.
     await page.waitForTimeout(EXPOSURE_SETTLE_MS);

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -22,7 +22,7 @@ interface AmplitudeEvent {
 declare global {
   interface Window {
     __exposureHarness: {
-      scrollElementTo: (fraction: number, element?: Element) => number;
+      scrollElementTo: (fraction: number, element?: Element) => Promise<number>;
       visibleFraction: (element: Element) => number;
       viewedDepth: (element: Element) => number;
       isMidHeightLineVisible: (element: Element) => boolean;
@@ -81,8 +81,8 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
     });
   });
 
-  async function openHarness(page: Page): Promise<void> {
-    await page.goto('/autocapture/viewport-exposure.html');
+  async function openHarness(page: Page, query = ''): Promise<void> {
+    await page.goto(`/autocapture/viewport-exposure.html${query}`);
     await expect(page.locator('#status')).toHaveText('initialized');
     // The page auto-flushes so a human sees exposures while scrolling. That resets
     // exposure state on a timer, so drive flushes by hand inside the tests.
@@ -187,11 +187,13 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
   });
 
   test('does not expose an element that scrolls back below half before the exposure duration', async ({ page }) => {
-    await openHarness(page);
+    // A 150ms dwell would leave this racing the runner: the scroll away has to land
+    // inside it, and a loaded machine can overshoot. A long dwell makes the visit
+    // unambiguously too short while testing the same rule.
+    await openHarness(page, '?exposureDuration=5000');
 
-    // Cross the threshold, then leave again faster than the 150ms exposure duration.
+    // Cross the midpoint, then leave again far inside the 5s dwell.
     await page.evaluate(() => window.__exposureHarness.scrollElementTo(0.6));
-    await page.waitForTimeout(50);
     await page.evaluate(() => window.__exposureHarness.scrollElementTo(0.2));
 
     await page.waitForTimeout(EXPOSURE_SETTLE_MS);
@@ -246,9 +248,9 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
   test('exposes an oversized zone when its midpoint is viewed', async ({ page }) => {
     await openHarness(page);
 
-    const geometry = await page.evaluate(() => {
+    const geometry = await page.evaluate(async () => {
       const element = document.getElementById('oversized-target')!;
-      const depth = window.__exposureHarness.scrollElementTo(0.5, element);
+      const depth = await window.__exposureHarness.scrollElementTo(0.5, element);
       return {
         depth,
         visibleFraction: window.__exposureHarness.visibleFraction(element),

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -5,6 +5,7 @@ const TRACK_ENDPOINT = 'https://api2.amplitude.com/2/httpapi';
 const VIEWPORT_CONTENT_UPDATED = '[Amplitude] Viewport Content Updated';
 const ELEMENT_EXPOSED_PROP = '[Amplitude] Element Exposed';
 const TARGET_PATH = 'button#exposure-target';
+const OVERSIZED_TARGET_PATH = 'button#oversized-target';
 
 // The harness configures exposureDuration: 150. Wait comfortably longer so a slow
 // runner cannot mistake "not exposed yet" for "not exposed at all".
@@ -22,6 +23,8 @@ declare global {
     __exposureHarness: {
       scrollElementTo: (fraction: number, element?: Element) => number;
       visibleFraction: (element: Element) => number;
+      viewedDepth: (element: Element) => number;
+      isMidHeightLineVisible: (element: Element) => boolean;
       flush: () => void;
       exposedPaths: string[];
       EXPOSURE_DURATION: number;
@@ -42,7 +45,7 @@ function parseRequestBody(request: Request): Record<string, unknown> | undefined
 }
 
 /**
- * Real-browser coverage for the 50% exposure threshold behind
+ * Real-browser coverage for Contentsquare-style midpoint exposure behind
  * `[Amplitude] Viewport Content Updated`. jsdom has no layout and no
  * IntersectionObserver, so the unit tests can only feed synthetic entries to
  * `trackExposure`; only a real browser exercises the observer options in
@@ -53,7 +56,7 @@ function parseRequestBody(request: Request): Record<string, unknown> | undefined
  *   npx vite dev   # then open http://localhost:5173/autocapture/viewport-exposure.html
  * `pnpm start` serves the same pages, but only after `pnpm build:vite`.
  */
-test.describe('autocapture viewport exposure (50% visibility)', () => {
+test.describe('autocapture viewport exposure (mid-height line)', () => {
   let events: AmplitudeEvent[] = [];
   let pageErrors: string[] = [];
 
@@ -85,10 +88,10 @@ test.describe('autocapture viewport exposure (50% visibility)', () => {
     events = [];
   }
 
-  /** Scroll the target to `fraction` visibility, then flush and collect exposed paths. */
+  /** Scroll to `fraction` of the target's depth, then flush and collect exposed paths. */
   async function exposedPathsAfterScrollingTo(page: Page, fraction: number): Promise<string[]> {
     const achieved = await page.evaluate((f) => window.__exposureHarness.scrollElementTo(f), fraction);
-    // Guard the geometry itself: a mis-sized viewport would make the assertions meaningless.
+    // Guard the scroll depth itself: a mis-sized page would make the assertions meaningless.
     expect(achieved).toBeCloseTo(fraction, 2);
 
     await page.waitForTimeout(EXPOSURE_SETTLE_MS);
@@ -103,7 +106,7 @@ test.describe('autocapture viewport exposure (50% visibility)', () => {
       .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
   }
 
-  test('exposes an element that is 60% visible', async ({ page }) => {
+  test('exposes an element after its 60% depth has been viewed', async ({ page }) => {
     await openHarness(page);
 
     const paths = await exposedPathsAfterScrollingTo(page, 0.6);
@@ -112,7 +115,16 @@ test.describe('autocapture viewport exposure (50% visibility)', () => {
     expect(pageErrors).toEqual([]);
   });
 
-  test('does not expose an element that is only 30% visible', async ({ page }) => {
+  test('exposes an element when its mid-height line is reached', async ({ page }) => {
+    await openHarness(page);
+
+    const paths = await exposedPathsAfterScrollingTo(page, 0.5);
+
+    expect(paths, `expected ${TARGET_PATH} in ${JSON.stringify(paths)}`).toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('does not expose an element when only its first 30% has been viewed', async ({ page }) => {
     await openHarness(page);
 
     const paths = await exposedPathsAfterScrollingTo(page, 0.3);
@@ -121,7 +133,16 @@ test.describe('autocapture viewport exposure (50% visibility)', () => {
     expect(pageErrors).toEqual([]);
   });
 
-  test('still exposes an element scrolled fully into view', async ({ page }) => {
+  test('does not expose an element before its mid-height line is reached', async ({ page }) => {
+    await openHarness(page);
+
+    const paths = await exposedPathsAfterScrollingTo(page, 0.49);
+
+    expect(paths).not.toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('still exposes an element after its full depth has been viewed', async ({ page }) => {
     await openHarness(page);
 
     const paths = await exposedPathsAfterScrollingTo(page, 1);
@@ -134,11 +155,9 @@ test.describe('autocapture viewport exposure (50% visibility)', () => {
     await openHarness(page);
 
     // Cross the threshold, then leave again faster than the 150ms exposure duration.
-    await page.evaluate(() => {
-      const harness = window.__exposureHarness;
-      harness.scrollElementTo(0.6);
-      harness.scrollElementTo(0.2);
-    });
+    await page.evaluate(() => window.__exposureHarness.scrollElementTo(0.6));
+    await page.waitForTimeout(50);
+    await page.evaluate(() => window.__exposureHarness.scrollElementTo(0.2));
 
     await page.waitForTimeout(EXPOSURE_SETTLE_MS);
     await page.evaluate(() => window.__exposureHarness.flush());
@@ -148,6 +167,36 @@ test.describe('autocapture viewport exposure (50% visibility)', () => {
       .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
       .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
     expect(paths).not.toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('exposes an oversized zone when its midpoint is viewed', async ({ page }) => {
+    await openHarness(page);
+
+    const geometry = await page.evaluate(() => {
+      const element = document.getElementById('oversized-target')!;
+      const depth = window.__exposureHarness.scrollElementTo(0.5, element);
+      return {
+        depth,
+        visibleFraction: window.__exposureHarness.visibleFraction(element),
+        midpointVisible: window.__exposureHarness.isMidHeightLineVisible(element),
+      };
+    });
+    expect(geometry.depth).toBeCloseTo(0.5, 2);
+    expect(geometry.visibleFraction).toBeLessThan(0.5);
+    expect(geometry.midpointVisible).toBe(true);
+
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+    await expect
+      .poll(
+        () =>
+          events
+            .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+            .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+        { timeout: 10_000 },
+      )
+      .toContain(OVERSIZED_TARGET_PATH);
     expect(pageErrors).toEqual([]);
   });
 });

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect, Page, Request } from '@playwright/test';
+import { gunzipSync } from 'zlib';
+
+const TRACK_ENDPOINT = 'https://api2.amplitude.com/2/httpapi';
+const VIEWPORT_CONTENT_UPDATED = '[Amplitude] Viewport Content Updated';
+const ELEMENT_EXPOSED_PROP = '[Amplitude] Element Exposed';
+const TARGET_PATH = 'button#exposure-target';
+
+// The harness configures exposureDuration: 150. Wait comfortably longer so a slow
+// runner cannot mistake "not exposed yet" for "not exposed at all".
+const EXPOSURE_SETTLE_MS = 1_000;
+
+interface AmplitudeEvent {
+  event_type: string;
+  event_properties?: Record<string, unknown>;
+}
+
+// Scroll/flush helpers the harness page hangs off `window` so the geometry math
+// lives next to the markup it depends on.
+declare global {
+  interface Window {
+    __exposureHarness: {
+      scrollElementTo: (fraction: number, element?: Element) => number;
+      visibleFraction: (element: Element) => number;
+      flush: () => void;
+      exposedPaths: string[];
+      EXPOSURE_DURATION: number;
+    };
+  }
+}
+
+function parseRequestBody(request: Request): Record<string, unknown> | undefined {
+  const contentEncoding = request.headers()['content-encoding'];
+  if (contentEncoding === 'gzip') {
+    const buffer = request.postDataBuffer();
+    if (!buffer || buffer.length === 0) return undefined;
+    return JSON.parse(gunzipSync(buffer).toString('utf8')) as Record<string, unknown>;
+  }
+  const postData = request.postData();
+  if (!postData) return undefined;
+  return JSON.parse(postData) as Record<string, unknown>;
+}
+
+/**
+ * Real-browser coverage for the 50% exposure threshold behind
+ * `[Amplitude] Viewport Content Updated`. jsdom has no layout and no
+ * IntersectionObserver, so the unit tests can only feed synthetic entries to
+ * `trackExposure`; only a real browser exercises the observer options in
+ * `createExposureObservable` together with actual scroll geometry.
+ *
+ * The same page doubles as a manual harness — it has a scroll/flush control bar
+ * and a live visibility readout:
+ *   pnpm build:vite && pnpm start   # then open /autocapture/viewport-exposure.html
+ */
+test.describe('autocapture viewport exposure (50% visibility)', () => {
+  let events: AmplitudeEvent[] = [];
+  let pageErrors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    events = [];
+    pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    await page.route(TRACK_ENDPOINT, async (route) => {
+      const body = parseRequestBody(route.request());
+      const batch = body?.events;
+      if (Array.isArray(batch)) {
+        events.push(...(batch as AmplitudeEvent[]));
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 200, events_ingested: 0, payload_size_bytes: 0, server_upload_time: 0 }),
+      });
+    });
+  });
+
+  async function openHarness(page: Page): Promise<void> {
+    await page.goto('/autocapture/viewport-exposure.html');
+    await expect(page.locator('#status')).toHaveText('initialized');
+    // The initial snapshot reports whatever is already on screen; drop it so each
+    // test only sees exposures caused by its own scrolling.
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+    events = [];
+  }
+
+  /** Scroll the target to `fraction` visibility, then flush and collect exposed paths. */
+  async function exposedPathsAfterScrollingTo(page: Page, fraction: number): Promise<string[]> {
+    const achieved = await page.evaluate((f) => window.__exposureHarness.scrollElementTo(f), fraction);
+    // Guard the geometry itself: a mis-sized viewport would make the assertions meaningless.
+    expect(achieved).toBeCloseTo(fraction, 2);
+
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+
+    await expect
+      .poll(() => events.filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED).length, { timeout: 10_000 })
+      .toBeGreaterThan(0);
+
+    return events
+      .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+      .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
+  }
+
+  test('exposes an element that is 60% visible', async ({ page }) => {
+    await openHarness(page);
+
+    const paths = await exposedPathsAfterScrollingTo(page, 0.6);
+
+    expect(paths, `expected ${TARGET_PATH} in ${JSON.stringify(paths)}`).toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('does not expose an element that is only 30% visible', async ({ page }) => {
+    await openHarness(page);
+
+    const paths = await exposedPathsAfterScrollingTo(page, 0.3);
+
+    expect(paths).not.toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('still exposes an element scrolled fully into view', async ({ page }) => {
+    await openHarness(page);
+
+    const paths = await exposedPathsAfterScrollingTo(page, 1);
+
+    expect(paths, `expected ${TARGET_PATH} in ${JSON.stringify(paths)}`).toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('does not expose an element that scrolls back below half before the exposure duration', async ({ page }) => {
+    await openHarness(page);
+
+    // Cross the threshold, then leave again faster than the 150ms exposure duration.
+    await page.evaluate(() => {
+      const harness = window.__exposureHarness;
+      harness.scrollElementTo(0.6);
+      harness.scrollElementTo(0.2);
+    });
+
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+
+    const paths = events
+      .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+      .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
+    expect(paths).not.toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -7,6 +7,7 @@ const ELEMENT_EXPOSED_PROP = '[Amplitude] Element Exposed';
 const TARGET_PATH = 'button#exposure-target';
 const OVERSIZED_TARGET_PATH = 'button#oversized-target';
 const NESTED_SCROLL_TARGET_PATH = 'button#nested-scroll-target';
+const SITE_HEADER_PATH = 'button#site-header';
 
 // The harness configures exposureDuration: 150. Wait comfortably longer so a slow
 // runner cannot mistake "not exposed yet" for "not exposed at all".
@@ -48,7 +49,7 @@ function parseRequestBody(request: Request): Record<string, unknown> | undefined
 }
 
 /**
- * Real-browser coverage for Contentsquare-style midpoint exposure behind
+ * Real-browser coverage for midpoint exposure behind
  * `[Amplitude] Viewport Content Updated`. jsdom has no layout and no
  * IntersectionObserver, so the unit tests can only feed synthetic entries to
  * `trackExposure`; only a real browser exercises the observer options in
@@ -111,6 +112,37 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
       .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
       .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
   }
+
+  test('exposes a sticky site header on the first event and keeps it in view after scroll', async ({ page }) => {
+    await page.goto('/autocapture/viewport-exposure.html');
+    await expect(page.locator('#status')).toHaveText('initialized');
+    await page.evaluate(() => window.__exposureHarness.setAutoFlush(false));
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+
+    await expect
+      .poll(
+        () =>
+          events
+            .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+            .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+        { timeout: 10_000 },
+      )
+      .toContain(SITE_HEADER_PATH);
+
+    await page.evaluate(() => window.scrollTo(0, 2500));
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => window.__exposureHarness.isMidHeightLineVisible(document.getElementById('site-header')!)),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    const cumulative = await page.evaluate(() => window.__exposureHarness.exposedPaths);
+    expect(cumulative).toContain(SITE_HEADER_PATH);
+    expect(pageErrors).toEqual([]);
+  });
 
   test('exposes an element after its 60% depth has been viewed', async ({ page }) => {
     await openHarness(page);

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -49,8 +49,9 @@ function parseRequestBody(request: Request): Record<string, unknown> | undefined
  * `createExposureObservable` together with actual scroll geometry.
  *
  * The same page doubles as a manual harness — it has a scroll/flush control bar
- * and a live visibility readout:
- *   pnpm build:vite && pnpm start   # then open /autocapture/viewport-exposure.html
+ * and a live visibility readout. From the repo root, after `pnpm build`:
+ *   npx vite dev   # then open http://localhost:5173/autocapture/viewport-exposure.html
+ * `pnpm start` serves the same pages, but only after `pnpm build:vite`.
  */
 test.describe('autocapture viewport exposure (50% visibility)', () => {
   let events: AmplitudeEvent[] = [];

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -274,6 +274,37 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
     expect(pageErrors).toEqual([]);
   });
 
+  test('exposes an absolute element that paints outside a static overflow ancestor', async ({ page }) => {
+    await openHarness(page);
+
+    await page.evaluate(() => {
+      // `overflow: hidden` on a static wrapper does not clip an absolute child, so
+      // this button really is on screen below the wrapper.
+      const wrapper = document.createElement('div');
+      wrapper.style.cssText = 'position:static;width:200px;height:20px;overflow:hidden';
+      const element = document.createElement('button');
+      element.id = 'escaping-absolute-target';
+      element.style.cssText = 'position:absolute;top:200px;left:20px;width:120px;height:100px';
+      element.textContent = 'escaping target';
+      wrapper.appendChild(element);
+      document.body.appendChild(wrapper);
+    });
+
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+
+    await expect
+      .poll(
+        () =>
+          events
+            .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+            .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+        { timeout: 10_000 },
+      )
+      .toContain('button#escaping-absolute-target');
+    expect(pageErrors).toEqual([]);
+  });
+
   test('rechecks midpoint exposure when the viewport is resized', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 600 });
     await openHarness(page);

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -245,6 +245,70 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
     expect(pageErrors).toEqual([]);
   });
 
+  test('does not clip a viewport-fixed element against an overflow ancestor', async ({ page }) => {
+    await openHarness(page);
+
+    await page.evaluate(() => {
+      const clipper = document.createElement('div');
+      clipper.style.cssText = 'position:absolute;top:400px;height:20px;overflow:hidden';
+      const element = document.createElement('button');
+      element.id = 'fixed-exposure-target';
+      element.style.cssText = 'position:fixed;top:100px;left:20px;width:100px;height:100px';
+      element.textContent = 'fixed target';
+      clipper.appendChild(element);
+      document.body.appendChild(clipper);
+    });
+
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+
+    await expect
+      .poll(
+        () =>
+          events
+            .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+            .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+        { timeout: 10_000 },
+      )
+      .toContain('button#fixed-exposure-target');
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('rechecks midpoint exposure when the viewport is resized', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 600 });
+    await openHarness(page);
+
+    await page.evaluate(() => {
+      const element = document.createElement('button');
+      element.id = 'resize-exposure-target';
+      // Partly visible, but its midpoint starts 50px below the viewport.
+      element.style.cssText = 'position:fixed;top:550px;left:20px;width:100px;height:200px';
+      element.textContent = 'resize target';
+      document.body.appendChild(element);
+    });
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+    expect(
+      events.flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+    ).not.toContain('button#resize-exposure-target');
+
+    events = [];
+    await page.setViewportSize({ width: 1280, height: 700 });
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+
+    await expect
+      .poll(
+        () =>
+          events
+            .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+            .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+        { timeout: 10_000 },
+      )
+      .toContain('button#resize-exposure-target');
+    expect(pageErrors).toEqual([]);
+  });
+
   test('exposes an oversized zone when its midpoint is viewed', async ({ page }) => {
     await openHarness(page);
 

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -28,6 +28,7 @@ declare global {
       flush: () => void;
       setAutoFlush: (enabled: boolean) => void;
       exposedPaths: string[];
+      payloads: { at: string; event: AmplitudeEvent }[];
       EXPOSURE_DURATION: number;
     };
   }
@@ -125,6 +126,35 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
     const paths = await exposedPathsAfterScrollingTo(page, 0.5);
 
     expect(paths, `expected ${TARGET_PATH} in ${JSON.stringify(paths)}`).toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('reports the exposed element inside the Viewport Content Updated payload', async ({ page }) => {
+    await openHarness(page);
+    await exposedPathsAfterScrollingTo(page, 0.6);
+
+    const payload = events.find(
+      (e) =>
+        e.event_type === VIEWPORT_CONTENT_UPDATED &&
+        ((e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []).includes(TARGET_PATH),
+    );
+
+    expect(payload, `no payload carried ${TARGET_PATH}: ${JSON.stringify(events)}`).toBeDefined();
+    expect(payload?.event_properties?.[ELEMENT_EXPOSED_PROP]).toEqual(expect.arrayContaining([TARGET_PATH]));
+    expect(payload?.event_properties).toMatchObject({
+      '[Amplitude] Page URL': expect.stringContaining('/autocapture/viewport-exposure.html'),
+      '[Amplitude] Viewport Height': expect.any(Number),
+      '[Amplitude] Viewport Width': expect.any(Number),
+      '[Amplitude] Max Page X': expect.any(Number),
+      '[Amplitude] Max Page Y': expect.any(Number),
+    });
+
+    // The harness panel shows the same object, so what a human reads is what was sent.
+    const shown = await page.evaluate(() => window.__exposureHarness.payloads.map((entry) => entry.event));
+    expect(shown).toEqual(expect.arrayContaining([expect.objectContaining({ event_type: VIEWPORT_CONTENT_UPDATED })]));
+    expect(
+      shown.flatMap((event) => (event.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+    ).toContain(TARGET_PATH);
     expect(pageErrors).toEqual([]);
   });
 

--- a/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
+++ b/packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
@@ -6,6 +6,7 @@ const VIEWPORT_CONTENT_UPDATED = '[Amplitude] Viewport Content Updated';
 const ELEMENT_EXPOSED_PROP = '[Amplitude] Element Exposed';
 const TARGET_PATH = 'button#exposure-target';
 const OVERSIZED_TARGET_PATH = 'button#oversized-target';
+const NESTED_SCROLL_TARGET_PATH = 'button#nested-scroll-target';
 
 // The harness configures exposureDuration: 150. Wait comfortably longer so a slow
 // runner cannot mistake "not exposed yet" for "not exposed at all".
@@ -201,6 +202,44 @@ test.describe('autocapture viewport exposure (mid-height line)', () => {
       .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
       .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
     expect(paths).not.toContain(TARGET_PATH);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('tracks midpoint exposure inside an overflow container without counting clipped content', async ({ page }) => {
+    await openHarness(page);
+
+    const scroller = page.locator('#overflow-container');
+    await scroller.scrollIntoViewIfNeeded();
+    await page.evaluate(() => {
+      document.getElementById('overflow-container')!.scrollTop = 0;
+    });
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+
+    const before = events
+      .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+      .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []);
+    expect(before).not.toContain(NESTED_SCROLL_TARGET_PATH);
+
+    events = [];
+    await page.evaluate(() => {
+      // The target begins with 50px visible in a 300px scroller, but its midpoint
+      // is below the clip edge. Scrolling 60px brings that midpoint into the panel.
+      document.getElementById('overflow-container')!.scrollTop = 60;
+    });
+    await page.waitForTimeout(EXPOSURE_SETTLE_MS);
+    await page.evaluate(() => window.__exposureHarness.flush());
+
+    await expect
+      .poll(
+        () =>
+          events
+            .filter((e) => e.event_type === VIEWPORT_CONTENT_UPDATED)
+            .flatMap((e) => (e.event_properties?.[ELEMENT_EXPOSED_PROP] as string[] | undefined) ?? []),
+        { timeout: 10_000 },
+      )
+      .toContain(NESTED_SCROLL_TARGET_PATH);
     expect(pageErrors).toEqual([]);
   });
 

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -5,31 +5,14 @@ import { EXPOSURE_INTERSECTION_THRESHOLD } from '../constants';
 import { DataExtractor } from '../data-extractor';
 
 // Sub-pixel rounding can report a ratio a hair below the threshold on the very callback that
-// crossed it, which would strand an element that stops scrolling right at the boundary.
+// crossed it, which would otherwise strand an element that stops scrolling right at the boundary.
 const INTERSECTION_RATIO_TOLERANCE = 0.001;
 const MIN_INTERSECTION_RATIO = EXPOSURE_INTERSECTION_THRESHOLD - INTERSECTION_RATIO_TOLERANCE;
 
-// An element larger than the viewport can never reach EXPOSURE_INTERSECTION_THRESHOLD of its own
-// area, so it instead counts as seen once its visible part fills that fraction of the viewport.
-const fillsViewport = (entry: IntersectionObserverEntry): boolean => {
-  const rootBounds = entry.rootBounds;
-  if (!rootBounds) {
-    return false;
-  }
-  const rootArea = rootBounds.width * rootBounds.height;
-  if (rootArea <= 0) {
-    return false;
-  }
-  const visibleArea = entry.intersectionRect.width * entry.intersectionRect.height;
-  return visibleArea / rootArea >= MIN_INTERSECTION_RATIO;
-};
-
-const isSeen = (entry: IntersectionObserverEntry): boolean => {
-  if (!entry.isIntersecting) {
-    return false;
-  }
-  return entry.intersectionRatio >= MIN_INTERSECTION_RATIO || fillsViewport(entry);
-};
+// `isIntersecting` alone is not enough: the spec defines it as any overlap with the root, so the
+// ratio is what actually holds the element to EXPOSURE_INTERSECTION_THRESHOLD.
+const isSeen = (entry: IntersectionObserverEntry): boolean =>
+  entry.isIntersecting && entry.intersectionRatio >= MIN_INTERSECTION_RATIO;
 
 export function trackExposure({
   allObservables,

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -1,7 +1,35 @@
 /* eslint-disable no-restricted-globals */
 import { DEFAULT_EXPOSURE_DURATION } from '@amplitude/analytics-core';
 import { AllWindowObservables } from '../autocapture-plugin';
+import { EXPOSURE_INTERSECTION_THRESHOLD } from '../constants';
 import { DataExtractor } from '../data-extractor';
+
+// Sub-pixel rounding can report a ratio a hair below the threshold on the very callback that
+// crossed it, which would strand an element that stops scrolling right at the boundary.
+const INTERSECTION_RATIO_TOLERANCE = 0.001;
+const MIN_INTERSECTION_RATIO = EXPOSURE_INTERSECTION_THRESHOLD - INTERSECTION_RATIO_TOLERANCE;
+
+// An element larger than the viewport can never reach EXPOSURE_INTERSECTION_THRESHOLD of its own
+// area, so it instead counts as seen once its visible part fills that fraction of the viewport.
+const fillsViewport = (entry: IntersectionObserverEntry): boolean => {
+  const rootBounds = entry.rootBounds;
+  if (!rootBounds) {
+    return false;
+  }
+  const rootArea = rootBounds.width * rootBounds.height;
+  if (rootArea <= 0) {
+    return false;
+  }
+  const visibleArea = entry.intersectionRect.width * entry.intersectionRect.height;
+  return visibleArea / rootArea >= MIN_INTERSECTION_RATIO;
+};
+
+const isSeen = (entry: IntersectionObserverEntry): boolean => {
+  if (!entry.isIntersecting) {
+    return false;
+  }
+  return entry.intersectionRatio >= MIN_INTERSECTION_RATIO || fillsViewport(entry);
+};
 
 export function trackExposure({
   allObservables,
@@ -26,8 +54,8 @@ export function trackExposure({
     const entry = event as unknown as IntersectionObserverEntry;
     const element = entry.target;
 
-    if (entry.isIntersecting) {
-      // Element became visible - start exposure timer if not already exposed
+    if (isSeen(entry)) {
+      // Element became visible enough - start exposure timer if not already exposed
       if (!exposureMap.get(element)) {
         const existingTimer = exposureTimerMap.get(element);
         if (existingTimer) {
@@ -47,8 +75,8 @@ export function trackExposure({
 
         exposureTimerMap.set(element, timer);
       }
-    } else if (!entry.isIntersecting && entry.intersectionRatio < 1.0) {
-      // Element left viewport - cancel exposure timer if one exists
+    } else {
+      // Element left the viewport or dropped below the threshold - cancel exposure timer if one exists
       const timer = exposureTimerMap.get(element);
       if (timer) {
         clearTimeout(timer);

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -20,6 +20,19 @@ const getVisualParent = (element: Element): Element | null => {
   return element.assignedSlot || element.parentElement || (element.parentNode as ShadowRoot | null)?.host || null;
 };
 
+/**
+ * The next ancestor whose overflow can clip `element`. Absolute and fixed elements
+ * are only clipped from their containing block upwards, which browsers expose as
+ * `offsetParent` — so static wrappers they paint outside of are skipped, and a
+ * transform/filter/contain ancestor that does establish a containing block still
+ * clips. `null` means the containing block is the viewport.
+ */
+const getClippingParent = (element: Element, position: string): Element | null => {
+  return (position === 'fixed' || position === 'absolute') && element instanceof HTMLElement
+    ? element.offsetParent
+    : getVisualParent(element);
+};
+
 const isMidHeightLineVisible = (element: Element): boolean => {
   const globalScope = getGlobalScope();
   /* istanbul ignore next -- trackExposure is only installed in a browser */
@@ -28,40 +41,44 @@ const isMidHeightLineVisible = (element: Element): boolean => {
   const viewportWidth = globalScope!.document.documentElement.clientWidth || globalScope!.innerWidth;
   const rect = element.getBoundingClientRect();
   const midHeightLine = rect.top + rect.height * EXPOSURE_VIEWED_THRESHOLD;
+  // Track the still-visible span of the mid-height line as ancestors clip it.
+  let visibleLeft = Math.max(rect.left, 0);
+  let visibleRight = Math.min(rect.right, viewportWidth);
 
   if (
     midHeightLine < -MID_HEIGHT_LINE_TOLERANCE_PX ||
     midHeightLine > viewportHeight + MID_HEIGHT_LINE_TOLERANCE_PX ||
-    rect.right <= 0 ||
-    rect.left >= viewportWidth ||
+    visibleLeft >= visibleRight ||
     rect.width <= 0
   ) {
     return false;
   }
 
-  const elementStyle = globalScope!.getComputedStyle(element);
-  // A fixed element whose containing block is the viewport escapes ancestor
-  // overflow clipping. If transform/filter/contain establishes an ancestor
-  // containing block, browsers expose that element as offsetParent; clipping
-  // resumes there without us having to duplicate the CSS containing-block rules.
-  let ancestor =
-    elementStyle.position === 'fixed' && element instanceof HTMLElement
-      ? element.offsetParent
-      : getVisualParent(element);
+  let ancestor = getClippingParent(element, globalScope!.getComputedStyle(element).position);
   while (ancestor) {
     /* istanbul ignore next -- trackExposure is only installed in a browser */
-    const overflow = globalScope!.getComputedStyle(ancestor).overflowY;
+    const style = globalScope!.getComputedStyle(ancestor);
     // Browsers return "visible" by default; jsdom returns an empty string.
-    if (overflow && overflow !== 'visible') {
+    const clipsY = style.overflowY && style.overflowY !== 'visible';
+    const clipsX = style.overflowX && style.overflowX !== 'visible';
+    if (clipsY || clipsX) {
       const ancestorRect = ancestor.getBoundingClientRect();
       if (
-        midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
-        midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX
+        clipsY &&
+        (midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
+          midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX)
       ) {
         return false;
       }
+      if (clipsX) {
+        visibleLeft = Math.max(visibleLeft, ancestorRect.left);
+        visibleRight = Math.min(visibleRight, ancestorRect.right);
+        if (visibleLeft >= visibleRight) {
+          return false;
+        }
+      }
     }
-    ancestor = getVisualParent(ancestor);
+    ancestor = getClippingParent(ancestor, style.position);
   }
 
   return true;

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -16,6 +16,20 @@ import { DataExtractor } from '../data-extractor';
 // A sub-pixel difference should not decide whether a zone was viewed.
 const MID_HEIGHT_LINE_TOLERANCE_PX = 1;
 
+const CLIPPING_OVERFLOW_VALUES = new Set(['auto', 'clip', 'hidden', 'overlay', 'scroll']);
+const clipsAxis = (overflow: string): boolean => CLIPPING_OVERFLOW_VALUES.has(overflow);
+
+const getVisualParent = (element: Element): Element | null => {
+  if (element.assignedSlot) {
+    return element.assignedSlot;
+  }
+  if (element.parentElement) {
+    return element.parentElement;
+  }
+  const root = element.getRootNode();
+  return root instanceof ShadowRoot ? root.host : null;
+};
+
 const isMidHeightLineVisible = (element: Element): boolean => {
   const globalScope = getGlobalScope();
   /* istanbul ignore next -- trackExposure is only installed in a browser */
@@ -24,14 +38,43 @@ const isMidHeightLineVisible = (element: Element): boolean => {
   const viewportWidth = globalScope?.innerWidth ?? 0;
   const rect = element.getBoundingClientRect();
   const midHeightLine = rect.top + rect.height * EXPOSURE_VIEWED_THRESHOLD;
+  let visibleLeft = Math.max(rect.left, 0);
+  let visibleRight = Math.min(rect.right, viewportWidth);
 
-  return (
-    midHeightLine >= -MID_HEIGHT_LINE_TOLERANCE_PX &&
-    midHeightLine <= viewportHeight + MID_HEIGHT_LINE_TOLERANCE_PX &&
-    rect.right > 0 &&
-    rect.left < viewportWidth &&
-    rect.width > 0
-  );
+  if (
+    midHeightLine < -MID_HEIGHT_LINE_TOLERANCE_PX ||
+    midHeightLine > viewportHeight + MID_HEIGHT_LINE_TOLERANCE_PX ||
+    visibleLeft >= visibleRight ||
+    rect.width <= 0
+  ) {
+    return false;
+  }
+
+  let ancestor = getVisualParent(element);
+  while (ancestor) {
+    /* istanbul ignore next -- getComputedStyle exists whenever trackExposure is installed */
+    const style = globalScope?.getComputedStyle(ancestor);
+    if (style) {
+      const ancestorRect = ancestor.getBoundingClientRect();
+      if (
+        clipsAxis(style.overflowY) &&
+        (midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
+          midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX)
+      ) {
+        return false;
+      }
+      if (clipsAxis(style.overflowX)) {
+        visibleLeft = Math.max(visibleLeft, ancestorRect.left);
+        visibleRight = Math.min(visibleRight, ancestorRect.right);
+        if (visibleLeft >= visibleRight) {
+          return false;
+        }
+      }
+    }
+    ancestor = getVisualParent(ancestor);
+  }
+
+  return true;
 };
 
 export function trackExposure({

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -1,18 +1,33 @@
 /* eslint-disable no-restricted-globals */
-import { DEFAULT_EXPOSURE_DURATION } from '@amplitude/analytics-core';
+import { DEFAULT_EXPOSURE_DURATION, getGlobalScope } from '@amplitude/analytics-core';
 import { AllWindowObservables } from '../autocapture-plugin';
-import { EXPOSURE_INTERSECTION_THRESHOLD } from '../constants';
+import { EXPOSURE_VIEWED_THRESHOLD } from '../constants';
 import { DataExtractor } from '../data-extractor';
 
-// Sub-pixel rounding can report a ratio a hair below the threshold on the very callback that
-// crossed it, which would otherwise strand an element that stops scrolling right at the boundary.
-const INTERSECTION_RATIO_TOLERANCE = 0.001;
-const MIN_INTERSECTION_RATIO = EXPOSURE_INTERSECTION_THRESHOLD - INTERSECTION_RATIO_TOLERANCE;
+/**
+ * Contentsquare's Zoning exposure metric considers a zone viewed when its
+ * mid-height pixel line is inside the viewport. This is intentionally not an
+ * intersection-area check: a zone taller than the viewport can still expose
+ * its midpoint as the visitor scrolls through it.
+ * https://support.contentsquare.com/hc/en-us/articles/37271856122001-Exposure-Rate
+ */
+const isMidHeightLineVisible = (element: Element): boolean => {
+  const globalScope = getGlobalScope();
+  /* istanbul ignore next -- trackExposure is only installed in a browser */
+  const viewportHeight = globalScope?.innerHeight ?? 0;
+  /* istanbul ignore next -- trackExposure is only installed in a browser */
+  const viewportWidth = globalScope?.innerWidth ?? 0;
+  const rect = element.getBoundingClientRect();
+  const midHeightLine = rect.top + rect.height * EXPOSURE_VIEWED_THRESHOLD;
 
-// `isIntersecting` alone is not enough: the spec defines it as any overlap with the root, so the
-// ratio is what actually holds the element to EXPOSURE_INTERSECTION_THRESHOLD.
-const isSeen = (entry: IntersectionObserverEntry): boolean =>
-  entry.isIntersecting && entry.intersectionRatio >= MIN_INTERSECTION_RATIO;
+  return (
+    midHeightLine >= 0 &&
+    midHeightLine <= viewportHeight &&
+    rect.right > 0 &&
+    rect.left < viewportWidth &&
+    rect.width > 0
+  );
+};
 
 export function trackExposure({
   allObservables,
@@ -31,55 +46,75 @@ export function trackExposure({
   // Track active timers for elements that are currently visible but not yet exposed
   const exposureTimerMap = new Map<Element, ReturnType<typeof setTimeout> | null | undefined>();
 
-  const { exposureObservable } = allObservables;
+  // IntersectionObserver keeps this set limited to elements touching the viewport,
+  // so scroll handling does not measure every allowlisted element on the page.
+  const intersectingElements = new Set<Element>();
+
+  const cancelExposure = (element: Element) => {
+    const timer = exposureTimerMap.get(element);
+    if (timer) {
+      clearTimeout(timer);
+      exposureTimerMap.set(element, null);
+    }
+  };
+
+  const updateExposure = (element: Element) => {
+    if (!isMidHeightLineVisible(element)) {
+      cancelExposure(element);
+      return;
+    }
+
+    if (exposureMap.get(element) || exposureTimerMap.get(element)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      exposureMap.set(element, true);
+
+      const elementPath = dataExtractor.getElementPath(element);
+      onExposure(elementPath);
+      exposureTimerMap.set(element, null);
+    }, exposureDuration);
+
+    exposureTimerMap.set(element, timer);
+  };
+
+  const { exposureObservable, scrollObservable } = allObservables;
 
   const exposureSubscription = exposureObservable.subscribe((event) => {
     const entry = event as unknown as IntersectionObserverEntry;
     const element = entry.target;
 
-    if (isSeen(entry)) {
-      // Element became visible enough - start exposure timer if not already exposed
-      if (!exposureMap.get(element)) {
-        const existingTimer = exposureTimerMap.get(element);
-        if (existingTimer) {
-          clearTimeout(existingTimer);
-        }
-        const timer = setTimeout(() => {
-          // Element has been visible for exposureDuration - mark as exposed
-          exposureMap.set(element, true);
-
-          // Record the CSS selector path in the shared exposure state
-          const elementPath = dataExtractor.getElementPath(element);
-          onExposure(elementPath);
-
-          // Clear the timer reference
-          exposureTimerMap.set(element, null);
-        }, exposureDuration);
-
-        exposureTimerMap.set(element, timer);
-      }
+    if (entry.isIntersecting) {
+      intersectingElements.add(element);
+      updateExposure(element);
     } else {
-      // Element left the viewport or dropped below the threshold - cancel exposure timer if one exists
-      const timer = exposureTimerMap.get(element);
-      if (timer) {
-        clearTimeout(timer);
-        exposureTimerMap.set(element, null);
-      }
+      intersectingElements.delete(element);
+      cancelExposure(element);
     }
   });
+
+  const scrollSubscription = scrollObservable.subscribe(() => {
+    intersectingElements.forEach(updateExposure);
+  });
+
+  const clearExposureState = () => {
+    exposureTimerMap.forEach((timer) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    });
+    exposureTimerMap.clear();
+    exposureMap.clear();
+    intersectingElements.clear();
+  };
 
   return {
     unsubscribe: () => {
       exposureSubscription.unsubscribe();
+      scrollSubscription.unsubscribe();
+      clearExposureState();
     },
-    reset: () => {
-      exposureTimerMap.forEach((timer) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-      });
-      exposureTimerMap.clear();
-      exposureMap.clear();
-    },
+    reset: clearExposureState,
   };
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -23,9 +23,9 @@ const getVisualParent = (element: Element): Element | null => {
 const isMidHeightLineVisible = (element: Element): boolean => {
   const globalScope = getGlobalScope();
   /* istanbul ignore next -- trackExposure is only installed in a browser */
-  const viewportHeight = globalScope?.innerHeight ?? 0;
+  const viewportHeight = globalScope!.document.documentElement.clientHeight || globalScope!.innerHeight;
   /* istanbul ignore next -- trackExposure is only installed in a browser */
-  const viewportWidth = globalScope?.innerWidth ?? 0;
+  const viewportWidth = globalScope!.document.documentElement.clientWidth || globalScope!.innerWidth;
   const rect = element.getBoundingClientRect();
   const midHeightLine = rect.top + rect.height * EXPOSURE_VIEWED_THRESHOLD;
 
@@ -39,7 +39,15 @@ const isMidHeightLineVisible = (element: Element): boolean => {
     return false;
   }
 
-  let ancestor = getVisualParent(element);
+  const elementStyle = globalScope!.getComputedStyle(element);
+  // A fixed element whose containing block is the viewport escapes ancestor
+  // overflow clipping. If transform/filter/contain establishes an ancestor
+  // containing block, browsers expose that element as offsetParent; clipping
+  // resumes there without us having to duplicate the CSS containing-block rules.
+  let ancestor =
+    elementStyle.position === 'fixed' && element instanceof HTMLElement
+      ? element.offsetParent
+      : getVisualParent(element);
   while (ancestor) {
     /* istanbul ignore next -- trackExposure is only installed in a browser */
     const overflow = globalScope!.getComputedStyle(ancestor).overflowY;

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -16,18 +16,8 @@ import { DataExtractor } from '../data-extractor';
 // A sub-pixel difference should not decide whether a zone was viewed.
 const MID_HEIGHT_LINE_TOLERANCE_PX = 1;
 
-const CLIPPING_OVERFLOW_VALUES = new Set(['auto', 'clip', 'hidden', 'overlay', 'scroll']);
-const clipsAxis = (overflow: string): boolean => CLIPPING_OVERFLOW_VALUES.has(overflow);
-
 const getVisualParent = (element: Element): Element | null => {
-  if (element.assignedSlot) {
-    return element.assignedSlot;
-  }
-  if (element.parentElement) {
-    return element.parentElement;
-  }
-  const root = element.getRootNode();
-  return root instanceof ShadowRoot ? root.host : null;
+  return element.assignedSlot || element.parentElement || (element.parentNode as ShadowRoot | null)?.host || null;
 };
 
 const isMidHeightLineVisible = (element: Element): boolean => {
@@ -38,13 +28,12 @@ const isMidHeightLineVisible = (element: Element): boolean => {
   const viewportWidth = globalScope?.innerWidth ?? 0;
   const rect = element.getBoundingClientRect();
   const midHeightLine = rect.top + rect.height * EXPOSURE_VIEWED_THRESHOLD;
-  let visibleLeft = Math.max(rect.left, 0);
-  let visibleRight = Math.min(rect.right, viewportWidth);
 
   if (
     midHeightLine < -MID_HEIGHT_LINE_TOLERANCE_PX ||
     midHeightLine > viewportHeight + MID_HEIGHT_LINE_TOLERANCE_PX ||
-    visibleLeft >= visibleRight ||
+    rect.right <= 0 ||
+    rect.left >= viewportWidth ||
     rect.width <= 0
   ) {
     return false;
@@ -52,23 +41,16 @@ const isMidHeightLineVisible = (element: Element): boolean => {
 
   let ancestor = getVisualParent(element);
   while (ancestor) {
-    /* istanbul ignore next -- getComputedStyle exists whenever trackExposure is installed */
-    const style = globalScope?.getComputedStyle(ancestor);
-    if (style) {
+    /* istanbul ignore next -- trackExposure is only installed in a browser */
+    const overflow = globalScope!.getComputedStyle(ancestor).overflowY;
+    // Browsers return "visible" by default; jsdom returns an empty string.
+    if (overflow && overflow !== 'visible') {
       const ancestorRect = ancestor.getBoundingClientRect();
       if (
-        clipsAxis(style.overflowY) &&
-        (midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
-          midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX)
+        midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
+        midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX
       ) {
         return false;
-      }
-      if (clipsAxis(style.overflowX)) {
-        visibleLeft = Math.max(visibleLeft, ancestorRect.left);
-        visibleRight = Math.min(visibleRight, ancestorRect.right);
-        if (visibleLeft >= visibleRight) {
-          return false;
-        }
       }
     }
     ancestor = getVisualParent(ancestor);

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -128,7 +128,12 @@ export function trackExposure({
     intersectingElements.forEach(updateExposure);
   });
 
-  const clearExposureState = () => {
+  // Page-view scoped: which zones were already reported, plus any dwell in
+  // progress. The intersecting set is deliberately left alone — it tracks live
+  // viewport geometry, and IntersectionObserver does not re-notify an element
+  // that is already intersecting, so dropping it here would silently stop the
+  // scroll checks for everything currently on screen.
+  const clearPageViewState = () => {
     exposureTimerMap.forEach((timer) => {
       if (timer) {
         clearTimeout(timer);
@@ -136,15 +141,20 @@ export function trackExposure({
     });
     exposureTimerMap.clear();
     exposureMap.clear();
-    intersectingElements.clear();
   };
 
   return {
     unsubscribe: () => {
       exposureSubscription.unsubscribe();
       scrollSubscription.unsubscribe();
-      clearExposureState();
+      clearPageViewState();
+      intersectingElements.clear();
     },
-    reset: clearExposureState,
+    reset: () => {
+      clearPageViewState();
+      // A new page view starts fresh, so anything already sitting at its midpoint
+      // begins its dwell again rather than waiting for the next scroll.
+      intersectingElements.forEach(updateExposure);
+    },
   };
 }

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -5,11 +5,9 @@ import { EXPOSURE_VIEWED_THRESHOLD } from '../constants';
 import { DataExtractor } from '../data-extractor';
 
 /**
- * Contentsquare's Zoning exposure metric considers a zone viewed when its
- * mid-height pixel line is inside the viewport. This is intentionally not an
- * intersection-area check: a zone taller than the viewport can still expose
- * its midpoint as the visitor scrolls through it.
- * https://support.contentsquare.com/hc/en-us/articles/37271856122001-Exposure-Rate
+ * A zone is viewed when its mid-height pixel line is inside the viewport.
+ * This is intentionally not an intersection-area check: a zone taller than
+ * the viewport can still expose its midpoint as the visitor scrolls through it.
  */
 // Engines round fractional scroll offsets differently, so after the same scroll the
 // mid-height line can land a fraction of a pixel either side of the viewport edge.

--- a/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
+++ b/packages/plugin-autocapture-browser/src/autocapture/track-exposure.ts
@@ -11,6 +11,11 @@ import { DataExtractor } from '../data-extractor';
  * its midpoint as the visitor scrolls through it.
  * https://support.contentsquare.com/hc/en-us/articles/37271856122001-Exposure-Rate
  */
+// Engines round fractional scroll offsets differently, so after the same scroll the
+// mid-height line can land a fraction of a pixel either side of the viewport edge.
+// A sub-pixel difference should not decide whether a zone was viewed.
+const MID_HEIGHT_LINE_TOLERANCE_PX = 1;
+
 const isMidHeightLineVisible = (element: Element): boolean => {
   const globalScope = getGlobalScope();
   /* istanbul ignore next -- trackExposure is only installed in a browser */
@@ -21,8 +26,8 @@ const isMidHeightLineVisible = (element: Element): boolean => {
   const midHeightLine = rect.top + rect.height * EXPOSURE_VIEWED_THRESHOLD;
 
   return (
-    midHeightLine >= 0 &&
-    midHeightLine <= viewportHeight &&
+    midHeightLine >= -MID_HEIGHT_LINE_TOLERANCE_PX &&
+    midHeightLine <= viewportHeight + MID_HEIGHT_LINE_TOLERANCE_PX &&
     rect.right > 0 &&
     rect.left < viewportWidth &&
     rect.width > 0

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -62,6 +62,9 @@ export const PAGE_VIEW_SESSION_STORAGE_KEY = 'AMP_PAGE_VIEW';
 
 export const MAX_ELEMENT_EXPOSED_STR_LENGTH = 18_000;
 
+/** Fraction of an element that must be inside the viewport for it to count as seen. */
+export const EXPOSURE_INTERSECTION_THRESHOLD = 0.5;
+
 /** DOM must be quiet for this long before the initial exposure snapshot runs. Matches DEFAULT_EXPOSURE_DURATION. */
 export const EXPOSURE_SNAPSHOT_QUIET_MS = 150;
 

--- a/packages/plugin-autocapture-browser/src/constants.ts
+++ b/packages/plugin-autocapture-browser/src/constants.ts
@@ -63,7 +63,8 @@ export const PAGE_VIEW_SESSION_STORAGE_KEY = 'AMP_PAGE_VIEW';
 export const MAX_ELEMENT_EXPOSED_STR_LENGTH = 18_000;
 
 /** Fraction of an element that must be inside the viewport for it to count as seen. */
-export const EXPOSURE_INTERSECTION_THRESHOLD = 0.5;
+/** Vertical depth of a zone that must enter the viewport for it to count as viewed. */
+export const EXPOSURE_VIEWED_THRESHOLD = 0.5;
 
 /** DOM must be quiet for this long before the initial exposure snapshot runs. Matches DEFAULT_EXPOSURE_DURATION. */
 export const EXPOSURE_SNAPSHOT_QUIET_MS = 150;

--- a/packages/plugin-autocapture-browser/src/observables.ts
+++ b/packages/plugin-autocapture-browser/src/observables.ts
@@ -1,4 +1,5 @@
 import { collectOpenShadowRoots, isShadowRoot } from '@amplitude/element-selector';
+import { EXPOSURE_INTERSECTION_THRESHOLD } from './constants';
 import { querySelectorAllDeep, TimestampedEvent } from './helpers';
 import { type ShadowGate, type ShadowMode } from './shadow-mode';
 import { Observable, consoleObserver, getGlobalScope, merge } from '@amplitude/analytics-core';
@@ -223,7 +224,7 @@ export const createExposureObservable = (
       {
         root: null, // viewport
         rootMargin: '0px', // start exactly at the viewport edge
-        threshold: 1.0, // trigger when 100% of the element is visible
+        threshold: EXPOSURE_INTERSECTION_THRESHOLD, // trigger when half of the element is visible
       },
     );
 

--- a/packages/plugin-autocapture-browser/src/observables.ts
+++ b/packages/plugin-autocapture-browser/src/observables.ts
@@ -171,9 +171,12 @@ export const createScrollObservable = (): Observable<Event> => {
       observer.next(event);
     };
 
-    getGlobalScope()?.addEventListener('scroll', handler);
+    // Element scroll events do not bubble, but they do travel through the capture
+    // phase. Capture at window so overflow containers and document scrolling share
+    // one observable.
+    getGlobalScope()?.addEventListener('scroll', handler, { capture: true, passive: true });
     return () => {
-      getGlobalScope()?.removeEventListener('scroll', handler);
+      getGlobalScope()?.removeEventListener('scroll', handler, { capture: true });
     };
   });
 };

--- a/packages/plugin-autocapture-browser/src/observables.ts
+++ b/packages/plugin-autocapture-browser/src/observables.ts
@@ -175,8 +175,12 @@ export const createScrollObservable = (): Observable<Event> => {
     // phase. Capture at window so overflow containers and document scrolling share
     // one observable.
     getGlobalScope()?.addEventListener('scroll', handler, { capture: true, passive: true });
+    // IntersectionObserver with threshold 0 does not necessarily emit when a
+    // resize keeps an element intersecting but moves its midpoint into view.
+    getGlobalScope()?.addEventListener('resize', handler, { passive: true });
     return () => {
       getGlobalScope()?.removeEventListener('scroll', handler, { capture: true });
+      getGlobalScope()?.removeEventListener('resize', handler);
     };
   });
 };

--- a/packages/plugin-autocapture-browser/src/observables.ts
+++ b/packages/plugin-autocapture-browser/src/observables.ts
@@ -1,5 +1,4 @@
 import { collectOpenShadowRoots, isShadowRoot } from '@amplitude/element-selector';
-import { EXPOSURE_INTERSECTION_THRESHOLD } from './constants';
 import { querySelectorAllDeep, TimestampedEvent } from './helpers';
 import { type ShadowGate, type ShadowMode } from './shadow-mode';
 import { Observable, consoleObserver, getGlobalScope, merge } from '@amplitude/analytics-core';
@@ -224,7 +223,9 @@ export const createExposureObservable = (
       {
         root: null, // viewport
         rootMargin: '0px', // start exactly at the viewport edge
-        threshold: EXPOSURE_INTERSECTION_THRESHOLD, // trigger when half of the element is visible
+        // Keep intersecting elements as a small candidate set. Their mid-height
+        // line is evaluated on scroll by trackExposure.
+        threshold: 0,
       },
     );
 

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -52,6 +52,8 @@ describe('trackExposure', () => {
     observers.forEach((observer) => observer(entry));
   };
 
+  const rect = (width: number, height: number) => ({ width, height } as DOMRectReadOnly);
+
   test('should mark element as exposed after 2 seconds of visibility', () => {
     const element = document.createElement('div');
     element.id = 'test-div';
@@ -208,13 +210,100 @@ describe('trackExposure', () => {
     triggerExposure({
       isIntersecting: false,
       target: element,
-      intersectionRatio: 0.5, // < 1.0
+      intersectionRatio: 0,
     });
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
     expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should expose an element that is half visible', () => {
+    const element = document.createElement('div');
+    element.id = 'half-visible';
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.5,
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    expect(onExposure).toHaveBeenCalledWith('div#half-visible');
+  });
+
+  test('should not expose an element that is visible by less than half', () => {
+    const element = document.createElement('div');
+    element.id = 'barely-visible';
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.3,
+      rootBounds: null,
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should not expose a partially visible element when the viewport has no area', () => {
+    const element = document.createElement('div');
+    element.id = 'zero-area-viewport';
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.3,
+      rootBounds: rect(0, 0),
+      intersectionRect: rect(0, 0),
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should cancel a pending exposure when the element scrolls below half visible', () => {
+    const element = document.createElement('div');
+    element.id = 'scrolled-away';
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.6,
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION / 2);
+
+    // Still touching the viewport, but no longer visible enough to count.
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.4,
+      rootBounds: rect(1024, 768),
+      intersectionRect: rect(1024, 100),
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should expose an element taller than the viewport once it fills half the viewport', () => {
+    const element = document.createElement('div');
+    element.id = 'taller-than-viewport';
+
+    // A 2560px tall element can only ever reach a ratio of 0.3 in a 768px viewport.
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.3,
+      rootBounds: rect(1024, 768),
+      intersectionRect: rect(1024, 768),
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    expect(onExposure).toHaveBeenCalledWith('div#taller-than-viewport');
   });
 
   test('should clear all timers and exposure map on reset', () => {

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -52,8 +52,6 @@ describe('trackExposure', () => {
     observers.forEach((observer) => observer(entry));
   };
 
-  const rect = (width: number, height: number) => ({ width, height } as DOMRectReadOnly);
-
   test('should mark element as exposed after 2 seconds of visibility', () => {
     const element = document.createElement('div');
     element.id = 'test-div';
@@ -241,23 +239,6 @@ describe('trackExposure', () => {
       isIntersecting: true,
       target: element,
       intersectionRatio: 0.3,
-      rootBounds: null,
-    });
-
-    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
-    expect(onExposure).not.toHaveBeenCalled();
-  });
-
-  test('should not expose a partially visible element when the viewport has no area', () => {
-    const element = document.createElement('div');
-    element.id = 'zero-area-viewport';
-
-    triggerExposure({
-      isIntersecting: true,
-      target: element,
-      intersectionRatio: 0.3,
-      rootBounds: rect(0, 0),
-      intersectionRect: rect(0, 0),
     });
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
@@ -281,29 +262,10 @@ describe('trackExposure', () => {
       isIntersecting: true,
       target: element,
       intersectionRatio: 0.4,
-      rootBounds: rect(1024, 768),
-      intersectionRect: rect(1024, 100),
     });
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
     expect(onExposure).not.toHaveBeenCalled();
-  });
-
-  test('should expose an element taller than the viewport once it fills half the viewport', () => {
-    const element = document.createElement('div');
-    element.id = 'taller-than-viewport';
-
-    // A 2560px tall element can only ever reach a ratio of 0.3 in a 768px viewport.
-    triggerExposure({
-      isIntersecting: true,
-      target: element,
-      intersectionRatio: 0.3,
-      rootBounds: rect(1024, 768),
-      intersectionRect: rect(1024, 768),
-    });
-
-    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
-    expect(onExposure).toHaveBeenCalledWith('div#taller-than-viewport');
   });
 
   test('should clear all timers and exposure map on reset', () => {

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -382,16 +382,11 @@ describe('trackExposure', () => {
     expect(onExposure).toHaveBeenCalledTimes(1);
   });
 
-  test('should not expose a midpoint whose entire line is horizontally clipped', () => {
-    const scroller = document.createElement('div');
-    scroller.style.overflowX = 'hidden';
+  test('should not expose a midpoint whose entire line is outside the viewport horizontally', () => {
     const element = document.createElement('div');
-    element.id = 'horizontally-clipped';
-    scroller.appendChild(element);
-    document.body.appendChild(scroller);
+    element.id = 'horizontally-outside';
 
-    setRect(scroller, { top: 0, height: 300, left: 200, width: 100 });
-    setRect(element, { top: 100, height: 100, left: 100, width: 100 });
+    setRect(element, { top: 100, height: 100, left: -100, width: 100 });
     triggerExposure({ isIntersecting: true, target: element });
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -262,6 +262,22 @@ describe('trackExposure', () => {
     expect(onExposure).toHaveBeenCalledWith('div#half-visible');
   });
 
+  test('should expose when the mid-height line lands a sub-pixel below the viewport edge', () => {
+    const element = document.createElement('div');
+    element.id = 'sub-pixel-boundary';
+    // jsdom reports innerHeight 768; engines disagree by well under a pixel on where
+    // the line sits after an identical scroll, so this must not flip the outcome.
+    setRect(element, { top: 718.6 });
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('div#sub-pixel-boundary');
+  });
+
   test('should not expose an element before its mid-height line enters the viewport', () => {
     const element = document.createElement('div');
     element.id = 'barely-visible';

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -433,6 +433,55 @@ describe('trackExposure', () => {
     expect(onExposure).not.toHaveBeenCalled();
   });
 
+  test('should keep evaluating still-intersecting elements on scroll after a reset', () => {
+    const element = document.createElement('div');
+    element.id = 'reset-then-scroll';
+    // Below its midpoint, so nothing is exposed before the reset.
+    setRect(element, { top: 740 });
+    triggerExposure({ isIntersecting: true, target: element });
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+
+    // A page-view end resets state. IntersectionObserver will not fire again for
+    // an element that never stopped intersecting, so scroll must still drive it.
+    reset();
+
+    setRect(element, { top: 700 });
+    triggerScroll();
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('div#reset-then-scroll');
+  });
+
+  test('should restart the dwell on reset for an element already at its midpoint', () => {
+    const element = document.createElement('div');
+    element.id = 'reset-at-midpoint';
+    setRect(element, { top: 700 });
+    triggerExposure({ isIntersecting: true, target: element });
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledTimes(1);
+    onExposure.mockClear();
+
+    // New page view: the zone is still on screen at its midpoint, so it should be
+    // reported again without requiring another scroll or intersection change.
+    reset();
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('div#reset-at-midpoint');
+  });
+
+  test('should stop evaluating elements after unsubscribe', () => {
+    const element = document.createElement('div');
+    element.id = 'after-unsubscribe';
+    setRect(element, { top: 700 });
+    triggerExposure({ isIntersecting: true, target: element });
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    onExposure.mockClear();
+
+    unsubscribe();
+    triggerScroll();
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
   test('should clear all timers and exposure map on reset', () => {
     const element1 = document.createElement('div');
     element1.id = 'reset-div-1';
@@ -456,24 +505,23 @@ describe('trackExposure', () => {
       target: element1,
       intersectionRatio: 1.0,
     });
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 0.6);
 
     // Call reset
     reset();
 
-    // Expect pending timer for element 1 to be cleared
+    // Expect the part-elapsed timer for element 1 to be cleared
     expect(clearTimeoutSpy).toHaveBeenCalled();
 
-    // Fast forward to see if pending timer fires (should not)
-    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    // The partially elapsed dwell must not carry into the new page view: element 1
+    // is still at its midpoint, so it re-exposes only after a full fresh duration.
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 0.6);
     expect(onExposure).not.toHaveBeenCalledWith('div#reset-div-1');
 
-    // Re-expose element 2 (should work again because map was cleared)
-    triggerExposure({
-      isIntersecting: true,
-      target: element2,
-      intersectionRatio: 1.0,
-    });
-    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
+    // Both zones remain at their midpoints, so the new page view reports both again
+    // because the exposure map was cleared.
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 0.6);
+    expect(onExposure).toHaveBeenCalledWith('div#reset-div-1');
     expect(onExposure).toHaveBeenCalledWith('div#reset-div-2');
   });
 });

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -5,19 +5,29 @@ import { DEFAULT_EXPOSURE_DURATION } from '@amplitude/analytics-core';
 
 describe('trackExposure', () => {
   let exposureObservable: any;
+  let scrollObservable: any;
   let allObservables: AllWindowObservables;
   let onExposure: jest.Mock;
   let unsubscribe: () => void;
   let reset: () => void;
-  let observers: Array<(val: any) => void> = [];
+  let exposureObservers: Array<(val: any) => void> = [];
+  let scrollObservers: Array<(val: any) => void> = [];
 
   beforeEach(() => {
     jest.useFakeTimers();
     onExposure = jest.fn();
-    observers = [];
+    exposureObservers = [];
+    scrollObservers = [];
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 700,
+      bottom: 800,
+      left: 0,
+      right: 100,
+      width: 100,
+      height: 100,
+    } as DOMRect);
 
-    // Mock Observable implementation
-    exposureObservable = {
+    const observable = (observers: Array<(val: any) => void>) => ({
       subscribe: (fn: (val: any) => void) => {
         observers.push(fn);
         return {
@@ -26,10 +36,13 @@ describe('trackExposure', () => {
           },
         };
       },
-    };
+    });
+    exposureObservable = observable(exposureObservers);
+    scrollObservable = observable(scrollObservers);
 
     allObservables = {
       [ObservablesEnum.ExposureObservable]: exposureObservable,
+      [ObservablesEnum.ScrollObservable]: scrollObservable,
     } as any;
 
     const dataExtractor = new DataExtractor({});
@@ -49,24 +62,44 @@ describe('trackExposure', () => {
   });
 
   const triggerExposure = (entry: Partial<IntersectionObserverEntry>) => {
-    observers.forEach((observer) => observer(entry));
+    exposureObservers.forEach((observer) => observer(entry));
   };
 
-  test('should mark element as exposed after 2 seconds of visibility', () => {
+  const triggerScroll = () => {
+    scrollObservers.forEach((observer) => observer(new Event('scroll')));
+  };
+
+  const setRect = (
+    element: Element,
+    { top, height = 100, left = 0, width = 100 }: { top: number; height?: number; left?: number; width?: number },
+  ) => {
+    element.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          top,
+          bottom: top + height,
+          left,
+          right: left + width,
+          width,
+          height,
+        } as DOMRect),
+    );
+  };
+
+  test('should mark element as exposed after its mid-height line is visible for the exposure duration', () => {
     const element = document.createElement('div');
     element.id = 'test-div';
+    setRect(element, { top: 700 });
 
     triggerExposure({
       isIntersecting: true,
       target: element,
-      intersectionRatio: 1.0,
     });
 
     // Should not be exposed yet
     expect(onExposure).not.toHaveBeenCalled();
 
-    // Fast forward 2 seconds
-    jest.advanceTimersByTime(2000);
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
 
     expect(onExposure).toHaveBeenCalledWith('div#test-div');
   });
@@ -95,7 +128,7 @@ describe('trackExposure', () => {
     expect(onExposure).not.toHaveBeenCalled();
   });
 
-  test('should replace a pending exposure timer on a second intersecting callback', () => {
+  test('should preserve a pending exposure timer across repeated intersecting callbacks', () => {
     const element = document.createElement('div');
     element.id = 'test-div-reobserve';
     const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
@@ -107,17 +140,14 @@ describe('trackExposure', () => {
     });
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION / 2);
 
-    // A rescan unobserve/observe delivers another intersecting callback while the
-    // first timer is still pending. The old timer must not fire after reset/nav.
+    // A rescan or scroll can evaluate an element again while its midpoint remains
+    // visible. That must not restart the timer or slow scrolling would never expose.
     triggerExposure({
       isIntersecting: true,
       target: element,
       intersectionRatio: 1.0,
     });
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-
-    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION / 2);
-    expect(onExposure).not.toHaveBeenCalled();
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION / 2);
     expect(onExposure).toHaveBeenCalledTimes(1);
@@ -217,23 +247,25 @@ describe('trackExposure', () => {
     expect(onExposure).not.toHaveBeenCalled();
   });
 
-  test('should expose an element that is half visible', () => {
+  test('should expose an element once its mid-height line enters the viewport', () => {
     const element = document.createElement('div');
     element.id = 'half-visible';
+    setRect(element, { top: 718 });
 
     triggerExposure({
       isIntersecting: true,
       target: element,
-      intersectionRatio: 0.5,
+      intersectionRatio: 0.1,
     });
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
     expect(onExposure).toHaveBeenCalledWith('div#half-visible');
   });
 
-  test('should not expose an element that is visible by less than half', () => {
+  test('should not expose an element before its mid-height line enters the viewport', () => {
     const element = document.createElement('div');
     element.id = 'barely-visible';
+    setRect(element, { top: 740 });
 
     triggerExposure({
       isIntersecting: true,
@@ -245,9 +277,45 @@ describe('trackExposure', () => {
     expect(onExposure).not.toHaveBeenCalled();
   });
 
-  test('should cancel a pending exposure when the element scrolls below half visible', () => {
+  test('should expose a zone taller than the viewport when its mid-height line is viewed', () => {
+    const element = document.createElement('div');
+    element.id = 'oversized';
+    setRect(element, { top: -900, height: 2000 });
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      // Less than half its area can ever be visible at once.
+      intersectionRatio: 0.384,
+    });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('div#oversized');
+  });
+
+  test('should start exposure on scroll when an intersecting zone reaches its mid-height line', () => {
+    const element = document.createElement('div');
+    element.id = 'scrolled-to-midpoint';
+    setRect(element, { top: 740 });
+
+    triggerExposure({
+      isIntersecting: true,
+      target: element,
+      intersectionRatio: 0.28,
+    });
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+
+    setRect(element, { top: 700 });
+    triggerScroll();
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('div#scrolled-to-midpoint');
+  });
+
+  test('should cancel a pending exposure when the mid-height line leaves the viewport', () => {
     const element = document.createElement('div');
     element.id = 'scrolled-away';
+    setRect(element, { top: 700 });
 
     triggerExposure({
       isIntersecting: true,
@@ -257,12 +325,9 @@ describe('trackExposure', () => {
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION / 2);
 
-    // Still touching the viewport, but no longer visible enough to count.
-    triggerExposure({
-      isIntersecting: true,
-      target: element,
-      intersectionRatio: 0.4,
-    });
+    // Still touching the viewport, but its midpoint is now below it.
+    setRect(element, { top: 740 });
+    triggerScroll();
 
     jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION * 1.5);
     expect(onExposure).not.toHaveBeenCalled();

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -341,6 +341,42 @@ describe('trackExposure', () => {
     expect(onExposure).not.toHaveBeenCalled();
   });
 
+  test('should ignore overflow ancestors for a viewport-fixed element', () => {
+    const clipper = document.createElement('div');
+    clipper.style.overflowY = 'hidden';
+    const element = document.createElement('button');
+    element.style.position = 'fixed';
+    element.id = 'viewport-fixed';
+    clipper.appendChild(element);
+    document.body.appendChild(clipper);
+
+    setRect(clipper, { top: 200, height: 100 });
+    setRect(element, { top: 100, height: 100 });
+    expect(element.offsetParent).toBeNull();
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('button#viewport-fixed');
+  });
+
+  test('should clip a fixed element when an ancestor establishes its containing block', () => {
+    const clipper = document.createElement('div');
+    clipper.style.overflowY = 'hidden';
+    const element = document.createElement('button');
+    element.style.position = 'fixed';
+    element.id = 'ancestor-fixed';
+    clipper.appendChild(element);
+    document.body.appendChild(clipper);
+    Object.defineProperty(element, 'offsetParent', { configurable: true, value: clipper });
+
+    setRect(clipper, { top: 200, height: 100 });
+    setRect(element, { top: 100, height: 100 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
   test('should expose through non-clipping ancestors and open shadow roots', () => {
     const host = document.createElement('div');
     const root = host.attachShadow({ mode: 'open' });

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -309,6 +309,95 @@ describe('trackExposure', () => {
     expect(onExposure).toHaveBeenCalledWith('div#oversized');
   });
 
+  test('should not expose a midpoint clipped by an overflow ancestor', () => {
+    const scroller = document.createElement('div');
+    scroller.style.overflowY = 'hidden';
+    const element = document.createElement('div');
+    element.id = 'vertically-clipped';
+    scroller.appendChild(element);
+    document.body.appendChild(scroller);
+
+    setRect(scroller, { top: 200, height: 100 });
+    setRect(element, { top: 100, height: 100 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should not expose a midpoint below an overflow ancestor', () => {
+    const scroller = document.createElement('div');
+    scroller.style.overflowY = 'auto';
+    const element = document.createElement('div');
+    element.id = 'clipped-below';
+    scroller.appendChild(element);
+    document.body.appendChild(scroller);
+
+    setRect(scroller, { top: 0, height: 100 });
+    setRect(element, { top: 100, height: 100 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should expose through non-clipping ancestors and open shadow roots', () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    const wrapper = document.createElement('div');
+    const element = document.createElement('button');
+    element.id = 'shadow-midpoint';
+    wrapper.appendChild(element);
+    root.appendChild(wrapper);
+    document.body.appendChild(host);
+
+    setRect(host, { top: 0, height: 300 });
+    setRect(wrapper, { top: 0, height: 300 });
+    setRect(element, { top: 100, height: 100 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledTimes(1);
+  });
+
+  test('should follow assigned slots when checking clipping ancestors', () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    const slot = document.createElement('slot');
+    slot.name = 'content';
+    root.appendChild(slot);
+    const element = document.createElement('button');
+    element.slot = 'content';
+    element.id = 'slotted-midpoint';
+    host.appendChild(element);
+    document.body.appendChild(host);
+
+    expect(element.assignedSlot).toBe(slot);
+    setRect(host, { top: 0, height: 300 });
+    setRect(slot, { top: 0, height: 300 });
+    setRect(element, { top: 100, height: 100 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not expose a midpoint whose entire line is horizontally clipped', () => {
+    const scroller = document.createElement('div');
+    scroller.style.overflowX = 'hidden';
+    const element = document.createElement('div');
+    element.id = 'horizontally-clipped';
+    scroller.appendChild(element);
+    document.body.appendChild(scroller);
+
+    setRect(scroller, { top: 0, height: 300, left: 200, width: 100 });
+    setRect(element, { top: 100, height: 100, left: 100, width: 100 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
   test('should start exposure on scroll when an intersecting zone reaches its mid-height line', () => {
     const element = document.createElement('div');
     element.id = 'scrolled-to-midpoint';

--- a/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
+++ b/packages/plugin-autocapture-browser/test/autocapture-plugin/track-exposure.test.ts
@@ -418,6 +418,60 @@ describe('trackExposure', () => {
     expect(onExposure).toHaveBeenCalledTimes(1);
   });
 
+  test('should not expose a midpoint whose line is fully clipped by a horizontal overflow ancestor', () => {
+    const scroller = document.createElement('div');
+    scroller.style.overflowX = 'hidden';
+    const element = document.createElement('div');
+    element.id = 'horizontally-clipped';
+    scroller.appendChild(element);
+    document.body.appendChild(scroller);
+
+    // The line sits to the right of the scroller's window onto its content.
+    setRect(scroller, { top: 0, height: 300, left: 0, width: 200 });
+    setRect(element, { top: 100, height: 100, left: 300, width: 120 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).not.toHaveBeenCalled();
+  });
+
+  test('should expose a sliver of the line that survives horizontal clipping', () => {
+    const scroller = document.createElement('div');
+    scroller.style.overflowX = 'hidden';
+    const element = document.createElement('div');
+    element.id = 'horizontally-slivered';
+    scroller.appendChild(element);
+    document.body.appendChild(scroller);
+
+    setRect(scroller, { top: 0, height: 300, left: 0, width: 200 });
+    setRect(element, { top: 100, height: 100, left: 190, width: 120 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('div#horizontally-slivered');
+  });
+
+  test('should expose an absolute element that paints outside a static overflow ancestor', () => {
+    // CSS only clips an absolute element from its containing block upwards, so a
+    // static `overflow: hidden` wrapper does not hide it — and the browser reports
+    // the containing block via offsetParent.
+    const staticClipper = document.createElement('div');
+    staticClipper.style.overflow = 'hidden';
+    const element = document.createElement('button');
+    element.style.position = 'absolute';
+    element.id = 'escaping-absolute';
+    staticClipper.appendChild(element);
+    document.body.appendChild(staticClipper);
+    Object.defineProperty(element, 'offsetParent', { configurable: true, value: document.body });
+
+    setRect(staticClipper, { top: 0, height: 20 });
+    setRect(element, { top: 300, height: 80 });
+    triggerExposure({ isIntersecting: true, target: element });
+
+    jest.advanceTimersByTime(DEFAULT_EXPOSURE_DURATION);
+    expect(onExposure).toHaveBeenCalledWith('button#escaping-absolute');
+  });
+
   test('should not expose a midpoint whose entire line is outside the viewport horizontally', () => {
     const element = document.createElement('div');
     element.id = 'horizontally-outside';

--- a/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
+++ b/packages/plugin-autocapture-browser/test/default-event-tracking-advanced.test.ts
@@ -9,6 +9,17 @@ import * as constants from '../src/constants';
 
 const TESTING_DEBOUNCE_TIME = 4;
 
+const setMidHeightLineVisible = (element: Element) => {
+  jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    top: 0,
+    bottom: 100,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 100,
+  } as DOMRect);
+};
+
 describe('autoTrackingPlugin', () => {
   let plugin: EnrichmentPlugin | undefined;
 
@@ -166,6 +177,7 @@ describe('autoTrackingPlugin', () => {
       const element = document.createElement('button');
       element.id = 'exposure-test-button';
       document.body.appendChild(element);
+      setMidHeightLineVisible(element);
 
       // Trigger intersection (element becomes visible)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -236,6 +248,7 @@ describe('autoTrackingPlugin', () => {
       const element = document.createElement('button');
       element.id = 'exposure-test-button';
       document.body.appendChild(element);
+      setMidHeightLineVisible(element);
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       intersectionCallback!([
@@ -303,6 +316,7 @@ describe('autoTrackingPlugin', () => {
       const element = document.createElement('button');
       element.id = 'precedence-test-button';
       document.body.appendChild(element);
+      setMidHeightLineVisible(element);
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       intersectionCallback!([
@@ -2102,6 +2116,7 @@ describe('autoTrackingPlugin', () => {
         const el = document.createElement('div');
         el.id = `${longIdPrefix}-${i}`;
         document.body.appendChild(el);
+        setMidHeightLineVisible(el);
         elements.push(el);
 
         entries.push({

--- a/packages/plugin-autocapture-browser/test/observable.test.ts
+++ b/packages/plugin-autocapture-browser/test/observable.test.ts
@@ -51,6 +51,11 @@ describe('createExposureObservable', () => {
     });
 
     expect(mockIntersectionObserver.observe).toHaveBeenCalledWith(div);
+    expect(global.IntersectionObserver).toHaveBeenCalledWith(expect.any(Function), {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0,
+    });
   });
 
   test('should emit event when element intersects (visible)', () => {

--- a/packages/plugin-autocapture-browser/test/observable.test.ts
+++ b/packages/plugin-autocapture-browser/test/observable.test.ts
@@ -1,4 +1,4 @@
-import { createExposureObservable } from '../src/observables';
+import { createExposureObservable, createScrollObservable } from '../src/observables';
 import { Observable } from '@amplitude/analytics-core';
 import { TimestampedEvent } from '../src/helpers';
 
@@ -274,5 +274,23 @@ describe('createExposureObservable', () => {
 
     subscription.unsubscribe();
     (global as any).IntersectionObserver = originalIntersectionObserver;
+  });
+});
+
+describe('createScrollObservable', () => {
+  test('captures non-bubbling scroll events from overflow elements', () => {
+    const scroller = document.createElement('div');
+    document.body.appendChild(scroller);
+    const listener = jest.fn();
+    const subscription = createScrollObservable().subscribe(listener);
+
+    scroller.dispatchEvent(new Event('scroll', { bubbles: false }));
+
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ target: scroller }));
+
+    subscription.unsubscribe();
+    listener.mockClear();
+    scroller.dispatchEvent(new Event('scroll', { bubbles: false }));
+    expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugin-autocapture-browser/test/observable.test.ts
+++ b/packages/plugin-autocapture-browser/test/observable.test.ts
@@ -278,7 +278,7 @@ describe('createExposureObservable', () => {
 });
 
 describe('createScrollObservable', () => {
-  test('captures non-bubbling scroll events from overflow elements', () => {
+  test('captures overflow scrolls and viewport resizes', () => {
     const scroller = document.createElement('div');
     document.body.appendChild(scroller);
     const listener = jest.fn();
@@ -287,10 +287,13 @@ describe('createScrollObservable', () => {
     scroller.dispatchEvent(new Event('scroll', { bubbles: false }));
 
     expect(listener).toHaveBeenCalledWith(expect.objectContaining({ target: scroller }));
+    window.dispatchEvent(new Event('resize'));
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ type: 'resize' }));
 
     subscription.unsubscribe();
     listener.mockClear();
     scroller.dispatchEvent(new Event('scroll', { bubbles: false }));
+    window.dispatchEvent(new Event('resize'));
     expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -118,12 +118,12 @@
         data-note="sticky site header — stays on screen while you scroll"
     >
         <span class="site-header-nav">
-            <span>All Sports</span>
-            <span>Men</span>
-            <span>Women</span>
-            <span>Kids</span>
+            <span>Home</span>
+            <span>Shop</span>
+            <span>About</span>
+            <span>Help</span>
         </span>
-        <span class="site-header-logo">DECATHLON</span>
+        <span class="site-header-logo">LOGO</span>
         <span class="site-header-actions" aria-hidden="true">
             <span>Search</span>
             <span>Account</span>

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Viewport Exposure (mid-height line) Test</title>
     <style>
-        body { margin: 0; font: 14px/1.5 system-ui, sans-serif; }
+        /* This page's whole purpose is precise scroll positions, and the HUD rewrites
+           itself on every scroll. Scroll anchoring reacts to those updates by nudging
+           the page a line's worth, which silently moves the zone under test. */
+        body { margin: 0; font: 14px/1.5 system-ui, sans-serif; overflow-anchor: none; }
 
         #hud {
             position: fixed; top: 0; left: 0; right: 0; z-index: 2147483647;
@@ -117,6 +120,7 @@
             <button id="scroll-oversized" type="button">#oversized-target 50%</button>
         </div>
         <div id="summary">exposed 0 of 0 zones</div>
+        <div class="hint" id="duration-note"></div>
         <div id="zone-table"></div>
         <div id="status">ready</div>
     </div>
@@ -202,9 +206,12 @@
 
         window.amplitude = amplitude;
 
-        // Matches the plugin default; stated explicitly so the harness and the
-        // Playwright spec can size their waits off the same number.
-        const EXPOSURE_DURATION = 150;
+        // Defaults to the plugin's 150ms, stated explicitly so the harness and the
+        // Playwright spec size their waits off the same number. `?exposureDuration=`
+        // stretches the dwell, which makes it observable by hand and lets timing
+        // assertions keep a wide margin on a loaded CI runner.
+        const EXPOSURE_DURATION =
+            Number(new URLSearchParams(location.search).get('exposureDuration')) || 150;
         const AUTO_FLUSH_MS = 500;
 
         const zones = Array.from(document.querySelectorAll('.zone'));
@@ -237,7 +244,12 @@
             element.parentElement ??
             (element.getRootNode() instanceof ShadowRoot ? element.getRootNode().host : null);
 
-        const isMidHeightLineVisible = (element) => {
+        /**
+         * Returns what is hiding the element's mid-height line: the string 'viewport',
+         * the clipping ancestor element, or null when the line is visible. Naming the
+         * blocker lets the HUD explain *why* a zone has not been exposed.
+         */
+        const midHeightLineBlocker = (element) => {
             const rect = element.getBoundingClientRect();
             const midHeightLine = rect.top + rect.height * 0.5;
             let visibleLeft = Math.max(rect.left, 0);
@@ -247,7 +259,7 @@
                 midHeightLine > viewportHeight() + MID_HEIGHT_LINE_TOLERANCE_PX ||
                 visibleLeft >= visibleRight
             ) {
-                return false;
+                return 'viewport';
             }
 
             let ancestor = getVisualParent(element);
@@ -259,28 +271,63 @@
                     (midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
                         midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX)
                 ) {
-                    return false;
+                    return ancestor;
                 }
                 if (CLIPPING_OVERFLOW_VALUES.has(style.overflowX)) {
                     visibleLeft = Math.max(visibleLeft, ancestorRect.left);
                     visibleRight = Math.min(visibleRight, ancestorRect.right);
-                    if (visibleLeft >= visibleRight) return false;
+                    if (visibleLeft >= visibleRight) return ancestor;
                 }
                 ancestor = getVisualParent(ancestor);
             }
-            return true;
+            return null;
+        };
+
+        const isMidHeightLineVisible = (element) => midHeightLineBlocker(element) === null;
+
+        // Window scrolling alone can never expose a zone parked inside a scrollable
+        // panel, so that panel is the actionable hint rather than scroll speed.
+        const scrollableClippingAncestor = (element) => {
+            let ancestor = getVisualParent(element);
+            while (ancestor) {
+                const overflowY = getComputedStyle(ancestor).overflowY;
+                if (
+                    CLIPPING_OVERFLOW_VALUES.has(overflowY) &&
+                    ancestor.scrollHeight > ancestor.clientHeight + MID_HEIGHT_LINE_TOLERANCE_PX
+                ) {
+                    return ancestor;
+                }
+                ancestor = getVisualParent(ancestor);
+            }
+            return null;
         };
 
         /**
          * Scroll the viewport's bottom edge to `fraction` of the element's vertical
          * depth and return the depth actually reached (clamped by the scroll range).
+         *
+         * Converges with relative scrolls off freshly measured geometry rather than
+         * computing one absolute offset: the layout viewport can change as scrollbars
+         * appear, which silently threw off an absolute target by ~20px.
          */
-        const scrollElementTo = (fraction, element = document.getElementById('exposure-target')) => {
-            const rect = element.getBoundingClientRect();
-            const documentTop = rect.top + window.scrollY;
-            const maxScroll = document.documentElement.scrollHeight - viewportHeight();
-            const scrollY = documentTop + fraction * rect.height - viewportHeight();
-            window.scrollTo(0, Math.max(0, Math.min(scrollY, maxScroll)));
+        const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+        const scrollElementTo = async (fraction, element = document.getElementById('exposure-target')) => {
+            for (let attempt = 0; attempt < 5; attempt++) {
+                const rect = element.getBoundingClientRect();
+                const delta = rect.top - (viewportHeight() - fraction * rect.height);
+                if (Math.abs(delta) < 0.5) break;
+                const before = window.scrollY;
+                window.scrollBy(0, delta);
+                // Let the scroll settle before re-measuring; the position can still
+                // shift by a line's worth after the synchronous call returns.
+                await nextFrame();
+                // Hit the top or bottom of the document; no further correction possible.
+                if (window.scrollY === before) break;
+            }
+            // Report what actually happened rather than what was requested, so the
+            // Playwright guard on the achieved depth is meaningful.
+            await nextFrame();
             return viewedDepth(element);
         };
 
@@ -306,6 +353,7 @@
             visibleFraction,
             viewedDepth,
             isMidHeightLineVisible,
+            midHeightLineBlocker,
             flush,
             setAutoFlush,
             exposedPaths,
@@ -345,11 +393,13 @@
         const render = () => {
             const rows = [];
 
+            const unexposed = [];
+
             zones.forEach((zone) => {
                 const state = zoneState.get(zone);
-                const midpointInView = isMidHeightLineVisible(zone);
-                const depthFraction = viewedDepth(zone);
-                state.maxDepth = Math.max(state.maxDepth, depthFraction);
+                const blocker = midHeightLineBlocker(zone);
+                const midpointInView = blocker === null;
+                state.maxDepth = Math.max(state.maxDepth, viewedDepth(zone));
 
                 // The SDK must never report a zone whose 50% line was never reached.
                 const impossible = state.exposed && state.maxDepth < 0.5;
@@ -361,7 +411,9 @@
                     ? 'viewed'
                     : 'pending';
 
-                const depth = Math.round(depthFraction * 100);
+                // Max depth, not the instantaneous value: an exposed zone you have
+                // since scrolled past should not read "depth 0%".
+                const depth = Math.round(state.maxDepth * 100);
                 const visible = Math.round(visibleFraction(zone) * 100);
 
                 // Derived from measured geometry so the labels cannot drift from the CSS.
@@ -372,31 +424,42 @@
                     (zone.dataset.note ? ` · ${zone.dataset.note}` : '');
                 // Reaching the line is not enough: scrolling straight past it without
                 // dwelling 150ms is excluded, which is the point of the duration.
-                const passedWithoutDwell = !state.exposed && !midpointInView && state.maxDepth >= 0.5;
+                const panel = scrollableClippingAncestor(zone);
+                const clipper = blocker instanceof Element ? blocker : panel;
+                const reason = clipper
+                    ? `50% line clipped by #${clipper.id || clipper.tagName.toLowerCase()} — scroll inside it`
+                    : state.maxDepth >= 0.5
+                    ? `50% line passed without dwelling ${EXPOSURE_DURATION}ms — scroll it slower`
+                    : '50% line not reached yet — keep scrolling';
                 const note = impossible
                     ? 'EXPOSED WITHOUT REACHING ITS 50% LINE'
                     : state.exposed
                     ? 'exposed'
                     : midpointInView
                     ? `50% line in view, waiting ${EXPOSURE_DURATION}ms`
-                    : passedWithoutDwell
-                    ? `50% line passed without dwelling ${EXPOSURE_DURATION}ms`
-                    : '50% line not reached yet';
+                    : reason;
+                if (!state.exposed && !impossible) {
+                    unexposed.push(`#${zone.id} (${midpointInView ? 'waiting' : reason.split(' — ')[0]})`);
+                }
+
                 zone.querySelector('.zone-state').textContent = impossible
-                    ? `EXPOSED WITHOUT REACHING ITS 50% LINE (depth ${depth}%)`
+                    ? `EXPOSED WITHOUT REACHING ITS 50% LINE (max depth ${depth}%)`
                     : state.exposed
-                    ? `exposed ✓ (depth viewed ${depth}%, ${visible}% on screen now)`
-                    : `${note} (depth ${depth}%)`;
+                    ? `exposed ✓ (max depth ${depth}%, ${visible}% on screen now)`
+                    : `${note} (max depth ${depth}%)`;
                 rows.push(
                     `<div class="${zone.dataset.state}">` +
-                        `#${zone.id.padEnd(17)} depth ${String(depth).padStart(3)}%   ` +
+                        `#${zone.id.padEnd(20)} max depth ${String(depth).padStart(3)}%   ` +
                         `on screen ${String(visible).padStart(3)}%   ${note}</div>`,
                 );
             });
 
             document.getElementById('zone-table').innerHTML = rows.join('');
-            const exposedCount = zones.filter((zone) => zoneState.get(zone).exposed).length;
-            document.getElementById('summary').textContent = `exposed ${exposedCount} of ${zones.length} zones`;
+            const exposedCount = zones.length - unexposed.length;
+            // Say why the count is short, so a partial tally is self-explanatory.
+            document.getElementById('summary').textContent =
+                `exposed ${exposedCount} of ${zones.length} zones` +
+                (unexposed.length ? ` · still waiting on ${unexposed.join(', ')}` : '');
         };
 
         // Reads the exposed element paths off each captured
@@ -442,13 +505,13 @@
             setAutoFlush(event.target.checked),
         );
         document.getElementById('flush').addEventListener('click', flush);
-        document.getElementById('scroll-30').addEventListener('click', () => scrollElementTo(0.3));
-        document.getElementById('scroll-49').addEventListener('click', () => scrollElementTo(0.49));
-        document.getElementById('scroll-50').addEventListener('click', () => scrollElementTo(0.5));
-        document.getElementById('scroll-60').addEventListener('click', () => scrollElementTo(0.6));
-        document.getElementById('scroll-100').addEventListener('click', () => scrollElementTo(1));
+        document.getElementById('scroll-30').addEventListener('click', () => void scrollElementTo(0.3));
+        document.getElementById('scroll-49').addEventListener('click', () => void scrollElementTo(0.49));
+        document.getElementById('scroll-50').addEventListener('click', () => void scrollElementTo(0.5));
+        document.getElementById('scroll-60').addEventListener('click', () => void scrollElementTo(0.6));
+        document.getElementById('scroll-100').addEventListener('click', () => void scrollElementTo(1));
         document.getElementById('scroll-oversized').addEventListener('click', () =>
-            scrollElementTo(0.5, document.getElementById('oversized-target')),
+            void scrollElementTo(0.5, document.getElementById('oversized-target')),
         );
 
         // Self-contained: fall back to a dummy key so the page works without a
@@ -474,6 +537,8 @@
         }).promise.then(() => {
             amplitude.add(exposureLogger);
             setAutoFlush(true);
+            document.getElementById('duration-note').textContent =
+                `dwell required: ${EXPOSURE_DURATION}ms (override with ?exposureDuration=)`;
             render();
             renderPayloads();
             document.getElementById('status').textContent = 'initialized';

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -76,6 +76,15 @@
         /* Fixed height keeps the 30 / 49 / 50 / 60 / 100% jump arithmetic easy to eyeball. */
         #exposure-target { height: 240px; }
         #oversized-target { height: 250vh; }
+
+        #overflow-container {
+            width: 70%; height: 300px; margin: 24px auto; overflow: auto;
+            border: 3px solid #7c3aed; background: #faf5ff;
+        }
+        #overflow-container .scroll-spacer {
+            height: 250px; padding: 8px; box-sizing: border-box; color: #7c3aed;
+        }
+        #nested-scroll-target { width: 80%; height: 200px; margin: 0 auto 250px; }
     </style>
 </head>
 <body>
@@ -137,6 +146,23 @@
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
+
+        <div id="overflow-container">
+            <div class="scroll-spacer">
+                Nested overflow container — scroll inside this purple panel. The target below begins
+                partially intersecting but its 50% line is clipped by the panel.
+            </div>
+            <button
+                class="zone"
+                id="nested-scroll-target"
+                type="button"
+                data-note="inside an overflow container"
+            >
+                <span class="zone-label"></span>
+                <span class="mid-line"></span>
+                <span class="zone-state">not viewed</span>
+            </button>
+        </div>
 
         <button class="zone" id="zone-3" type="button">
             <span class="zone-label"></span>
@@ -204,16 +230,45 @@
         // Mirrors the plugin, including its sub-pixel tolerance, so the page's own
         // expectation cannot disagree with the SDK over a fraction of a pixel.
         const MID_HEIGHT_LINE_TOLERANCE_PX = 1;
+        const CLIPPING_OVERFLOW_VALUES = new Set(['auto', 'clip', 'hidden', 'overlay', 'scroll']);
+
+        const getVisualParent = (element) =>
+            element.assignedSlot ??
+            element.parentElement ??
+            (element.getRootNode() instanceof ShadowRoot ? element.getRootNode().host : null);
 
         const isMidHeightLineVisible = (element) => {
             const rect = element.getBoundingClientRect();
             const midHeightLine = rect.top + rect.height * 0.5;
-            return (
-                midHeightLine >= -MID_HEIGHT_LINE_TOLERANCE_PX &&
-                midHeightLine <= viewportHeight() + MID_HEIGHT_LINE_TOLERANCE_PX &&
-                rect.right > 0 &&
-                rect.left < innerWidth
-            );
+            let visibleLeft = Math.max(rect.left, 0);
+            let visibleRight = Math.min(rect.right, innerWidth);
+            if (
+                midHeightLine < -MID_HEIGHT_LINE_TOLERANCE_PX ||
+                midHeightLine > viewportHeight() + MID_HEIGHT_LINE_TOLERANCE_PX ||
+                visibleLeft >= visibleRight
+            ) {
+                return false;
+            }
+
+            let ancestor = getVisualParent(element);
+            while (ancestor) {
+                const style = getComputedStyle(ancestor);
+                const ancestorRect = ancestor.getBoundingClientRect();
+                if (
+                    CLIPPING_OVERFLOW_VALUES.has(style.overflowY) &&
+                    (midHeightLine < ancestorRect.top - MID_HEIGHT_LINE_TOLERANCE_PX ||
+                        midHeightLine > ancestorRect.bottom + MID_HEIGHT_LINE_TOLERANCE_PX)
+                ) {
+                    return false;
+                }
+                if (CLIPPING_OVERFLOW_VALUES.has(style.overflowX)) {
+                    visibleLeft = Math.max(visibleLeft, ancestorRect.left);
+                    visibleRight = Math.min(visibleRight, ancestorRect.right);
+                    if (visibleLeft >= visibleRight) return false;
+                }
+                ancestor = getVisualParent(ancestor);
+            }
+            return true;
         };
 
         /**

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -13,66 +13,137 @@
             box-shadow: 0 2px 8px rgba(0, 0, 0, .4);
         }
         #hud h1 { font-size: 14px; margin: 0 0 4px; }
-        #hud .hint { color: #999; font-size: 12px; }
-        #hud button { margin: 4px 4px 0 0; }
-        #readout { margin-top: 6px; font-family: monospace; }
-        #exposed { margin-top: 4px; font-family: monospace; color: #6cf; max-height: 20vh; overflow: auto; }
-        #status { margin-top: 4px; font-family: monospace; color: #888; }
+        #hud .hint { color: #999; font-size: 12px; max-width: 70ch; }
+        #hud .controls { margin-top: 6px; font-size: 12px; }
+        #hud button { margin-right: 4px; }
+        #summary { margin-top: 6px; font-family: monospace; }
+        #status { margin-top: 2px; font-family: monospace; color: #888; }
 
-        .spacer { display: flex; align-items: center; justify-content: center; color: #bbb; background: #f6f6f6; }
-        .spacer.lead { height: 150vh; }
-        .spacer.gap { height: 150vh; }
-        .spacer.tail { height: 150vh; }
+        /* Live state for every zone, so it stays readable even when a zone is
+           taller than the viewport and its own labels are scrolled off screen. */
+        #zone-table { margin-top: 4px; font: 12px/1.45 monospace; }
+        #zone-table div { white-space: pre; }
+        #zone-table .pending { color: #94a3b8; }
+        #zone-table .viewed { color: #fbbf24; }
+        #zone-table .exposed { color: #34d399; }
+        #zone-table .mismatch { color: #f87171; font-weight: 700; }
 
-        /* Fixed height keeps the 30% / 50% / 100% arithmetic easy to eyeball. */
-        #exposure-target {
-            display: block; width: 60%; height: 240px; margin: 0 auto;
-            font-size: 18px; background: #d9ecff; border: 2px solid #3b82f6;
+        /* Clears the fixed HUD so the first zone does not start underneath it. */
+        main { padding-top: 320px; }
+        .lead, .tail { height: 60vh; display: flex; align-items: center; justify-content: center; color: #bbb; }
+
+        .zone {
+            position: relative; display: block; width: 70%; margin: 24px auto; padding: 0;
+            font: inherit; text-align: left; background: #f4f7fb; border: 2px solid #94a3b8;
+        }
+        .zone .zone-label { position: absolute; top: 8px; left: 12px; font-weight: 600; }
+        .zone .zone-state { position: absolute; bottom: 8px; left: 12px; font-family: monospace; }
+
+        /* The rule this page demonstrates: exposure keys off this line, not off area. */
+        .zone .mid-line {
+            position: absolute; top: 50%; left: 0; right: 0;
+            border-top: 2px dashed #ef4444;
+        }
+        .zone .mid-line::after {
+            content: '50% line'; position: absolute; top: 2px; right: 8px;
+            font-size: 11px; color: #ef4444;
         }
 
-        /* Taller than the viewport: validates depth viewed rather than visible area. */
-        #oversized-target {
-            display: block; width: 60%; height: 250vh; margin: 0 auto;
-            font-size: 18px; background: #ffeaea; border: 2px solid #ef4444;
-        }
+        .zone[data-state='viewed'] { background: #fff7ed; border-color: #f59e0b; }
+        .zone[data-state='exposed'] { background: #ecfdf5; border-color: #10b981; }
+        .zone[data-state='mismatch'] { background: #fef2f2; border-color: #dc2626; }
+
+        #zone-1 { height: 30vh; }
+        #zone-2 { height: 18vh; }
+        #zone-3 { height: 45vh; }
+        /* Taller than the viewport: its midpoint still gets viewed while scrolling. */
+        #zone-4 { height: 120vh; }
+        #zone-5 { height: 25vh; }
+        /* Fixed height keeps the 30 / 49 / 50 / 60 / 100% jump arithmetic easy to eyeball. */
+        #exposure-target { height: 240px; }
+        #oversized-target { height: 250vh; }
     </style>
 </head>
 <body>
     <div id="hud">
-        <h1>Viewport Exposure Test — exposure fires when the mid-height line is viewed</h1>
+        <h1>Viewport Exposure Test — a zone exposes once its 50% line has been in view for 150ms</h1>
         <div class="hint">
-            Scroll to a percentage of <code>#exposure-target</code>'s vertical depth, wait a moment, then
-            flush. Before its 50% line enters the viewport it must not be exposed; once that line has
-            been displayed for 150ms it must be. This matches Contentsquare Zoning and is not the same
-            as requiring half of the element's area on screen at once.
+            Just scroll down. Each zone turns amber while its dashed 50% line is inside the viewport and
+            green once the SDK reports it as exposed. This matches Contentsquare Zoning: what counts is
+            scrolling <em>through</em> a zone's mid-height line, not fitting half its area on screen — so
+            zones taller than the viewport still expose.
         </div>
-        <div>
-            <button id="scroll-30" type="button">Scroll target to 30%</button>
+        <div class="controls">
+            <label>
+                <input type="checkbox" id="auto-flush" checked>
+                Auto-flush every 500ms so exposures appear while scrolling
+            </label>
+            <button id="flush" type="button">Flush now</button>
+            <span class="hint">
+                (the SDK batches exposures and reports them on navigation/unload, not per scroll)
+            </span>
+        </div>
+        <div class="controls">
+            Jump <code>#exposure-target</code> to depth:
+            <button id="scroll-30" type="button">30%</button>
             <button id="scroll-49" type="button">49%</button>
             <button id="scroll-50" type="button">50%</button>
             <button id="scroll-60" type="button">60%</button>
             <button id="scroll-100" type="button">100%</button>
-            <button id="scroll-oversized" type="button">View 50% line of oversized element</button>
-            <button id="flush" type="button">Flush exposures</button>
+            <button id="scroll-oversized" type="button">#oversized-target 50%</button>
         </div>
-        <div id="readout">target depth viewed: —</div>
-        <div id="verdict">last flush: (nothing flushed yet)</div>
-        <div id="exposed">exposed in last flush: (none)</div>
+        <div id="summary">exposed 0 of 0 zones</div>
+        <div id="zone-table"></div>
         <div id="status">ready</div>
     </div>
 
-    <div class="spacer lead">scroll down</div>
+    <main>
+        <div class="lead">scroll down</div>
 
-    <button id="exposure-target" type="button">Exposure target (240px tall)</button>
+        <button class="zone" id="zone-1" type="button">
+            <span class="zone-label">#zone-1 — 40vh</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
 
-    <div class="spacer gap">keep scrolling</div>
+        <button class="zone" id="zone-2" type="button">
+            <span class="zone-label">#zone-2 — 25vh</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
 
-    <button id="oversized-target" type="button">
-        Oversized target — taller than the viewport. It should expose when its mid-height line is viewed,
-        even though less than half of its area can fit on screen.
-    </button>
+        <button class="zone" id="zone-3" type="button">
+            <span class="zone-label">#zone-3 — 70vh</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
 
-    <div class="spacer tail">end of page</div>
+        <button class="zone" id="zone-4" type="button">
+            <span class="zone-label">#zone-4 — 130vh, taller than the viewport</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
+
+        <button class="zone" id="zone-5" type="button">
+            <span class="zone-label">#zone-5 — 35vh</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
+
+        <button class="zone" id="exposure-target" type="button">
+            <span class="zone-label">#exposure-target — 240px, used by the jump buttons</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
+
+        <button class="zone" id="oversized-target" type="button">
+            <span class="zone-label">#oversized-target — 250vh, less than half can ever be on screen</span>
+            <span class="mid-line"></span>
+            <span class="zone-state">not viewed</span>
+        </button>
+
+        <div class="tail">end of page</div>
+    </main>
 
     <script type="module">
         import * as amplitude from '@amplitude/analytics-browser';
@@ -82,12 +153,13 @@
         // Matches the plugin default; stated explicitly so the harness and the
         // Playwright spec can size their waits off the same number.
         const EXPOSURE_DURATION = 150;
+        const AUTO_FLUSH_MS = 500;
 
-        const target = () => document.getElementById('exposure-target');
-        let selectedTarget = target();
+        const zones = Array.from(document.querySelectorAll('.zone'));
+        const zoneState = new Map(zones.map((zone) => [zone, { exposed: false, maxDepth: 0 }]));
 
-        // IntersectionObserver clips against the layout viewport, so the ratio the
-        // observer sees is measured against clientHeight, not innerHeight.
+        // IntersectionObserver clips against the layout viewport, so the geometry the
+        // plugin sees is measured against clientHeight, not innerHeight.
         const viewportHeight = () => document.documentElement.clientHeight;
 
         const visibleFraction = (element) => {
@@ -96,23 +168,33 @@
             return Math.max(0, Math.min(visible, rect.height)) / rect.height;
         };
 
+        // How far down the element the viewport's bottom edge has travelled. Unlike
+        // visible area, this keeps rising for elements taller than the viewport.
         const viewedDepth = (element) => {
             const rect = element.getBoundingClientRect();
             return Math.max(0, Math.min(1, (viewportHeight() - rect.top) / rect.height));
         };
 
+        // Mirrors the plugin, including its sub-pixel tolerance, so the page's own
+        // expectation cannot disagree with the SDK over a fraction of a pixel.
+        const MID_HEIGHT_LINE_TOLERANCE_PX = 1;
+
         const isMidHeightLineVisible = (element) => {
             const rect = element.getBoundingClientRect();
             const midHeightLine = rect.top + rect.height * 0.5;
-            return midHeightLine >= 0 && midHeightLine <= viewportHeight() && rect.right > 0 && rect.left < innerWidth;
+            return (
+                midHeightLine >= -MID_HEIGHT_LINE_TOLERANCE_PX &&
+                midHeightLine <= viewportHeight() + MID_HEIGHT_LINE_TOLERANCE_PX &&
+                rect.right > 0 &&
+                rect.left < innerWidth
+            );
         };
 
         /**
          * Scroll the viewport's bottom edge to `fraction` of the element's vertical
-         * depth and return the depth actually reached. Unlike visible area, this
-         * works for elements taller than the viewport.
+         * depth and return the depth actually reached (clamped by the scroll range).
          */
-        const scrollElementTo = (fraction, element = target()) => {
+        const scrollElementTo = (fraction, element = document.getElementById('exposure-target')) => {
             const rect = element.getBoundingClientRect();
             const documentTop = rect.top + window.scrollY;
             const maxScroll = document.documentElement.scrollHeight - viewportHeight();
@@ -121,17 +203,17 @@
             return viewedDepth(element);
         };
 
-        const exposedPaths = [];
-        // Flushing resets the plugin's page-view state, which re-arms the exposure
-        // snapshot — so one flush can produce more than one event. Collect per flush
-        // rather than per event, and report the union.
-        let pathsSinceFlush = [];
-
         // Exposure is reported on navigation/unload, so dispatch beforeunload to
         // flush whatever has been exposed since the last flush.
-        const flush = () => {
-            pathsSinceFlush = [];
-            window.dispatchEvent(new Event('beforeunload'));
+        const flush = () => window.dispatchEvent(new Event('beforeunload'));
+
+        const exposedPaths = [];
+
+        let autoFlushTimer;
+        const setAutoFlush = (enabled) => {
+            document.getElementById('auto-flush').checked = enabled;
+            clearInterval(autoFlushTimer);
+            autoFlushTimer = enabled ? setInterval(flush, AUTO_FLUSH_MS) : undefined;
         };
 
         window.__exposureHarness = {
@@ -140,22 +222,59 @@
             viewedDepth,
             isMidHeightLineVisible,
             flush,
+            setAutoFlush,
             exposedPaths,
             EXPOSURE_DURATION,
         };
 
-        const renderFlushResult = () => {
-            const selectedPath = `button#${selectedTarget.id}`;
-            const exposed = pathsSinceFlush.includes(selectedPath);
-            const shouldExpose = isMidHeightLineVisible(selectedTarget);
-            const agrees = exposed === shouldExpose;
-            const verdict = document.getElementById('verdict');
-            verdict.textContent =
-                `last flush: #${selectedTarget.id} ${exposed ? 'exposed' : 'not exposed'} — ` +
-                (agrees ? 'as expected' : 'DOES NOT MATCH the depth above');
-            verdict.style.color = agrees ? '#7bd88f' : '#ff6b6b';
-            document.getElementById('exposed').textContent =
-                'exposed in last flush: ' + (pathsSinceFlush.length ? pathsSinceFlush.join(', ') : '(none)');
+        const render = () => {
+            const rows = [];
+
+            zones.forEach((zone) => {
+                const state = zoneState.get(zone);
+                const midpointInView = isMidHeightLineVisible(zone);
+                const depthFraction = viewedDepth(zone);
+                state.maxDepth = Math.max(state.maxDepth, depthFraction);
+
+                // The SDK must never report a zone whose 50% line was never reached.
+                const impossible = state.exposed && state.maxDepth < 0.5;
+                zone.dataset.state = impossible
+                    ? 'mismatch'
+                    : state.exposed
+                    ? 'exposed'
+                    : midpointInView
+                    ? 'viewed'
+                    : 'pending';
+
+                const depth = Math.round(depthFraction * 100);
+                const visible = Math.round(visibleFraction(zone) * 100);
+                // Reaching the line is not enough: scrolling straight past it without
+                // dwelling 150ms is excluded, which is the point of the duration.
+                const passedWithoutDwell = !state.exposed && !midpointInView && state.maxDepth >= 0.5;
+                const note = impossible
+                    ? 'EXPOSED WITHOUT REACHING ITS 50% LINE'
+                    : state.exposed
+                    ? 'exposed'
+                    : midpointInView
+                    ? `50% line in view, waiting ${EXPOSURE_DURATION}ms`
+                    : passedWithoutDwell
+                    ? `50% line passed without dwelling ${EXPOSURE_DURATION}ms`
+                    : '50% line not reached yet';
+                zone.querySelector('.zone-state').textContent = impossible
+                    ? `EXPOSED WITHOUT REACHING ITS 50% LINE (depth ${depth}%)`
+                    : state.exposed
+                    ? `exposed ✓ (depth viewed ${depth}%, ${visible}% on screen now)`
+                    : `${note} (depth ${depth}%)`;
+                rows.push(
+                    `<div class="${zone.dataset.state}">` +
+                        `#${zone.id.padEnd(17)} depth ${String(depth).padStart(3)}%   ` +
+                        `on screen ${String(visible).padStart(3)}%   ${note}</div>`,
+                );
+            });
+
+            document.getElementById('zone-table').innerHTML = rows.join('');
+            const exposedCount = zones.filter((zone) => zoneState.get(zone).exposed).length;
+            document.getElementById('summary').textContent = `exposed ${exposedCount} of ${zones.length} zones`;
         };
 
         // Reads the exposed element paths off each captured
@@ -169,49 +288,41 @@
                 if (event.event_type === '[Amplitude] Viewport Content Updated') {
                     const paths = event.event_properties?.['[Amplitude] Element Exposed'] ?? [];
                     exposedPaths.push(...paths);
-                    pathsSinceFlush.push(...paths.filter((path) => !pathsSinceFlush.includes(path)));
                     // eslint-disable-next-line no-console
                     console.log('%c[Amplitude] Viewport Content Updated', 'color:#0a0', paths);
-                    renderFlushResult();
+                    zones.forEach((zone) => {
+                        if (paths.includes(`button#${zone.id}`)) {
+                            zoneState.get(zone).exposed = true;
+                        }
+                    });
+                    render();
                 }
                 return event;
             },
         };
 
-        const renderReadout = () => {
-            const depth = viewedDepth(selectedTarget);
-            const visible = visibleFraction(selectedTarget);
-            const percent = Math.round(depth * 100);
-            document.getElementById('readout').textContent =
-                `#${selectedTarget.id} depth viewed: ${percent}% ` +
-                `(${Math.round(visible * 100)}% currently visible) → ` +
-                (isMidHeightLineVisible(selectedTarget) ? 'should expose' : 'should NOT expose');
-        };
-
-        let readoutQueued = false;
+        let renderQueued = false;
         window.addEventListener('scroll', () => {
-            if (readoutQueued) return;
-            readoutQueued = true;
+            if (renderQueued) return;
+            renderQueued = true;
             requestAnimationFrame(() => {
-                readoutQueued = false;
-                renderReadout();
+                renderQueued = false;
+                render();
             });
         });
 
-        const selectAndScroll = (fraction, element = target()) => {
-            selectedTarget = element;
-            scrollElementTo(fraction, element);
-        };
-
-        document.getElementById('scroll-30').addEventListener('click', () => selectAndScroll(0.3));
-        document.getElementById('scroll-49').addEventListener('click', () => selectAndScroll(0.49));
-        document.getElementById('scroll-50').addEventListener('click', () => selectAndScroll(0.5));
-        document.getElementById('scroll-60').addEventListener('click', () => selectAndScroll(0.6));
-        document.getElementById('scroll-100').addEventListener('click', () => selectAndScroll(1));
-        document.getElementById('scroll-oversized').addEventListener('click', () =>
-            selectAndScroll(0.5, document.getElementById('oversized-target')),
+        document.getElementById('auto-flush').addEventListener('change', (event) =>
+            setAutoFlush(event.target.checked),
         );
         document.getElementById('flush').addEventListener('click', flush);
+        document.getElementById('scroll-30').addEventListener('click', () => scrollElementTo(0.3));
+        document.getElementById('scroll-49').addEventListener('click', () => scrollElementTo(0.49));
+        document.getElementById('scroll-50').addEventListener('click', () => scrollElementTo(0.5));
+        document.getElementById('scroll-60').addEventListener('click', () => scrollElementTo(0.6));
+        document.getElementById('scroll-100').addEventListener('click', () => scrollElementTo(1));
+        document.getElementById('scroll-oversized').addEventListener('click', () =>
+            scrollElementTo(0.5, document.getElementById('oversized-target')),
+        );
 
         // Self-contained: fall back to a dummy key so the page works without a
         // configured environment. The Playwright spec intercepts track requests,
@@ -235,7 +346,8 @@
             logLevel: 0,
         }).promise.then(() => {
             amplitude.add(exposureLogger);
-            renderReadout();
+            setAutoFlush(true);
+            render();
             document.getElementById('status').textContent = 'initialized';
         });
     </script>

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -41,9 +41,10 @@
     <div id="hud">
         <h1>Viewport Exposure Test — exposure fires at 50% visibility</h1>
         <div class="hint">
-            Scroll <code>#exposure-target</code> partly into view, then flush. Below 50% it must not be
-            exposed; at 50% or more it must be. Control buttons are autocaptured elements too, so they
-            also show up in the exposed list.
+            Scroll <code>#exposure-target</code> partly into view, wait a moment, then flush: below 50%
+            visibility it must not be exposed, at 50% or more it must be. The verdict line compares the
+            two. These control buttons are autocaptured elements too, so they show up in the exposed
+            list as well.
         </div>
         <div>
             <button id="scroll-30" type="button">Scroll target to 30%</button>
@@ -55,7 +56,8 @@
             <button id="flush" type="button">Flush exposures</button>
         </div>
         <div id="readout">target visibility: —</div>
-        <div id="exposed">exposed so far: (none)</div>
+        <div id="verdict">last flush: (nothing flushed yet)</div>
+        <div id="exposed">exposed in last flush: (none)</div>
         <div id="status">ready</div>
     </div>
 
@@ -107,17 +109,37 @@
             return visibleFraction(element);
         };
 
+        const exposedPaths = [];
+        // Flushing resets the plugin's page-view state, which re-arms the exposure
+        // snapshot — so one flush can produce more than one event. Collect per flush
+        // rather than per event, and report the union.
+        let pathsSinceFlush = [];
+
         // Exposure is reported on navigation/unload, so dispatch beforeunload to
         // flush whatever has been exposed since the last flush.
-        const flush = () => window.dispatchEvent(new Event('beforeunload'));
-
-        const exposedPaths = [];
+        const flush = () => {
+            pathsSinceFlush = [];
+            window.dispatchEvent(new Event('beforeunload'));
+        };
 
         window.__exposureHarness = { scrollElementTo, visibleFraction, flush, exposedPaths, EXPOSURE_DURATION };
 
-        // Renders every exposed element path from the captured
-        // `[Amplitude] Viewport Content Updated` events. Enrichment plugin, so
-        // nothing is swallowed and the payload still goes out to the network.
+        const renderFlushResult = () => {
+            const exposed = pathsSinceFlush.includes('button#exposure-target');
+            const shouldExpose = visibleFraction(target()) >= 0.5;
+            const agrees = exposed === shouldExpose;
+            const verdict = document.getElementById('verdict');
+            verdict.textContent =
+                `last flush: #exposure-target ${exposed ? 'exposed' : 'not exposed'} — ` +
+                (agrees ? 'as expected' : 'DOES NOT MATCH the visibility above');
+            verdict.style.color = agrees ? '#7bd88f' : '#ff6b6b';
+            document.getElementById('exposed').textContent =
+                'exposed in last flush: ' + (pathsSinceFlush.length ? pathsSinceFlush.join(', ') : '(none)');
+        };
+
+        // Reads the exposed element paths off each captured
+        // `[Amplitude] Viewport Content Updated`. Enrichment plugin, so nothing is
+        // swallowed and the payload still goes out to the network.
         const exposureLogger = {
             name: 'harness-exposure-logger',
             type: 'enrichment',
@@ -126,10 +148,10 @@
                 if (event.event_type === '[Amplitude] Viewport Content Updated') {
                     const paths = event.event_properties?.['[Amplitude] Element Exposed'] ?? [];
                     exposedPaths.push(...paths);
+                    pathsSinceFlush.push(...paths.filter((path) => !pathsSinceFlush.includes(path)));
                     // eslint-disable-next-line no-console
                     console.log('%c[Amplitude] Viewport Content Updated', 'color:#0a0', paths);
-                    document.getElementById('exposed').textContent =
-                        'exposed so far: ' + (exposedPaths.length ? exposedPaths.join(', ') : '(none)');
+                    renderFlushResult();
                 }
                 return event;
             },

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Viewport Exposure (50% visibility) Test</title>
+    <title>Viewport Exposure (mid-height line) Test</title>
     <style>
         body { margin: 0; font: 14px/1.5 system-ui, sans-serif; }
 
@@ -30,7 +30,7 @@
             font-size: 18px; background: #d9ecff; border: 2px solid #3b82f6;
         }
 
-        /* Taller than any viewport, so it can never reach 50% of its own area. */
+        /* Taller than the viewport: validates depth viewed rather than visible area. */
         #oversized-target {
             display: block; width: 60%; height: 250vh; margin: 0 auto;
             font-size: 18px; background: #ffeaea; border: 2px solid #ef4444;
@@ -39,12 +39,12 @@
 </head>
 <body>
     <div id="hud">
-        <h1>Viewport Exposure Test — exposure fires at 50% visibility</h1>
+        <h1>Viewport Exposure Test — exposure fires when the mid-height line is viewed</h1>
         <div class="hint">
-            Scroll <code>#exposure-target</code> partly into view, wait a moment, then flush: below 50%
-            visibility it must not be exposed, at 50% or more it must be. The verdict line compares the
-            two. These control buttons are autocaptured elements too, so they show up in the exposed
-            list as well.
+            Scroll to a percentage of <code>#exposure-target</code>'s vertical depth, wait a moment, then
+            flush. Before its 50% line enters the viewport it must not be exposed; once that line has
+            been displayed for 150ms it must be. This matches Contentsquare Zoning and is not the same
+            as requiring half of the element's area on screen at once.
         </div>
         <div>
             <button id="scroll-30" type="button">Scroll target to 30%</button>
@@ -52,10 +52,10 @@
             <button id="scroll-50" type="button">50%</button>
             <button id="scroll-60" type="button">60%</button>
             <button id="scroll-100" type="button">100%</button>
-            <button id="scroll-oversized" type="button">Fill viewport with oversized element</button>
+            <button id="scroll-oversized" type="button">View 50% line of oversized element</button>
             <button id="flush" type="button">Flush exposures</button>
         </div>
-        <div id="readout">target visibility: —</div>
+        <div id="readout">target depth viewed: —</div>
         <div id="verdict">last flush: (nothing flushed yet)</div>
         <div id="exposed">exposed in last flush: (none)</div>
         <div id="status">ready</div>
@@ -68,8 +68,8 @@
     <div class="spacer gap">keep scrolling</div>
 
     <button id="oversized-target" type="button">
-        Oversized target — taller than the viewport, so it never reaches 50% of its own area and is
-        expected to stay unexposed
+        Oversized target — taller than the viewport. It should expose when its mid-height line is viewed,
+        even though less than half of its area can fit on screen.
     </button>
 
     <div class="spacer tail">end of page</div>
@@ -84,6 +84,7 @@
         const EXPOSURE_DURATION = 150;
 
         const target = () => document.getElementById('exposure-target');
+        let selectedTarget = target();
 
         // IntersectionObserver clips against the layout viewport, so the ratio the
         // observer sees is measured against clientHeight, not innerHeight.
@@ -95,10 +96,21 @@
             return Math.max(0, Math.min(visible, rect.height)) / rect.height;
         };
 
+        const viewedDepth = (element) => {
+            const rect = element.getBoundingClientRect();
+            return Math.max(0, Math.min(1, (viewportHeight() - rect.top) / rect.height));
+        };
+
+        const isMidHeightLineVisible = (element) => {
+            const rect = element.getBoundingClientRect();
+            const midHeightLine = rect.top + rect.height * 0.5;
+            return midHeightLine >= 0 && midHeightLine <= viewportHeight() && rect.right > 0 && rect.left < innerWidth;
+        };
+
         /**
-         * Scroll so that `fraction` of `element` sits inside the viewport, entering
-         * from the bottom edge, and return the fraction actually achieved (clamped
-         * by the document's scroll range).
+         * Scroll the viewport's bottom edge to `fraction` of the element's vertical
+         * depth and return the depth actually reached. Unlike visible area, this
+         * works for elements taller than the viewport.
          */
         const scrollElementTo = (fraction, element = target()) => {
             const rect = element.getBoundingClientRect();
@@ -106,7 +118,7 @@
             const maxScroll = document.documentElement.scrollHeight - viewportHeight();
             const scrollY = documentTop + fraction * rect.height - viewportHeight();
             window.scrollTo(0, Math.max(0, Math.min(scrollY, maxScroll)));
-            return visibleFraction(element);
+            return viewedDepth(element);
         };
 
         const exposedPaths = [];
@@ -122,16 +134,25 @@
             window.dispatchEvent(new Event('beforeunload'));
         };
 
-        window.__exposureHarness = { scrollElementTo, visibleFraction, flush, exposedPaths, EXPOSURE_DURATION };
+        window.__exposureHarness = {
+            scrollElementTo,
+            visibleFraction,
+            viewedDepth,
+            isMidHeightLineVisible,
+            flush,
+            exposedPaths,
+            EXPOSURE_DURATION,
+        };
 
         const renderFlushResult = () => {
-            const exposed = pathsSinceFlush.includes('button#exposure-target');
-            const shouldExpose = visibleFraction(target()) >= 0.5;
+            const selectedPath = `button#${selectedTarget.id}`;
+            const exposed = pathsSinceFlush.includes(selectedPath);
+            const shouldExpose = isMidHeightLineVisible(selectedTarget);
             const agrees = exposed === shouldExpose;
             const verdict = document.getElementById('verdict');
             verdict.textContent =
-                `last flush: #exposure-target ${exposed ? 'exposed' : 'not exposed'} — ` +
-                (agrees ? 'as expected' : 'DOES NOT MATCH the visibility above');
+                `last flush: #${selectedTarget.id} ${exposed ? 'exposed' : 'not exposed'} — ` +
+                (agrees ? 'as expected' : 'DOES NOT MATCH the depth above');
             verdict.style.color = agrees ? '#7bd88f' : '#ff6b6b';
             document.getElementById('exposed').textContent =
                 'exposed in last flush: ' + (pathsSinceFlush.length ? pathsSinceFlush.join(', ') : '(none)');
@@ -158,10 +179,13 @@
         };
 
         const renderReadout = () => {
-            const fraction = visibleFraction(target());
-            const percent = Math.round(fraction * 100);
+            const depth = viewedDepth(selectedTarget);
+            const visible = visibleFraction(selectedTarget);
+            const percent = Math.round(depth * 100);
             document.getElementById('readout').textContent =
-                `target visibility: ${percent}% → ${fraction >= 0.5 ? 'should expose' : 'should NOT expose'}`;
+                `#${selectedTarget.id} depth viewed: ${percent}% ` +
+                `(${Math.round(visible * 100)}% currently visible) → ` +
+                (isMidHeightLineVisible(selectedTarget) ? 'should expose' : 'should NOT expose');
         };
 
         let readoutQueued = false;
@@ -174,13 +198,18 @@
             });
         });
 
-        document.getElementById('scroll-30').addEventListener('click', () => scrollElementTo(0.3));
-        document.getElementById('scroll-49').addEventListener('click', () => scrollElementTo(0.49));
-        document.getElementById('scroll-50').addEventListener('click', () => scrollElementTo(0.5));
-        document.getElementById('scroll-60').addEventListener('click', () => scrollElementTo(0.6));
-        document.getElementById('scroll-100').addEventListener('click', () => scrollElementTo(1));
+        const selectAndScroll = (fraction, element = target()) => {
+            selectedTarget = element;
+            scrollElementTo(fraction, element);
+        };
+
+        document.getElementById('scroll-30').addEventListener('click', () => selectAndScroll(0.3));
+        document.getElementById('scroll-49').addEventListener('click', () => selectAndScroll(0.49));
+        document.getElementById('scroll-50').addEventListener('click', () => selectAndScroll(0.5));
+        document.getElementById('scroll-60').addEventListener('click', () => selectAndScroll(0.6));
+        document.getElementById('scroll-100').addEventListener('click', () => selectAndScroll(1));
         document.getElementById('scroll-oversized').addEventListener('click', () =>
-            scrollElementTo(0.5, document.getElementById('oversized-target')),
+            selectAndScroll(0.5, document.getElementById('oversized-target')),
         );
         document.getElementById('flush').addEventListener('click', flush);
 

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -10,8 +10,28 @@
            the page a line's worth, which silently moves the zone under test. */
         body { margin: 0; font: 14px/1.5 system-ui, sans-serif; overflow-anchor: none; }
 
+        /* Sticky site header sits at the top of the viewport, like a storefront
+           nav that remains on screen while the page scrolls. The HUD is offset
+           below it so both stay readable. */
+        #site-header.zone {
+            position: sticky; top: 0; z-index: 2147483646;
+            display: flex; align-items: center; justify-content: space-between;
+            width: 100%; height: 52px; margin: 0; padding: 0 20px; box-sizing: border-box;
+            background: #fff; border: 0; border-bottom: 3px solid #1d4ed8; border-radius: 0;
+            font: 13px/1 system-ui, sans-serif;
+        }
+        #site-header .site-header-nav,
+        #site-header .site-header-actions { display: flex; gap: 18px; color: #111; }
+        #site-header .site-header-logo { font-weight: 700; letter-spacing: 0.12em; color: #1d4ed8; }
+        #site-header .zone-label,
+        #site-header .zone-state { display: none; }
+        #site-header .mid-line { border-top-color: #93c5fd; }
+        #site-header .mid-line::after { content: none; }
+        #site-header[data-state='viewed'] { background: #fff7ed; }
+        #site-header[data-state='exposed'] { background: #ecfdf5; }
+
         #hud {
-            position: fixed; top: 0; left: 0; right: 0; z-index: 2147483647;
+            position: fixed; top: 52px; left: 0; right: 0; z-index: 2147483647;
             padding: 8px 12px; background: #111; color: #eee;
             box-shadow: 0 2px 8px rgba(0, 0, 0, .4);
         }
@@ -33,10 +53,10 @@
 
         /* Clears the fixed HUD so the first zone does not start underneath it, and
            the payload panel so zones are never hidden behind it. */
-        main { padding-top: 320px; padding-right: 440px; }
+        main { padding-top: 372px; padding-right: 440px; }
 
         #payload-panel {
-            position: fixed; top: 328px; right: 8px; width: 400px; max-height: 60vh; overflow: auto;
+            position: fixed; top: 380px; right: 8px; width: 400px; max-height: 60vh; overflow: auto;
             z-index: 2147483647; padding: 8px 10px; background: #111; color: #eee; border-radius: 6px;
             font: 11px/1.45 monospace; box-shadow: 0 4px 16px rgba(0, 0, 0, .4);
         }
@@ -91,14 +111,38 @@
     </style>
 </head>
 <body>
+    <button
+        class="zone"
+        id="site-header"
+        type="button"
+        data-note="sticky site header — stays on screen while you scroll"
+    >
+        <span class="site-header-nav">
+            <span>All Sports</span>
+            <span>Men</span>
+            <span>Women</span>
+            <span>Kids</span>
+        </span>
+        <span class="site-header-logo">DECATHLON</span>
+        <span class="site-header-actions" aria-hidden="true">
+            <span>Search</span>
+            <span>Account</span>
+            <span>Cart</span>
+        </span>
+        <span class="zone-label"></span>
+        <span class="mid-line"></span>
+        <span class="zone-state">not viewed</span>
+    </button>
+
     <div id="hud">
         <h1>Viewport Exposure Test — a zone exposes once its 50% line has been in view for 150ms</h1>
         <div class="hint">
             Just scroll down. Each zone turns amber while its dashed 50% line is inside the viewport and
-            green once the SDK reports it as exposed. This matches Contentsquare Zoning: what counts is
-            scrolling <em>through</em> a zone's mid-height line, not fitting half its area on screen — so
-            zones taller than the viewport still expose. The panel on the right shows the actual event
-            payloads the SDK sends.
+            green once the SDK reports it as exposed. What counts is scrolling <em>through</em> a zone's
+            mid-height line, not fitting half its area on screen — so zones taller than the viewport still
+            expose. The top bar is a sticky site header: it stays in the viewport, so it should appear in
+            an exposed event on load and remain counted as you scroll. The panel on the right shows the
+            actual event payloads the SDK sends.
         </div>
         <div class="controls">
             <label>

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -28,8 +28,22 @@
         #zone-table .exposed { color: #34d399; }
         #zone-table .mismatch { color: #f87171; font-weight: 700; }
 
-        /* Clears the fixed HUD so the first zone does not start underneath it. */
-        main { padding-top: 320px; }
+        /* Clears the fixed HUD so the first zone does not start underneath it, and
+           the payload panel so zones are never hidden behind it. */
+        main { padding-top: 320px; padding-right: 440px; }
+
+        #payload-panel {
+            position: fixed; top: 328px; right: 8px; width: 400px; max-height: 60vh; overflow: auto;
+            z-index: 2147483647; padding: 8px 10px; background: #111; color: #eee; border-radius: 6px;
+            font: 11px/1.45 monospace; box-shadow: 0 4px 16px rgba(0, 0, 0, .4);
+        }
+        #payload-panel h2 { font-size: 12px; margin: 0 0 2px; }
+        #payload-panel .panel-hint { color: #999; font-size: 11px; }
+        #payload-panel .payload { margin-top: 8px; border-top: 1px solid #333; padding-top: 6px; }
+        #payload-panel .payload-meta { color: #6cf; }
+        #payload-panel .payload.empty .payload-meta { color: #777; }
+        #payload-panel pre { margin: 2px 0 0; white-space: pre-wrap; word-break: break-word; }
+        #payload-panel .payload.empty pre { color: #777; }
         .lead, .tail { height: 60vh; display: flex; align-items: center; justify-content: center; color: #bbb; }
 
         .zone {
@@ -71,7 +85,8 @@
             Just scroll down. Each zone turns amber while its dashed 50% line is inside the viewport and
             green once the SDK reports it as exposed. This matches Contentsquare Zoning: what counts is
             scrolling <em>through</em> a zone's mid-height line, not fitting half its area on screen — so
-            zones taller than the viewport still expose.
+            zones taller than the viewport still expose. The panel on the right shows the actual event
+            payloads the SDK sends.
         </div>
         <div class="controls">
             <label>
@@ -97,47 +112,58 @@
         <div id="status">ready</div>
     </div>
 
+    <div id="payload-panel">
+        <h2>Events sent to Amplitude</h2>
+        <div class="panel-hint">
+            Newest first. This is the actual <code>[Amplitude] Viewport Content Updated</code> payload,
+            read off an enrichment plugin, so it is exactly what the SDK uploads.
+            <code>[Amplitude] Element Exposed</code> carries the newly exposed element paths, and is
+            empty when a flush only reports new scroll depth.
+        </div>
+        <div id="payloads"></div>
+    </div>
+
     <main>
         <div class="lead">scroll down</div>
 
         <button class="zone" id="zone-1" type="button">
-            <span class="zone-label">#zone-1 — 40vh</span>
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
 
         <button class="zone" id="zone-2" type="button">
-            <span class="zone-label">#zone-2 — 25vh</span>
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
 
         <button class="zone" id="zone-3" type="button">
-            <span class="zone-label">#zone-3 — 70vh</span>
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
 
         <button class="zone" id="zone-4" type="button">
-            <span class="zone-label">#zone-4 — 130vh, taller than the viewport</span>
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
 
         <button class="zone" id="zone-5" type="button">
-            <span class="zone-label">#zone-5 — 35vh</span>
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
 
-        <button class="zone" id="exposure-target" type="button">
-            <span class="zone-label">#exposure-target — 240px, used by the jump buttons</span>
+        <button class="zone" id="exposure-target" type="button" data-note="target of the jump buttons">
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
 
-        <button class="zone" id="oversized-target" type="button">
-            <span class="zone-label">#oversized-target — 250vh, less than half can ever be on screen</span>
+        <button class="zone" id="oversized-target" type="button" data-note="less than half of it can ever be on screen">
+            <span class="zone-label"></span>
             <span class="mid-line"></span>
             <span class="zone-state">not viewed</span>
         </button>
@@ -208,6 +234,10 @@
         const flush = () => window.dispatchEvent(new Event('beforeunload'));
 
         const exposedPaths = [];
+        // Full event objects the SDK sent, newest first, so the page can show the
+        // real payload shape rather than just the element paths pulled out of it.
+        const payloads = [];
+        const MAX_PAYLOADS_SHOWN = 6;
 
         let autoFlushTimer;
         const setAutoFlush = (enabled) => {
@@ -224,7 +254,37 @@
             flush,
             setAutoFlush,
             exposedPaths,
+            payloads,
             EXPOSURE_DURATION,
+        };
+
+        const renderPayloads = () => {
+            const container = document.getElementById('payloads');
+            container.textContent = '';
+
+            if (!payloads.length) {
+                const placeholder = document.createElement('div');
+                placeholder.className = 'payload empty';
+                placeholder.textContent = 'no events sent yet — scroll to expose a zone';
+                container.appendChild(placeholder);
+                return;
+            }
+
+            payloads.slice(0, MAX_PAYLOADS_SHOWN).forEach(({ at, event }) => {
+                const exposed = event.event_properties?.['[Amplitude] Element Exposed'] ?? [];
+                const entry = document.createElement('div');
+                entry.className = exposed.length ? 'payload' : 'payload empty';
+
+                const meta = document.createElement('div');
+                meta.className = 'payload-meta';
+                meta.textContent = `${at} · ${event.event_type} · ${exposed.length} newly exposed`;
+
+                const body = document.createElement('pre');
+                body.textContent = JSON.stringify(event, null, 2);
+
+                entry.append(meta, body);
+                container.appendChild(entry);
+            });
         };
 
         const render = () => {
@@ -248,6 +308,13 @@
 
                 const depth = Math.round(depthFraction * 100);
                 const visible = Math.round(visibleFraction(zone) * 100);
+
+                // Derived from measured geometry so the labels cannot drift from the CSS.
+                const height = Math.round(zone.getBoundingClientRect().height);
+                const ofViewport = Math.round((height / viewportHeight()) * 100);
+                zone.querySelector('.zone-label').textContent =
+                    `#${zone.id} — ${height}px, ${ofViewport}% of the viewport` +
+                    (zone.dataset.note ? ` · ${zone.dataset.note}` : '');
                 // Reaching the line is not enough: scrolling straight past it without
                 // dwelling 150ms is excluded, which is the point of the duration.
                 const passedWithoutDwell = !state.exposed && !midpointInView && state.maxDepth >= 0.5;
@@ -288,14 +355,19 @@
                 if (event.event_type === '[Amplitude] Viewport Content Updated') {
                     const paths = event.event_properties?.['[Amplitude] Element Exposed'] ?? [];
                     exposedPaths.push(...paths);
+                    payloads.unshift({
+                        at: new Date().toISOString().slice(11, 23),
+                        event: { event_type: event.event_type, event_properties: event.event_properties },
+                    });
                     // eslint-disable-next-line no-console
-                    console.log('%c[Amplitude] Viewport Content Updated', 'color:#0a0', paths);
+                    console.log('%c[Amplitude] Viewport Content Updated', 'color:#0a0', event.event_properties);
                     zones.forEach((zone) => {
                         if (paths.includes(`button#${zone.id}`)) {
                             zoneState.get(zone).exposed = true;
                         }
                     });
                     render();
+                    renderPayloads();
                 }
                 return event;
             },
@@ -348,6 +420,7 @@
             amplitude.add(exposureLogger);
             setAutoFlush(true);
             render();
+            renderPayloads();
             document.getElementById('status').textContent = 'initialized';
         });
     </script>

--- a/test-server/autocapture/viewport-exposure.html
+++ b/test-server/autocapture/viewport-exposure.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Viewport Exposure (50% visibility) Test</title>
+    <style>
+        body { margin: 0; font: 14px/1.5 system-ui, sans-serif; }
+
+        #hud {
+            position: fixed; top: 0; left: 0; right: 0; z-index: 2147483647;
+            padding: 8px 12px; background: #111; color: #eee;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, .4);
+        }
+        #hud h1 { font-size: 14px; margin: 0 0 4px; }
+        #hud .hint { color: #999; font-size: 12px; }
+        #hud button { margin: 4px 4px 0 0; }
+        #readout { margin-top: 6px; font-family: monospace; }
+        #exposed { margin-top: 4px; font-family: monospace; color: #6cf; max-height: 20vh; overflow: auto; }
+        #status { margin-top: 4px; font-family: monospace; color: #888; }
+
+        .spacer { display: flex; align-items: center; justify-content: center; color: #bbb; background: #f6f6f6; }
+        .spacer.lead { height: 150vh; }
+        .spacer.gap { height: 150vh; }
+        .spacer.tail { height: 150vh; }
+
+        /* Fixed height keeps the 30% / 50% / 100% arithmetic easy to eyeball. */
+        #exposure-target {
+            display: block; width: 60%; height: 240px; margin: 0 auto;
+            font-size: 18px; background: #d9ecff; border: 2px solid #3b82f6;
+        }
+
+        /* Taller than any viewport, so it can never reach 50% of its own area. */
+        #oversized-target {
+            display: block; width: 60%; height: 250vh; margin: 0 auto;
+            font-size: 18px; background: #ffeaea; border: 2px solid #ef4444;
+        }
+    </style>
+</head>
+<body>
+    <div id="hud">
+        <h1>Viewport Exposure Test — exposure fires at 50% visibility</h1>
+        <div class="hint">
+            Scroll <code>#exposure-target</code> partly into view, then flush. Below 50% it must not be
+            exposed; at 50% or more it must be. Control buttons are autocaptured elements too, so they
+            also show up in the exposed list.
+        </div>
+        <div>
+            <button id="scroll-30" type="button">Scroll target to 30%</button>
+            <button id="scroll-49" type="button">49%</button>
+            <button id="scroll-50" type="button">50%</button>
+            <button id="scroll-60" type="button">60%</button>
+            <button id="scroll-100" type="button">100%</button>
+            <button id="scroll-oversized" type="button">Fill viewport with oversized element</button>
+            <button id="flush" type="button">Flush exposures</button>
+        </div>
+        <div id="readout">target visibility: —</div>
+        <div id="exposed">exposed so far: (none)</div>
+        <div id="status">ready</div>
+    </div>
+
+    <div class="spacer lead">scroll down</div>
+
+    <button id="exposure-target" type="button">Exposure target (240px tall)</button>
+
+    <div class="spacer gap">keep scrolling</div>
+
+    <button id="oversized-target" type="button">
+        Oversized target — taller than the viewport, so it never reaches 50% of its own area and is
+        expected to stay unexposed
+    </button>
+
+    <div class="spacer tail">end of page</div>
+
+    <script type="module">
+        import * as amplitude from '@amplitude/analytics-browser';
+
+        window.amplitude = amplitude;
+
+        // Matches the plugin default; stated explicitly so the harness and the
+        // Playwright spec can size their waits off the same number.
+        const EXPOSURE_DURATION = 150;
+
+        const target = () => document.getElementById('exposure-target');
+
+        // IntersectionObserver clips against the layout viewport, so the ratio the
+        // observer sees is measured against clientHeight, not innerHeight.
+        const viewportHeight = () => document.documentElement.clientHeight;
+
+        const visibleFraction = (element) => {
+            const rect = element.getBoundingClientRect();
+            const visible = Math.min(rect.bottom, viewportHeight()) - Math.max(rect.top, 0);
+            return Math.max(0, Math.min(visible, rect.height)) / rect.height;
+        };
+
+        /**
+         * Scroll so that `fraction` of `element` sits inside the viewport, entering
+         * from the bottom edge, and return the fraction actually achieved (clamped
+         * by the document's scroll range).
+         */
+        const scrollElementTo = (fraction, element = target()) => {
+            const rect = element.getBoundingClientRect();
+            const documentTop = rect.top + window.scrollY;
+            const maxScroll = document.documentElement.scrollHeight - viewportHeight();
+            const scrollY = documentTop + fraction * rect.height - viewportHeight();
+            window.scrollTo(0, Math.max(0, Math.min(scrollY, maxScroll)));
+            return visibleFraction(element);
+        };
+
+        // Exposure is reported on navigation/unload, so dispatch beforeunload to
+        // flush whatever has been exposed since the last flush.
+        const flush = () => window.dispatchEvent(new Event('beforeunload'));
+
+        const exposedPaths = [];
+
+        window.__exposureHarness = { scrollElementTo, visibleFraction, flush, exposedPaths, EXPOSURE_DURATION };
+
+        // Renders every exposed element path from the captured
+        // `[Amplitude] Viewport Content Updated` events. Enrichment plugin, so
+        // nothing is swallowed and the payload still goes out to the network.
+        const exposureLogger = {
+            name: 'harness-exposure-logger',
+            type: 'enrichment',
+            setup: async () => undefined,
+            execute: async (event) => {
+                if (event.event_type === '[Amplitude] Viewport Content Updated') {
+                    const paths = event.event_properties?.['[Amplitude] Element Exposed'] ?? [];
+                    exposedPaths.push(...paths);
+                    // eslint-disable-next-line no-console
+                    console.log('%c[Amplitude] Viewport Content Updated', 'color:#0a0', paths);
+                    document.getElementById('exposed').textContent =
+                        'exposed so far: ' + (exposedPaths.length ? exposedPaths.join(', ') : '(none)');
+                }
+                return event;
+            },
+        };
+
+        const renderReadout = () => {
+            const fraction = visibleFraction(target());
+            const percent = Math.round(fraction * 100);
+            document.getElementById('readout').textContent =
+                `target visibility: ${percent}% → ${fraction >= 0.5 ? 'should expose' : 'should NOT expose'}`;
+        };
+
+        let readoutQueued = false;
+        window.addEventListener('scroll', () => {
+            if (readoutQueued) return;
+            readoutQueued = true;
+            requestAnimationFrame(() => {
+                readoutQueued = false;
+                renderReadout();
+            });
+        });
+
+        document.getElementById('scroll-30').addEventListener('click', () => scrollElementTo(0.3));
+        document.getElementById('scroll-49').addEventListener('click', () => scrollElementTo(0.49));
+        document.getElementById('scroll-50').addEventListener('click', () => scrollElementTo(0.5));
+        document.getElementById('scroll-60').addEventListener('click', () => scrollElementTo(0.6));
+        document.getElementById('scroll-100').addEventListener('click', () => scrollElementTo(1));
+        document.getElementById('scroll-oversized').addEventListener('click', () =>
+            scrollElementTo(0.5, document.getElementById('oversized-target')),
+        );
+        document.getElementById('flush').addEventListener('click', flush);
+
+        // Self-contained: fall back to a dummy key so the page works without a
+        // configured environment. The Playwright spec intercepts track requests,
+        // so the key value is irrelevant to the assertions.
+        const apiKey = import.meta.env.VITE_AMPLITUDE_API_KEY || 'viewport-exposure-e2e-key';
+
+        amplitude.init(apiKey, 'test-user', {
+            fetchRemoteConfig: false,
+            // Flush eagerly so exposure events reach the network quickly.
+            flushIntervalMillis: 300,
+            flushQueueSize: 1,
+            autocapture: {
+                pageViews: false,
+                sessions: false,
+                formInteractions: false,
+                fileDownloads: false,
+                elementInteractions: {
+                    viewportContentUpdated: { enabled: true, exposureDuration: EXPOSURE_DURATION },
+                },
+            },
+            logLevel: 0,
+        }).promise.then(() => {
+            amplitude.add(exposureLogger);
+            renderReadout();
+            document.getElementById('status').textContent = 'initialized';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

A zone is exposed when its **mid-height pixel line has been displayed for at least 150ms**.

This is vertical depth scrolled through, not the share of the element's area on screen at one moment. The difference matters for zones taller than the viewport: less than half their area can ever be visible, but their midpoint is still scrolled through.

### Implementation

- The shared `IntersectionObserver` uses `threshold: 0` purely to keep a small candidate set of elements touching the viewport.
- The shared scroll observable listens in the capture phase, so non-bubbling scroll events from overflow containers are included alongside window scrolling.
- `trackExposure` evaluates candidates on intersection changes and scroll via `getBoundingClientRect()`.
- Midpoint visibility is clipped against the viewport and each overflow-clipping visual ancestor, including assigned slots and open shadow-root hosts. A midpoint hidden outside a scroll panel does not count.
- A 150ms timer starts when the element's mid-height line is visible, and is cancelled if that line leaves first, so scrolling straight past a zone does not expose it.
- Repeated evaluations do not restart a pending timer, so slow scrolling across the midpoint still satisfies the dwell.
- `reset()` clears only page-view state (reported zones and in-flight dwells) and re-evaluates what is still on screen. It deliberately keeps the intersecting candidate set: `IntersectionObserver` never re-notifies an element that never stopped intersecting, so clearing it silently stopped scroll-driven checks for everything currently visible after any page-view end or SPA navigation. Teardown clears everything.
- The line check allows 1px of tolerance. Engines round fractional scroll offsets differently: after an identical scroll to a zone's exact midpoint, Chromium put the line 0.41px inside the viewport and WebKit 0.59px outside. A sub-pixel rounding artifact should not decide the metric.

### Tests

Unit tests cover sub-pixel boundaries, clipping ancestors, slots, open shadow roots, capture of non-bubbling element scroll events, and the reset regression (both that scroll keeps working afterwards and that a partly elapsed dwell does not carry into the next page view).

Real browser (Chromium + WebKit) coverage in the plugin e2e directory includes 49% depth (not exposed), exactly the mid-height line (exposed), 60% and full depth (exposed), crossing the midpoint then leaving before the dwell (not exposed), an oversized zone (exposed once its midpoint is viewed, with under half its area on screen), a nested overflow scroller whose clipped midpoint must not expose until the panel is scrolled, a sticky site header that is reported on the first event and stays in view after scroll, and the emitted payload shape.

### Manual verification

From the repository root:

```bash
pnpm install
pnpm build
npx vite dev
```

Open http://localhost:5173/autocapture/viewport-exposure.html and simply scroll. Each zone shows a dashed 50% line, turns amber while that line is in view, and green once the SDK reports it. The top bar is a sticky site header that stays in the viewport, so it should appear in an exposed event on load. The HUD lists every zone with its max depth viewed, share on screen, and state, and the summary names any zone it is still waiting on together with the reason — clipped by a scroll panel, passed without dwelling, or not reached yet. `?exposureDuration=` stretches the dwell if you want to watch it happen. The purple panel covers the nested-scroller case, and the jump buttons cover the precise 30 / 49 / 50 / 60 / 100% cases.

The right-hand panel shows the actual event objects the SDK sends, newest first, read off an enrichment plugin so it is exactly what gets uploaded — `[Amplitude] Element Exposed` alongside the page URL, viewport size, and max scroll that ship with it. Flushes that only advance scroll depth appear with an empty `Element Exposed` array, which makes the batching visible:

![Harness with the event payload panel showing an Element Exposed array and the rest of the event properties](https://cursor.com/artifacts/c/art-3d385384-0e55-4374-b62c-27995a4bcca6)

Partway down a normal scroll, zones expose one after another as each midpoint is passed:

![Harness partway down a scroll: four zones exposed, later zones still pending](https://cursor.com/artifacts/c/art-c9135848-c7cc-4b33-a946-b5464e1a9803)

The 250vh zone exposes with only 40% of it on screen, which an area-based threshold could never do. Note also `#zone-5` and `#exposure-target`, which a jump scrolled straight past: their line was reached but never dwelled on, so they are correctly unexposed.

![Oversized zone exposed at its midpoint with 40% on screen; skipped zones remain unexposed](https://cursor.com/artifacts/c/art-96da398d-24c6-4573-a88c-646b4df7e90b)

To run the automated spec while that server is up:

```bash
npx playwright test packages/plugin-autocapture-browser/e2e/viewport-exposure.spec.ts
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No, but exposure semantics change intentionally — from requiring the whole element visible to midpoint viewing, so more elements (including ones taller than the viewport) will now be reported.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4ec441-e00f-42a2-ae74-96cf241790f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4ec441-e00f-42a2-ae74-96cf241790f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

