### PR TITLE
fix: re-order delayedEventsServerUrl parsing

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -44,17 +44,22 @@ import { AmplitudeBrowser } from './browser-client';
 import { VERSION } from './version';
 import { getDomain, KNOWN_2LDS } from './attribution/helpers';
 
+/**
+ * Delayed (heartbeat) events go to the dedicated delayed events endpoint, which is where the
+ * `/delayed` route is served. A customer-provided `serverUrl` still wins so all traffic stays
+ * on their domain; `useBatch` is not consulted because the Batch API has no `/delayed` route.
+ */
 export const getDelayedEventsServerUrl = (
   serverUrl: string | undefined,
   delayedEventsServerUrl: string | undefined,
   serverZone: ServerZoneType = DEFAULT_SERVER_ZONE,
 ) => {
-  if (serverUrl) {
-    // serverUrl already includes /2/httpapi; Destination uses the same `${serverUrl}/delayed` fallback.
-    return `${serverUrl}/delayed`;
-  }
   if (delayedEventsServerUrl) {
     return delayedEventsServerUrl;
+  }
+  if (serverUrl) {
+    // serverUrl already includes /2/httpapi
+    return `${serverUrl}/delayed`;
   }
   switch (serverZone) {
     case 'EU':

--- a/packages/analytics-browser/test/config.test.ts
+++ b/packages/analytics-browser/test/config.test.ts
@@ -177,22 +177,30 @@ describe('config', () => {
       );
     });
 
-    test('should derive delayedEventsServerUrl from custom serverUrl', async () => {
+    test('should derive delayedEventsServerUrl from a custom serverUrl', async () => {
       jest.spyOn(Config, 'getTopLevelDomain').mockResolvedValueOnce('.amplitude.com');
       const serverUrl = 'https://proxy.example.com/2/httpapi';
       const config = await Config.useBrowserConfig(apiKey, { serverUrl }, new AmplitudeBrowser());
       expect(config.delayedEventsServerUrl).toBe(`${serverUrl}/delayed`);
     });
 
-    test('should prefer custom serverUrl over delayedEventsServerUrl', async () => {
+    test('should keep the delayed events endpoint when useBatch is enabled', async () => {
       jest.spyOn(Config, 'getTopLevelDomain').mockResolvedValueOnce('.amplitude.com');
-      const serverUrl = 'https://proxy.example.com/2/httpapi';
+      const config = await Config.useBrowserConfig(apiKey, { useBatch: true }, new AmplitudeBrowser());
+      expect(config.delayedEventsServerUrl).toBe(
+        'https://delayed-events.prod.us-west-2.amplitude.com/2/httpapi/delayed',
+      );
+    });
+
+    test('should prefer delayedEventsServerUrl over a custom serverUrl', async () => {
+      jest.spyOn(Config, 'getTopLevelDomain').mockResolvedValueOnce('.amplitude.com');
+      const delayedEventsServerUrl = 'https://example.com/2/httpapi/delayed';
       const config = await Config.useBrowserConfig(
         apiKey,
-        { serverUrl, delayedEventsServerUrl: 'https://example.com/2/httpapi/delayed' },
+        { serverUrl: 'https://proxy.example.com/2/httpapi', delayedEventsServerUrl },
         new AmplitudeBrowser(),
       );
-      expect(config.delayedEventsServerUrl).toBe(`${serverUrl}/delayed`);
+      expect(config.delayedEventsServerUrl).toBe(delayedEventsServerUrl);
     });
 
     test('should fall back to memoryStorage when storageProvider is not enabled', async () => {
@@ -416,6 +424,12 @@ describe('config', () => {
     test('should default unknown server zones to the US delayed events endpoint', () => {
       expect(Config.getDelayedEventsServerUrl(undefined, undefined, 'STAGING' as never)).toBe(
         'https://delayed-events.prod.us-west-2.amplitude.com/2/httpapi/delayed',
+      );
+    });
+
+    test('should use the EU delayed events endpoint for the EU server zone', () => {
+      expect(Config.getDelayedEventsServerUrl(undefined, undefined, 'EU')).toBe(
+        'https://delayed-events.prod.eu-central-1.amplitude.com/2/httpapi/delayed',
       );
     });
 


### PR DESCRIPTION
### Summary

If the client provides a "delayedEventsServerUrl", that should take precedence over "serverUrl" when setting delayed service url.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which URL receives heartbeat/delayed events when both `serverUrl` and `delayedEventsServerUrl` are set—a behavior fix that could alter production routing for customers who relied on the old order.
> 
> **Overview**
> **Fixes resolution order for the delayed (heartbeat) events URL** in `getDelayedEventsServerUrl`. An explicit `delayedEventsServerUrl` is now applied **before** deriving `${serverUrl}/delayed`, so a custom proxy `serverUrl` no longer overrides a dedicated delayed endpoint.
> 
> Adds a short comment that delayed traffic targets the `/delayed` route (not the Batch API). **Tests** match the new precedence, assert the US delayed-events host when `useBatch: true`, and cover EU defaults on the helper directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe803977b03988cd04defa7bea1853d089fce2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->