### PR TITLE
fix: move delayedEventsServerUrl to end of function params

### DIFF
--- a/packages/analytics-browser/src/config.ts
+++ b/packages/analytics-browser/src/config.ts
@@ -113,7 +113,6 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     public partnerId?: string,
     public plan?: Plan,
     public serverUrl: string = '',
-    public delayedEventsServerUrl?: string,
     public serverZone: ServerZoneType = DEFAULT_SERVER_ZONE,
     sessionId?: number,
     deferredSessionId?: number,
@@ -139,6 +138,7 @@ export class BrowserConfig extends Config implements IBrowserConfig {
     public topLevelDomain?: string,
     public enableRequestBodyCompression: boolean = false,
     public customEnrichment?: boolean | CustomEnrichmentOptions,
+    public delayedEventsServerUrl?: string,
   ) {
     super({ apiKey, storageProvider, transportProvider: createTransport(transport) });
     this._cookieStorage = cookieStorage;
@@ -426,7 +426,6 @@ export const useBrowserConfig = async (
     options.partnerId,
     options.plan,
     options.serverUrl,
-    options.delayedEventsServerUrl,
     // Use earlyConfig.serverZone to ensure consistent serverZone
     earlyConfig?.serverZone ?? options.serverZone,
     sessionId,
@@ -450,6 +449,7 @@ export const useBrowserConfig = async (
     defaultCookieDomain,
     options.enableRequestBodyCompression,
     options.customEnrichment,
+    options.delayedEventsServerUrl,
   );
 
   if (!(await browserConfig.storageProvider.isEnabled())) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical parameter reorder with a single call site updated; no change to delayed-events URL logic.
> 
> **Overview**
> Reorders **`BrowserConfig`** constructor parameters so **`delayedEventsServerUrl`** is the last argument instead of sitting immediately after **`serverUrl`**.
> 
> The **`useBrowserConfig`** call site is updated to pass **`options.delayedEventsServerUrl`** at the end of the argument list, keeping positional arguments aligned with the constructor. Runtime behavior is unchanged: the constructor still derives the effective URL via **`getDelayedEventsServerUrl`** using **`serverUrl`**, the optional override, and **`serverZone`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e7d18145833b5ff5b071817ba375ad855b092c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->