### PR TITLE
feat(react-native): apply diagnostics sample rate from remote config

### DIFF
--- a/packages/analytics-core/src/remote-config/remote-config.ts
+++ b/packages/analytics-core/src/remote-config/remote-config.ts
@@ -180,6 +180,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
   // Optional custom transport. When provided, it replaces the internal fetch for the config GET
   // (e.g. to attach auth and route through a proxy). Retry stays in the client around it.
   readonly customFetch?: RemoteConfigCustomFetch;
+  readonly configGroup: string;
 
   constructor(
     apiKey: string,
@@ -187,12 +188,14 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     serverZone: ServerZoneType = 'US',
     serverUrl?: string,
     customFetch?: RemoteConfigCustomFetch,
+    configGroup: string = RemoteConfigClient.CONFIG_GROUP,
   ) {
     this.apiKey = apiKey;
     this.serverUrl = serverUrl || (serverZone === 'US' ? US_SERVER_URL : EU_SERVER_URL);
     this.logger = logger;
     this.storage = new RemoteConfigLocalStorage(apiKey, logger);
     this.customFetch = customFetch;
+    this.configGroup = configGroup;
   }
 
   subscribe(key: string | undefined, deliveryMode: DeliveryMode, callback: RemoteConfigCallback): string {
@@ -487,7 +490,7 @@ export class RemoteConfigClient implements IRemoteConfigClient {
     const encodedApiKey = encodeURIComponent(this.apiKey);
 
     const urlParams = new URLSearchParams();
-    urlParams.append('config_group', RemoteConfigClient.CONFIG_GROUP);
+    urlParams.append('config_group', this.configGroup);
 
     return `${this.serverUrl}/${encodedApiKey}?${urlParams.toString()}`;
   }

--- a/packages/analytics-core/test/remote-config/remote-config.test.ts
+++ b/packages/analytics-core/test/remote-config/remote-config.test.ts
@@ -1205,5 +1205,12 @@ describe('RemoteConfigClient', () => {
       const url = client.getUrlParams();
       expect(url).toBe(expectedUrl);
     });
+
+    test('should generate URL with a custom config group', () => {
+      client = new RemoteConfigClient(mockApiKey, mockLogger, 'US', undefined, undefined, 'android');
+      const expectedUrl = `https://sr-client-cfg.amplitude.com/config/test-api-key?config_group=android`;
+      const url = client.getUrlParams();
+      expect(url).toBe(expectedUrl);
+    });
   });
 });

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -162,7 +162,6 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     }
     const serverZone = options.serverZone ?? 'US';
     let remoteConfigClient: IRemoteConfigClient | undefined;
-    const diagnosticsClientRef: { current?: DiagnosticsClient } = {};
     let diagnosticsSampleRate = 0;
 
     // Step 0.2: Fetch diagnostics config
@@ -197,7 +196,6 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
               const sampleRate = remoteConfig.sampleRate as number;
               if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
                 diagnosticsSampleRate = sampleRate;
-                diagnosticsClientRef.current?._setSampleRate(sampleRate);
               }
             }
             resolve();
@@ -217,7 +215,6 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
       { sampleRate: diagnosticsSampleRate },
       new ReactNativeDiagnosticsStorage(options.apiKey, loggerProvider),
     );
-    diagnosticsClientRef.current = diagnosticsClient;
     diagnosticsClient.setTag('library', `${LIBPREFIX}/${VERSION}`);
     diagnosticsClient.setTag('platform', 'ReactNative');
     diagnosticsClient.setTag('os', Platform.OS);

--- a/packages/analytics-react-native/src/react-native-client.ts
+++ b/packages/analytics-react-native/src/react-native-client.ts
@@ -89,8 +89,25 @@ const getActiveRouteName = (navigationState: NavigationState): string | undefine
   return routeName;
 };
 
-// TODO: Remove IS_DIAGNOSTICS_CAPTURED when we're ready for diagnostics capture
-const IS_DIAGNOSTICS_CAPTURED = false;
+const getRemoteConfigPlatform = () => {
+  switch (Platform.OS) {
+    case 'ios':
+      return {
+        configGroup: 'ios',
+        diagnosticsKey: 'configs.diagnostics.iosSDK',
+      };
+    case 'android':
+      return {
+        configGroup: 'android',
+        diagnosticsKey: 'configs.diagnostics.androidSDK',
+      };
+    default:
+      return {
+        configGroup: 'browser',
+        diagnosticsKey: 'configs.diagnostics.browserSDK',
+      };
+  }
+};
 const getNetworkTrackingConfig = (config: ReactNativeConfig): NetworkTrackingOptions | undefined => {
   let networkTrackingConfig;
   if (typeof config.autocapture === 'object' && typeof config.autocapture.networkTracking === 'object') {
@@ -145,67 +162,62 @@ export class AmplitudeReactNative extends AmplitudeCore implements ReactNativeCl
     }
     const serverZone = options.serverZone ?? 'US';
     let remoteConfigClient: IRemoteConfigClient | undefined;
+    const diagnosticsClientRef: { current?: DiagnosticsClient } = {};
+    let diagnosticsSampleRate = 0;
 
     // Step 0.2: Fetch diagnostics config
-    // let diagnosticsSampleRate: number;
-    // let enableDiagnostics: boolean = false;
     if (fetchRemoteConfig) {
+      const remoteConfigPlatform = getRemoteConfigPlatform();
       remoteConfigClient = new RemoteConfigClient(
         options.apiKey,
         loggerProvider,
         serverZone,
         /* istanbul ignore next */ options.remoteConfig?.serverUrl,
+        undefined,
+        remoteConfigPlatform.configGroup,
       );
-      // Diagnostics capture is intentionally disabled for React Native until ready.
-      /* istanbul ignore if */
-      if (IS_DIAGNOSTICS_CAPTURED) {
-        await new Promise<void>((resolve) => {
-          remoteConfigClient?.subscribe(
-            'configs.diagnostics.reactNativeSDK',
-            'all',
-            (remoteConfig: RemoteConfig | null, source: Source, lastFetch: Date) => {
-              loggerProvider.debug(
-                'Diagnostics remote configuration received:',
-                safeJsonStringify(
-                  {
-                    remoteConfig,
-                    source,
-                    lastFetch,
-                  },
-                  null,
-                  2,
-                ),
-              );
-              if (remoteConfig) {
-                // Validate and set sampleRate (must be a valid number)
-                // const sampleRate = remoteConfig.sampleRate as number;
-                // if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
-                //   diagnosticsSampleRate = sampleRate;
-                // }
-                // // Validate and set enabled (must be a boolean)
-                // const enabled = remoteConfig.enabled as boolean;
-                // if (typeof enabled === 'boolean') {
-                //   enableDiagnostics = enabled;
-                // }
+      await new Promise<void>((resolve) => {
+        remoteConfigClient?.subscribe(
+          remoteConfigPlatform.diagnosticsKey,
+          'all',
+          (remoteConfig: RemoteConfig | null, source: Source, lastFetch: Date) => {
+            loggerProvider.debug(
+              'Diagnostics remote configuration received:',
+              safeJsonStringify(
+                {
+                  remoteConfig,
+                  source,
+                  lastFetch,
+                },
+                null,
+                2,
+              ),
+            );
+            if (remoteConfig) {
+              const sampleRate = remoteConfig.sampleRate as number;
+              if (typeof sampleRate === 'number' && !isNaN(sampleRate)) {
+                diagnosticsSampleRate = sampleRate;
+                diagnosticsClientRef.current?._setSampleRate(sampleRate);
               }
-              resolve();
-            },
-          );
-        });
-      }
+            }
+            resolve();
+          },
+        );
+      });
     }
 
     // Step 0.3: Initialize diagnostics client as early as possible so it can record failures
     // during config setup. Mirrors the browser SDK; storage is injected because RN has no
-    // IndexedDB. Options are left at their defaults (enabled, sample rate 0), which keeps the
-    // client inert until the remote config gate above is turned on.
+    // IndexedDB. The platform-specific remote config sample rate keeps the client inert when
+    // diagnostics are not configured, since the default sample rate is 0.
     const diagnosticsClient = new DiagnosticsClient(
       options.apiKey,
       loggerProvider,
       serverZone,
-      undefined,
+      { sampleRate: diagnosticsSampleRate },
       new ReactNativeDiagnosticsStorage(options.apiKey, loggerProvider),
     );
+    diagnosticsClientRef.current = diagnosticsClient;
     diagnosticsClient.setTag('library', `${LIBPREFIX}/${VERSION}`);
     diagnosticsClient.setTag('platform', 'ReactNative');
     diagnosticsClient.setTag('os', Platform.OS);

--- a/packages/analytics-react-native/test/react-native-client.test.ts
+++ b/packages/analytics-react-native/test/react-native-client.test.ts
@@ -11,7 +11,7 @@ import {
   getCookieName as getStorageKey,
   RemoteConfigClient,
 } from '@amplitude/analytics-core';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { isWeb } from '../src/utils/platform';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Config from '../src/config';
@@ -56,6 +56,8 @@ describe('react-native-client', () => {
       disabled: true,
     },
   };
+  const expectedRemoteConfigGroup = () =>
+    Platform.OS === 'ios' || Platform.OS === 'android' ? Platform.OS : 'browser';
 
   beforeEach(() => {
     originalRemoteConfigClient = core.RemoteConfigClient;
@@ -383,7 +385,14 @@ describe('react-native-client', () => {
         ...attributionConfig,
       }).promise;
 
-      expect(MockedRemoteConfigClient).toHaveBeenCalledWith(API_KEY, expect.anything(), 'US', customServerUrl);
+      expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
+        API_KEY,
+        expect.anything(),
+        'US',
+        customServerUrl,
+        undefined,
+        expectedRemoteConfigGroup(),
+      );
     });
 
     test('should share the same loggerProvider between RemoteConfigClient and final config', async () => {
@@ -396,7 +405,14 @@ describe('react-native-client', () => {
         ...attributionConfig,
       }).promise;
 
-      expect(MockedRemoteConfigClient).toHaveBeenCalledWith(API_KEY, client.config.loggerProvider, 'US', undefined);
+      expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
+        API_KEY,
+        client.config.loggerProvider,
+        'US',
+        undefined,
+        undefined,
+        expectedRemoteConfigGroup(),
+      );
     });
 
     test('should call updateReactNativeConfigWithRemoteConfig when remoteConfig is not null', async () => {
@@ -1669,6 +1685,118 @@ describe('react-native-client', () => {
   });
 
   describe('diagnostics', () => {
+    test('should use the iOS diagnostics config and pass its sample rate to DiagnosticsClient', async () => {
+      const originalPlatform = Platform.OS;
+      Platform.OS = 'ios';
+      const platformRemoteConfigClient = {
+        subscribe: jest.fn(
+          (
+            configKey: string,
+            _deliveryMode: string,
+            callback: (remoteConfig: any, source: any, date: Date) => void,
+          ) => {
+            callback(configKey === 'configs.diagnostics.iosSDK' ? { sampleRate: 0.25 } : null, 'remote', new Date());
+          },
+        ),
+        unsubscribe: jest.fn(),
+        updateConfigs: jest.fn(),
+      };
+      MockedRemoteConfigClient = jest.fn(() => platformRemoteConfigClient);
+      Object.defineProperty(core, 'RemoteConfigClient', { value: MockedRemoteConfigClient });
+      const client = new AmplitudeReactNative();
+      const addSpy = jest.spyOn(client, 'add');
+
+      try {
+        await client.init(API_KEY, undefined, {
+          ...useDefaultConfig(),
+          remoteConfig: { fetchRemoteConfig: true },
+        }).promise;
+
+        expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
+          API_KEY,
+          expect.anything(),
+          'US',
+          undefined,
+          undefined,
+          'ios',
+        );
+        expect(platformRemoteConfigClient.subscribe).toHaveBeenCalledWith(
+          'configs.diagnostics.iosSDK',
+          'all',
+          expect.any(Function),
+        );
+        const destination = addSpy.mock.calls
+          .map(([plugin]) => plugin as core.Destination)
+          .find((plugin) => plugin.name === 'amplitude');
+        expect((destination?.diagnosticsClient as core.DiagnosticsClient).config.sampleRate).toBe(0.25);
+      } finally {
+        Platform.OS = originalPlatform;
+      }
+    });
+
+    test('should use the Android config group and diagnostics key on Android', async () => {
+      const originalPlatform = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        const client = new AmplitudeReactNative();
+        await client.init(API_KEY, undefined, {
+          ...useDefaultConfig(),
+          remoteConfig: { fetchRemoteConfig: true },
+        }).promise;
+
+        expect(MockedRemoteConfigClient).toHaveBeenCalledWith(
+          API_KEY,
+          expect.anything(),
+          'US',
+          undefined,
+          undefined,
+          'android',
+        );
+        expect(mockRemoteConfigClient.subscribe).toHaveBeenCalledWith(
+          'configs.diagnostics.androidSDK',
+          'all',
+          expect.any(Function),
+        );
+      } finally {
+        Platform.OS = originalPlatform;
+      }
+    });
+
+    test.each([{ sampleRate: '0.5' }, { sampleRate: Number.NaN }, {}])(
+      'should keep the default diagnostics sample rate for invalid remote config %#',
+      async (remoteConfig) => {
+        const originalPlatform = Platform.OS;
+        Platform.OS = 'ios';
+        const invalidRemoteConfigClient = {
+          subscribe: jest.fn(
+            (configKey: string, _deliveryMode: string, callback: (config: any, source: any, date: Date) => void) => {
+              callback(configKey === 'configs.diagnostics.iosSDK' ? remoteConfig : null, 'remote', new Date());
+            },
+          ),
+          unsubscribe: jest.fn(),
+          updateConfigs: jest.fn(),
+        };
+        MockedRemoteConfigClient = jest.fn(() => invalidRemoteConfigClient);
+        Object.defineProperty(core, 'RemoteConfigClient', { value: MockedRemoteConfigClient });
+        const client = new AmplitudeReactNative();
+        const addSpy = jest.spyOn(client, 'add');
+
+        try {
+          await client.init(API_KEY, undefined, {
+            ...useDefaultConfig(),
+            remoteConfig: { fetchRemoteConfig: true },
+          }).promise;
+
+          const destination = addSpy.mock.calls
+            .map(([plugin]) => plugin as core.Destination)
+            .find((plugin) => plugin.name === 'amplitude');
+          expect((destination?.diagnosticsClient as core.DiagnosticsClient).config.sampleRate).toBe(0);
+        } finally {
+          Platform.OS = originalPlatform;
+        }
+      },
+    );
+
     test('should give Destination a diagnostics client backed by RN storage', async () => {
       const client = new AmplitudeReactNative();
       const addSpy = jest.spyOn(client, 'add');


### PR DESCRIPTION
Linear: [SDKRN-72](https://linear.app/amplitude/issue/SDKRN-72/fetch-diagnostics-sample-rate-from-platform-remote-config)

### Summary

- select the iOS or Android Remote Config group from the React Native runtime platform
- subscribe only to `configs.diagnostics.iosSDK` or `configs.diagnostics.androidSDK` and validate `sampleRate`
- initialize the React Native diagnostics client with the remote sample rate and apply later subscription updates
- retain the browser config group/key fallback for non-native platforms

### Testing

- `pnpm --filter @amplitude/analytics-core test --runInBand --no-watchman --coverage=false test/remote-config/remote-config.test.ts`
- `pnpm --filter @amplitude/analytics-react-native test:mobile --runInBand --no-watchman --coverage=false --forceExit test/react-native-client.test.ts`
- `pnpm --filter @amplitude/analytics-react-native test:web --runInBand --no-watchman --coverage=false --forceExit test/react-native-client.test.ts`
- `env NX_DAEMON=false pnpm exec lerna run build --stream --scope @amplitude/analytics-react-native --include-dependencies --skip-nx-cache`
- `pnpm --filter @amplitude/analytics-react-native lint:eslint`
- `pnpm --filter @amplitude/analytics-core lint:eslint`
- `pnpm docs:check`

### Local test
#### Android
remote config fetch diagnostics sample rate 1
<img width="3874" height="2798" alt="image" src="https://github.com/user-attachments/assets/f363435c-a4c9-4bdd-93ad-488c2bd32715" />

diagnostics request
<img width="3896" height="1630" alt="image" src="https://github.com/user-attachments/assets/7325ae54-2a2b-4841-a6a1-0bc47253c03d" />

#### iOS
<img width="1254" height="786" alt="image" src="https://github.com/user-attachments/assets/9fe10c0b-0dfd-4784-b973-cd38f58f3561" />

#### Datadog
Observe them at datadog
<img width="1918" height="538" alt="image" src="https://github.com/user-attachments/assets/48fb4486-da3c-4c62-9d65-9d18dd938073" />


### Checklist

- [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
- Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init-time remote config and diagnostics sampling for React Native; misconfigured sample rates could affect diagnostics volume, but invalid rates are rejected to 0.
> 
> **Overview**
> React Native now requests the **ios** or **android** remote config group (via a new optional `configGroup` on `RemoteConfigClient`) instead of always using **browser**, with a browser fallback for non-native runtimes.
> 
> Init performs **one** full-config fetch (1s timeout delivery mode) and derives both analytics settings (`configs.analyticsSDK.reactNativeSDK`) and the **diagnostics `sampleRate`** for the platform-specific key (`iosSDK` / `androidSDK` / `browserSDK`). That validated rate is passed into `DiagnosticsClient`, replacing the previous always-off diagnostics gate. Invalid or missing `sampleRate` values stay at **0**.
> 
> Tests and the on-device harness were updated to assert the platform `config_group` query param and the consolidated fetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d3fc38cba9d66edd94b6641bab10a14bc0557b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->