### PR TITLE
fix: remove extra event_properties

### DIFF
--- a/packages/analytics-browser/src/video-capture/video-capture.ts
+++ b/packages/analytics-browser/src/video-capture/video-capture.ts
@@ -13,6 +13,28 @@ import { DEFAULT_CONTENT_STARTED_EVENT, DEFAULT_CONTENT_STOPPED_EVENT } from '..
 /** Playback states where a view session is still in progress (e.g. buffering). */
 const ACTIVE_PLAYBACK_STATES = new Set<VideoState['playbackState']>(['playing', 'waiting']);
 
+/**
+ * Observer fields that never reach event properties: `last_position` is an observer internal,
+ * and `percent_completed`/`stop_reason` describe the player event rather than the play session,
+ * which tracks its own values.
+ */
+const OMITTED_VIDEO_EVENT_PROPERTIES = new Set(['last_position', 'percent_completed', 'stop_reason']);
+
+/**
+ * Copy remaining player-event fields (vendor metadata such as `mux_playback_id`, ids, titles)
+ * onto the Amplitude event, dropping empty values so absent metadata is omitted.
+ */
+function parseVideoEventProperties(lastEvent: VideoState['lastEvent']): Record<string, string | number | boolean> {
+  const properties: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(lastEvent ?? {})) {
+    if (OMITTED_VIDEO_EVENT_PROPERTIES.has(key) || value === null || value === undefined) {
+      continue;
+    }
+    properties[key] = value as string | number | boolean;
+  }
+  return properties;
+}
+
 export class VideoCapture {
   private videoEl: HTMLMediaElement | null = null;
   private heartbeat: ReturnType<typeof getHeartbeatInstance>;
@@ -88,7 +110,6 @@ export class VideoCapture {
           event_type: DEFAULT_CONTENT_STARTED_EVENT,
           time: now,
           event_properties: {
-            ...nextState.lastEvent,
             ...this.parseStartEventProperties(nextState),
             ...this.extraEventProperties,
             play_id: this.playId,
@@ -100,7 +121,6 @@ export class VideoCapture {
           event_type: DEFAULT_CONTENT_STOPPED_EVENT,
           time: now + 1,
           event_properties: {
-            ...nextState.lastEvent,
             ...this.parseStopEventProperties(nextState),
             ...this.extraEventProperties,
             stop_reason: 'timeout',
@@ -214,6 +234,7 @@ export class VideoCapture {
 
   parseStartEventProperties(nextState: VideoState): Record<string, string | number | boolean> {
     return {
+      ...parseVideoEventProperties(nextState.lastEvent),
       duration: nextState.lastEvent?.duration ?? 0,
       start_time: nextState.lastEvent?.start_time ?? 0,
       position: nextState.position ?? 0,

--- a/packages/analytics-browser/test/video-capture/video-capture.test.ts
+++ b/packages/analytics-browser/test/video-capture/video-capture.test.ts
@@ -151,9 +151,63 @@ describe('VideoCapture', () => {
   });
 
   describe('withVendor()', () => {
-    it('should capture start and stop events', () => {
+    it('should capture start and stop events', async () => {
       const videoCapture = new VideoCapture(mockAmplitude).withVendor('mux');
       expect((videoCapture as unknown as { vendor: string }).vendor).toBe('mux');
+    });
+    it('should capture start and stop events with mux properties', async () => {
+      const capture = new VideoCapture(mockAmplitude)
+        .withVideoElement(document.createElement('video'))
+        .withVendor('mux')
+        .captureVideoStarted()
+        .captureVideoStopped()
+        .start();
+
+      const muxLastEvent = {
+        duration: 10,
+        last_position: 0,
+        mux_playback_id: 'playback-id',
+        mux_video_id: 'video-id',
+        mux_video_title: 'video-title',
+      };
+      currentVideoObserver!.emitStateChange(
+        { playbackState: 'paused', lastEvent: undefined },
+        { playbackState: 'playing', lastEvent: muxLastEvent, position: 0 },
+      );
+      await flushHeartbeat();
+      expect(mockAmplitude.track).toHaveBeenNthCalledWith(
+        1,
+        '[Amplitude] Content Started',
+        expect.objectContaining({
+          mux_playback_id: 'playback-id',
+          mux_video_id: 'video-id',
+          mux_video_title: 'video-title',
+        }),
+        expect.any(Object),
+      );
+
+      currentVideoObserver!.emitStateChange(
+        { playbackState: 'playing', lastEvent: muxLastEvent, position: 0 },
+        {
+          playbackState: 'paused',
+          lastEvent: { ...muxLastEvent, last_position: 5, percent_completed: 20, stop_reason: 'paused' },
+          position: 5,
+        },
+      );
+      await flushHeartbeat();
+      expect(mockAmplitude.track).toHaveBeenNthCalledWith(
+        3,
+        '[Amplitude] Content Stopped',
+        expect.objectContaining({
+          mux_playback_id: 'playback-id',
+          mux_video_id: 'video-id',
+          mux_video_title: 'video-title',
+          stop_reason: 'paused',
+          percent_completed: 50,
+        }),
+        expect.any(Object),
+      );
+      capture.stop();
     });
   });
 
@@ -715,6 +769,36 @@ describe('VideoCapture', () => {
       });
     });
 
+    it('should keep vendor metadata and drop empty or recomputed fields', () => {
+      const capture = new VideoCapture(mockAmplitude);
+      expect(
+        capture.parseStartEventProperties({
+          playbackState: 'playing',
+          lastEvent: {
+            duration: 10,
+            start_time: 2,
+            last_position: 5,
+            percent_completed: 50,
+            stop_reason: 'paused',
+            mux_playback_id: 'playback-id',
+            mux_video_id: 'video-id',
+            mux_video_title: 'video-title',
+            mux_session_id: null,
+            video_id: undefined,
+          },
+          position: 5,
+        }),
+      ).toEqual({
+        duration: 10,
+        start_time: 2,
+        position: 5,
+        delivery_mode: 'video',
+        mux_playback_id: 'playback-id',
+        mux_video_id: 'video-id',
+        mux_video_title: 'video-title',
+      });
+    });
+
     it('should set delivery_mode to audio for an audio element', () => {
       const capture = new VideoCapture(mockAmplitude).withVideoElement(document.createElement('audio'));
       expect(
@@ -762,6 +846,33 @@ describe('VideoCapture', () => {
         watch_duration: 0,
         percent_completed: 0,
         delivery_mode: 'video',
+      });
+    });
+
+    it('should keep vendor metadata without inheriting the player event percent_completed or stop_reason', () => {
+      const capture = new VideoCapture(mockAmplitude);
+      expect(
+        capture.parseStopEventProperties({
+          playbackState: 'paused',
+          lastEvent: {
+            duration: 10,
+            start_time: 2,
+            last_position: 5,
+            percent_completed: 20,
+            stop_reason: 'paused',
+            mux_playback_id: 'playback-id',
+          },
+          position: 5,
+          watchTime: 30,
+        }),
+      ).toEqual({
+        duration: 10,
+        start_time: 2,
+        position: 5,
+        watch_duration: 30,
+        percent_completed: 50,
+        delivery_mode: 'video',
+        mux_playback_id: 'playback-id',
       });
     });
 


### PR DESCRIPTION
### Summary

Remove unneeded events from event_properties. It was capturing every event that came from the `VideoEvent` object when it didn't need them

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics event shape change only; narrows properties on video capture events with no auth or data-pipeline impact.
> 
> **Overview**
> **Content Started** and **Content Stopped** no longer spread the full player `lastEvent` onto Amplitude `event_properties`. That was pulling in observer internals and player-only fields alongside the session fields `VideoCapture` already computes.
> 
> The PR adds **`parseVideoEventProperties`**, which forwards vendor metadata (e.g. Mux `mux_*` ids/titles) while **omitting** `last_position`, `percent_completed`, and `stop_reason`, and skipping null/undefined values. Start/stop payloads are built through **`parseStartEventProperties`** / **`parseStopEventProperties`** so **`percent_completed`** and **`stop_reason`** still come from the play session logic, not the raw player event.
> 
> Tests cover Mux fields on tracked events and the filtering behavior on the parse helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8c3f9cde686d6d92a4015262eea2cf13cc29cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->