### PR TITLE
fix: transpose pause and ended handlers

### DIFF
--- a/packages/analytics-core/src/video-analytics/track-video.ts
+++ b/packages/analytics-core/src/video-analytics/track-video.ts
@@ -52,7 +52,12 @@ function getMuxMetadata(videoEl: MuxElement) {
  * @returns A function to untrack the video.
  */
 export function trackHtmlVideo(videoEl: HTMLMediaElement | MuxElement, handlers: VideoHandler, vendor?: Vendor) {
+  // reaching the end of the media fires `pause` right before `ended`, so end of media is
+  // reported once, as `ended`
+  let hasReportedEnded = false;
+
   const playHandler = () => {
+    hasReportedEnded = false;
     const startEvent: VideoEvent = {
       ...getVideoData(videoEl),
       ...(vendor === 'mux' ? getMuxMetadata(videoEl) : {}),
@@ -61,16 +66,11 @@ export function trackHtmlVideo(videoEl: HTMLMediaElement | MuxElement, handlers:
   };
   videoEl.addEventListener('play', playHandler);
 
-  const pauseHandler = () => {
-    const pauseEvent: VideoEvent = {
-      ...getVideoData(videoEl, 'paused'),
-      ...(vendor === 'mux' ? getMuxMetadata(videoEl) : {}),
-    };
-    handlers.onPause(pauseEvent);
-  };
-  videoEl.addEventListener('pause', pauseHandler);
-
   const endedHandler = () => {
+    if (hasReportedEnded) {
+      return;
+    }
+    hasReportedEnded = true;
     const endedEvent: VideoEvent = {
       ...getVideoData(videoEl, 'ended'),
       ...(vendor === 'mux' ? getMuxMetadata(videoEl) : {}),
@@ -78,6 +78,19 @@ export function trackHtmlVideo(videoEl: HTMLMediaElement | MuxElement, handlers:
     handlers.onEnded(endedEvent);
   };
   videoEl.addEventListener('ended', endedHandler);
+
+  const pauseHandler = () => {
+    if ((videoEl as HTMLMediaElement).ended === true) {
+      endedHandler();
+      return;
+    }
+    const pauseEvent: VideoEvent = {
+      ...getVideoData(videoEl, 'paused'),
+      ...(vendor === 'mux' ? getMuxMetadata(videoEl) : {}),
+    };
+    handlers.onPause(pauseEvent);
+  };
+  videoEl.addEventListener('pause', pauseHandler);
 
   const seekingHandler = () => {
     const seekingEvent: VideoEvent = {
@@ -114,8 +127,8 @@ export function trackHtmlVideo(videoEl: HTMLMediaElement | MuxElement, handlers:
 
   return () => {
     videoEl.removeEventListener('play', playHandler);
-    videoEl.removeEventListener('pause', pauseHandler);
     videoEl.removeEventListener('ended', endedHandler);
+    videoEl.removeEventListener('pause', pauseHandler);
     videoEl.removeEventListener('seeking', seekingHandler);
     videoEl.removeEventListener('seeked', seekedHandler);
     videoEl.removeEventListener('error', errorHandler);
@@ -179,18 +192,6 @@ export function trackEmbeddedVideo(player: EmbeddedVideoPlayer, handlers: VideoH
     player.on('play', playHandler);
     onUnsubscribe.push(() => player.off('play', playHandler));
 
-    const pauseHandler = () => {
-      getIframeMetadata(player, elem, vendor, 'paused')
-        .then((playerState) => {
-          handlers.onPause(playerState);
-        })
-        .catch((error) => {
-          handlers.onError(`Error getting iframe metadata from 'pause' handler: ${error as string}`);
-        });
-    };
-    player.on('pause', pauseHandler);
-    onUnsubscribe.push(() => player.off('pause', pauseHandler));
-
     const endedHandler = () => {
       getIframeMetadata(player, elem, vendor, 'ended')
         .then((playerState) => {
@@ -202,6 +203,18 @@ export function trackEmbeddedVideo(player: EmbeddedVideoPlayer, handlers: VideoH
     };
     player.on('ended', endedHandler);
     onUnsubscribe.push(() => player.off('ended', endedHandler));
+
+    const pauseHandler = () => {
+      getIframeMetadata(player, elem, vendor, 'paused')
+        .then((playerState) => {
+          handlers.onPause(playerState);
+        })
+        .catch((error) => {
+          handlers.onError(`Error getting iframe metadata from 'pause' handler: ${error as string}`);
+        });
+    };
+    player.on('pause', pauseHandler);
+    onUnsubscribe.push(() => player.off('pause', pauseHandler));
 
     const seekingHandler = () => {
       isSeeking = true;

--- a/packages/analytics-core/test/video-analytics/track-video.test.ts
+++ b/packages/analytics-core/test/video-analytics/track-video.test.ts
@@ -53,6 +53,32 @@ describe('trackHtmlVideo', () => {
     expect(handler.onPlay).not.toHaveBeenCalled();
   });
 
+  test('should report the pause that precedes the end of the media as an ended event', () => {
+    trackHtmlVideo(video, handler);
+
+    video.play();
+    Object.defineProperty(video, 'ended', { configurable: true, value: true });
+    Object.defineProperty(video, 'currentTime', { configurable: true, value: 10 });
+    video.dispatchEvent(new Event('pause'));
+    video.dispatchEvent(new Event('ended'));
+
+    expect(handler.onPause).not.toHaveBeenCalled();
+    expect(handler.onEnded).toHaveBeenCalledTimes(1);
+    expect(handler.onEnded).toHaveBeenCalledWith({
+      duration: 10,
+      start_time: 10,
+      last_position: 10,
+      percent_completed: 100,
+      stop_reason: 'ended',
+    });
+
+    // replaying restores normal pause reporting
+    video.play();
+    Object.defineProperty(video, 'ended', { configurable: true, value: false });
+    video.pause();
+    expect(handler.onPause).toHaveBeenCalledTimes(1);
+  });
+
   test('should track seeking events', () => {
     const untrack = trackHtmlVideo(video, handler);
 


### PR DESCRIPTION
### Summary

Problem: when a video ends, the 'pause' event triggers and the 'stop_reason' is reported as 'paused'.
Fix: when a pause handler happens, trigger the "end" handler if the video is ended. And also make it so that endedHandler is only called once

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics classification only; no auth, data persistence, or playback control changes, though completion metrics may shift for customers who relied on the old pause-at-end behavior.
> 
> **Overview**
> Fixes incorrect **`stop_reason: 'paused'`** when playback finishes: browsers fire **`pause`** immediately before **`ended`**, which was surfacing completions as pauses in video analytics.
> 
> **`trackHtmlVideo`** now routes a pause on an already-ended element through the ended path ( **`stop_reason: 'ended'`** ), uses a **`hasReportedEnded`** guard so **`onEnded`** fires once across pause+ended, and resets that flag on **`play`** so mid-play pauses behave normally after replay. A unit test covers the pause-then-ended sequence and replay.
> 
> **`trackEmbeddedVideo`** only reorders when pause vs ended listeners are registered (no dedupe / ended-on-pause logic in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20818a3b6a22f438d663749b37b3f333bd5e01a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->