### PR TITLE
fix: fixes delayed events cleanup logic

### DIFF
--- a/packages/analytics-core/src/plugins/destination.ts
+++ b/packages/analytics-core/src/plugins/destination.ts
@@ -1,5 +1,5 @@
 import { DestinationPlugin } from '../types/plugin';
-import { Event } from '../types/event/event';
+import { DelayedEvent, Event } from '../types/event/event';
 import { Delay } from '../types/event/base-event';
 import { Result } from '../types/result';
 import { Status } from '../types/status';
@@ -63,6 +63,10 @@ const shouldCompressUploadBodyForRequest = (serverUrl: string, enableRequestBody
 function getErrorMessage(error: unknown) {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function isDelayedEvent(event: Event) {
+  return event.delay !== undefined && event.delay !== null;
 }
 
 export function getResponseBodyString(res: Response) {
@@ -131,7 +135,9 @@ export class Destination implements DestinationPlugin {
         callback: (result: Result) => resolve(result),
         timeout: 0,
       };
-      this.removeStaleDelayedEvents(event);
+      if (isDelayedEvent(event)) {
+        this.removeStaleDelayedEvents(event as DelayedEvent);
+      }
       this.queue.push(context);
       this.schedule(this.config.flushIntervalMillis);
       this.saveEvents();
@@ -142,31 +148,49 @@ export class Destination implements DestinationPlugin {
    * If a stale delayed event is sitting in the queue, and it is not in flight,
    * remove it and resolve as "stale" with status code 0.
    *
-   * If this delayed event is already in flight, mark it as fresh, so that
-   * when it completes, it won't clean-up the updated event.
+   * If a matching delayed event is already in flight, clone `delay` onto the
+   * incoming event and set skipRemoval so the in-flight send does not drop the
+   * replacement. Earlier replacements waiting on the same send are discarded
+   * as stale so only the latest copy remains.
    * @param incomingEvent { Event } the new event to check old events against
    * @returns void
    */
-  private removeStaleDelayedEvents(incomingEvent: Event) {
+  private removeStaleDelayedEvents(incomingEvent: DelayedEvent) {
     try {
-      if (!incomingEvent.delay?.id) {
-        return;
-      }
       /* istanbul ignore next */
       this.queue = this.queue.filter((context) => {
-        if (
-          incomingEvent.delay &&
-          context.event.delay &&
-          context.event.delay.id === incomingEvent.delay.id &&
-          context.event.insert_id === incomingEvent.insert_id
-        ) {
-          if (this.inFlightDelayedEvents[incomingEvent.delay.id]) {
-            incomingEvent.delay.isFresh = true;
-            return true;
-          }
-          context.callback(buildResult(context.event, 0, 'Stale event overwritten'));
+        const targetEvent = context.event;
+
+        if (!isDelayedEvent(targetEvent)) {
+          return true;
+        }
+
+        // target event matches the incoming event if it has the same insert_id and delay id
+        // as the incoming event (the incoming event takes precedence)
+        const isMatchingEvent =
+          targetEvent.delay!.id === incomingEvent.delay.id && targetEvent.insert_id === incomingEvent.insert_id;
+
+        // do not filter out non matching events
+        if (!isMatchingEvent) {
+          return true;
+        }
+
+        // are there delayed events for this delay id currently in flight?
+        const areDelayedEventsInFlight = this.inFlightDelayedEvents[incomingEvent.delay.id];
+
+        // if they are, then protect the target event from being removed from the queue
+        // after the in-flight send completes by setting skipRemoval on the incoming event
+        if (areDelayedEventsInFlight) {
+          incomingEvent.delay = { ...incomingEvent.delay, skipRemoval: true };
+        }
+
+        // if events are not in flight, or if the target event is marked to skipRemoval,
+        // then the incoming event supersedes the target event, and target event should be dropped
+        if (!areDelayedEventsInFlight || targetEvent.delay?.skipRemoval) {
+          context.callback(buildResult(targetEvent, 0, 'Stale event overwritten'));
           return false;
         }
+
         return true;
       });
       /* istanbul ignore next */
@@ -556,13 +580,14 @@ export class Destination implements DestinationPlugin {
     this.queue = this.queue.filter(
       (queuedContext) =>
         !eventsToRemove.some(
-          (context) => context.event.insert_id === queuedContext.event.insert_id && !queuedContext.event.delay?.isFresh,
+          (context) =>
+            context.event.insert_id === queuedContext.event.insert_id && !queuedContext.event.delay?.skipRemoval,
         ),
     );
 
     this.queue.forEach((context) => {
-      if (context.event.delay?.isFresh && insertIdsBeingRemoved.has(context.event.insert_id)) {
-        delete context.event.delay.isFresh;
+      if (context.event.delay?.skipRemoval && insertIdsBeingRemoved.has(context.event.insert_id)) {
+        delete context.event.delay.skipRemoval;
       }
     });
 

--- a/packages/analytics-core/src/types/event/base-event.ts
+++ b/packages/analytics-core/src/types/event/base-event.ts
@@ -4,9 +4,8 @@ import { IngestionMetadataEventProperty } from './ingestion-metadata';
 export interface Delay {
   id: string;
   timeout?: number;
-  // indicates that this event was updated while in flight,
-  // so do not clean-up after it was sent
-  isFresh?: true;
+  // Do not drop this event when a send for the same insert_id completes.
+  skipRemoval?: true;
 }
 
 export interface BaseEvent extends EventOptions {

--- a/packages/analytics-core/src/types/event/event.ts
+++ b/packages/analytics-core/src/types/event/event.ts
@@ -1,4 +1,4 @@
-import { BaseEvent } from './base-event';
+import { BaseEvent, Delay } from './base-event';
 import { RevenueEventProperties } from '../../revenue';
 
 export enum IdentifyOperation {
@@ -122,6 +122,10 @@ export interface RevenueEvent extends BaseEvent {
     | {
         [key: string]: any;
       };
+}
+
+export interface DelayedEvent extends BaseEvent {
+  delay: Delay;
 }
 
 export type Event = TrackEvent | IdentifyEvent | GroupIdentifyEvent | RevenueEvent;

--- a/packages/analytics-core/test/plugins/destination.test.ts
+++ b/packages/analytics-core/test/plugins/destination.test.ts
@@ -14,6 +14,7 @@ import {
 import { uuidPattern } from '../helpers/util';
 import { DiagnosticsClient, RequestMetadata } from '../../src';
 import { TrackEvent } from '../../src/types/event/event';
+import { Delay } from '../../src/types/event/base-event';
 import { AMPLITUDE_SERVER_URL } from '../../src/types/constants';
 
 const jsons = (obj: any) => JSON.stringify(obj, null, 2);
@@ -230,7 +231,121 @@ describe('destination', () => {
         expect(send).toHaveBeenCalledTimes(2);
       });
 
-      test('should retain isFresh when a parallel regular flush completes first', async () => {
+      test('should not mark a shared in-flight delay object with skipRemoval', async () => {
+        const delay: Delay = { id: delayId };
+        const predecessor = {
+          event_type: 'before',
+          insert_id: '123',
+          delay,
+        };
+        const replacement = {
+          event_type: 'after',
+          insert_id: '123',
+          delay,
+        };
+        let resolveSend!: (value: Response) => void;
+        const sendPromise = new Promise<Response>((resolve) => {
+          resolveSend = resolve;
+        });
+        const successResponse = {
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        } as Response;
+        const send = jest.fn().mockReturnValueOnce(sendPromise).mockResolvedValueOnce(successResponse);
+        destination.config = {
+          ...useDefaultConfig(),
+          transportProvider: { send },
+        };
+
+        const predecessorResult = destination.execute(predecessor);
+        const flushPromise = destination.flush(true);
+        const replacementResult = destination.execute(replacement);
+
+        expect(destination.queue).toHaveLength(2);
+        expect(predecessor.delay.skipRemoval).toBeUndefined();
+        expect(replacement.delay).not.toBe(delay);
+        expect(replacement.delay.skipRemoval).toBe(true);
+
+        resolveSend(successResponse);
+        await predecessorResult;
+        await flushPromise;
+
+        expect(destination.queue).toHaveLength(1);
+        expect(destination.queue[0].event).toBe(replacement);
+
+        await destination.flush(true);
+
+        await expect(replacementResult).resolves.toEqual({
+          event: replacement,
+          code: 200,
+          message: SUCCESS_MESSAGE,
+        });
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(send.mock.calls[1][1].instant_events).toHaveLength(1);
+      });
+
+      test('should keep only the latest replacement while a predecessor is in flight', async () => {
+        const event3 = {
+          event_type: 'after-after',
+          insert_id: '123',
+          delay: { id: delayId },
+        };
+        let resolveSend!: (value: Response) => void;
+        const sendPromise = new Promise<Response>((resolve) => {
+          resolveSend = resolve;
+        });
+        const successResponse = {
+          status: Status.Success,
+          statusCode: 200,
+          body: {
+            eventsIngested: 1,
+            payloadSizeBytes: 1,
+            serverUploadTime: 1,
+          },
+        } as Response;
+        const send = jest.fn().mockReturnValueOnce(sendPromise).mockResolvedValueOnce(successResponse);
+        destination.config = {
+          ...useDefaultConfig(),
+          transportProvider: { send },
+        };
+
+        const predecessorResult = destination.execute(event1);
+        const flushPromise = destination.flush(true);
+        const firstReplacementResult = destination.execute(event2);
+        const secondReplacementResult = destination.execute(event3);
+
+        expect(destination.queue).toHaveLength(2);
+        expect(destination.queue.map((context) => context.event)).toEqual([event1, event3]);
+        await expect(firstReplacementResult).resolves.toEqual({
+          event: event2,
+          code: 0,
+          message: 'Stale event overwritten',
+        });
+
+        resolveSend(successResponse);
+        await predecessorResult;
+        await flushPromise;
+
+        expect(destination.queue).toHaveLength(1);
+        expect(destination.queue[0].event).toEqual(event3);
+
+        await destination.flush(true);
+
+        await expect(secondReplacementResult).resolves.toEqual({
+          event: event3,
+          code: 200,
+          message: SUCCESS_MESSAGE,
+        });
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(send.mock.calls[1][1].instant_events).toHaveLength(1);
+      });
+
+      test('should retain skipRemoval when a parallel regular flush completes first', async () => {
         let resolveDelayedSend!: (value: Response) => void;
         const delayedSendPromise = new Promise<Response>((resolve) => {
           resolveDelayedSend = resolve;
@@ -263,13 +378,13 @@ describe('destination', () => {
         const replacementResult = destination.execute(event2);
 
         expect(destination.queue).toHaveLength(3);
-        expect(destination.queue[2].event.delay?.isFresh).toBe(true);
+        expect(destination.queue[2].event.delay?.skipRemoval).toBe(true);
 
         // Regular batch completes while delayed predecessor is still in flight.
-        // removeEvents must not clear isFresh on the unrelated replacement.
+        // removeEvents must not clear skipRemoval on the unrelated replacement.
         await regularResult;
         expect(destination.queue).toHaveLength(2);
-        expect(destination.queue.find((c) => c.event === event2)?.event.delay?.isFresh).toBe(true);
+        expect(destination.queue.find((c) => c.event === event2)?.event.delay?.skipRemoval).toBe(true);
 
         resolveDelayedSend(successResponse);
         await predecessorResult;


### PR DESCRIPTION
### Summary

Fixing issues with destination and refactored to be more readable.

Logic:
* if a delayed-event **Event A** with `insert_id=1` is in the queue, and another delayed-event **Event B** with `insert_id=1` is enqueued; then delete event A
* if a delayed-event **Event A** with `insert_id=1` is in-flight, and another delayed-event **Event B** with `insert_id=1` is enqueued; then let A complete, and do not delete B. Deletion is prevent by adding a temporary flag called `skipRemoval`
* if a delayed-event **Event A** with `insert_id=1` is in-flight, and another delayed-event **Event B** with `insert_id=1` is enqueued with `skipRemoval=true`; and another delayed-event **Event C** with `insert_id=1` is incoming; then delete **Event B** and set `skipRemoval=true` on **Event C**

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event upload queue and post-response removal for delayed events; incorrect logic could drop or duplicate analytics payloads, though scope is limited to delayed-event paths and is heavily tested.
> 
> **Overview**
> Fixes **delayed event** deduplication in the destination plugin when the same `insert_id` and delay id are enqueued again while an older copy is queued or in flight.
> 
> The temporary **`Delay.isFresh` flag is renamed to `skipRemoval`**, with clearer semantics: after an in-flight send completes, queue cleanup must not drop a replacement that was enqueued during the send. **`removeStaleDelayedEvents`** is refactored so queued duplicates are resolved as stale immediately; if a matching send is in flight, the **incoming** event gets a **cloned** `delay` with `skipRemoval` (avoiding mutation of a shared delay object on the in-flight predecessor); intermediate replacements marked `skipRemoval` can still be superseded so **only the latest** replacement remains. Stale cleanup runs only for events that pass a new **`DelayedEvent` / `isDelayedEvent`** check.
> 
> Tests cover shared delay objects, chained replacements during in-flight sends, and parallel regular flush not clearing `skipRemoval`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7108ec751cdc905510ed86f9d4b3e7d4d47a0aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->