### PR TITLE
fix: add error handling to video element

### DIFF
--- a/packages/analytics-browser/src/video-capture/video-capture.ts
+++ b/packages/analytics-browser/src/video-capture/video-capture.ts
@@ -233,6 +233,7 @@ export class VideoCapture {
       start_time: this.playStartTime ?? nextState.lastEvent?.start_time ?? 0,
       watch_duration: nextState.watchTime ?? 0,
       percent_completed: calculatePercentCompleted(nextState.position ?? 0, nextState.lastEvent?.duration ?? 0),
+      ...(nextState.errorMessage ? { error_message: nextState.errorMessage } : {}),
     };
   }
 }

--- a/packages/analytics-browser/test/video-capture/video-capture.test.ts
+++ b/packages/analytics-browser/test/video-capture/video-capture.test.ts
@@ -378,6 +378,44 @@ describe('VideoCapture', () => {
       );
     });
 
+    it('should end a stalled play session when the media element errors', async () => {
+      new VideoCapture(mockAmplitude)
+        .withVideoElement(document.createElement('video'))
+        .captureVideoStarted()
+        .captureVideoStopped()
+        .start();
+
+      currentVideoObserver!.emitStateChange({ playbackState: 'paused', lastEvent: undefined }, playingState);
+      await flushHeartbeat();
+      currentVideoObserver!.emitStateChange(playingState, waitingState);
+      await flushHeartbeat();
+      jest.clearAllMocks();
+
+      currentVideoObserver!.emitStateChange(waitingState, {
+        ...waitingState,
+        playbackState: 'error',
+        errorMessage: 'Media element error (code 2): network',
+      });
+      await flushHeartbeat();
+
+      expect(mockAmplitude.track).toHaveBeenCalledTimes(1);
+      expect(mockAmplitude.track).toHaveBeenCalledWith(
+        '[Amplitude] Content Stopped',
+        expect.objectContaining({
+          stop_reason: 'error',
+          error_message: 'Media element error (code 2): network',
+          position: 5,
+          watch_duration: 5,
+        }),
+        expect.objectContaining({ delay: { id: expect.any(String) } }),
+      );
+
+      // the session is closed out, so the 1-hour delayed stop event no longer heartbeats
+      jest.clearAllMocks();
+      await jest.advanceTimersByTimeAsync(60_000);
+      expect(mockAmplitude.track).not.toHaveBeenCalled();
+    });
+
     it('should heartbeat the delayed stop event with the latest playback progress', async () => {
       new VideoCapture(mockAmplitude)
         .withVideoElement(document.createElement('video'))

--- a/packages/analytics-core/src/observers/video.ts
+++ b/packages/analytics-core/src/observers/video.ts
@@ -101,6 +101,7 @@ export class VideoObserver {
     const nextState: State = {
       ...this.state,
       playbackState,
+      errorMessage: undefined,
       lastEvent: event,
       position: event.last_position,
     };

--- a/packages/analytics-core/src/video-analytics/track-video.ts
+++ b/packages/analytics-core/src/video-analytics/track-video.ts
@@ -29,6 +29,13 @@ function getVideoData(videoEl: HTMLMediaElement | MuxElement, stopReason?: Video
   };
 }
 
+function getMediaErrorMessage(error: MediaError | null | undefined) {
+  if (!error) {
+    return 'Media element error';
+  }
+  return `Media element error (code ${error.code})${error.message ? `: ${error.message}` : ''}`;
+}
+
 function getMuxMetadata(videoEl: MuxElement) {
   return {
     mux_playback_id: videoEl.getAttribute('playback-id'),
@@ -90,6 +97,11 @@ export function trackHtmlVideo(videoEl: HTMLMediaElement | MuxElement, handlers:
   };
   videoEl.addEventListener('seeked', seekedHandler);
 
+  const errorHandler = () => {
+    handlers.onError(getMediaErrorMessage((videoEl as HTMLMediaElement).error));
+  };
+  videoEl.addEventListener('error', errorHandler);
+
   const timeupdateHandler = () => {
     const media = videoEl as HTMLMediaElement;
     const timeupdateEvent: TimeUpdateEvent = {
@@ -106,6 +118,7 @@ export function trackHtmlVideo(videoEl: HTMLMediaElement | MuxElement, handlers:
     videoEl.removeEventListener('ended', endedHandler);
     videoEl.removeEventListener('seeking', seekingHandler);
     videoEl.removeEventListener('seeked', seekedHandler);
+    videoEl.removeEventListener('error', errorHandler);
     videoEl.removeEventListener('timeupdate', timeupdateHandler);
   };
 }

--- a/packages/analytics-core/test/video-analytics/mock-video.ts
+++ b/packages/analytics-core/test/video-analytics/mock-video.ts
@@ -134,6 +134,17 @@ export function createMockVideo(options: { isMux: boolean } = { isMux: false }):
     }),
   });
 
+  Object.defineProperty(HTMLMediaElement.prototype, 'simulateError', {
+    configurable: true,
+    value: jest.fn(function (
+      this: HTMLVideoElement,
+      error: Partial<MediaError> | null = { code: 2, message: 'network' },
+    ) {
+      Object.defineProperty(this, 'error', { configurable: true, value: error });
+      this.dispatchEvent(new Event('error'));
+    }),
+  });
+
   Object.defineProperty(HTMLMediaElement.prototype, 'seeked', {
     configurable: true,
     value: jest.fn(function (this: HTMLVideoElement, time?: number) {

--- a/packages/analytics-core/test/video-analytics/track-video.test.ts
+++ b/packages/analytics-core/test/video-analytics/track-video.test.ts
@@ -91,6 +91,25 @@ describe('trackHtmlVideo', () => {
     expect(handler.onSeeked).not.toHaveBeenCalled();
   });
 
+  test('should track error events', () => {
+    const untrack = trackHtmlVideo(video, handler);
+
+    video.play();
+    (video as any).simulateError({ code: 2, message: 'network' });
+    expect(handler.onError).toHaveBeenCalledWith('Media element error (code 2): network');
+
+    (video as any).simulateError({ code: 4, message: '' });
+    expect(handler.onError).toHaveBeenLastCalledWith('Media element error (code 4)');
+
+    (video as any).simulateError(null);
+    expect(handler.onError).toHaveBeenLastCalledWith('Media element error');
+
+    untrack();
+    handler.onError = jest.fn();
+    (video as any).simulateError();
+    expect(handler.onError).not.toHaveBeenCalled();
+  });
+
   test('should track timeupdate events', () => {
     const untrack = trackHtmlVideo(video, handler);
 

--- a/test-server/video-analytics/track-html-video.html
+++ b/test-server/video-analytics/track-html-video.html
@@ -9,6 +9,7 @@
       Your browser does not support the video tag.
     </video>
     <button id="stop-video">Stop Capturing</button>
+    <button id="force-error">Force Error</button>
     <script src="https://cdn.jsdelivr.net/npm/@mux/mux-player" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/mux-embed@latest/dist/mux.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
@@ -75,6 +76,10 @@
 
       document.getElementById('stop-video').addEventListener('click', () => {
         stopVideoCapture();
+      });
+
+      document.getElementById('force-error').addEventListener('click', () => {
+        video.dispatchEvent(new Event('error'));
       });
     </script>
   </body>


### PR DESCRIPTION
### Summary

Handles a video "error" event. When video errors, triggered a Stop event.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics behavior on the existing video pipeline with tests; no auth or breaking API changes.
> 
> **Overview**
> **HTML video error events** are now listened to in `trackHtmlVideo`, formatted via `getMediaErrorMessage`, and forwarded through `VideoObserver` into an **`error` playback state** with a stored message.
> 
> When an active play session hits that state, **`VideoCapture` immediately flushes `[Amplitude] Content Stopped`** with **`stop_reason: 'error'`** and, when present, **`error_message`** on the stop payload—then closes the session so the delayed timeout stop no longer heartbeats. **`errorMessage` is cleared** on subsequent normal playback transitions so stale errors do not leak into later events.
> 
> Tests add **`simulateError`** for mocks plus coverage at the track and capture layers; the manual test page gets a **Force Error** button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6eb87ebddef89d06f5104939e4cf0d3501ed04. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->